### PR TITLE
Added override for SetHint(string hint)

### DIFF
--- a/Driver/Core/MongoCursor.cs
+++ b/Driver/Core/MongoCursor.cs
@@ -203,6 +203,15 @@ namespace MongoDB.Driver {
         }
 
         public virtual MongoCursor<TDocument> SetHint(
+            string indexName
+        )
+        {
+            if (isFrozen) { ThrowFrozen(); }
+            SetOption("$hint", indexName);
+            return this;
+        }
+
+        public virtual MongoCursor<TDocument> SetHint(
             BsonDocument hint
         ) {
             if (isFrozen) { ThrowFrozen(); }

--- a/DriverOnlineTests/Core/MongoCollectionTests.cs
+++ b/DriverOnlineTests/Core/MongoCollectionTests.cs
@@ -715,6 +715,15 @@ namespace MongoDB.DriverOnlineTests {
         }
 
         [Test]
+        public void TestSetHint()
+        {
+            collection.RemoveAll();
+            collection.Insert(new BsonDocument { { "x", 1 }, { "y", 2 } });
+            collection.CreateIndex(IndexKeys.Ascending("x"), IndexOptions.SetName("xIndex"));
+            var result = collection.FindAll().SetHint("xIndex");
+        }
+
+        [Test]
         public void TestSortAndLimit() {
             collection.RemoveAll();
             collection.Insert(new BsonDocument { { "x", 4 }, { "y", 2 } });


### PR DESCRIPTION
Looked like SetHint() only allowed full-index definition to set the hint like:

db.collection.find({a:4,b:5,c:6}).hint({a:1,b:1});

Now can SetHint() with the index name like:

db.collection.find({a:4,b:5,c:6}).hint("a_1_b_1");

I think this is useful and more consistent with the shell
http://www.mongodb.org/display/DOCS/Optimization#Optimization-Hint
