### PR TITLE
Adding Metadata Support for FileStream Operations

### DIFF
--- a/Driver/GridFS/MongoGridFSStream.cs
+++ b/Driver/GridFS/MongoGridFSStream.cs
@@ -509,7 +509,8 @@ namespace MongoDB.Driver.GridFS {
                 { "chunkSize", fileInfo.ChunkSize },
                 { "uploadDate", fileInfo.UploadDate },
                 { "contentType", fileInfo.ContentType, !string.IsNullOrEmpty(fileInfo.ContentType) }, // optional
-                { "aliases", BsonArray.Create((IEnumerable<string>) fileInfo.Aliases), fileInfo.Aliases != null && fileInfo.Aliases.Length > 0 } // optional
+                { "aliases", BsonArray.Create((IEnumerable<string>) fileInfo.Aliases), fileInfo.Aliases != null && fileInfo.Aliases.Length > 0 }, // optional
+                { "metadata", fileInfo.Metadata } //optional
             };
             gridFS.Files.Insert(file);
             length = 0;


### PR DESCRIPTION
Currently if you call GridFS.OpenWrite(filename, options), and the MongoGridFSCreateOptions class contains a metadata BsonDocument, the information in the metadata BsonDocument does not get persisted to Mongo.  This is because the Metadata property does not get added to the BsonDocument which gets stored in the files collection.  

I've added the metadata property to this BsonDocument in the MongoGridFSStream class.
