### PR TITLE
Change to IIdGenerator interface to accept original document

### DIFF
--- a/Bson/Serialization/IIdGenerator.cs
+++ b/Bson/Serialization/IIdGenerator.cs
@@ -25,8 +25,9 @@ namespace MongoDB.Bson.Serialization {
         /// <summary>
         /// Generates an Id.
         /// </summary>
+        /// <param name="document">The document for which an id is being generated.</param>
         /// <returns>An Id.</returns>
-        object GenerateId();
+        object GenerateId(object document);
         /// <summary>
         /// Tests whether an Id is empty.
         /// </summary>

--- a/Bson/Serialization/IdGenerators/IdGenerators.cs
+++ b/Bson/Serialization/IdGenerators/IdGenerators.cs
@@ -50,11 +50,13 @@ namespace MongoDB.Bson.Serialization.IdGenerators {
         #endregion
 
         #region public methods
+
         /// <summary>
         /// Generates an Id.
         /// </summary>
+        /// <param name="document"></param>
         /// <returns>An Id.</returns>
-        public object GenerateId() {
+        public object GenerateId(object document) {
             var guidArray = Guid.NewGuid().ToByteArray();
 
             var baseDate = new DateTime(1900, 1, 1);
@@ -114,11 +116,13 @@ namespace MongoDB.Bson.Serialization.IdGenerators {
         #endregion
 
         #region public methods
+
         /// <summary>
         /// Generates an Id.
         /// </summary>
+        /// <param name="document"></param>
         /// <returns>An Id.</returns>
-        public object GenerateId() {
+        public object GenerateId(object document) {
             return Guid.NewGuid();
         }
 
@@ -161,11 +165,13 @@ namespace MongoDB.Bson.Serialization.IdGenerators {
         #endregion
 
         #region public methods
+
         /// <summary>
         /// Throws an exception because we can't generate an Id.
         /// </summary>
+        /// <param name="document"></param>
         /// <returns>Nothing.</returns>
-        public object GenerateId() {
+        public object GenerateId(object document) {
             throw new InvalidOperationException("Id cannot be null");
         }
 
@@ -208,11 +214,13 @@ namespace MongoDB.Bson.Serialization.IdGenerators {
         #endregion
 
         #region public methods
+
         /// <summary>
         /// Generates an Id.
         /// </summary>
+        /// <param name="document"></param>
         /// <returns>An Id.</returns>
-        public object GenerateId() {
+        public object GenerateId(object document) {
             return ObjectId.GenerateNewId();
         }
 
@@ -255,11 +263,13 @@ namespace MongoDB.Bson.Serialization.IdGenerators {
         #endregion
 
         #region public methods
+
         /// <summary>
         /// Generates an Id.
         /// </summary>
+        /// <param name="document"></param>
         /// <returns>An Id.</returns>
-        public object GenerateId() {
+        public object GenerateId(object document) {
             return ObjectId.GenerateNewId().ToString();
         }
 
@@ -290,11 +300,13 @@ namespace MongoDB.Bson.Serialization.IdGenerators {
         #endregion
 
         #region public methods
+
         /// <summary>
         /// Throws an exception because we can't generate an Id.
         /// </summary>
+        /// <param name="document"></param>
         /// <returns>An Id.</returns>
-        public object GenerateId() {
+        public object GenerateId(object document) {
             throw new InvalidOperationException("Id cannot be default value (all zeros)");
         }
 

--- a/BsonUnitTests/Jira/CSharp81Tests.cs
+++ b/BsonUnitTests/Jira/CSharp81Tests.cs
@@ -49,7 +49,7 @@ namespace MongoDB.BsonUnitTests.Jira {
 
             var serializer = BsonSerializer.LookupSerializer(typeof(User));
             var idGenerator = BsonSerializer.LookupIdGenerator(typeof(ObjectId));
-            serializer.SetDocumentId(u, idGenerator.GenerateId());
+            serializer.SetDocumentId(u, idGenerator.GenerateId(u));
             Assert.IsFalse(idGenerator.IsEmpty(u.Id));
             Assert.IsTrue(idGenerator.IsEmpty(u.FriendId));
 

--- a/Driver/Core/MongoCollection.cs
+++ b/Driver/Core/MongoCollection.cs
@@ -734,7 +734,7 @@ namespace MongoDB.Driver {
                             IIdGenerator idGenerator;
                             if (serializer.GetDocumentId(document, out id, out idGenerator)) {
                                 if (idGenerator != null && idGenerator.IsEmpty(id)) {
-                                    id = idGenerator.GenerateId();
+                                    id = idGenerator.GenerateId(document);
                                     serializer.SetDocumentId(document, id);
                                 }
                             }
@@ -966,7 +966,7 @@ namespace MongoDB.Driver {
                 }
 
                 if (idGenerator != null && idGenerator.IsEmpty(id)) {
-                    id = idGenerator.GenerateId();
+                    id = idGenerator.GenerateId(document);
                     serializer.SetDocumentId(document, id);
                     return Insert(document, safeMode);
                 } else {


### PR DESCRIPTION
Changed IIdGenerator to accept the original document. This supports the scenario where the IIdGenerator implementation requires access to the document for which the id is being generated.

We are using this in the case where id's are generated on the server (such as with "hilo") where the deserialised instance of the document is useful for determining the scope for id generation.
