### PR TITLE
Small code cleanup item follow up for CSHARP-385.

### DIFF
--- a/Bson/Serialization/BsonMemberMap.cs
+++ b/Bson/Serialization/BsonMemberMap.cs
@@ -450,14 +450,34 @@ namespace MongoDB.Bson.Serialization
         // private methods
         private static object GetDefaultValue(Type type)
         {
-            if (type.IsValueType)
+            switch (Type.GetTypeCode(type))
             {
-                return Activator.CreateInstance(type);
+                case TypeCode.Empty:
+                case TypeCode.DBNull:
+                case TypeCode.String:
+                    break;
+                case TypeCode.Object:
+                    if (type.IsValueType)
+                    {
+                        return Activator.CreateInstance(type);
+                    }
+                    break;
+                case TypeCode.Boolean: return false;
+                case TypeCode.Char: return '\0';
+                case TypeCode.SByte: return (sbyte)0;
+                case TypeCode.Byte: return (byte)0;
+                case TypeCode.Int16: return (short)0;
+                case TypeCode.UInt16: return (ushort)0;
+                case TypeCode.Int32: return 0;
+                case TypeCode.UInt32: return 0U;
+                case TypeCode.Int64: return 0L;
+                case TypeCode.UInt64: return 0UL;
+                case TypeCode.Single: return 0F;
+                case TypeCode.Double: return 0D;
+                case TypeCode.Decimal: return 0M;
+                case TypeCode.DateTime: return DateTime.MinValue;
             }
-            else
-            {
-                return null;
-            }
+            return null;
         }
 
         private Action<object, object> GetFieldSetter()
@@ -488,9 +508,9 @@ namespace MongoDB.Bson.Serialization
 
         private Func<object, object> GetGetter()
         {
-            if (_memberInfo is PropertyInfo)
+            var propertyInfo = _memberInfo as PropertyInfo;
+            if (propertyInfo != null)
             {
-                var propertyInfo = (PropertyInfo)_memberInfo;
                 var getMethodInfo = propertyInfo.GetGetMethod(true);
                 if (getMethodInfo == null)
                 {

--- a/DriverOnlineTests/Linq/SelectQueryTests.cs
+++ b/DriverOnlineTests/Linq/SelectQueryTests.cs
@@ -1277,7 +1277,7 @@ namespace MongoDB.DriverOnlineTests.Linq
             Assert.AreSame(typeof(C), translatedQuery.DocumentType);
 
             var selectQuery = (SelectQuery)translatedQuery;
-            Assert.AreEqual("c => (c.X = 1)", selectQuery.Where.ToString());
+            Assert.AreEqual("c => (c.X == 1)", selectQuery.Where.ToString());
             Assert.IsNull(selectQuery.OrderBy);
             Assert.IsNull(selectQuery.Projection);
             Assert.IsNull(selectQuery.Skip);
@@ -1300,7 +1300,7 @@ namespace MongoDB.DriverOnlineTests.Linq
             Assert.AreSame(typeof(C), translatedQuery.DocumentType);
 
             var selectQuery = (SelectQuery)translatedQuery;
-            Assert.AreEqual("c => ((c.X = 1) && (c.Y = 11))", selectQuery.Where.ToString());
+            Assert.AreEqual("c => ((c.X == 1) AndAlso (c.Y == 11))", selectQuery.Where.ToString());
             Assert.IsNull(selectQuery.OrderBy);
             Assert.IsNull(selectQuery.Projection);
             Assert.IsNull(selectQuery.Skip);
@@ -1323,7 +1323,7 @@ namespace MongoDB.DriverOnlineTests.Linq
             Assert.AreSame(typeof(C), translatedQuery.DocumentType);
 
             var selectQuery = (SelectQuery)translatedQuery;
-            Assert.AreEqual("c => ((c.X = 1) || (c.Y = 33))", selectQuery.Where.ToString());
+            Assert.AreEqual("c => ((c.X == 1) OrElse (c.Y == 33))", selectQuery.Where.ToString());
             Assert.IsNull(selectQuery.OrderBy);
             Assert.IsNull(selectQuery.Projection);
             Assert.IsNull(selectQuery.Skip);


### PR DESCRIPTION
Improve BsonMemberMap.GetDefaultValue to not need to call Activator.CreateInstance for simple cases.
Improve BsonClassMap<TClass>.GetMemberInfoFromLambda and BsonClassMap<TClass>.GetMemberNameFromLambda to not need to perform extra reflection.
Update several failing DriverOnline unit tests.
