### PR TITLE
Constant for ID_Field="_id"

### DIFF
--- a/Bson/ObjectModel/BsonDocument.cs
+++ b/Bson/ObjectModel/BsonDocument.cs
@@ -35,6 +35,11 @@ namespace MongoDB.Bson
     [Serializable]
     public class BsonDocument : BsonValue, IBsonSerializable, IComparable<BsonDocument>, IConvertibleToBsonDocument, IEnumerable<BsonElement>, IEquatable<BsonDocument>
     {
+		/// <summary>
+		/// Constant Field name that Mongo uses to store Ids.
+		/// </summary>
+		public const string ID_FIELD = "_id";
+
         // private fields
         // use a list and a dictionary because we want to preserve the order in which the elements were added
         // if duplicate names are present only the first one will be in the dictionary (the others can only be accessed by index)
@@ -763,7 +768,7 @@ namespace MongoDB.Bson
         public bool GetDocumentId(out object id, out Type idNominalType, out IIdGenerator idGenerator)
         {
             BsonElement idElement;
-            if (TryGetElement("_id", out idElement))
+            if (TryGetElement(ID_FIELD, out idElement))
             {
                 id = idElement.Value.RawValue;
                 if (id == null)
@@ -1005,7 +1010,7 @@ namespace MongoDB.Bson
 
             var documentOptions = (options == null) ? DocumentSerializationOptions.Defaults : (DocumentSerializationOptions)options;
             int idIndex;
-            if (documentOptions.SerializeIdFirst && _indexes.TryGetValue("_id", out idIndex))
+            if (documentOptions.SerializeIdFirst && _indexes.TryGetValue(ID_FIELD, out idIndex))
             {
                 _elements[idIndex].WriteTo(bsonWriter);
             }
@@ -1069,13 +1074,13 @@ namespace MongoDB.Bson
         public void SetDocumentId(object id)
         {
             BsonElement idElement;
-            if (TryGetElement("_id", out idElement))
+            if (TryGetElement(ID_FIELD, out idElement))
             {
                 idElement.Value = BsonValue.Create(id);
             }
             else
             {
-                idElement = new BsonElement("_id", BsonValue.Create(id));
+                idElement = new BsonElement(ID_FIELD, BsonValue.Create(id));
                 InsertAt(0, idElement);
             }
         }

--- a/Bson/Serialization/BsonClassMap.cs
+++ b/Bson/Serialization/BsonClassMap.cs
@@ -855,7 +855,7 @@ namespace MongoDB.Bson.Serialization
                 throw new BsonInternalException("Invalid memberMap.");
             }
 
-            memberMap.SetElementName("_id");
+            memberMap.SetElementName(BsonDocument.ID_FIELD);
             _idMemberMap = memberMap;
         }
 
@@ -1073,7 +1073,7 @@ namespace MongoDB.Bson.Serialization
                 var idAttribute = attribute as BsonIdAttribute;
                 if (idAttribute != null)
                 {
-                    memberMap.SetElementName("_id");
+                    memberMap.SetElementName(BsonDocument.ID_FIELD);
                     memberMap.SetOrder(idAttribute.Order);
                     var idGeneratorType = idAttribute.IdGenerator;
                     if (idGeneratorType != null)

--- a/Bson/Serialization/Conventions/ConventionProfile.cs
+++ b/Bson/Serialization/Conventions/ConventionProfile.cs
@@ -89,7 +89,7 @@ namespace MongoDB.Bson.Serialization.Conventions
                 .SetDefaultValueConvention(new NullDefaultValueConvention())
                 .SetElementNameConvention(new MemberNameElementNameConvention())
                 .SetExtraElementsMemberConvention(new NamedExtraElementsMemberConvention("ExtraElements"))
-                .SetIdMemberConvention(new NamedIdMemberConvention("Id", "id", "_id"))
+                .SetIdMemberConvention(new NamedIdMemberConvention("Id", "id", BsonDocument.ID_FIELD))
                 .SetIgnoreExtraElementsConvention(new NeverIgnoreExtraElementsConvention())
                 .SetIgnoreIfDefaultConvention(new NeverIgnoreIfDefaultConvention())
                 .SetIgnoreIfNullConvention(new NeverIgnoreIfNullConvention())

--- a/BsonUnitTests/BsonExtensionMethodsTests.cs
+++ b/BsonUnitTests/BsonExtensionMethodsTests.cs
@@ -76,7 +76,7 @@ namespace MongoDB.BsonUnitTests
             var document = c.ToBsonDocument();
             Assert.AreEqual(2, document.ElementCount);
             Assert.AreEqual("N", document.GetElement(0).Name);
-            Assert.AreEqual("_id", document.GetElement(1).Name);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(1).Name);
             Assert.IsInstanceOf<BsonInt32>(document[0]);
             Assert.IsInstanceOf<BsonObjectId>(document[1]);
             Assert.AreEqual(1, document[0].AsInt32);
@@ -89,7 +89,7 @@ namespace MongoDB.BsonUnitTests
             var c = new C { N = 1, Id = ObjectId.Empty };
             var document = c.ToBsonDocument(DocumentSerializationOptions.SerializeIdFirstInstance);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
             Assert.AreEqual("N", document.GetElement(1).Name);
             Assert.IsInstanceOf<BsonObjectId>(document[0]);
             Assert.IsInstanceOf<BsonInt32>(document[1]);

--- a/BsonUnitTests/DefaultSerializer/Attributes/BsonAttributeTests.cs
+++ b/BsonUnitTests/DefaultSerializer/Attributes/BsonAttributeTests.cs
@@ -113,7 +113,7 @@ namespace MongoDB.BsonUnitTests.Serialization.Attributes
             var classMap = BsonClassMap.LookupClassMap(typeof(Test));
 
             var isId = classMap.GetMemberMap("IsId");
-            Assert.AreEqual("_id", isId.ElementName);
+            Assert.AreEqual(BsonDocument.ID_FIELD, isId.ElementName);
             Assert.AreSame(classMap.IdMemberMap, isId);
 
             var isNotId = classMap.GetMemberMap("IsNotId");

--- a/BsonUnitTests/DefaultSerializer/BsonClassMapTests.cs
+++ b/BsonUnitTests/DefaultSerializer/BsonClassMapTests.cs
@@ -87,7 +87,7 @@ namespace MongoDB.BsonUnitTests.Serialization
             var classMap = new BsonClassMap<C>(cm => cm.MapIdField("f"));
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
-            Assert.AreEqual("_id", idMemberMap.ElementName);
+            Assert.AreEqual(BsonDocument.ID_FIELD, idMemberMap.ElementName);
             Assert.AreEqual("f", idMemberMap.MemberName);
         }
 
@@ -98,7 +98,7 @@ namespace MongoDB.BsonUnitTests.Serialization
             var classMap = new BsonClassMap<C>(cm => cm.MapIdMember(fieldInfo));
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
-            Assert.AreEqual("_id", idMemberMap.ElementName);
+            Assert.AreEqual(BsonDocument.ID_FIELD, idMemberMap.ElementName);
             Assert.AreEqual("f", idMemberMap.MemberName);
         }
 
@@ -108,7 +108,7 @@ namespace MongoDB.BsonUnitTests.Serialization
             var classMap = new BsonClassMap<C>(cm => cm.MapIdProperty("p"));
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
-            Assert.AreEqual("_id", idMemberMap.ElementName);
+            Assert.AreEqual(BsonDocument.ID_FIELD, idMemberMap.ElementName);
             Assert.AreEqual("p", idMemberMap.MemberName);
         }
 
@@ -161,7 +161,7 @@ namespace MongoDB.BsonUnitTests.Serialization
             var classMap = new BsonClassMap<C>(cm => cm.MapIdField(c => c.F));
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
-            Assert.AreEqual("_id", idMemberMap.ElementName);
+            Assert.AreEqual(BsonDocument.ID_FIELD, idMemberMap.ElementName);
             Assert.AreEqual("F", idMemberMap.MemberName);
         }
 
@@ -171,7 +171,7 @@ namespace MongoDB.BsonUnitTests.Serialization
             var classMap = new BsonClassMap<C>(cm => cm.MapIdMember(c => c.F));
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
-            Assert.AreEqual("_id", idMemberMap.ElementName);
+            Assert.AreEqual(BsonDocument.ID_FIELD, idMemberMap.ElementName);
             Assert.AreEqual("F", idMemberMap.MemberName);
         }
 
@@ -181,7 +181,7 @@ namespace MongoDB.BsonUnitTests.Serialization
             var classMap = new BsonClassMap<C>(cm => cm.MapIdProperty(c => c.P));
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
-            Assert.AreEqual("_id", idMemberMap.ElementName);
+            Assert.AreEqual(BsonDocument.ID_FIELD, idMemberMap.ElementName);
             Assert.AreEqual("P", idMemberMap.MemberName);
         }
 

