### PR TITLE
Use OriginalString instead of AbsoluteUri for Uri serialization

### DIFF
--- a/Bson/Serialization/Serializers/NetPrimitiveSerializers.cs
+++ b/Bson/Serialization/Serializers/NetPrimitiveSerializers.cs
@@ -1883,7 +1883,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                     bsonReader.ReadNull();
                     return null;
                 case BsonType.String:
-                    return new Uri(bsonReader.ReadString());
+                    return new Uri(bsonReader.ReadString(), UriKind.RelativeOrAbsolute);
                 default:
                     var message = string.Format("Cannot deserialize Uri from BsonType {0}.", bsonType);
                     throw new FileFormatException(message);
@@ -1909,7 +1909,7 @@ namespace MongoDB.Bson.Serialization.Serializers
             }
             else
             {
-                bsonWriter.WriteString(((Uri)value).AbsoluteUri);
+                bsonWriter.WriteString(((Uri)value).OriginalString);
             }
         }
     }

--- a/BsonUnitTests/DefaultSerializer/Serializers/NetPrimitiveSerializerTests.cs
+++ b/BsonUnitTests/DefaultSerializer/Serializers/NetPrimitiveSerializerTests.cs
@@ -1786,13 +1786,29 @@ namespace MongoDB.BsonUnitTests.Serialization
                 V = new Uri("http://www.cnn.com")
             };
             var json = obj.ToJson();
-            var expected = "{ 'V' : 'http://www.cnn.com/' }".Replace("'", "\"");
+            var expected = "{ 'V' : 'http://www.cnn.com' }".Replace("'", "\"");
             Assert.AreEqual(expected, json);
 
             var bson = obj.ToBson();
             var rehydrated = BsonSerializer.Deserialize<TestClass>(bson);
             Assert.IsTrue(bson.SequenceEqual(rehydrated.ToBson()));
         }
+
+		[Test]
+		public void TestRelative()
+		{
+			var obj = new TestClass
+			{
+				V = new Uri("/relative/page.html", UriKind.RelativeOrAbsolute)
+			};
+			var json = obj.ToJson();
+			var expected = "{ 'V' : '/relative/page.html' }".Replace("'", "\"");
+			Assert.AreEqual(expected, json);
+
+			var bson = obj.ToBson();
+			var rehydrated = BsonSerializer.Deserialize<TestClass>(bson);
+			Assert.IsTrue(bson.SequenceEqual(rehydrated.ToBson()));
+		}
 
         [Test]
         public void TestMongoDB()


### PR DESCRIPTION
Prevents the url being subtly changed e.g. http://domainonly -> http://domainonly/ (with trailing forward slash)
Also allows relative urls to be persisted and loaded
