### PR TITLE
Issue with GuidByteOrder when writing Guid after ToBsonDocument()

### DIFF
--- a/Bson/ObjectModel/BsonValue.cs
+++ b/Bson/ObjectModel/BsonValue.cs
@@ -1175,7 +1175,7 @@ namespace MongoDB.Bson {
                 case BsonType.Binary:
                     var binaryData = (BsonBinaryData) this;
                     var bytes = binaryData.Bytes;
-                    if (binaryData.SubType == BsonBinarySubType.Uuid && binaryData.GuidByteOrder != bsonWriter.GuidByteOrder) {
+                    if (binaryData.SubType == BsonBinarySubType.Uuid && binaryData.GuidByteOrder != bsonWriter.GuidByteOrder && binaryData.GuidByteOrder != GuidByteOrder.Unspecified) {
                         var guid = GuidConverter.FromBytes(bytes, binaryData.GuidByteOrder);
                         bytes = GuidConverter.ToBytes(guid, bsonWriter.GuidByteOrder);
                     }

--- a/BsonUnitTests/IO/JsonWriterTests.cs
+++ b/BsonUnitTests/IO/JsonWriterTests.cs
@@ -314,6 +314,21 @@ namespace MongoDB.BsonUnitTests.IO {
         }
 
         [Test]
+        public void TestGuidToDocument()
+        {
+            var x = new Test {Id = new Guid("B5F21E0C2A0D42d6AD03D827008D8AB6")};
+            var document = x.ToBsonDocument();
+            string expected = "{ \"_id\" : new BinData(3, \"DB7ytQ0q1kKtA9gnAI2Ktg==\") }";
+            string actual = document.ToJson();
+            Assert.AreEqual(expected, actual);
+        }
+
+        public class Test
+        {
+            public Guid Id { get; set; }
+        }
+
+        [Test]
         public void TestMaxKey() {
             var document = new BsonDocument {
                 { "maxkey", BsonMaxKey.Value }


### PR DESCRIPTION
Hi Robert

I'm not sure this is really the right way to solve this but it should demonstrate the issue.

If you use `[object].ToBsonDocument()` then this converts the bytes of the Guid correctly based on the `BsonDefaults.GuidByteOrder` but the `BsonBinaryData` created ends up with `GuidByteOrder.Unspecified`.

When you attempt to write the document (using `.ToJson()` or maybe in an Update command) it causes the `GuidConverter` to raise the `InvalidOperationException("Unable to convert byte array to Guid because GuidByteOrder is Unspecified.")`.

I think a proper fix would be to have the `BsonDocumentWriter` pass the GuidByteOrder to the `BsonBinaryData` instance it creates via an overloaded `WriteBinaryData` method so that the resulting BsonDocument should be the same as it if was created via the initializer:

```
var document = new BsonDocument {
    { "guid", new Guid("B5F21E0C2A0D42d6AD03D827008D8AB6") }
};
```

Hope that makes sense!