--- a/BsonUnitTests/DefaultSerializer/Conventions/IdMemberConventionsTests.cs
+++ b/BsonUnitTests/DefaultSerializer/Conventions/IdMemberConventionsTests.cs
@@ -52,7 +52,7 @@ namespace MongoDB.BsonUnitTests.Serialization.Conventions
         [Test]
         public void TestNamedIdMemberConvention()
         {
-            var convention = new NamedIdMemberConvention("Id", "id", "_id");
+            var convention = new NamedIdMemberConvention("Id", "id", BsonDocument.ID_FIELD);
 
             var idMemberName = convention.FindIdMember(typeof(TestClassA));
             Assert.IsNotNull(idMemberName);
@@ -67,7 +67,7 @@ namespace MongoDB.BsonUnitTests.Serialization.Conventions
 
             idMemberName = convention.FindIdMember(typeof(TestClassD));
             Assert.IsNotNull(idMemberName);
-            Assert.AreEqual("_id", idMemberName);
+            Assert.AreEqual(BsonDocument.ID_FIELD, idMemberName);
         }
     }
 }

--- a/BsonUnitTests/DefaultSerializer/Serializers/AnimalHierarchyWithAttributesTests.cs
+++ b/BsonUnitTests/DefaultSerializer/Serializers/AnimalHierarchyWithAttributesTests.cs
@@ -62,7 +62,7 @@ namespace MongoDB.BsonUnitTests.Serialization
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.Empty },
+                { BsonDocument.ID_FIELD, ObjectId.Empty },
                 { "_t", new BsonArray { "Animal", "Bear" } },
                 { "Age", 123 },
                 { "Name", "Panda Bear" }
@@ -83,7 +83,7 @@ namespace MongoDB.BsonUnitTests.Serialization
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.Empty },
+                { BsonDocument.ID_FIELD, ObjectId.Empty },
                 { "_t", new BsonArray { "Animal", "Cat", "Tiger" } },
                 { "Age", 234 },
                 { "Name", "Striped Tiger" }
@@ -104,7 +104,7 @@ namespace MongoDB.BsonUnitTests.Serialization
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.Empty },
+                { BsonDocument.ID_FIELD, ObjectId.Empty },
                 { "_t", new BsonArray { "Animal", "Cat", "Lion" } },
                 { "Age", 234 },
                 { "Name", "King Lion" }

--- a/BsonUnitTests/DefaultSerializer/Serializers/AnimalHierarchyWithoutAttributesTests.cs
+++ b/BsonUnitTests/DefaultSerializer/Serializers/AnimalHierarchyWithoutAttributesTests.cs
@@ -66,7 +66,7 @@ namespace MongoDB.BsonUnitTests.Serialization
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.Empty },
+                { BsonDocument.ID_FIELD, ObjectId.Empty },
                 { "_t", new BsonArray { "Animal", "Bear" } },
                 { "Age", 123 },
                 { "Name", "Panda Bear" }
@@ -87,7 +87,7 @@ namespace MongoDB.BsonUnitTests.Serialization
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.Empty },
+                { BsonDocument.ID_FIELD, ObjectId.Empty },
                 { "_t", new BsonArray { "Animal", "Cat", "Tiger" } },
                 { "Age", 234 },
                 { "Name", "Striped Tiger" }
@@ -108,7 +108,7 @@ namespace MongoDB.BsonUnitTests.Serialization
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.Empty },
+                { BsonDocument.ID_FIELD, ObjectId.Empty },
                 { "_t", new BsonArray { "Animal", "Cat", "Lion" } },
                 { "Age", 234 },
                 { "Name", "King Lion" }

--- a/BsonUnitTests/Jira/CSharp270Tests.cs
+++ b/BsonUnitTests/Jira/CSharp270Tests.cs
@@ -59,7 +59,7 @@ namespace MongoDB.BsonUnitTests.Jira.CSharp270
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.GenerateNewId() },
+                { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() },
                 { "property", 0 }
             };
             var message = "Required element 'field' for field 'Field' of class MongoDB.BsonUnitTests.Jira.CSharp270.C is missing.";
@@ -72,7 +72,7 @@ namespace MongoDB.BsonUnitTests.Jira.CSharp270
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.GenerateNewId() },
+                { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() },
                 { "field", 0 }
             };
             var message = "Required element 'property' for property 'Property' of class MongoDB.BsonUnitTests.Jira.CSharp270.C is missing.";

--- a/BsonUnitTests/Jira/CSharp71Tests.cs
+++ b/BsonUnitTests/Jira/CSharp71Tests.cs
@@ -36,7 +36,7 @@ namespace MongoDB.BsonUnitTests.Jira
             // document initializer
             var document = new BsonDocument
             {
-                { "_id", "5d37e102e4a297f4156e0000" },
+                { BsonDocument.ID_FIELD, "5d37e102e4a297f4156e0000" },
                 { "Name", "IMG_2962.JPG" },
                 { "AccountId", "94bb3e04e4a297080c000000" },
                 { "Properties", new BsonArray

--- a/Driver/Core/MongoCollection.cs
+++ b/Driver/Core/MongoCollection.cs
@@ -542,7 +542,7 @@ namespace MongoDB.Driver
         /// <returns>A TDocument (or null if not found).</returns>
         public virtual TDocument FindOneByIdAs<TDocument>(BsonValue id)
         {
-            return FindOneAs<TDocument>(Query.EQ("_id", id));
+            return FindOneAs<TDocument>(Query.EQ(BsonDocument.ID_FIELD, id));
         }
 
         /// <summary>
@@ -553,7 +553,7 @@ namespace MongoDB.Driver
         /// <returns>A TDocument (or null if not found).</returns>
         public virtual object FindOneByIdAs(Type documentType, BsonValue id)
         {
-            return FindOneAs(documentType, Query.EQ("_id", id));
+            return FindOneAs(documentType, Query.EQ(BsonDocument.ID_FIELD, id));
         }
 
         /// <summary>
@@ -1370,7 +1370,7 @@ namespace MongoDB.Driver
                             idBsonValue = ObjectId.Parse(idBsonValue.AsString);
                         }
                     }
-                    var query = Query.EQ("_id", idBsonValue);
+                    var query = Query.EQ(BsonDocument.ID_FIELD, idBsonValue);
                     var update = Builders.Update.Replace(nominalType, document);
                     var updateOptions = new MongoUpdateOptions
                     {

--- a/Driver/Core/MongoDatabase.cs
+++ b/Driver/Core/MongoDatabase.cs
@@ -456,7 +456,7 @@ namespace MongoDB.Driver
             }
 
             var collection = GetCollection(dbRef.CollectionName);
-            var query = Query.EQ("_id", BsonValue.Create(dbRef.Id));
+            var query = Query.EQ(BsonDocument.ID_FIELD, BsonValue.Create(dbRef.Id));
             return collection.FindOneAs(documentType, query);
         }
 

--- a/Driver/GridFS/MongoGridFS.cs
+++ b/Driver/GridFS/MongoGridFS.cs
@@ -216,7 +216,7 @@ namespace MongoDB.Driver.GridFS
         /// <param name="id">The GridFS file Id.</param>
         public void DeleteById(BsonValue id)
         {
-            Delete(Query.EQ("_id", id));
+            Delete(Query.EQ(BsonDocument.ID_FIELD, id));
         }
 
         /// <summary>
@@ -489,7 +489,7 @@ namespace MongoDB.Driver.GridFS
         /// <returns>True if the GridFS file exists.</returns>
         public bool ExistsById(BsonValue id)
         {
-            return Exists(Query.EQ("_id", id));
+            return Exists(Query.EQ(BsonDocument.ID_FIELD, id));
         }
 
         /// <summary>
@@ -594,7 +594,7 @@ namespace MongoDB.Driver.GridFS
         /// <returns>The GridFS file.</returns>
         public MongoGridFSFileInfo FindOneById(BsonValue id)
         {
-            return FindOne(Query.EQ("_id", id));
+            return FindOne(Query.EQ(BsonDocument.ID_FIELD, id));
         }
 
         /// <summary>
@@ -708,7 +708,7 @@ namespace MongoDB.Driver.GridFS
         /// <param name="aliases">The aliases.</param>
         public void SetAliases(MongoGridFSFileInfo fileInfo, string[] aliases)
         {
-            var query = Query.EQ("_id", fileInfo.Id);
+            var query = Query.EQ(BsonDocument.ID_FIELD, fileInfo.Id);
             var update = (aliases == null) ? Update.Unset("aliases") : Update.Set("aliases", BsonArray.Create(aliases));
             _files.Update(query, update);
         }
@@ -720,7 +720,7 @@ namespace MongoDB.Driver.GridFS
         /// <param name="contentType">The content type.</param>
         public void SetContentType(MongoGridFSFileInfo fileInfo, string contentType)
         {
-            var query = Query.EQ("_id", fileInfo.Id);
+            var query = Query.EQ(BsonDocument.ID_FIELD, fileInfo.Id);
             var update = (contentType == null) ? Update.Unset("contentType") : Update.Set("contentType", contentType);
             _files.Update(query, update);
         }
