### PR TITLE
Add support for constructor injection

### DIFF
--- a/Bson/Serialization/BsonClassMap.cs
+++ b/Bson/Serialization/BsonClassMap.cs
@@ -886,7 +886,16 @@ namespace MongoDB.Bson.Serialization
 
             _extraElementsMemberMap = memberMap;
         }
+        /// <summary>
+        /// Sets the constructor for the object
+        /// </summary>
+        /// <param name="constructor"></param>
+        public BsonClassMap SetConstructor(Func<object> constructor)
+        {
+            this._creator = constructor;
+            return this;
 
+        }
         /// <summary>
         /// Sets the Id member.
         /// </summary>
@@ -1383,6 +1392,8 @@ namespace MongoDB.Bson.Serialization
             var memberName = GetMemberNameFromLambda(memberLambda);
             return GetMemberMap(memberName);
         }
+
+        
 
         /// <summary>
         /// Creates a member map for the extra elements field and adds it to the class map.


### PR DESCRIPTION
Using the method SetConstructor in BsonClassMap, you'll be able to inject object creation (low coupling into IoC frameworks). 
This way you can inject services, configuration dependencies and other objects making rich objects instead POCO
