### PR TITLE
Added implicit string and ObjectId operators to ObjectId

### DIFF
--- a/Bson/ObjectModel/ObjectId.cs
+++ b/Bson/ObjectModel/ObjectId.cs
@@ -142,6 +142,23 @@ namespace MongoDB.Bson {
         ) {
             return lhs.CompareTo(rhs) > 0;
         }
+
+        public static implicit operator string(
+            ObjectId oid
+        ) {
+            return oid == null ? null : oid.ToString();
+        }
+
+        public static implicit operator ObjectId(
+            string oidString
+        ) {
+            ObjectId retval = ObjectId.Empty;
+            if (! string.IsNullOrEmpty(oidString)) {
+                retval = new ObjectId(oidString);
+            }
+            return retval;
+        }
+
         #endregion
 
         #region public static methods


### PR DESCRIPTION
Code and idea borrowed from NoRM...  Having implicit conversions between ObjectId and String allows for easier object mappings with frameworks like AutoMapper or ASP.NET MVC Model data binding.  