@@ -732,7 +732,7 @@ namespace MongoDB.Driver.GridFS
         /// <param name="metadata">The metadata.</param>
         public void SetMetadata(MongoGridFSFileInfo fileInfo, BsonValue metadata)
         {
-            var query = Query.EQ("_id", fileInfo.Id);
+            var query = Query.EQ(BsonDocument.ID_FIELD, fileInfo.Id);
             var update = (metadata == null) ? Update.Unset("metadata") : Update.Set("metadata", metadata);
             _files.Update(query, update);
         }
@@ -808,7 +808,7 @@ namespace MongoDB.Driver.GridFS
 
                         var chunk = new BsonDocument
                         {
-                            { "_id", BsonObjectId.GenerateNewId() },
+                            { BsonDocument.ID_FIELD, BsonObjectId.GenerateNewId() },
                             { "files_id", files_id },
                             { "n", n },
                             { "data", new BsonBinaryData(data) }
@@ -843,7 +843,7 @@ namespace MongoDB.Driver.GridFS
                 var uploadDate = createOptions.UploadDate == DateTime.MinValue ? DateTime.UtcNow : createOptions.UploadDate;
                 BsonDocument fileInfo = new BsonDocument
                 {
-                    { "_id", files_id },
+                    { BsonDocument.ID_FIELD, files_id },
                     { "filename", remoteFileName },
                     { "length", length },
                     { "chunkSize", chunkSize },

--- a/Driver/GridFS/MongoGridFSFileInfo.cs
+++ b/Driver/GridFS/MongoGridFSFileInfo.cs
@@ -327,7 +327,7 @@ namespace MongoDB.Driver.GridFS
                 using (_gridFS.Database.RequestStart(false)) // not slaveOk
                 {
                     _gridFS.EnsureIndexes();
-                    _gridFS.Files.Remove(Query.EQ("_id", _id), _gridFS.Settings.SafeMode);
+                    _gridFS.Files.Remove(Query.EQ(BsonDocument.ID_FIELD, _id), _gridFS.Settings.SafeMode);
                     _gridFS.Chunks.Remove(Query.EQ("files_id", _id), _gridFS.Settings.SafeMode);
                 }
             }
@@ -389,7 +389,7 @@ namespace MongoDB.Driver.GridFS
         /// <param name="destFileName">The destination file name.</param>
         public void MoveTo(string destFileName)
         {
-            var query = Query.EQ("_id", _id);
+            var query = Query.EQ(BsonDocument.ID_FIELD, _id);
             var update = Update.Set("filename", destFileName);
             _gridFS.Files.Update(query, update, _gridFS.Settings.SafeMode);
         }
@@ -451,7 +451,7 @@ namespace MongoDB.Driver.GridFS
             MongoCursor<BsonDocument> cursor;
             if (_id != null)
             {
-                cursor = _gridFS.Files.Find(Query.EQ("_id", _id));
+                cursor = _gridFS.Files.Find(Query.EQ(BsonDocument.ID_FIELD, _id));
             }
             else
             {
@@ -513,7 +513,7 @@ namespace MongoDB.Driver.GridFS
                     _contentType = null;
                 }
                 _exists = true;
-                _id = fileInfo["_id"];
+                _id = fileInfo[BsonDocument.ID_FIELD];
                 _length = fileInfo["length"].ToInt64();
                 var md5Value = fileInfo["md5", null];
                 if (md5Value != null && !md5Value.IsBsonNull)

--- a/Driver/GridFS/MongoGridFSStream.cs
+++ b/Driver/GridFS/MongoGridFSStream.cs
@@ -469,7 +469,7 @@ namespace MongoDB.Driver.GridFS
                     }
                     var missingChunk = new BsonDocument
                     {
-                        { "_id", ObjectId.GenerateNewId() },
+                        { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() },
                         { "files_id", _fileInfo.Id },
                         { "n", n },
                         { "data", zeros }
@@ -512,7 +512,7 @@ namespace MongoDB.Driver.GridFS
                     Buffer.BlockCopy(bytes, 0, _chunk, 0, bytes.Length);
                     Array.Clear(_chunk, bytes.Length, _chunk.Length - bytes.Length);
                 }
-                _chunkId = document["_id"];
+                _chunkId = document[BsonDocument.ID_FIELD];
             }
             _chunkIndex = chunkIndex;
         }
@@ -530,7 +530,7 @@ namespace MongoDB.Driver.GridFS
             }
 
             var query = Query.And(Query.EQ("files_id", _fileInfo.Id), Query.EQ("n", chunkIndex));
-            var fields = Fields.Include("_id");
+            var fields = Fields.Include(BsonDocument.ID_FIELD);
             var document = _gridFS.Chunks.Find(query).SetFields(fields).SetLimit(1).FirstOrDefault();
             if (document == null)
             {
@@ -538,7 +538,7 @@ namespace MongoDB.Driver.GridFS
             }
             else
             {
-                _chunkId = document["_id"];
+                _chunkId = document[BsonDocument.ID_FIELD];
             }
             _chunkIndex = chunkIndex;
         }
@@ -558,7 +558,7 @@ namespace MongoDB.Driver.GridFS
 
             var file = new BsonDocument
             {
-                { "_id", _fileInfo.Id },
+                { BsonDocument.ID_FIELD, _fileInfo.Id },
                 { "filename", _fileInfo.Name },
                 { "length", 0 },
                 { "chunkSize", _fileInfo.ChunkSize },
@@ -613,10 +613,10 @@ namespace MongoDB.Driver.GridFS
                 data = new BsonBinaryData(lastChunk);
             }
 
-            var query = Query.EQ("_id", _chunkId);
+            var query = Query.EQ(BsonDocument.ID_FIELD, _chunkId);
             var update = new UpdateDocument
             {
-                { "_id", _chunkId },
+                { BsonDocument.ID_FIELD, _chunkId },
                 { "files_id", _fileInfo.Id },
                 { "n", _chunkIndex },
                 { "data", data }
@@ -639,7 +639,7 @@ namespace MongoDB.Driver.GridFS
                 md5 = md5Result.Response["md5"].AsString;
             }
 
-            var query = Query.EQ("_id", _fileInfo.Id);
+            var query = Query.EQ(BsonDocument.ID_FIELD, _fileInfo.Id);
             var update = Update
                 .Set("length", _length)
                 .Set("md5", md5);

--- a/DriverOnlineTests/Core/CommandResults/GetLastErrorResultTests.cs
+++ b/DriverOnlineTests/Core/CommandResults/GetLastErrorResultTests.cs
@@ -62,12 +62,12 @@ namespace MongoDB.DriverOnlineTests.CommandResults
                 var id = ObjectId.GenerateNewId();
                 var document = new BsonDocument
                 {
-                    { "_id", id },
+                    { BsonDocument.ID_FIELD, id },
                     { "x", 1 }
                 };
                 _collection.Insert(document);
 
-                var query = Query.EQ("_id", id);
+                var query = Query.EQ(BsonDocument.ID_FIELD, id);
                 var update = Update.Inc("x", 1);
                 _collection.Update(query, update);
                 var result = _server.GetLastError();

--- a/DriverOnlineTests/Core/MongoCollectionTests.cs
+++ b/DriverOnlineTests/Core/MongoCollectionTests.cs
@@ -134,7 +134,7 @@ namespace MongoDB.DriverOnlineTests
             Assert.AreEqual(false, indexes[0].IsBackground);
             Assert.AreEqual(false, indexes[0].IsSparse);
             Assert.AreEqual(false, indexes[0].IsUnique);
-            Assert.AreEqual(new BsonDocument("_id", 1), indexes[0].Key);
+            Assert.AreEqual(new BsonDocument(BsonDocument.ID_FIELD, 1), indexes[0].Key);
             Assert.AreEqual("_id_", indexes[0].Name);
             Assert.AreEqual(_collection.FullName, indexes[0].Namespace);
             Assert.AreEqual(expectedIndexVersion, indexes[0].Version);
@@ -148,7 +148,7 @@ namespace MongoDB.DriverOnlineTests
             Assert.AreEqual(false, indexes[0].IsBackground);
             Assert.AreEqual(false, indexes[0].IsSparse);
             Assert.AreEqual(false, indexes[0].IsUnique);
-            Assert.AreEqual(new BsonDocument("_id", 1), indexes[0].Key);
+            Assert.AreEqual(new BsonDocument(BsonDocument.ID_FIELD, 1), indexes[0].Key);
             Assert.AreEqual("_id_", indexes[0].Name);
             Assert.AreEqual(_collection.FullName, indexes[0].Namespace);
             Assert.AreEqual(expectedIndexVersion, indexes[0].Version);
