### PR TITLE
Support nullable Enums

### DIFF
--- a/Bson/DefaultSerializer/Serializers/EnumSerializer.cs
+++ b/Bson/DefaultSerializer/Serializers/EnumSerializer.cs
@@ -105,7 +105,13 @@ namespace MongoDB.Bson.DefaultSerializer {
             Type nominalType,
             Type actualType
         ) {
-            if (nominalType != typeof(object) && nominalType != actualType) {
+            // problem is that the actual type of a nullable type that is not null will appear as the non-nullable type
+            // we want to allow both Enum and Nullable<Enum> here 
+            bool isNullableOfActual = (
+                nominalType.GetGenericTypeDefinition() == typeof(Nullable<>)
+                && nominalType.GetGenericArguments().FirstOrDefault() == actualType
+                );
+            if (nominalType != typeof(object) && nominalType != actualType && (!isNullableOfActual)) {
                 var message = string.Format("EnumSerializer.Serialize cannot be used with nominal type: {0}", nominalType.FullName);
                 throw new BsonSerializationException(message);
             }           

--- a/BsonUnitTests/DefaultSerializer/Serializers/NullableTypeSerializerTests.cs
+++ b/BsonUnitTests/DefaultSerializer/Serializers/NullableTypeSerializerTests.cs
@@ -38,6 +38,8 @@ namespace MongoDB.BsonUnitTests.DefaultSerializer {
             public int? Int32 { get; set; }
             public long? Int64 { get; set; }
             public ObjectId? ObjectId { get; set; }
+            [BsonRepresentation(BsonType.String)]
+            public ConsoleColor? Enum { get; set; }
             // public Struct? Struct { get; set; }
         }
 
@@ -54,7 +56,8 @@ namespace MongoDB.BsonUnitTests.DefaultSerializer {
             "'Guid' : null, " +
             "'Int32' : null, " +
             "'Int64' : null, " +
-            "'ObjectId' : null" +
+            "'ObjectId' : null, " +
+            "'Enum' : null" +
             // "'Struct' : null" +
             " }";
 
@@ -118,6 +121,18 @@ namespace MongoDB.BsonUnitTests.DefaultSerializer {
             Assert.IsTrue(bson.SequenceEqual(rehydrated.ToBson()));
         }
 
+        [Test]
+        public void TestEnum()
+        {
+            C c = new C { Enum = ConsoleColor.Red};
+            var json = c.ToJson();
+            var expected = template.Replace("'Enum' : null", "'Enum' : \"Red\"").Replace("'", "\"");
+            Assert.AreEqual(expected, json);
+
+            var bson = c.ToBson();
+            var rehydrated = BsonSerializer.Deserialize<C>(bson);
+            Assert.IsTrue(bson.SequenceEqual(rehydrated.ToBson()));
+        }
         [Test]
         public void TestGuid() {
             C c = new C { Guid = Guid.Empty };


### PR DESCRIPTION
A nullable enum will appear in the serializer as a normal enum and will thus not have actualType == nominalType. Added an extra check for the Nullable<enum>.

This should probably be implemented for all structs, but I'm not sure if there would be a central place to do this.
