### PR TITLE
Custom BsonTypeMapping

### DIFF
--- a/Bson/Bson.csproj
+++ b/Bson/Bson.csproj
@@ -81,6 +81,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="BsonExtensionMethods.cs" />
+    <Compile Include="ObjectModel\CustomBsonTypeMapper.cs" />
     <Compile Include="Serialization\Attributes\BsonDateTimeOptionsAttribute.cs" />
     <Compile Include="Serialization\Attributes\BsonExtraElementsAttribute.cs" />
     <Compile Include="Serialization\Attributes\BsonGuidOptionsAttribute.cs" />

--- a/Bson/ObjectModel/BsonTypeMapper.cs
+++ b/Bson/ObjectModel/BsonTypeMapper.cs
@@ -147,6 +147,8 @@ namespace MongoDB.Bson {
             { Mapping.FromTo(typeof(ulong), BsonType.Int64), Conversion.UInt64ToBsonInt64 },
             { Mapping.FromTo(typeof(ulong), BsonType.Timestamp), Conversion.UInt64ToBsonTimestamp }
         };
+
+    	public static Dictionary<Type, CustomBsonTypeMapper> CustomMappers = new Dictionary<Type, CustomBsonTypeMapper>();
         #endregion
 
         #region public static methods
@@ -259,6 +261,13 @@ namespace MongoDB.Bson {
                 bsonValue = Convert(value, conversion);
                 return true;
             }
+			// custom mappings
+			if (CustomMappers.ContainsKey(valueType))
+			{
+				var customMapper = CustomMappers[valueType];
+				bsonValue = customMapper.Convert(value);
+				return true;
+			}
 
             // these mappings can't be handled by the mappings table (because of the interfaces)
             if (value is IEnumerable<object>) {

--- a/Bson/ObjectModel/CustomBsonTypeMapper.cs
+++ b/Bson/ObjectModel/CustomBsonTypeMapper.cs
@@ -1,0 +1,17 @@
+namespace MongoDB.Bson
+{
+	public abstract class CustomBsonTypeMapper
+	{
+		public abstract BsonValue Convert(object source);
+	}
+
+	public abstract class CustomBsonTypeMapper<T> : CustomBsonTypeMapper
+	{
+		public override BsonValue Convert(object source)
+		{
+			return Convert((T) source);
+		}
+
+		public abstract BsonValue Convert(T source);
+	}
+}

--- a/BsonUnitTests/ObjectModel/BsonTypeMapperTests.cs
+++ b/BsonUnitTests/ObjectModel/BsonTypeMapperTests.cs
@@ -554,5 +554,32 @@ namespace MongoDB.BsonUnitTests {
             var bsonInt64 = (BsonInt64) BsonTypeMapper.MapToBsonValue(value, BsonType.Int64);
             Assert.AreEqual((long) (ulong) value, bsonInt64.Value);
         }
+
+    	public struct OurDate
+    	{
+    		public readonly DateTime InternalDate;
+
+    		public OurDate(DateTime internalDate)
+    		{
+    			InternalDate = internalDate;
+    		}
+    	}
+
+    	public class OurDateCustomMapper : CustomBsonTypeMapper<OurDate>
+    	{
+    		public override BsonValue Convert(OurDate source)
+    		{
+    			return new BsonDateTime(source.InternalDate);
+    		}
+    	}
+
+    	[Test]
+    	public void TestMapOurDate()
+    	{
+    		var value = new OurDate(new DateTime(2011, 1, 1));
+    		BsonTypeMapper.CustomMappers.Add(typeof (OurDate), new OurDateCustomMapper());
+    		var bsonValue = BsonTypeMapper.MapToBsonValue(value);
+    		Assert.AreEqual(bsonValue, new BsonDateTime(value.InternalDate));
+    	}
     }
 }


### PR DESCRIPTION
I added a source of custom bson type mappers to BsonTypeMapper to create custom mappers for custom types, an example might be a custom Date struct to hold only dates instead of using DateTime in code.