@@ -170,7 +170,7 @@ namespace MongoDB.DriverOnlineTests
             Assert.AreEqual(false, indexes[0].IsBackground);
             Assert.AreEqual(false, indexes[0].IsSparse);
             Assert.AreEqual(false, indexes[0].IsUnique);
-            Assert.AreEqual(new BsonDocument("_id", 1), indexes[0].Key);
+            Assert.AreEqual(new BsonDocument(BsonDocument.ID_FIELD, 1), indexes[0].Key);
             Assert.AreEqual("_id_", indexes[0].Name);
             Assert.AreEqual(_collection.FullName, indexes[0].Namespace);
             Assert.AreEqual(expectedIndexVersion, indexes[0].Version);
@@ -266,8 +266,8 @@ namespace MongoDB.DriverOnlineTests
         public void TestFindAndModify()
         {
             _collection.RemoveAll();
-            _collection.Insert(new BsonDocument { { "_id", 1 }, { "priority", 1 }, { "inprogress", false }, { "name", "abc" } });
-            _collection.Insert(new BsonDocument { { "_id", 2 }, { "priority", 2 }, { "inprogress", false }, { "name", "def" } });
+            _collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, 1 }, { "priority", 1 }, { "inprogress", false }, { "name", "abc" } });
+            _collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, 2 }, { "priority", 2 }, { "inprogress", false }, { "name", "def" } });
 
             var query = Query.EQ("inprogress", false);
             var sortBy = SortBy.Descending("priority");
@@ -276,7 +276,7 @@ namespace MongoDB.DriverOnlineTests
             var update = Update.Set("inprogress", true).Set("started", started);
             var result = _collection.FindAndModify(query, sortBy, update, false); // return old
             Assert.IsTrue(result.Ok);
-            Assert.AreEqual(2, result.ModifiedDocument["_id"].AsInt32);
+            Assert.AreEqual(2, result.ModifiedDocument[BsonDocument.ID_FIELD].AsInt32);
             Assert.AreEqual(2, result.ModifiedDocument["priority"].AsInt32);
             Assert.AreEqual(false, result.ModifiedDocument["inprogress"].AsBoolean);
             Assert.AreEqual("def", result.ModifiedDocument["name"].AsString);
@@ -287,7 +287,7 @@ namespace MongoDB.DriverOnlineTests
             update = Update.Set("inprogress", true).Set("started", started);
             result = _collection.FindAndModify(query, sortBy, update, true); // return new
             Assert.IsTrue(result.Ok);
-            Assert.AreEqual(1, result.ModifiedDocument["_id"].AsInt32);
+            Assert.AreEqual(1, result.ModifiedDocument[BsonDocument.ID_FIELD].AsInt32);
             Assert.AreEqual(1, result.ModifiedDocument["priority"].AsInt32);
             Assert.AreEqual(true, result.ModifiedDocument["inprogress"].AsBoolean);
             Assert.AreEqual("abc", result.ModifiedDocument["name"].AsString);
@@ -337,7 +337,7 @@ namespace MongoDB.DriverOnlineTests
             var obj = new FindAndModifyClass { Id = ObjectId.GenerateNewId(), Value = 1 };
             _collection.Insert(obj);
 
-            var query = Query.EQ("_id", obj.Id);
+            var query = Query.EQ(BsonDocument.ID_FIELD, obj.Id);
             var sortBy = SortBy.Null;
             var update = Update.Inc("Value", 1);
             var result = _collection.FindAndModify(query, sortBy, update, true); // returnNew
@@ -490,7 +490,7 @@ namespace MongoDB.DriverOnlineTests
         {
             _collection.RemoveAll();
             var id = ObjectId.GenerateNewId();
-            _collection.Insert(new BsonDocument { { "_id", id }, { "x", 1 }, { "y", 2 } });
+            _collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, id }, { "x", 1 }, { "y", 2 } });
             var result = _collection.FindOneById(id);
             Assert.AreEqual(1, result["x"].AsInt32);
             Assert.AreEqual(2, result["y"].AsInt32);
@@ -501,7 +501,7 @@ namespace MongoDB.DriverOnlineTests
         {
             _collection.RemoveAll();
             var id = ObjectId.GenerateNewId();
-            _collection.Insert(new BsonDocument { { "_id", id }, { "X", 1 } });
+            _collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, id }, { "X", 1 } });
             var result = (TestClass)_collection.FindOneByIdAs(typeof(TestClass), id);
             Assert.AreEqual(id, result.Id);
             Assert.AreEqual(1, result.X);
@@ -512,7 +512,7 @@ namespace MongoDB.DriverOnlineTests
         {
             _collection.RemoveAll();
             var id = ObjectId.GenerateNewId();
-            _collection.Insert(new BsonDocument { { "_id", id }, { "X", 1 } });
+            _collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, id }, { "X", 1 } });
             var result = _collection.FindOneByIdAs<TestClass>(id);
             Assert.AreEqual(id, result.Id);
             Assert.AreEqual(1, result.X);
@@ -992,13 +992,13 @@ namespace MongoDB.DriverOnlineTests
                 { "B", 3 },
                 { "C", 1 },
                 { "X", 1 },
-                { "_id", 3 }
+                { BsonDocument.ID_FIELD, 3 }
             };
 
             // read output collection ourselves
             foreach (var document in _database[result.CollectionName].FindAll())
             {
-                var key = document["_id"].AsString;
+                var key = document[BsonDocument.ID_FIELD].AsString;
                 var count = document["value"].AsBsonDocument["count"].ToInt32();
                 Assert.AreEqual(expectedCounts[key], count);
             }
@@ -1006,7 +1006,7 @@ namespace MongoDB.DriverOnlineTests
             // test GetResults
             foreach (var document in result.GetResults())
             {
-                var key = document["_id"].AsString;
+                var key = document[BsonDocument.ID_FIELD].AsString;
                 var count = document["value"].AsBsonDocument["count"].ToInt32();
                 Assert.AreEqual(expectedCounts[key], count);
             }
@@ -1061,13 +1061,13 @@ namespace MongoDB.DriverOnlineTests
                     { "B", 3 },
                     { "C", 1 },
                     { "X", 1 },
-                    { "_id", 3 }
+                    { BsonDocument.ID_FIELD, 3 }
                 };
 
                 // test InlineResults as BsonDocuments
                 foreach (var document in result.InlineResults)
                 {
-                    var key = document["_id"].AsString;
+                    var key = document[BsonDocument.ID_FIELD].AsString;
                     var count = document["value"].AsBsonDocument["count"].ToInt32();
                     Assert.AreEqual(expectedCounts[key], count);
                 }
@@ -1083,7 +1083,7 @@ namespace MongoDB.DriverOnlineTests
                 // test GetResults
                 foreach (var document in result.GetResults())
                 {
-                    var key = document["_id"].AsString;
+                    var key = document[BsonDocument.ID_FIELD].AsString;
                     var count = document["value"].AsBsonDocument["count"].ToInt32();
                     Assert.AreEqual(expectedCounts[key], count);
                 }
@@ -1141,13 +1141,13 @@ namespace MongoDB.DriverOnlineTests
                     { "B", 3 },
                     { "C", 1 },
                     { "X", 1 },
-                    { "_id", 3 }
+                    { BsonDocument.ID_FIELD, 3 }
                 };
 
                 // test InlineResults as BsonDocuments
                 foreach (var document in result.InlineResults)
                 {
-                    var key = document["_id"].AsString;
+                    var key = document[BsonDocument.ID_FIELD].AsString;
                     var count = document["value"].AsBsonDocument["count"].ToInt32();
                     Assert.AreEqual(expectedCounts[key], count);
                 }
@@ -1163,7 +1163,7 @@ namespace MongoDB.DriverOnlineTests
                 // test GetResults
                 foreach (var document in result.GetResults())
                 {
-                    var key = document["_id"].AsString;
+                    var key = document[BsonDocument.ID_FIELD].AsString;
                     var count = document["value"].AsBsonDocument["count"].ToInt32();
                     Assert.AreEqual(expectedCounts[key], count);
                 }
@@ -1204,7 +1204,7 @@ namespace MongoDB.DriverOnlineTests
             _collection.Insert(new BsonDocument { { "x", 1 }, { "y", 2 } });
             var result = _collection.FindAll().SetFields("x").FirstOrDefault();
             Assert.AreEqual(2, result.ElementCount);
-            Assert.AreEqual("_id", result.GetElement(0).Name);
+            Assert.AreEqual(BsonDocument.ID_FIELD, result.GetElement(0).Name);
             Assert.AreEqual("x", result.GetElement(1).Name);
         }
 

--- a/DriverOnlineTests/Core/MongoDatabaseTests.cs
+++ b/DriverOnlineTests/Core/MongoDatabaseTests.cs
@@ -112,15 +112,15 @@ namespace MongoDB.DriverOnlineTests
         {
             var collectionName = "testdbref";
             var collection = _database.GetCollection(collectionName);
-            var document = new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "P", "x" } };
+            var document = new BsonDocument { { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() }, { "P", "x" } };
             collection.Insert(document);
 
