### PR TITLE
Idconvention bug

### DIFF
--- a/Bson/DefaultSerializer/BsonClassMap.cs
+++ b/Bson/DefaultSerializer/BsonClassMap.cs
@@ -495,7 +495,10 @@ namespace MongoDB.Bson.DefaultSerializer {
 
                 // if no base class provided an idPropertyMap maybe we have one?
                 if (idPropertyMap == null) {
-                    idPropertyMap = conventions.IdPropertyConvention.FindIdPropertyMap(propertyMaps);
+                    var propertyInfo = conventions.IdPropertyConvention.FindIdPropertyMap(classType);
+                    idPropertyMap = propertyMaps.SingleOrDefault(x => x.PropertyInfo == propertyInfo);
+                    if (idPropertyMap != null)
+                        idPropertyMap.SetElementName("_id");
                 }
             }
 

--- a/Bson/DefaultSerializer/BsonPropertyMap.cs
+++ b/Bson/DefaultSerializer/BsonPropertyMap.cs
@@ -158,6 +158,13 @@ namespace MongoDB.Bson.DefaultSerializer {
             return this;
         }
 
+        public BsonPropertyMap SetElementName(
+            string elementName
+        ) {
+            this.elementName = elementName;
+            return this;
+        }
+
         public BsonPropertyMap SetIdGenerator(
             IBsonIdGenerator idGenerator
         ) {

--- a/Bson/DefaultSerializer/Conventions/IdPropertyConventions.cs
+++ b/Bson/DefaultSerializer/Conventions/IdPropertyConventions.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 
 namespace MongoDB.Bson.DefaultSerializer.Conventions {
     public interface IIdPropertyConvention {
-        BsonPropertyMap FindIdPropertyMap(IEnumerable<BsonPropertyMap> propertyMaps); 
+        PropertyInfo FindIdPropertyMap(Type type); 
     }
 
     public class NamedIdPropertyConvention : IIdPropertyConvention {
@@ -33,10 +33,10 @@ namespace MongoDB.Bson.DefaultSerializer.Conventions {
             Name = name;
         }
 
-        public BsonPropertyMap FindIdPropertyMap(
-            IEnumerable<BsonPropertyMap> propertyMaps
+        public PropertyInfo FindIdPropertyMap(
+            Type type
         ) {
-            return propertyMaps.FirstOrDefault(x => x.PropertyName == Name);
+            return type.GetProperty(Name);
         }
     }
 }

--- a/BsonUnitTests/DefaultSerializer/Conventions/IdPropertyConventionsTests.cs
+++ b/BsonUnitTests/DefaultSerializer/Conventions/IdPropertyConventionsTests.cs
@@ -40,14 +40,12 @@ namespace MongoDB.BsonUnitTests.DefaultSerializer.Conventions {
         public void TestIdPropertyConvention() {
             var convention = new NamedIdPropertyConvention("Id");
 
-            var classAMap = BsonClassMap.RegisterClassMap<TestClassA>();
-            var idMap = convention.FindIdPropertyMap(classAMap.PropertyMaps);
-            Assert.IsNotNull(idMap);
-            Assert.AreEqual("Id", idMap.PropertyName);
+            var idProperty = convention.FindIdPropertyMap(typeof(TestClassA));
+            Assert.IsNotNull(idProperty);
+            Assert.AreEqual("Id", idProperty.Name);
 
-            var classBMap = BsonClassMap.RegisterClassMap<TestClassB>();
-            idMap = convention.FindIdPropertyMap(classBMap.PropertyMaps);
-            Assert.IsNull(idMap);
+            idProperty = convention.FindIdPropertyMap(typeof(TestClassB));
+            Assert.IsNull(idProperty);
         }
     }
 }


### PR DESCRIPTION
I fixed an issue when the id property was discovered late in the mapping cycle.  It wouldn't get it's element name changed to "_id" which would break the deserialization process.

I also changed the IIdPropertyConvention to take a type and return a property info so as to allow the possibility of discovering an Id property that wasn't necessarily mapped (like a private property).  In addition, it allows for better future extensibility and easier to write custom IIdPropertyConventions.
