### PR TITLE
add dropTarget arg to RenameCollection()

### DIFF
--- a/Driver/Core/MongoDatabase.cs
+++ b/Driver/Core/MongoDatabase.cs
@@ -727,15 +727,20 @@ namespace MongoDB.Driver {
         /// </summary>
         /// <param name="oldCollectionName">The old name for the collection.</param>
         /// <param name="newCollectionName">The new name for the collection.</param>
+        /// <param name="dropTarget">drop target collection if exist in db</param>
         /// <returns>A CommandResult.</returns>
         public virtual CommandResult RenameCollection(
             string oldCollectionName,
-            string newCollectionName
+            string newCollectionName,
+            bool dropTarget = false
         ) {
             var command = new CommandDocument {
                 { "renameCollection", string.Format("{0}.{1}", name, oldCollectionName) },
                 { "to", string.Format("{0}.{1}", name, newCollectionName) }
             };
+            if (dropTarget) {
+              command.Add("dropTarget", BsonBoolean.True);
+            }
             return server.RunAdminCommand(command);
         }
 

--- a/DriverOnlineTests/Core/MongoDatabaseTests.cs
+++ b/DriverOnlineTests/Core/MongoDatabaseTests.cs
@@ -163,6 +163,24 @@ namespace MongoDB.DriverOnlineTests {
         }
 
         [Test]
+        public void TestRenameCollectionDropTarget() {
+            const string collectionName1 = "testrenamecollection3";
+            const string collectionName2 = "testrenamecollection4";
+            Assert.IsFalse(database.CollectionExists(collectionName1));
+            Assert.IsFalse(database.CollectionExists(collectionName2));
+
+            database[collectionName1].Insert(new BsonDocument());
+            database[collectionName2].Insert(new BsonDocument());
+            Assert.IsTrue(database.CollectionExists(collectionName1));
+            Assert.True(database.CollectionExists(collectionName2));
+
+            Assert.Throws(typeof(MongoCommandException), () => database.RenameCollection(collectionName1, collectionName2));
+            database.RenameCollection(collectionName1, collectionName2, true);
+            Assert.IsFalse(database.CollectionExists(collectionName1));
+            Assert.IsTrue(database.CollectionExists(collectionName2));
+        }
+
+        [Test]
         public void TestUserMethods() {
             var collection = database["system.users"];
             collection.RemoveAll();


### PR DESCRIPTION
if database has collection named with `newCollectionName', drop it
before rename in atomic way.