-            var dbRef = new MongoDBRef(collectionName, document["_id"].AsObjectId);
+            var dbRef = new MongoDBRef(collectionName, document[BsonDocument.ID_FIELD].AsObjectId);
             var fetched = _database.FetchDBRef(dbRef);
             Assert.AreEqual(document, fetched);
             Assert.AreEqual(document.ToJson(), fetched.ToJson());
 
-            var dbRefWithDatabaseName = new MongoDBRef(_database.Name, collectionName, document["_id"].AsObjectId);
+            var dbRefWithDatabaseName = new MongoDBRef(_database.Name, collectionName, document[BsonDocument.ID_FIELD].AsObjectId);
             fetched = _server.FetchDBRef(dbRefWithDatabaseName);
             Assert.AreEqual(document, fetched);
             Assert.AreEqual(document.ToJson(), fetched.ToJson());

--- a/DriverOnlineTests/Jira/CSharp101Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp101Tests.cs
@@ -87,20 +87,20 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
             };
             _collection.Save(document);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
-            Assert.IsInstanceOf<BsonObjectId>(document["_id"]);
-            Assert.AreNotEqual(ObjectId.Empty, document["_id"].AsObjectId);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
+            Assert.IsInstanceOf<BsonObjectId>(document[BsonDocument.ID_FIELD]);
+            Assert.AreNotEqual(ObjectId.Empty, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(1, _collection.Count());
 
-            var id = document["_id"].AsObjectId;
+            var id = document[BsonDocument.ID_FIELD].AsObjectId;
             document["A"] = 2;
             _collection.Save(document);
-            Assert.AreEqual(id, document["_id"].AsObjectId);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(1, _collection.Count());
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(id, document["_id"].AsObjectId);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 
@@ -111,7 +111,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
 
             var document = new BsonDocument
             {
-                { "_id", BsonNull.Value },
+                { BsonDocument.ID_FIELD, BsonNull.Value },
                 { "A", 1 }
             };
             _collection.Save(document);
@@ -123,7 +123,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(BsonNull.Value, document["_id"].AsBsonNull);
+            Assert.AreEqual(BsonNull.Value, document[BsonDocument.ID_FIELD].AsBsonNull);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 
@@ -134,25 +134,25 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
 
             var document = new BsonDocument
             {
-                { "_id", ObjectId.Empty },
+                { BsonDocument.ID_FIELD, ObjectId.Empty },
                 { "A", 1 }
             };
             _collection.Save(document);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
-            Assert.IsInstanceOf<BsonObjectId>(document["_id"]);
-            Assert.AreNotEqual(ObjectId.Empty, document["_id"].AsObjectId);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
+            Assert.IsInstanceOf<BsonObjectId>(document[BsonDocument.ID_FIELD]);
+            Assert.AreNotEqual(ObjectId.Empty, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(1, _collection.Count());
 
-            var id = document["_id"].AsObjectId;
+            var id = document[BsonDocument.ID_FIELD].AsObjectId;
             document["A"] = 2;
             _collection.Save(document);
-            Assert.AreEqual(id, document["_id"].AsObjectId);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(1, _collection.Count());
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(id, document["_id"].AsObjectId);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 
@@ -164,24 +164,24 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
             var id = ObjectId.GenerateNewId();
             var document = new BsonDocument
             {
-                { "_id", id },
+                { BsonDocument.ID_FIELD, id },
                 { "A", 1 }
             };
             _collection.Save(document);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
-            Assert.IsInstanceOf<BsonObjectId>(document["_id"]);
-            Assert.AreEqual(id, document["_id"].AsObjectId);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
+            Assert.IsInstanceOf<BsonObjectId>(document[BsonDocument.ID_FIELD]);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(1, _collection.Count());
 
             document["A"] = 2;
             _collection.Save(document);
-            Assert.AreEqual(id, document["_id"].AsObjectId);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(1, _collection.Count());
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(id, document["_id"].AsObjectId);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 
@@ -192,25 +192,25 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
 
             var document = new BsonDocument
             {
-                { "_id", Guid.Empty },
+                { BsonDocument.ID_FIELD, Guid.Empty },
                 { "A", 1 }
             };
             _collection.Save(document);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
-            Assert.IsInstanceOf<BsonBinaryData>(document["_id"]);
-            Assert.AreNotEqual(Guid.Empty, document["_id"].AsGuid);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
+            Assert.IsInstanceOf<BsonBinaryData>(document[BsonDocument.ID_FIELD]);
+            Assert.AreNotEqual(Guid.Empty, document[BsonDocument.ID_FIELD].AsGuid);
             Assert.AreEqual(1, _collection.Count());
 
-            var id = document["_id"].AsGuid;
+            var id = document[BsonDocument.ID_FIELD].AsGuid;
             document["A"] = 2;
             _collection.Save(document);
-            Assert.AreEqual(id, document["_id"].AsGuid);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsGuid);
             Assert.AreEqual(1, _collection.Count());
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(id, document["_id"].AsGuid);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsGuid);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 
@@ -222,25 +222,25 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
             var guid = Guid.NewGuid();
             var document = new BsonDocument
             {
-                { "_id", guid },
+                { BsonDocument.ID_FIELD, guid },
                 { "A", 1 }
             };
             _collection.Save(document);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
-            Assert.IsInstanceOf<BsonBinaryData>(document["_id"]);
-            Assert.AreEqual(guid, document["_id"].AsGuid);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
+            Assert.IsInstanceOf<BsonBinaryData>(document[BsonDocument.ID_FIELD]);
+            Assert.AreEqual(guid, document[BsonDocument.ID_FIELD].AsGuid);
             Assert.AreEqual(1, _collection.Count());
 
-            var id = document["_id"].AsGuid;
+            var id = document[BsonDocument.ID_FIELD].AsGuid;
             document["A"] = 2;
             _collection.Save(document);
-            Assert.AreEqual(id, document["_id"].AsGuid);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsGuid);
             Assert.AreEqual(1, _collection.Count());
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(id, document["_id"].AsGuid);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsGuid);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 
@@ -252,24 +252,24 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
             var id = 123;
             var document = new BsonDocument
             {
-                { "_id", id },
+                { BsonDocument.ID_FIELD, id },
                 { "A", 1 }
             };
             _collection.Save(document);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
-            Assert.IsInstanceOf<BsonInt32>(document["_id"]);
-            Assert.AreEqual(id, document["_id"].AsInt32);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
+            Assert.IsInstanceOf<BsonInt32>(document[BsonDocument.ID_FIELD]);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsInt32);
             Assert.AreEqual(1, _collection.Count());
 
             document["A"] = 2;
             _collection.Save(document);
-            Assert.AreEqual(id, document["_id"].AsInt32);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsInt32);
             Assert.AreEqual(1, _collection.Count());
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(id, document["_id"].AsInt32);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsInt32);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 
@@ -281,24 +281,24 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
             var id = 123L;
             var document = new BsonDocument
             {
-                { "_id", id },
+                { BsonDocument.ID_FIELD, id },
                 { "A", 1 }
             };
             _collection.Save(document);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
-            Assert.IsInstanceOf<BsonInt64>(document["_id"]);
-            Assert.AreEqual(id, document["_id"].AsInt64);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
+            Assert.IsInstanceOf<BsonInt64>(document[BsonDocument.ID_FIELD]);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsInt64);
             Assert.AreEqual(1, _collection.Count());
 
             document["A"] = 2;
             _collection.Save(document);
-            Assert.AreEqual(id, document["_id"].AsInt64);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsInt64);
             Assert.AreEqual(1, _collection.Count());
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(id, document["_id"].AsInt64);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsInt64);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 
@@ -310,24 +310,24 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp101
             var id = "123";
             var document = new BsonDocument
             {
-                { "_id", id },
+                { BsonDocument.ID_FIELD, id },
                 { "A", 1 }
             };
             _collection.Save(document);
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual("_id", document.GetElement(0).Name);
-            Assert.IsInstanceOf<BsonString>(document["_id"]);
-            Assert.AreEqual(id, document["_id"].AsString);
+            Assert.AreEqual(BsonDocument.ID_FIELD, document.GetElement(0).Name);
+            Assert.IsInstanceOf<BsonString>(document[BsonDocument.ID_FIELD]);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsString);
             Assert.AreEqual(1, _collection.Count());
 
             document["A"] = 2;
             _collection.Save(document);
-            Assert.AreEqual(id, document["_id"].AsString);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsString);
             Assert.AreEqual(1, _collection.Count());
 
             document = _collection.FindOneAs<BsonDocument>();
             Assert.AreEqual(2, document.ElementCount);
