### PR TITLE
added support for ISupportInitialize into the BsonClassMapSerialier.

### DIFF
--- a/Bson/Serialization/BsonClassMapSerializer.cs
+++ b/Bson/Serialization/BsonClassMapSerializer.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -128,6 +129,12 @@ namespace MongoDB.Bson.Serialization
                     throw new FileFormatException(message);
                 }
 
+                var supportsInitialization = obj as ISupportInitialize;
+                if (supportsInitialization != null)
+                {
+                    supportsInitialization.BeginInit();
+                }
+
                 bsonReader.ReadStartDocument();
                 var missingElementMemberMaps = new HashSet<BsonMemberMap>(classMap.MemberMaps); // make a copy!
                 var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(nominalType);
@@ -182,6 +189,11 @@ namespace MongoDB.Bson.Serialization
                     {
                         memberMap.ApplyDefaultValue(obj);
                     }
+                }
+
+                if (supportsInitialization != null)
+                {
+                    supportsInitialization.EndInit();
                 }
 
                 return obj;

--- a/BsonUnitTests/DefaultSerializer/BsonDefaultSerializerTests.cs
+++ b/BsonUnitTests/DefaultSerializer/BsonDefaultSerializerTests.cs
@@ -26,6 +26,8 @@ using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.Serializers;
+using System.ComponentModel;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDB.BsonUnitTests.Serialization
 {
@@ -143,6 +145,38 @@ namespace MongoDB.BsonUnitTests.Serialization
             var bson = order.ToBson();
             var rehydrated = BsonSerializer.Deserialize<Order>(bson);
             Assert.IsTrue(bson.SequenceEqual(rehydrated.ToBson()));
+        }
+
+        public class InventoryItem : ISupportInitialize
+        {
+            [BsonIgnore]
+            public bool WasBeginInitCalled;
+            [BsonIgnore]
+            public bool WasEndInitCalled;
+
+            public int Price { get; set; }
+
+            public void BeginInit()
+            {
+                WasBeginInitCalled = true;
+            }
+
+            public void EndInit()
+            {
+                WasEndInitCalled = true;
+            }
+        }
+
+        [Test]
+        public void TestSerializeInventoryItem()
+        {
+            var item = new InventoryItem { Price = 42 };
+            var json = item.ToJson();
+
+            var bson = item.ToBson();
+            var rehydrated = BsonSerializer.Deserialize<InventoryItem>(bson);
+            Assert.IsTrue(rehydrated.WasBeginInitCalled);
+            Assert.IsTrue(rehydrated.WasEndInitCalled);
         }
     }
 }


### PR DESCRIPTION
Not much code to handle this.  Let's the consumer decide what and how they want to deal with this type of scenario without using reflection on the serializer side.
