### PR TITLE
Unify Driver.Builder APIs so callers do not need explicitly deal with BsonValues or Wrappers in most cases.

### DIFF
--- a/Bson/ObjectModel/BsonArray.cs
+++ b/Bson/ObjectModel/BsonArray.cs
@@ -66,6 +66,16 @@ namespace MongoDB.Bson
         /// Initializes a new instance of the BsonArray class.
         /// </summary>
         /// <param name="values">A list of values to add to the array.</param>
+        public BsonArray(params BsonValue[] values)
+            : this(0) // AddRange optimizes Capacity after parameter checking
+        {
+            AddRange(values);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BsonArray class.
+        /// </summary>
+        /// <param name="values">A list of values to add to the array.</param>
         public BsonArray(IEnumerable<DateTime> values)
             : this(0)
         {
@@ -130,6 +140,18 @@ namespace MongoDB.Bson
             : this(0)
         {
             AddRange(values);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BsonArray class.
+        /// </summary>
+        /// <param name="value1">The first value to add to the array.</param>
+        /// <param name="value2">The second value to add to the array.</param>
+        /// <param name="values">A list of additional values to add to the array.</param>
+        public BsonArray(object value1, object value2, params object[] values)
+            : this(0) // AddRange optimizes Capacity after parameter checking
+        {
+            AddRange(value1, value2, values);
         }
 
         /// <summary>
@@ -244,6 +266,23 @@ namespace MongoDB.Bson
         /// <param name="values">A list of values to add to the array.</param>
         /// <returns>A BsonArray or null.</returns>
         public static BsonArray Create(IEnumerable<BsonValue> values)
+        {
+            if (values != null)
+            {
+                return new BsonArray(values);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new BsonArray.
+        /// </summary>
+        /// <param name="values">A list of values to add to the array.</param>
+        /// <returns>A BsonArray or null.</returns>
+        public static BsonArray Create(params BsonValue[] values)
         {
             if (values != null)
             {
@@ -377,6 +416,28 @@ namespace MongoDB.Bson
         /// <summary>
         /// Creates a new BsonArray.
         /// </summary>
+        /// <param name="value1">The first value to add to the array.</param>
+        /// <param name="value2">The second value to add to the array.</param>
+        /// <param name="values">A list of additional values to add to the array.</param>
+        /// <returns>A BsonArray or null.</returns>
+        public static BsonArray Create(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            if (values != null)
+            {
+                return new BsonArray(value1, value2, values);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new BsonArray.
+        /// </summary>
         /// <param name="value">A value to be mapped to a BsonArray.</param>
         /// <returns>A BsonArray or null.</returns>
         public new static BsonArray Create(object value)
@@ -417,10 +478,12 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray Add(BsonValue value)
         {
-            if (value != null)
+            if (value == null)
             {
-                _values.Add(value);
+                throw new ArgumentNullException("value");
             }
+
+            _values.Add(value);
             return this;
         }
 
@@ -431,12 +494,14 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable<bool> values)
         {
-            if (values != null)
+            if (values == null)
             {
-                foreach (var value in values)
-                {
-                    _values.Add(BsonBoolean.Create(value));
-                }
+                throw new ArgumentNullException("values");
+            }
+
+            foreach (var value in values)
+            {
+                _values.Add(BsonBoolean.Create(value));
             }
             return this;
         }
@@ -448,9 +513,47 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable<BsonValue> values)
         {
-            if (values != null)
+            if (values == null)
             {
-                _values.AddRange(values);
+                throw new ArgumentNullException("values");
+            }
+
+            foreach (var value in values)
+            {
+                if (value == null)
+                {
+                    throw new ArgumentException("One of the values is null.", "values");
+                }
+
+                _values.Add(value);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Adds multiple elements to the array.
+        /// </summary>
+        /// <param name="values">A list of values to add to the array.</param>
+        /// <returns>The array (so method calls can be chained).</returns>
+        public BsonArray AddRange(params BsonValue[] values)
+        {
+            if (values == null)
+            {
+                throw new ArgumentNullException("values");
+            }
+
+            _values.Capacity += values.Length;
+
+            for (int i = 0; i < values.Length; ++i)
+            {
+                var value = values[i];
+
+                if (value == null)
+                {
+                    throw new ArgumentException("One of the values is null", "values");
+                }
+
+                _values.Add(value);
             }
             return this;
         }
@@ -462,12 +565,14 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable<DateTime> values)
         {
-            if (values != null)
+            if (values == null)
             {
-                foreach (var value in values)
-                {
-                    _values.Add(BsonDateTime.Create(value));
-                }
+                throw new ArgumentNullException("values");
+            }
+
+            foreach (var value in values)
+            {
+                _values.Add(BsonDateTime.Create(value));
             }
             return this;
         }
@@ -479,12 +584,14 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable<double> values)
         {
-            if (values != null)
+            if (values == null)
             {
-                foreach (var value in values)
-                {
-                    _values.Add(BsonDouble.Create(value));
-                }
+                throw new ArgumentNullException("values");
+            }
+
+            foreach (var value in values)
+            {
+                _values.Add(BsonDouble.Create(value));
             }
             return this;
         }
@@ -496,12 +603,14 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable<int> values)
         {
-            if (values != null)
+            if (values == null)
             {
-                foreach (var value in values)
-                {
-                    _values.Add(BsonInt32.Create(value));
-                }
+                throw new ArgumentNullException("values");
+            }
+
+            foreach (var value in values)
+            {
+                _values.Add(BsonInt32.Create(value));
             }
             return this;
         }
@@ -513,12 +622,14 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable<long> values)
         {
-            if (values != null)
+            if (values == null)
             {
-                foreach (var value in values)
-                {
-                    _values.Add(BsonInt64.Create(value));
-                }
+                throw new ArgumentNullException("values");
+            }
+
+            foreach (var value in values)
+            {
+                _values.Add(BsonInt64.Create(value));
             }
             return this;
         }
@@ -530,12 +641,14 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable<ObjectId> values)
         {
-            if (values != null)
+            if (values == null)
             {
-                foreach (var value in values)
-                {
-                    _values.Add(BsonObjectId.Create(value));
-                }
+                throw new ArgumentNullException("values");
+            }
+            
+            foreach (var value in values)
+            {
+                _values.Add(BsonObjectId.Create(value));
             }
             return this;
         }
@@ -547,12 +660,14 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable<string> values)
         {
-            if (values != null)
+            if (values == null)
             {
-                foreach (var value in values)
-                {
-                    _values.Add(BsonString.Create(value));
-                }
+                throw new ArgumentNullException("values");
+            }
+
+            foreach (var value in values)
+            {
+                _values.Add(BsonString.Create(value));
             }
             return this;
         }
@@ -564,12 +679,63 @@ namespace MongoDB.Bson
         /// <returns>The array (so method calls can be chained).</returns>
         public BsonArray AddRange(IEnumerable values)
         {
-            if (values != null)
+            if (values == null)
             {
-                foreach (var value in values)
+                throw new ArgumentNullException("values");
+            }
+
+            foreach (var value in values)
+            {
+                if (value == null)
                 {
-                    _values.Add(BsonValue.Create(value));
+                    throw new ArgumentException("One of the values is null.", "values");
                 }
+
+                _values.Add(BsonValue.Create(value));
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Adds multiple elements to the array.
+        /// </summary>
+        /// <param name="value1">The first value to add to the array.</param>
+        /// <param name="value2">The second value to add to the array.</param>
+        /// <param name="values">A list of additional values to add to the array.</param>
+        /// <returns>The array (so method calls can be chained).</returns>
+        public BsonArray AddRange(object value1, object value2, params object[] values)
+        {
+            if (value1 == null)
+            {
+                throw new ArgumentNullException("value1");
+            }
+
+            if (value2 == null)
+            {
+                throw new ArgumentNullException("value2");
+            }
+
+            if (values == null)
+            {
+                throw new ArgumentNullException("values");
+            }
+
+            _values.Capacity += 2 + values.Length;
+
+            _values.Add(BsonValue.Create(value1));
+
+            _values.Add(BsonValue.Create(value2));
+
+            for (int i = 0; i < values.Length; ++i)
+            {
+                var value = values[i];
+
+                if (value == null)
+                {
+                    throw new ArgumentException("One of the values is null.", "values");
+                }
+
+                _values.Add(BsonValue.Create(value));
             }
             return this;
         }

--- a/Bson/ObjectModel/BsonDocumentWrapper.cs
+++ b/Bson/ObjectModel/BsonDocumentWrapper.cs
@@ -140,50 +140,6 @@ namespace MongoDB.Bson
             }
         }
 
-        /// <summary>
-        /// Creates a list of new instances of the BsonDocumentWrapper class.
-        /// </summary>
-        /// <typeparam name="TNominalType">The nominal type of the wrapped objects.</typeparam>
-        /// <param name="values">A list of wrapped objects.</param>
-        /// <returns>A list of BsonDocumentWrappers or null.</returns>
-        public static IEnumerable<BsonDocumentWrapper> CreateMultiple<TNominalType>(IEnumerable<TNominalType> values)
-        {
-            if (values != null)
-            {
-                return values.Where(v => v != null).Select(v => new BsonDocumentWrapper(typeof(TNominalType), v));
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Creates a list of new instances of the BsonDocumentWrapper class.
-        /// </summary>
-        /// <param name="nominalType">The nominal type of the wrapped object.</param>
-        /// <param name="values">A list of wrapped objects.</param>
-        /// <returns>A list of BsonDocumentWrappers or null.</returns>
-        public static IEnumerable<BsonDocumentWrapper> CreateMultiple(Type nominalType, IEnumerable values)
-        {
-            if (values != null)
-            {
-                var wrappers = new List<BsonDocumentWrapper>();
-                foreach (var value in values)
-                {
-                    if (value != null)
-                    {
-                        wrappers.Add(new BsonDocumentWrapper(nominalType, value));
-                    }
-                }
-                return wrappers;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
         // public methods
         /// <summary>
         /// CompareTo is an invalid operation for BsonDocumentWrapper.

--- a/Bson/ObjectModel/BsonValue.cs
+++ b/Bson/ObjectModel/BsonValue.cs
@@ -1015,7 +1015,12 @@ namespace MongoDB.Bson
             }
             else
             {
-                return BsonTypeMapper.MapToBsonValue(value);
+                BsonValue bsonValue;
+                if (!BsonTypeMapper.TryMapToBsonValue(value, out bsonValue))
+                {
+                    bsonValue = BsonDocumentWrapper.Create(value.GetType(), value, false);
+                }
+                return bsonValue;
             }
         }
 

--- a/Driver/Builders/QueryBuilder.cs
+++ b/Driver/Builders/QueryBuilder.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -66,19 +67,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public static QueryConditionList All(string name, IEnumerable<BsonValue> values)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryConditionList(name).All(values);
+            return All(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -89,19 +78,35 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public static QueryConditionList All(string name, params BsonValue[] values)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryConditionList(name).All(values);
+            return All(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the named array element contains all of the values (see $all).
+        /// </summary>
+        /// <param name="name">The name of the element to test.</param>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static QueryConditionList All(string name, IEnumerable values)
+        {
+            return All(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the named array element contains all of the values (see $all).
+        /// </summary>
+        /// <param name="name">The name of the element to test.</param>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static QueryConditionList All(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return All(name, new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -115,12 +120,14 @@ namespace MongoDB.Driver.Builders
             {
                 throw new ArgumentNullException("queries");
             }
+
             if (queries.Length == 0)
             {
                 throw new ArgumentOutOfRangeException("queries", "Query.And cannot be called with zero queries.");
             }
 
             var queryDocument = new BsonDocument();
+
             foreach (var query in queries)
             {
                 if (query == null)
@@ -172,6 +179,17 @@ namespace MongoDB.Driver.Builders
                 throw new ArgumentNullException("value");
             }
             return new QueryComplete(new BsonDocument(name, value));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to some value.
+        /// </summary>
+        /// <param name="name">The name of the element to test.</param>
+        /// <param name="value">The value to compare to.</param>
+        /// <returns>A query.</returns>
+        public static QueryComplete EQ(string name, object value)
+        {
+            return EQ(name, BsonValue.Create(value));
         }
 
         /// <summary>
@@ -254,19 +272,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public static QueryConditionList In(string name, IEnumerable<BsonValue> values)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryConditionList(name).In(values);
+            return In(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -277,19 +283,35 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public static QueryConditionList In(string name, params BsonValue[] values)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryConditionList(name).In(values);
+            return In(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to one of a list of values (see $in).
+        /// </summary>
+        /// <param name="name">The name of the element to test.</param>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static QueryConditionList In(string name, IEnumerable values)
+        {
+            return In(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to one of a list of values (see $in).
+        /// </summary>
+        /// <param name="name">The name of the element to test.</param>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static QueryConditionList In(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return In(name, new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -382,6 +404,17 @@ namespace MongoDB.Driver.Builders
                 throw new ArgumentNullException("value");
             }
             return new QueryConditionList(name).NE(value);
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to some value (see $ne).
+        /// </summary>
+        /// <param name="name">The name of the element to test.</param>
+        /// <param name="value">The value to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static QueryConditionList NE(string name, object value)
+        {
+            return NE(name, BsonValue.Create(value));
         }
 
         /// <summary>
@@ -500,19 +533,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public static QueryConditionList NotIn(string name, IEnumerable<BsonValue> values)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryConditionList(name).NotIn(values);
+            return NotIn(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -523,19 +544,35 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public static QueryConditionList NotIn(string name, params BsonValue[] values)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryConditionList(name).NotIn(values);
+            return NotIn(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
+        /// </summary>
+        /// <param name="name">The name of the element to test.</param>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static QueryConditionList NotIn(string name, IEnumerable values)
+        {
+            return NotIn(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
+        /// </summary>
+        /// <param name="name">The name of the element to test.</param>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static QueryConditionList NotIn(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return NotIn(name, new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -890,16 +927,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryConditionList All(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$all", new BsonArray(values));
-            return this;
+            return All(new BsonArray(values));
         }
 
         /// <summary>
@@ -909,16 +937,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryConditionList All(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$all", new BsonArray(values));
-            return this;
+            return All(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the named array element contains all of the values (see $all).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryConditionList All(IEnumerable values)
+        {
+            return All(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the named array element contains all of the values (see $all).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryConditionList All(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return All(new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -999,16 +1043,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryConditionList In(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$in", new BsonArray(values));
-            return this;
+            return In(new BsonArray(values));
         }
 
         /// <summary>
@@ -1018,16 +1053,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryConditionList In(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$in", new BsonArray(values));
-            return this;
+            return In(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to one of a list of values (see $in).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryConditionList In(IEnumerable values)
+        {
+            return In(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to one of a list of values (see $in).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryConditionList In(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return In(new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -1085,6 +1136,16 @@ namespace MongoDB.Driver.Builders
             }
             _conditions.Add("$ne", value);
             return this;
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to some value (see $ne).
+        /// </summary>
+        /// <param name="value">The value to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryConditionList NE(object value)
+        {
+            return NE(BsonValue.Create(value));
         }
 
         /// <summary>
@@ -1151,16 +1212,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryConditionList NotIn(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$nin", new BsonArray(values));
-            return this;
+            return NotIn(new BsonArray(values));
         }
 
         /// <summary>
@@ -1170,16 +1222,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryConditionList NotIn(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$nin", new BsonArray(values));
-            return this;
+            return NotIn(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryConditionList NotIn(IEnumerable values)
+        {
+            return NotIn(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryConditionList NotIn(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return NotIn(new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -1320,15 +1388,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList All(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryNotConditionList(_name).All(values);
+            return All(new BsonArray(values));
         }
 
         /// <summary>
@@ -1338,15 +1398,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList All(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryNotConditionList(_name).All(values);
+            return All(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the named array element contains all of the values (see $all).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList All(IEnumerable values)
+        {
+            return All(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the named array element contains all of the values (see $all).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList All(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return All(new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -1422,15 +1499,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList In(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryNotConditionList(_name).In(values);
+            return In(new BsonArray(values));
         }
 
         /// <summary>
@@ -1440,15 +1509,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList In(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryNotConditionList(_name).In(values);
+            return In(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to one of a list of values (see $in).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList In(IEnumerable values)
+        {
+            return In(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to one of a list of values (see $in).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList In(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return In(new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -1505,6 +1591,16 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Tests that the value of the named element is not equal to some value (see $ne).
+        /// </summary>
+        /// <param name="value">The value to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList NE(object value)
+        {
+            return NE(BsonValue.Create(value));
+        }
+
+        /// <summary>
         /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
         /// </summary>
         /// <param name="values">The values to compare to.</param>
@@ -1525,15 +1621,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList NotIn(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryNotConditionList(_name).NotIn(values);
+            return NotIn(new BsonArray(values));
         }
 
         /// <summary>
@@ -1543,15 +1631,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList NotIn(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            return new QueryNotConditionList(_name).NotIn(values);
+            return NotIn(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList NotIn(IEnumerable values)
+        {
+            return NotIn(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList NotIn(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return NotIn(new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -1632,16 +1737,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList All(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$all", new BsonArray(values));
-            return this;
+            return All(new BsonArray(values));
         }
 
         /// <summary>
@@ -1651,16 +1747,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList All(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$all", new BsonArray(values));
-            return this;
+            return All(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the named array element contains all of the values (see $all).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList All(IEnumerable values)
+        {
+            return All(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the named array element contains all of the values (see $all).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList All(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return All(new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -1741,16 +1853,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList In(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$in", new BsonArray(values));
-            return this;
+            return In(new BsonArray(values));
         }
 
         /// <summary>
@@ -1760,16 +1863,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList In(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$in", new BsonArray(values));
-            return this;
+            return In(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to one of a list of values (see $in).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList In(IEnumerable values)
+        {
+            return In(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is equal to one of a list of values (see $in).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList In(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return In(new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -1830,6 +1949,16 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Tests that the value of the named element is not equal to some value (see $ne).
+        /// </summary>
+        /// <param name="value">The value to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList NE(object value)
+        {
+            return NE(BsonValue.Create(value));
+        }
+
+        /// <summary>
         /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
         /// </summary>
         /// <param name="values">The values to compare to.</param>
@@ -1851,16 +1980,7 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList NotIn(IEnumerable<BsonValue> values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$nin", new BsonArray(values));
-            return this;
+            return NotIn(new BsonArray(values));
         }
 
         /// <summary>
@@ -1870,16 +1990,32 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public QueryNotConditionList NotIn(params BsonValue[] values)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-            if (values.Contains(null))
-            {
-                throw new ArgumentOutOfRangeException("values", "One of the values is null.");
-            }
-            _conditions.Add("$nin", new BsonArray(values));
-            return this;
+            return NotIn(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
+        /// </summary>
+        /// <param name="values">The values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList NotIn(IEnumerable values)
+        {
+            return NotIn(new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Tests that the value of the named element is not equal to any of a list of values (see $nin).
+        /// </summary>
+        /// <param name="value1">The first value to compare to.</param>
+        /// <param name="value2">The second value to compare to.</param>
+        /// <param name="values">The additional values to compare to.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public QueryNotConditionList NotIn(
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return NotIn(new BsonArray(value1, value2, values));
         }
 
         /// <summary>

--- a/Driver/Builders/UpdateBuilder.cs
+++ b/Driver/Builders/UpdateBuilder.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -39,6 +40,17 @@ namespace MongoDB.Driver.Builders
         /// <param name="value">The value to add to the set.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
         public static UpdateBuilder AddToSet(string name, BsonValue value)
+        {
+            return new UpdateBuilder().AddToSet(name, value);
+        }
+
+        /// <summary>
+        /// Adds a value to a named array element if the value is not already in the array (see $addToSet).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value">The value to add to the set.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder AddToSet(string name, object value)
         {
             return new UpdateBuilder().AddToSet(name, value);
         }
@@ -77,12 +89,41 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Adds a list of values to a named array element adding each value only if it not already in the array (see $addToSet and $each).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="values">The values to add to the set.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder AddToSetEach(string name, IEnumerable values)
+        {
+            return new UpdateBuilder().AddToSetEach(name, values);
+        }
+
+        /// <summary>
+        /// Adds a list of values to a named array element adding each value only if it not already in the array (see $addToSet and $each).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value1">The first value to add to the set.</param>
+        /// <param name="value2">The second value to add to the set.</param>
+        /// <param name="values">The additional values to add to the set.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder AddToSetEach(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return new UpdateBuilder().AddToSetEach(name, value1, value2, values);
+        }
+
+        /// <summary>
         /// Adds a list of wrapped values to a named array element adding each value only if it not already in the array (see $addToSet and $each).
         /// </summary>
         /// <typeparam name="T">The type of wrapped values.</typeparam>
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to add to the set.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("AddToSetEachWrapped is obsolete and will be removed in a future version of the C# driver. Please use AddToSetEach instead.")]
         public static UpdateBuilder AddToSetEachWrapped<T>(string name, IEnumerable<T> values)
         {
             return new UpdateBuilder().AddToSetEachWrapped<T>(name, values);
@@ -95,6 +136,7 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to add to the set.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("AddToSetEachWrapped is obsolete and will be removed in a future version of the C# driver. Please use AddToSetEach instead.")]
         public static UpdateBuilder AddToSetEachWrapped<T>(string name, params T[] values)
         {
             return new UpdateBuilder().AddToSetEachWrapped<T>(name, values);
@@ -107,6 +149,7 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="value">The wrapped value to add to the set.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("AddToSetWrapped is obsolete and will be removed in a future version of the C# driver. Please use AddToSet instead.")]
         public static UpdateBuilder AddToSetWrapped<T>(string name, T value)
         {
             return new UpdateBuilder().AddToSetWrapped<T>(name, value);
@@ -247,14 +290,14 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
-        /// Removes all values from the named array element that match some query (see $pull).
+        /// Removes all values from the named array element that are equal to some value (see $pull).
         /// </summary>
         /// <param name="name">The name of the array element.</param>
-        /// <param name="query">A query that specifies which elements to remove.</param>
+        /// <param name="value">The value to remove.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
-        public static UpdateBuilder Pull(string name, IMongoQuery query)
+        public static UpdateBuilder Pull(string name, object value)
         {
-            return new UpdateBuilder().Pull(name, query);
+            return new UpdateBuilder().Pull(name, value);
         }
 
         /// <summary>
@@ -291,12 +334,41 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Removes all values from the named array element that are equal to any of a list of values (see $pullAll).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="values">The values to remove.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder PullAll(string name, IEnumerable values)
+        {
+            return new UpdateBuilder().PullAll(name, values);
+        }
+
+        /// <summary>
+        /// Removes all values from the named array element that are equal to any of a list of values (see $pullAll).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value1">The first value to remove.</param>
+        /// <param name="value2">The second value to remove.</param>
+        /// <param name="values">The additional values to remove.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder PullAll(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return new UpdateBuilder().PullAll(name, value1, value2, values);
+        }
+
+        /// <summary>
         /// Removes all values from the named array element that are equal to any of a list of wrapped values (see $pullAll).
         /// </summary>
         /// <typeparam name="T">The type of wrapped values.</typeparam>
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to remove.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PullAllWrapped is obsolete and will be removed in a future version of the C# driver. Please use PullAll instead.")]
         public static UpdateBuilder PullAllWrapped<T>(string name, IEnumerable<T> values)
         {
             return new UpdateBuilder().PullAllWrapped<T>(name, values);
@@ -309,6 +381,7 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to remove.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PullAllWrapped is obsolete and will be removed in a future version of the C# driver. Please use PullAll instead.")]
         public static UpdateBuilder PullAllWrapped<T>(string name, params T[] values)
         {
             return new UpdateBuilder().PullAllWrapped<T>(name, values);
@@ -321,6 +394,7 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="value">The wrapped value to remove.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PullWrapped is obsolete and will be removed in a future version of the C# driver. Please use Pull instead.")]
         public static UpdateBuilder PullWrapped<T>(string name, T value)
         {
             return new UpdateBuilder().PullWrapped<T>(name, value);
@@ -333,6 +407,17 @@ namespace MongoDB.Driver.Builders
         /// <param name="value">The value to add to the end of the array.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
         public static UpdateBuilder Push(string name, BsonValue value)
+        {
+            return new UpdateBuilder().Push(name, value);
+        }
+
+        /// <summary>
+        /// Adds a value to the end of the named array element (see $push).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value">The value to add to the end of the array.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder Push(string name, object value)
         {
             return new UpdateBuilder().Push(name, value);
         }
@@ -371,12 +456,41 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Adds a list of values to the end of the named array element (see $pushAll).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="values">The values to add to the end of the array.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder PushAll(string name, IEnumerable values)
+        {
+            return new UpdateBuilder().PushAll(name, values);
+        }
+
+        /// <summary>
+        /// Adds a list of values to the end of the named array element (see $pushAll).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value1">The first value to add to the end of the array.</param>
+        /// <param name="value2">The second value to add to the end of the array.</param>
+        /// <param name="values">The additional values to add to the end of the array.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder PushAll(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return new UpdateBuilder().PushAll(name, value1, value2, values);
+        }
+
+        /// <summary>
         /// Adds a list of wrapped values to the end of the named array element (see $pushAll).
         /// </summary>
         /// <typeparam name="T">The type of wrapped values.</typeparam>
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to add to the end of the array.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PushAllWrapped is obsolete and will be removed in a future version of the C# driver. Please use PushAll instead.")]
         public static UpdateBuilder PushAllWrapped<T>(string name, IEnumerable<T> values)
         {
             return new UpdateBuilder().PushAllWrapped<T>(name, values);
@@ -389,6 +503,7 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to add to the end of the array.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PushAllWrapped is obsolete and will be removed in a future version of the C# driver. Please use PushAll instead.")]
         public static UpdateBuilder PushAllWrapped<T>(string name, params T[] values)
         {
             return new UpdateBuilder().PushAllWrapped<T>(name, values);
@@ -401,6 +516,7 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="value">The wrapped value to add to the end of the array.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PushWrapped is obsolete and will be removed in a future version of the C# driver. Please use Push instead.")]
         public static UpdateBuilder PushWrapped<T>(string name, T value)
         {
             return new UpdateBuilder().PushWrapped<T>(name, value);
@@ -454,12 +570,24 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Sets the value of the named element to a new value (see $set).
+        /// </summary>
+        /// <param name="name">The name of the element to be set.</param>
+        /// <param name="value">The new value.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static UpdateBuilder Set(string name, object value)
+        {
+            return new UpdateBuilder().Set(name, value);
+        }
+
+        /// <summary>
         /// Sets the value of the named element to a new wrapped value (see $set).
         /// </summary>
         /// <typeparam name="T">The type of wrapped value.</typeparam>
         /// <param name="name">The name of the element to be set.</param>
         /// <param name="value">The new wrapped value.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("SetWrapped is obsolete and will be removed in a future version of the C# driver. Please use Set instead.")]
         public static UpdateBuilder SetWrapped<T>(string name, T value)
         {
             return new UpdateBuilder().SetWrapped<T>(name, value);
@@ -524,6 +652,17 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Adds a value to a named array element if the value is not already in the array (see $addToSet).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value">The value to add to the set.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder AddToSet(string name, object value)
+        {
+            return AddToSet(name, BsonValue.Create(value));
+        }
+
+        /// <summary>
         /// Adds a list of values to a named array element adding each value only if it not already in the array (see $addToSet and $each).
         /// </summary>
         /// <param name="name">The name of the array element.</param>
@@ -554,8 +693,6 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public UpdateBuilder AddToSetEach(string name, IEnumerable<BsonValue> values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
             return AddToSetEach(name, new BsonArray(values));
         }
 
@@ -567,9 +704,35 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public UpdateBuilder AddToSetEach(string name, params BsonValue[] values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            return AddToSetEach(name, (IEnumerable<BsonValue>)values);
+            return AddToSetEach(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Adds a list of values to a named array element adding each value only if it not already in the array (see $addToSet and $each).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="values">The values to add to the set.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder AddToSetEach(string name, IEnumerable values)
+        {
+            return AddToSetEach(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Adds a list of values to a named array element adding each value only if it not already in the array (see $addToSet and $each).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value1">The first value to add to the set.</param>
+        /// <param name="value2">The second value to add to the set.</param>
+        /// <param name="values">The additional values to add to the set.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder AddToSetEach(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return AddToSetEach(name, new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -579,12 +742,10 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to add to the set.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("AddToSetEachWrapped is obsolete and will be removed in a future version of the C# driver. Please use AddToSetEach instead.")]
         public UpdateBuilder AddToSetEachWrapped<T>(string name, IEnumerable<T> values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            var wrappedValues = BsonDocumentWrapper.CreateMultiple(values).Cast<BsonValue>(); // the cast to BsonValue is required
-            return AddToSetEach(name, wrappedValues);
+            return AddToSetEach(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -594,11 +755,10 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to add to the set.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("AddToSetEachWrapped is obsolete and will be removed in a future version of the C# driver. Please use AddToSetEach instead.")]
         public UpdateBuilder AddToSetEachWrapped<T>(string name, params T[] values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            return AddToSetEachWrapped(name, (IEnumerable<T>)values);
+            return AddToSetEach(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -608,9 +768,9 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="value">The wrapped value to add to the set.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("AddToSetWrapped is obsolete and will be removed in a future version of the C# driver. Please use AddToSet instead.")]
         public UpdateBuilder AddToSetWrapped<T>(string name, T value)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
             if (value == null) { throw new ArgumentNullException("value"); }
             var wrappedValue = (BsonValue)BsonDocumentWrapper.Create(value); // the cast to BsonValue is required
             return AddToSet(name, wrappedValue);
@@ -795,26 +955,14 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
-        /// Removes all values from the named array element that match some query (see $pull).
+        /// Removes all values from the named array element that are equal to some value (see $pull).
         /// </summary>
         /// <param name="name">The name of the array element.</param>
-        /// <param name="query">A query that specifies which elements to remove.</param>
+        /// <param name="value">The value to remove.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
-        public UpdateBuilder Pull(string name, IMongoQuery query)
+        public UpdateBuilder Pull(string name, object value)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (query == null) { throw new ArgumentNullException("query"); }
-            BsonValue wrappedQuery = BsonDocumentWrapper.Create(query);
-            BsonElement element;
-            if (_document.TryGetElement("$pull", out element))
-            {
-                element.Value.AsBsonDocument.Add(name, wrappedQuery);
-            }
-            else
-            {
-                _document.Add("$pull", new BsonDocument(name, wrappedQuery));
-            }
-            return this;
+            return Pull(name, BsonValue.Create(value));
         }
 
         /// <summary>
@@ -847,8 +995,6 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public UpdateBuilder PullAll(string name, IEnumerable<BsonValue> values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
             return PullAll(name, new BsonArray(values));
         }
 
@@ -860,9 +1006,35 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public UpdateBuilder PullAll(string name, params BsonValue[] values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            return PullAll(name, (IEnumerable<BsonValue>)values);
+            return PullAll(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Removes all values from the named array element that are equal to any of a list of values (see $pullAll).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="values">The values to remove.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder PullAll(string name, IEnumerable values)
+        {
+            return PullAll(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Removes all values from the named array element that are equal to any of a list of values (see $pullAll).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value1">The first value to remove.</param>
+        /// <param name="value2">The second value to remove.</param>
+        /// <param name="values">The additional values to remove.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder PullAll(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return PullAll(name, new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -872,21 +1044,10 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to remove.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PullAllWrapped is obsolete and will be removed in a future version of the C# driver. Please use PullAll instead.")]
         public UpdateBuilder PullAllWrapped<T>(string name, IEnumerable<T> values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            var wrappedValues = new BsonArray(BsonDocumentWrapper.CreateMultiple(values).Cast<BsonValue>()); // the cast to BsonValue is required
-            BsonElement element;
-            if (_document.TryGetElement("$pullAll", out element))
-            {
-                element.Value.AsBsonDocument.Add(name, wrappedValues);
-            }
-            else
-            {
-                _document.Add("$pullAll", new BsonDocument(name, wrappedValues));
-            }
-            return this;
+            return PullAll(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -896,11 +1057,10 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to remove.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PullAllWrapped is obsolete and will be removed in a future version of the C# driver. Please use PullAll instead.")]
         public UpdateBuilder PullAllWrapped<T>(string name, params T[] values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            return PullAllWrapped<T>(name, (IEnumerable<T>)values);
+            return PullAll(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -910,21 +1070,12 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="value">The wrapped value to remove.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PullWrapped is obsolete and will be removed in a future version of the C# driver. Please use Pull instead.")]
         public UpdateBuilder PullWrapped<T>(string name, T value)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
             if (value == null) { throw new ArgumentNullException("value"); }
             var wrappedValue = BsonDocumentWrapper.Create(value);
-            BsonElement element;
-            if (_document.TryGetElement("$pull", out element))
-            {
-                element.Value.AsBsonDocument.Add(name, wrappedValue);
-            }
-            else
-            {
-                _document.Add("$pull", new BsonDocument(name, wrappedValue));
-            }
-            return this;
+            return Pull(name, wrappedValue);
         }
 
         /// <summary>
@@ -947,6 +1098,17 @@ namespace MongoDB.Driver.Builders
                 _document.Add("$push", new BsonDocument(name, value));
             }
             return this;
+        }
+
+        /// <summary>
+        /// Adds a value to the end of the named array element (see $push).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value">The value to add to the end of the array.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder Push(string name, object value)
+        {
+            return Push(name, BsonValue.Create(value));
         }
 
         /// <summary>
@@ -979,8 +1141,6 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public UpdateBuilder PushAll(string name, IEnumerable<BsonValue> values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
             return PushAll(name, new BsonArray(values));
         }
 
@@ -992,9 +1152,35 @@ namespace MongoDB.Driver.Builders
         /// <returns>The builder (so method calls can be chained).</returns>
         public UpdateBuilder PushAll(string name, params BsonValue[] values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            return PushAll(name, (IEnumerable<BsonValue>)values);
+            return PushAll(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Adds a list of values to the end of the named array element (see $pushAll).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="values">The values to add to the end of the array.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder PushAll(string name, IEnumerable values)
+        {
+            return PushAll(name, new BsonArray(values));
+        }
+
+        /// <summary>
+        /// Adds a list of values to the end of the named array element (see $pushAll).
+        /// </summary>
+        /// <param name="name">The name of the array element.</param>
+        /// <param name="value1">The first value to add to the end of the array.</param>
+        /// <param name="value2">The second value to add to the end of the array.</param>
+        /// <param name="values">The additional values to add to the end of the array.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder PushAll(
+            string name,
+            object value1,
+            object value2,
+            params object[] values)
+        {
+            return PushAll(name, new BsonArray(value1, value2, values));
         }
 
         /// <summary>
@@ -1004,21 +1190,10 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to add to the end of the array.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PushAllWrapped is obsolete and will be removed in a future version of the C# driver. Please use PushAll instead.")]
         public UpdateBuilder PushAllWrapped<T>(string name, IEnumerable<T> values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            var wrappedValues = new BsonArray(BsonDocumentWrapper.CreateMultiple(values).Cast<BsonValue>()); // the cast to BsonValue is required
-            BsonElement element;
-            if (_document.TryGetElement("$pushAll", out element))
-            {
-                element.Value.AsBsonDocument.Add(name, wrappedValues);
-            }
-            else
-            {
-                _document.Add("$pushAll", new BsonDocument(name, wrappedValues));
-            }
-            return this;
+            return PushAll(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -1028,11 +1203,10 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="values">The wrapped values to add to the end of the array.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PushAllWrapped is obsolete and will be removed in a future version of the C# driver. Please use PushAll instead.")]
         public UpdateBuilder PushAllWrapped<T>(string name, params T[] values)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
-            if (values == null) { throw new ArgumentNullException("values"); }
-            return PushAllWrapped(name, (IEnumerable<T>)values);
+            return PushAll(name, new BsonArray(values));
         }
 
         /// <summary>
@@ -1042,21 +1216,12 @@ namespace MongoDB.Driver.Builders
         /// <param name="name">The name of the array element.</param>
         /// <param name="value">The wrapped value to add to the end of the array.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("PushWrapped is obsolete and will be removed in a future version of the C# driver. Please use Push instead.")]
         public UpdateBuilder PushWrapped<T>(string name, T value)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
             if (value == null) { throw new ArgumentNullException("value"); }
             var wrappedValue = BsonDocumentWrapper.Create<T>(value);
-            BsonElement element;
-            if (_document.TryGetElement("$push", out element))
-            {
-                element.Value.AsBsonDocument.Add(name, wrappedValue);
-            }
-            else
-            {
-                _document.Add("$push", new BsonDocument(name, wrappedValue));
-            }
-            return this;
+            return Push(name, wrappedValue);
         }
 
         /// <summary>
@@ -1104,27 +1269,29 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Sets the value of the named element to a new value (see $set).
+        /// </summary>
+        /// <param name="name">The name of the element to be set.</param>
+        /// <param name="value">The new value.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public UpdateBuilder Set(string name, object value)
+        {
+            return Set(name, BsonValue.Create(value));
+        }
+
+        /// <summary>
         /// Sets the value of the named element to a new wrapped value (see $set).
         /// </summary>
         /// <typeparam name="T">The type of wrapped value.</typeparam>
         /// <param name="name">The name of the element to be set.</param>
         /// <param name="value">The new wrapped value.</param>
         /// <returns>The builder (so method calls can be chained).</returns>
+        [Obsolete("SetWrapped is obsolete and will be removed in a future version of the C# driver. Please use Set instead.")]
         public UpdateBuilder SetWrapped<T>(string name, T value)
         {
-            if (name == null) { throw new ArgumentNullException("name"); }
             if (value == null) { throw new ArgumentNullException("value"); }
             var wrappedValue = BsonDocumentWrapper.Create<T>(value);
-            BsonElement element;
-            if (_document.TryGetElement("$set", out element))
-            {
-                element.Value.AsBsonDocument.Add(name, wrappedValue);
-            }
-            else
-            {
-                _document.Add("$set", new BsonDocument(name, wrappedValue));
-            }
-            return this;
+            return Set(name, value);
         }
 
         /// <summary>

--- a/Driver/Core/MongoCollection.cs
+++ b/Driver/Core/MongoCollection.cs
@@ -548,10 +548,32 @@ namespace MongoDB.Driver
         /// <summary>
         /// Returns a cursor that can be used to find one document in this collection by its _id value as a TDocument.
         /// </summary>
+        /// <typeparam name="TDocument">The nominal type of the document.</typeparam>
+        /// <param name="id">The id of the document.</param>
+        /// <returns>A TDocument (or null if not found).</returns>
+        public virtual TDocument FindOneByIdAs<TDocument>(object id)
+        {
+            return FindOneAs<TDocument>(Query.EQ("_id", id));
+        }
+
+        /// <summary>
+        /// Returns a cursor that can be used to find one document in this collection by its _id value as a TDocument.
+        /// </summary>
         /// <param name="documentType">The nominal type of the document.</param>
         /// <param name="id">The id of the document.</param>
         /// <returns>A TDocument (or null if not found).</returns>
         public virtual object FindOneByIdAs(Type documentType, BsonValue id)
+        {
+            return FindOneAs(documentType, Query.EQ("_id", id));
+        }
+
+        /// <summary>
+        /// Returns a cursor that can be used to find one document in this collection by its _id value as a TDocument.
+        /// </summary>
+        /// <param name="documentType">The nominal type of the document.</param>
+        /// <param name="id">The id of the document.</param>
+        /// <returns>A TDocument (or null if not found).</returns>
+        public virtual object FindOneByIdAs(Type documentType, object id)
         {
             return FindOneAs(documentType, Query.EQ("_id", id));
         }
@@ -1678,6 +1700,16 @@ namespace MongoDB.Driver
         /// <param name="id">The id of the document.</param>
         /// <returns>A TDefaultDocument (or null if not found).</returns>
         public virtual TDefaultDocument FindOneById(BsonValue id)
+        {
+            return FindOneByIdAs<TDefaultDocument>(id);
+        }
+
+        /// <summary>
+        /// Returns a cursor that can be used to find one document in this collection by its _id value as a TDefaultDocument.
+        /// </summary>
+        /// <param name="id">The id of the document.</param>
+        /// <returns>A TDefaultDocument (or null if not found).</returns>
+        public virtual TDefaultDocument FindOneById(object id)
         {
             return FindOneByIdAs<TDefaultDocument>(id);
         }

--- a/DriverOnlineTests/Jira/CSharp111Tests.cs
+++ b/DriverOnlineTests/Jira/CSharp111Tests.cs
@@ -60,12 +60,16 @@ namespace MongoDB.DriverOnlineTests.Jira.CSharp111
             var update = Update.AddToSet("InnerObjects", 1);
             collection.Update(query, update);
             var d1 = new D { X = 1 };
+#pragma warning disable 618 // AddToSetWrapped is obsolete
             update = Update.AddToSetWrapped("InnerObjects", d1);
+#pragma warning restore 618
             collection.Update(query, update);
 
             var d2 = new D { X = 2 };
             var d3 = new D { X = 3 };
+#pragma warning disable 618 // AddToSetEachWrapped is obsolete
             update = Update.AddToSetEachWrapped("InnerObjects", d1, d2, d3);
+#pragma warning restore 618
             collection.Update(query, update);
 
             var document = collection.FindOneAs<BsonDocument>();

--- a/DriverUnitTests/Builders/UpdateBuilderTests.cs
+++ b/DriverUnitTests/Builders/UpdateBuilderTests.cs
@@ -55,7 +55,9 @@ namespace MongoDB.DriverUnitTests.Builders
         [Test]
         public void TestAddToSetEachWrapped()
         {
+#pragma warning disable 618 // AddToSetEachWrapped is obsolete
             var update = Update.AddToSetEachWrapped("name", _a, _b);
+#pragma warning restore 618
             var expected = "{ \"$addToSet\" : { \"name\" : { \"$each\" : [{ \"X\" : 1 }, { \"X\" : 2 }] } } }";
             Assert.AreEqual(expected, update.ToJson());
         }
@@ -63,7 +65,9 @@ namespace MongoDB.DriverUnitTests.Builders
         [Test]
         public void TestAddToSetWrapped()
         {
+#pragma warning disable 618 // AddToSetWrapped is obsolete
             var update = Update.AddToSetWrapped("name", _a);
+#pragma warning restore 618
             var expected = "{ \"$addToSet\" : { \"name\" : { \"X\" : 1 } } }";
             Assert.AreEqual(expected, update.ToJson());
         }
@@ -229,7 +233,9 @@ namespace MongoDB.DriverUnitTests.Builders
         [Test]
         public void TestPullAllWrapped()
         {
+#pragma warning disable 618 // PullAllWrapped is obsolete
             var update = Update.PullAllWrapped("name", _a, _b);
+#pragma warning restore 618
             var expected = "{ \"$pullAll\" : { \"name\" : [{ \"X\" : 1 }, { \"X\" : 2 }] } }";
             Assert.AreEqual(expected, update.ToJson());
         }
@@ -237,7 +243,9 @@ namespace MongoDB.DriverUnitTests.Builders
         [Test]
         public void TestPullWrapped()
         {
+#pragma warning disable 618 // PullWrapped is obsolete
             var update = Update.PullWrapped("name", _a);
+#pragma warning restore 618
             var expected = "{ \"$pull\" : { \"name\" : { \"X\" : 1 } } }";
             Assert.AreEqual(expected, update.ToJson());
         }
@@ -261,7 +269,9 @@ namespace MongoDB.DriverUnitTests.Builders
         [Test]
         public void TestPushWrapped()
         {
+#pragma warning disable 618 // PushWrapped is obsolete
             var update = Update.PushWrapped("name", _a);
+#pragma warning restore 618
             var expected = "{ \"$push\" : { \"name\" : { \"X\" : 1 } } }";
             Assert.AreEqual(expected, update.ToJson());
         }
@@ -277,7 +287,9 @@ namespace MongoDB.DriverUnitTests.Builders
         [Test]
         public void TestPushAllWrapped()
         {
+#pragma warning disable 618 // PushAllWrapped is obsolete
             var update = Update.PushAllWrapped("name", _a, _b);
+#pragma warning restore 618
             var expected = "{ \"$pushAll\" : { \"name\" : [{ \"X\" : 1 }, { \"X\" : 2 }] } }";
             Assert.AreEqual(expected, update.ToJson());
         }
@@ -293,7 +305,9 @@ namespace MongoDB.DriverUnitTests.Builders
         [Test]
         public void TestSetWrapped()
         {
+#pragma warning disable 618 // SetWrapped is obsolete
             var update = Update.SetWrapped("name", _a);
+#pragma warning restore 618
             var expected = "{ \"$set\" : { \"name\" : { \"X\" : 1 } } }";
             Assert.AreEqual(expected, update.ToJson());
         }


### PR DESCRIPTION
Unify Driver.Builder APIs so callers do not need explicitly deal with BsonValues or Wrappers in most cases.
1. Improve the existing BsonValue.Create factory method to be able to generate document wrappers when presented with a document.
2. Improve BsonArray to call BsonValue.Create when presented with the object type.
3. Improve BsonArray to support variable parameter lists.
4. Refactor redundant API error checking by leveraging existing BsonArray error checking. Also improve performance by eliminating calls to Contains.
5. Reduce code complexity by having APIs that take lists call the BsonArray version rather than reimplementing logic in multiple places.
6. Deprecate UpdateBuilder Wrapped APIs as now regular UpdateBuilder APIs that take objects can be used.
7. Augmented query APIs: All, EQ, In, NE, NotIn to allow complex user types
8. Augmented update APIs: AddToSet, AddToSetEach, Pull, PullAll, Push, PushAll, Set to allow complex user types
9. Simplifies caller code by not pushing Wrapper and BsonValue complexity up the stack.
10. Enables callers to pass in BsonSerializable custom types.