-            Assert.AreEqual(id, document["_id"].AsString);
+            Assert.AreEqual(id, document[BsonDocument.ID_FIELD].AsString);
             Assert.AreEqual(2, document["A"].AsInt32);
         }
 

--- a/DriverOnlineTests/Jira/CSharp111Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp111Tests.cs
@@ -56,7 +56,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp111
             collection.Insert(c);
             var id = c.Id;
 
-            var query = Query.EQ("_id", id);
+            var query = Query.EQ(BsonDocument.ID_FIELD, id);
             var update = Update.AddToSet("InnerObjects", 1);
             collection.Update(query, update);
             var d1 = new D { X = 1 };

--- a/DriverOnlineTests/Jira/CSharp112Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp112Tests.cs
@@ -86,7 +86,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
             {
                 var document = new BsonDocument
                 {
-                    { "_id", i + 1 },
+                    { BsonDocument.ID_FIELD, i + 1 },
                     { "N", BsonValue.Create(values[i]) }
                 };
                 _collection.Insert(document);
@@ -94,7 +94,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
 
             for (int i = 0; i < values.Length; i++)
             {
-                var query = Query.EQ("_id", i + 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, i + 1);
                 var document = _collection.FindOneAs<D>(query);
                 Assert.AreEqual(BsonValue.Create(values[i]).ToDouble(), document.N);
             }
@@ -112,7 +112,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
             {
                 var document = new BsonDocument
                 {
-                    { "_id", i + 1 },
+                    { BsonDocument.ID_FIELD, i + 1 },
                     { "N", BsonValue.Create(values[i]) }
                 };
                 _collection.Insert(document);
@@ -120,7 +120,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
 
             for (int i = 0; i < values.Length; i++)
             {
-                var query = Query.EQ("_id", i + 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, i + 1);
                 try
                 {
                     _collection.FindOneAs<D>(query);
@@ -158,7 +158,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
             {
                 var document = new BsonDocument
                 {
-                    { "_id", i + 1 },
+                    { BsonDocument.ID_FIELD, i + 1 },
                     { "N", BsonValue.Create(values[i]) }
                 };
                 _collection.Insert(document);
@@ -166,7 +166,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
 
             for (int i = 0; i < values.Length; i++)
             {
-                var query = Query.EQ("_id", i + 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, i + 1);
                 var document = _collection.FindOneAs<I>(query);
                 Assert.AreEqual(BsonValue.Create(values[i]).ToInt32(), document.N);
             }
@@ -186,7 +186,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
             {
                 var document = new BsonDocument
                 {
-                    { "_id", i + 1 },
+                    { BsonDocument.ID_FIELD, i + 1 },
                     { "N", BsonValue.Create(values[i]) }
                 };
                 _collection.Insert(document);
@@ -194,7 +194,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
 
             for (int i = 0; i < values.Length; i++)
             {
-                var query = Query.EQ("_id", i + 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, i + 1);
                 try
                 {
                     _collection.FindOneAs<I>(query);
@@ -220,7 +220,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
             {
                 var document = new BsonDocument
                 {
-                    { "_id", i + 1 },
+                    { BsonDocument.ID_FIELD, i + 1 },
                     { "N", BsonValue.Create(values[i]) }
                 };
                 _collection.Insert(document);
@@ -228,7 +228,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
 
             for (int i = 0; i < values.Length; i++)
             {
-                var query = Query.EQ("_id", i + 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, i + 1);
                 try
                 {
                     _collection.FindOneAs<I>(query);
@@ -271,7 +271,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
             {
                 var document = new BsonDocument
                 {
-                    { "_id", i + 1 },
+                    { BsonDocument.ID_FIELD, i + 1 },
                     { "N", BsonValue.Create(values[i]) }
                 };
                 _collection.Insert(document);
@@ -279,7 +279,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
 
             for (int i = 0; i < values.Length; i++)
             {
-                var query = Query.EQ("_id", i + 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, i + 1);
                 var document = _collection.FindOneAs<L>(query);
                 Assert.AreEqual(BsonValue.Create(values[i]).ToInt64(), document.N);
             }
@@ -295,7 +295,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
             {
                 var document = new BsonDocument
                 {
-                    { "_id", i + 1 },
+                    { BsonDocument.ID_FIELD, i + 1 },
                     { "N", BsonValue.Create(values[i]) }
                 };
                 _collection.Insert(document);
@@ -303,7 +303,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
 
             for (int i = 0; i < values.Length; i++)
             {
-                var query = Query.EQ("_id", i + 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, i + 1);
                 try
                 {
                     _collection.FindOneAs<L>(query);
@@ -329,7 +329,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
             {
                 var document = new BsonDocument
                 {
-                    { "_id", i + 1 },
+                    { BsonDocument.ID_FIELD, i + 1 },
                     { "N", BsonValue.Create(values[i]) }
                 };
                 _collection.Insert(document);
@@ -337,7 +337,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp112
 
             for (int i = 0; i < values.Length; i++)
             {
-                var query = Query.EQ("_id", i + 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, i + 1);
                 try
                 {
                     _collection.FindOneAs<L>(query);

--- a/DriverOnlineTests/Jira/CSharp163Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp163Tests.cs
@@ -56,7 +56,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp163
             Assert.IsNull(fileInfo.Metadata);
             Assert.IsNull(fileInfo.Name);
 
-            var query = Query.EQ("_id", fileInfo.Id);
+            var query = Query.EQ(BsonDocument.ID_FIELD, fileInfo.Id);
             var files = _database.GridFS.Files.FindOne(query);
             Assert.IsFalse(files.Contains("aliases"));
             Assert.IsFalse(files.Contains("contentType"));

--- a/DriverOnlineTests/Jira/CSharp198Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp198Tests.cs
@@ -71,7 +71,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp198
             };
             _collection.Save(foo1);
 
-            var foo1Rehydrated = _collection.FindOne(Query.EQ("_id", BsonDocumentWrapper.Create(foo1.Id)));
+            var foo1Rehydrated = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, BsonDocumentWrapper.Create(foo1.Id)));
             Assert.IsInstanceOf<Foo>(foo1Rehydrated);
             Assert.IsInstanceOf<Id>(foo1Rehydrated.Id);
             Assert.AreEqual(1, foo1Rehydrated.Id.AccountId);
@@ -85,7 +85,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp198
             };
             _collection.Save(foo2);
 
-            var foo2Rehydrated = _collection.FindOne(Query.EQ("_id", BsonDocumentWrapper.Create(foo2.Id)));
+            var foo2Rehydrated = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, BsonDocumentWrapper.Create(foo2.Id)));
             Assert.IsInstanceOf<Foo>(foo2Rehydrated);
             Assert.IsInstanceOf<IdWithExtraField>(foo2Rehydrated.Id);
             Assert.AreEqual(3, foo2Rehydrated.Id.AccountId);

--- a/DriverOnlineTests/Jira/CSharp199Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp199Tests.cs
@@ -41,9 +41,9 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp199
                 var collection = Configuration.TestCollection;
 
                 collection.RemoveAll();
-                collection.Insert(new BsonDocument { { "_id", 1 }, { "a", 2 } });
+                collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, 1 }, { "a", 2 } });
 
-                var query = Query.EQ("_id", 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, 1);
                 var update = Update.Rename("a", "x");
                 collection.Update(query, update);
                 var document = collection.FindOne();
@@ -66,9 +66,9 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp199
                 var collection = Configuration.TestCollection;
 
                 collection.RemoveAll();
-                collection.Insert(new BsonDocument { { "_id", 1 }, { "a", 2 }, { "b", 3 } });
+                collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, 1 }, { "a", 2 }, { "b", 3 } });
 
-                var query = Query.EQ("_id", 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, 1);
                 var update = Update.Rename("a", "x").Rename("b", "y");
                 collection.Update(query, update);
                 var document = collection.FindOne();
@@ -91,9 +91,9 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp199
                 var collection = Configuration.TestCollection;
 
                 collection.RemoveAll();
-                collection.Insert(new BsonDocument { { "_id", 1 }, { "a", 2 }, { "b", 3 } });
+                collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, 1 }, { "a", 2 }, { "b", 3 } });
 
-                var query = Query.EQ("_id", 1);
+                var query = Query.EQ(BsonDocument.ID_FIELD, 1);
                 var update = Update.Rename("a", "x").Set("b", 4);
                 collection.Update(query, update);
                 var document = collection.FindOne();

--- a/DriverOnlineTests/Jira/CSharp218Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp218Tests.cs
@@ -100,7 +100,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp218
             var r = _collection.FindOne();
             Assert.AreEqual(2, r.ElementCount);
             Assert.AreEqual(2, r["P"].AsBsonDocument.ElementCount);
-            Assert.AreEqual(c.Id, r["_id"].AsObjectId);
+            Assert.AreEqual(c.Id, r[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(c.P.X, r["P"].AsBsonDocument["X"].AsInt32);
             Assert.AreEqual(c.P.Y, r["P"].AsBsonDocument["Y"].AsInt32);
         }
@@ -115,7 +115,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp218
             var r = _collection.FindOne();
             Assert.AreEqual(2, r.ElementCount);
             Assert.AreEqual(2, r["P"].AsBsonDocument.ElementCount);
-            Assert.AreEqual(c.Id, r["_id"].AsObjectId);
+            Assert.AreEqual(c.Id, r[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(c.P.X, r["P"].AsBsonDocument["X"].AsInt32);
             Assert.AreEqual(c.P.Y, r["P"].AsBsonDocument["Y"].AsInt32);
         }
@@ -130,7 +130,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp218
             var r = _collection.FindOne();
             Assert.AreEqual(2, r.ElementCount);
             Assert.AreEqual(2, r["P"].AsBsonDocument.ElementCount);
-            Assert.AreEqual(s.Id, r["_id"].AsObjectId);
+            Assert.AreEqual(s.Id, r[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(s.P.X, r["P"].AsBsonDocument["X"].AsInt32);
             Assert.AreEqual(s.P.Y, r["P"].AsBsonDocument["Y"].AsInt32);
         }
@@ -153,7 +153,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp218
             var r = _collection.FindOne();
             Assert.AreEqual(2, r.ElementCount);
             Assert.AreEqual(2, r["P"].AsBsonDocument.ElementCount);
-            Assert.AreEqual(c.Id, r["_id"].AsObjectId);
+            Assert.AreEqual(c.Id, r[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(c.P.X, r["P"].AsBsonDocument["X"].AsInt32);
             Assert.AreEqual(c.P.Y, r["P"].AsBsonDocument["Y"].AsInt32);
         }
@@ -168,7 +168,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp218
             var r = _collection.FindOne();
             Assert.AreEqual(2, r.ElementCount);
             Assert.AreEqual(2, r["P"].AsBsonDocument.ElementCount);
-            Assert.AreEqual(c.Id, r["_id"].AsObjectId);
+            Assert.AreEqual(c.Id, r[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(c.P.X, r["P"].AsBsonDocument["X"].AsInt32);
             Assert.AreEqual(c.P.Y, r["P"].AsBsonDocument["Y"].AsInt32);
         }
@@ -183,7 +183,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp218
             var r = _collection.FindOne();
             Assert.AreEqual(2, r.ElementCount);
             Assert.AreEqual(2, r["P"].AsBsonDocument.ElementCount);
-            Assert.AreEqual(s.Id, r["_id"].AsObjectId);
+            Assert.AreEqual(s.Id, r[BsonDocument.ID_FIELD].AsObjectId);
             Assert.AreEqual(s.P.X, r["P"].AsBsonDocument["X"].AsInt32);
             Assert.AreEqual(s.P.Y, r["P"].AsBsonDocument["Y"].AsInt32);
         }

--- a/DriverOnlineTests/Jira/CSharp231Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp231Tests.cs
@@ -186,10 +186,10 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", new BsonArray() }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, new BsonArray() }, { "X", 1 } };
             Assert.Throws<MongoSafeModeException>(() => { _collection.Insert(doc); });
 
-            doc = new BsonDocument { { "_id", new BsonArray { 1, 2, 3 } }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, new BsonArray { 1, 2, 3 } }, { "X", 1 } };
             Assert.Throws<MongoSafeModeException>(() => { _collection.Insert(doc); });
         }
 
@@ -198,10 +198,10 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonBinaryData.Create(new byte[] { }) }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonBinaryData.Create(new byte[] { }) }, { "X", 1 } };
             _collection.Insert(doc);
 
-            doc = new BsonDocument { { "_id", BsonBinaryData.Create(new byte[] { 1, 2, 3 }) }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonBinaryData.Create(new byte[] { 1, 2, 3 }) }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -210,10 +210,10 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonBoolean.Create(false) }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonBoolean.Create(false) }, { "X", 1 } };
             _collection.Insert(doc);
 
