### PR TITLE
MongoCollection - Remove Overloads

### DIFF
--- a/Driver/Core/MongoCollection.cs
+++ b/Driver/Core/MongoCollection.cs
@@ -1188,6 +1188,27 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Removes documents from this collection by its _id value.
+        /// </summary>
+        /// <param name="id">The id of the document.</param>
+        /// <returns>A SafeModeResult (or null if SafeMode is not being used).</returns>
+        public virtual SafeModeResult RemoveById(BsonValue id)
+        {
+            return Remove(Query.EQ("_id", id), RemoveFlags.Single, null);
+        }
+
+        /// <summary>
+        /// Removes documents from this collection by its _id value.
+        /// </summary>
+        /// <param name="id">The id of the document.</param>
+        /// <param name="safeMode">The SafeMode to use for this operation.</param>
+        /// <returns>A SafeModeResult (or null if SafeMode is not being used).</returns>
+        public virtual SafeModeResult RemoveById(BsonValue id, SafeMode safeMode)
+        {
+            return Remove(Query.EQ("_id", id), RemoveFlags.Single, safeMode);
+        }
+
+        /// <summary>
         /// Removes documents from this collection that match a query.
         /// </summary>
         /// <param name="query">The query (usually a QueryDocument or constructed using the Query builder).</param>


### PR DESCRIPTION
Adding overloads for Remove on MongoCollection to allow for the removing by id similar to the FindById overloads.
