### PR TITLE
Partially trusted callers

### DIFF
--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -29,8 +29,8 @@ using System.Security;
 
 // Setting AllowPartiallyTrustedCallers makes the assemblies callable
 // from other assemblies which are partially trusted.
-// If you would like to disable this, remove this line.
-[assembly: AllowPartiallyTrustedCallers]
+// If you would like to enable this, uncomment this line.
+//[assembly: AllowPartiallyTrustedCallers]
 
 // Version information for an assembly consists of the following four values:
 //


### PR DESCRIPTION
I was getting an error in my development environment which was causing me security exceptions. I have added a line to the assembly info which fixed the problem.

I don't want to enable this by default for everyone, but I did want to note it in the drivers in case someone ran into this issue.