-            doc = new BsonDocument { { "_id", BsonBoolean.Create(true) }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonBoolean.Create(true) }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -222,13 +222,13 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonDateTime.Create(DateTime.MinValue) }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonDateTime.Create(DateTime.MinValue) }, { "X", 1 } };
             _collection.Insert(doc);
 
-            doc = new BsonDocument { { "_id", BsonDateTime.Create(DateTime.UtcNow) }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonDateTime.Create(DateTime.UtcNow) }, { "X", 1 } };
             _collection.Insert(doc);
 
-            doc = new BsonDocument { { "_id", BsonDateTime.Create(DateTime.MaxValue) }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonDateTime.Create(DateTime.MaxValue) }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -237,10 +237,10 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", new BsonDocument() }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, new BsonDocument() }, { "X", 1 } };
             _collection.Insert(doc);
 
-            doc = new BsonDocument { { "_id", new BsonDocument { { "A", 1 }, { "B", 2 } } }, { "X", 3 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, new BsonDocument { { "A", 1 }, { "B", 2 } } }, { "X", 3 } };
             _collection.Insert(doc);
         }
 
@@ -249,10 +249,10 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonDouble.Create(0.0) }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonDouble.Create(0.0) }, { "X", 1 } };
             _collection.Insert(doc);
 
-            doc = new BsonDocument { { "_id", BsonDouble.Create(1.0) }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonDouble.Create(1.0) }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -261,10 +261,10 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonInt32.Create(0) }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonInt32.Create(0) }, { "X", 1 } };
             _collection.Insert(doc);
 
-            doc = new BsonDocument { { "_id", BsonInt32.Create(1) }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonInt32.Create(1) }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -273,10 +273,10 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonInt64.Create(0) }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonInt64.Create(0) }, { "X", 1 } };
             _collection.Insert(doc);
 
-            doc = new BsonDocument { { "_id", BsonInt64.Create(1) }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonInt64.Create(1) }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -285,7 +285,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonMaxKey.Value }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonMaxKey.Value }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -294,7 +294,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonMinKey.Value }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonMinKey.Value }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -303,9 +303,9 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonNull.Value }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonNull.Value }, { "X", 1 } };
             _collection.Insert(doc);
-            Assert.AreEqual(BsonNull.Value, doc["_id"]);
+            Assert.AreEqual(BsonNull.Value, doc[BsonDocument.ID_FIELD]);
         }
 
         [Test]
@@ -313,15 +313,15 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonNull.Value }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonNull.Value }, { "X", 1 } };
             _collection.Insert(doc);
-            Assert.AreEqual(BsonNull.Value, doc["_id"]);
+            Assert.AreEqual(BsonNull.Value, doc[BsonDocument.ID_FIELD]);
 
-            doc = new BsonDocument { { "_id", BsonObjectId.Empty }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonObjectId.Empty }, { "X", 1 } };
             _collection.Insert(doc);
-            Assert.AreNotEqual(ObjectId.Empty, doc["_id"].AsObjectId);
+            Assert.AreNotEqual(ObjectId.Empty, doc[BsonDocument.ID_FIELD].AsObjectId);
 
-            doc = new BsonDocument { { "_id", BsonObjectId.GenerateNewId() }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonObjectId.GenerateNewId() }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -330,11 +330,11 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonString.Create("") }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonString.Create("") }, { "X", 1 } };
             _collection.Insert(doc);
-            Assert.AreEqual("", doc["_id"].AsString);
+            Assert.AreEqual("", doc[BsonDocument.ID_FIELD].AsString);
 
-            doc = new BsonDocument { { "_id", BsonString.Create("123") }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonString.Create("123") }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -343,11 +343,11 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
         {
             _collection.RemoveAll();
 
-            var doc = new BsonDocument { { "_id", BsonTimestamp.Create(0, 0) }, { "X", 1 } };
+            var doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonTimestamp.Create(0, 0) }, { "X", 1 } };
             _collection.Insert(doc);
-            Assert.AreEqual(BsonTimestamp.Create(0, 0), doc["_id"].AsBsonTimestamp);
+            Assert.AreEqual(BsonTimestamp.Create(0, 0), doc[BsonDocument.ID_FIELD].AsBsonTimestamp);
 
-            doc = new BsonDocument { { "_id", BsonTimestamp.Create(1, 2) }, { "X", 1 } };
+            doc = new BsonDocument { { BsonDocument.ID_FIELD, BsonTimestamp.Create(1, 2) }, { "X", 1 } };
             _collection.Insert(doc);
         }
 
@@ -358,8 +358,8 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
 
             var doc = new BsonDocument { { "X", 1 } };
             _collection.Insert(doc);
-            Assert.IsInstanceOf<BsonObjectId>(doc["_id"]);
-            Assert.AreNotEqual(ObjectId.Empty, doc["_id"].AsObjectId);
+            Assert.IsInstanceOf<BsonObjectId>(doc[BsonDocument.ID_FIELD]);
+            Assert.AreNotEqual(ObjectId.Empty, doc[BsonDocument.ID_FIELD].AsObjectId);
         }
 
         [Test]
