### PR TITLE
Serialize ObservableCollection<> with EnumerableSerializer<>

### DIFF
--- a/Bson/DefaultSerializer/BsonDefaultSerializer.cs
+++ b/Bson/DefaultSerializer/BsonDefaultSerializer.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.IO;
@@ -111,6 +112,7 @@ namespace MongoDB.Bson.DefaultSerializer {
                 { typeof(LinkedList<>), typeof(EnumerableSerializer<>) },
                 { typeof(List<>), typeof(EnumerableSerializer<>) },
                 { typeof(Nullable<>), typeof(NullableSerializer<>) },
+                { typeof(ObservableCollection<>), typeof(EnumerableSerializer<>)},
                 { typeof(Queue<>), typeof(QueueSerializer<>) },
                 { typeof(SortedDictionary<,>), typeof(DictionarySerializer<,>) },
                 { typeof(SortedList<,>), typeof(DictionarySerializer<,>) },


### PR DESCRIPTION
ObservableCollection<T> instances are not serializing correctly by default.