@@ -544,11 +544,11 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp231
             _collection.RemoveAll();
 
             var doc = new ClassWithBsonNullId { Id = null, X = 1 };
-            _collection.Insert(doc); // serializes _id as { "_id" : { "$csharpnull" : true }, "X" : 1 }
+            _collection.Insert(doc); // serializes _id as { BsonDocument.ID_FIELD : { "$csharpnull" : true }, "X" : 1 }
             Assert.AreEqual(null, doc.Id);
 
             doc = new ClassWithBsonNullId { Id = BsonNull.Value, X = 1 };
-            _collection.Insert(doc); // serializes _id as { "_id" : null, "X" : 1 }
+            _collection.Insert(doc); // serializes _id as { BsonDocument.ID_FIELD : null, "X" : 1 }
             Assert.AreEqual(BsonNull.Value, doc.Id);
         }
 

--- a/DriverOnlineTests/Jira/CSharp253Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp253Tests.cs
@@ -80,7 +80,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp253
         {
             var document = new BsonDocument
             {
-                { "_id", ObjectId.GenerateNewId() },
+                { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() },
                 { "BsonNull", new BsonDocument("$csharpnull", true) },
                 { "Code", new BsonDocument
                     {

--- a/DriverOnlineTests/Jira/CSharp258Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp258Tests.cs
@@ -56,7 +56,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp258
             _collection.Insert(
                 new BsonDocument
                 {
-                    { "_id", ObjectId.GenerateNewId() },
+                    { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() },
                     { "DateTime", new BsonDateTime(253402300799999) }
                 });
 
@@ -71,7 +71,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp258
             _collection.Insert(
                 new BsonDocument
                 {
-                    { "_id", ObjectId.GenerateNewId() },
+                    { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() },
                     { "DateTime", new BsonDateTime(253402300800000) }
                 });
 
@@ -86,7 +86,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp258
             _collection.Insert(
                 new BsonDocument
                 {
-                    { "_id", ObjectId.GenerateNewId() },
+                    { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() },
                     { "DateTime", new BsonDateTime(253402300799999) }
                 });
 
@@ -102,7 +102,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp258
             _collection.Insert(
                 new BsonDocument
                 {
-                    { "_id", ObjectId.GenerateNewId() },
+                    { BsonDocument.ID_FIELD, ObjectId.GenerateNewId() },
                     { "DateTime", new BsonDateTime(253402300800000) }
                 });
 

--- a/DriverOnlineTests/Jira/CSharp265Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp265Tests.cs
@@ -95,7 +95,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["$a"]);
@@ -111,7 +111,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["a.b"]);
@@ -149,7 +149,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["abc"]);
@@ -165,7 +165,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["$a"]);
@@ -181,7 +181,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["a.b"]);
@@ -197,7 +197,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["$a"]);
@@ -213,7 +213,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["a.b"]);
@@ -251,7 +251,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["abc"]);
@@ -267,7 +267,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["$a"]);
@@ -283,7 +283,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp265
 
             _collection.RemoveAll();
             _collection.Insert(d);
-            var r = _collection.FindOne(Query.EQ("_id", d.Id));
+            var r = _collection.FindOne(Query.EQ(BsonDocument.ID_FIELD, d.Id));
             Assert.AreEqual(d.Id, r.Id);
             Assert.AreEqual(1, r.Data.Count);
             Assert.AreEqual(1, r.Data["a.b"]);

--- a/DriverOnlineTests/Jira/CSharp281Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp281Tests.cs
@@ -48,7 +48,7 @@ namespace MongoDB.DriverOnlineTests.Jira
             _collection.RemoveAll();
             _collection.Insert(document);
 
-            var query = Query.EQ("_id", document["_id"]);
+            var query = Query.EQ(BsonDocument.ID_FIELD, document[BsonDocument.ID_FIELD]);
             var update = Update.PopFirst("x");
             _collection.Update(query, update);
 
@@ -66,7 +66,7 @@ namespace MongoDB.DriverOnlineTests.Jira
             _collection.RemoveAll();
             _collection.Insert(document);
 
-            var query = Query.EQ("_id", document["_id"]);
+            var query = Query.EQ(BsonDocument.ID_FIELD, document[BsonDocument.ID_FIELD]);
             var update = Update.PopLast("x");
             _collection.Update(query, update);
 

--- a/DriverOnlineTests/Jira/CSharp282Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp282Tests.cs
@@ -47,7 +47,7 @@ namespace MongoDB.DriverOnlineTests.Jira
             var document = new BsonDocument("x", 1);
             _collection.Insert(document);
 
-            var query = Query.EQ("_id", document["_id"]);
+            var query = Query.EQ(BsonDocument.ID_FIELD, document[BsonDocument.ID_FIELD]);
             var update = new UpdateBuilder();
             Assert.Throws<ArgumentException>(() => _collection.Update(query, update));
         }

--- a/DriverOnlineTests/Jira/CSharp358Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp358Tests.cs
@@ -42,7 +42,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp358
 
             var document = new BsonDocument
             {
-                { "_id", 1 },
+                { BsonDocument.ID_FIELD, 1 },
                 { "v", new BsonDocument("$x", 1) } // server doesn't allow "$" at top level
             };
             var insertOptions = new MongoInsertOptions { CheckElementNames = false };
@@ -51,7 +51,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp358
             Assert.AreEqual(1, document["v"].AsBsonDocument["$x"].AsInt32);
 
             document["v"].AsBsonDocument["$x"] = 2;
-            var query = Query.EQ("_id", 1);
+            var query = Query.EQ(BsonDocument.ID_FIELD, 1);
             var update = Update.Replace(document);
             var updateOptions = new MongoUpdateOptions { CheckElementNames = false };
             collection.Update(query, update, updateOptions);

--- a/DriverOnlineTests/Jira/CSharp361Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp361Tests.cs
@@ -40,7 +40,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp361
             var collection = Configuration.TestCollection;
             collection.Drop();
 
-            collection.Insert(new BsonDocument("_id", 1));
+            collection.Insert(new BsonDocument(BsonDocument.ID_FIELD, 1));
             Assert.Throws<ArgumentException>(() => { database.RenameCollection("test", ""); });
         }
     }

--- a/DriverOnlineTests/Jira/CSharp365Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp365Tests.cs
@@ -40,13 +40,13 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp365
             var collection = Configuration.TestCollection;
             collection.Drop();
 
-            collection.EnsureIndex("A", "_id");
-            collection.Insert(new BsonDocument { { "_id", 1 }, { "A", 1 } });
-            collection.Insert(new BsonDocument { { "_id", 2 }, { "A", 2 } });
-            collection.Insert(new BsonDocument { { "_id", 3 }, { "A", 3 } });
+            collection.EnsureIndex("A", BsonDocument.ID_FIELD);
+            collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, 1 }, { "A", 1 } });
+            collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, 2 }, { "A", 2 } });
+            collection.Insert(new BsonDocument { { BsonDocument.ID_FIELD, 3 }, { "A", 3 } });
 
             var query = Query.EQ("A", 1);
-            var fields = Fields.Include("_id");
+            var fields = Fields.Include(BsonDocument.ID_FIELD);
             var cursor = collection.Find(query).SetFields(fields);
             var explain = cursor.Explain();
             Assert.IsTrue(explain["indexOnly"].ToBoolean());

--- a/DriverOnlineTests/Jira/CSharp77Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp77Tests.cs
@@ -45,7 +45,7 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp77
             var collection = Configuration.GetTestCollection<Foo>();
 
             var conventions = new ConventionProfile()
-                .SetIdMemberConvention(new NamedIdMemberConvention("_id"));
+                .SetIdMemberConvention(new NamedIdMemberConvention(BsonDocument.ID_FIELD));
             BsonClassMap.RegisterConventions(conventions, t => t == typeof(Foo));
 
             collection.RemoveAll();

--- a/DriverOnlineTests/Jira/CSharp92Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp92Tests.cs
@@ -44,13 +44,13 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp92
             var database = Configuration.TestDatabase;
             var collection = Configuration.TestCollection;
 
-            var document = new BsonDocument { { "_id", -1 }, { "P", "x" } };
+            var document = new BsonDocument { { BsonDocument.ID_FIELD, -1 }, { "P", "x" } };
             collection.RemoveAll();
             collection.Insert(document);
 
             var fetched = collection.FindOne();
             Assert.IsInstanceOf<BsonDocument>(fetched);
-            Assert.AreEqual(-1, fetched["_id"].AsInt32);
+            Assert.AreEqual(-1, fetched[BsonDocument.ID_FIELD].AsInt32);
             Assert.AreEqual("x", fetched["P"].AsString);
         }
 


### PR DESCRIPTION
Created a constant for the field "_id" which is used frequently and exposed it publicly as BsonDocument.ID_FIELD.  Should help users when building queries against the _id field to remove another magic string.  Especially since the IdConvention allows them to use "Id" as a field-name.
