### PR TITLE
Improve deserialization performance by ~22%.

### DIFF
--- a/Bson/Bson.csproj
+++ b/Bson/Bson.csproj
@@ -83,6 +83,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="BsonExtensionMethods.cs" />
+    <Compile Include="FastSingleton.cs" />
     <Compile Include="IO\BsonDocumentReaderSettings.cs" />
     <Compile Include="IO\BsonDocumentWriterSettings.cs" />
     <Compile Include="IO\BsonReaderSettings.cs" />

--- a/Bson/FastSingleton.cs
+++ b/Bson/FastSingleton.cs
@@ -1,0 +1,251 @@
+﻿/* Copyright 2010-2012 10gen Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+
+namespace MongoDB.Bson
+{
+    /// <summary>
+    /// Fast singleton abstract base class. Enables runtime, static, and lazy binding.
+    /// </summary>
+    /// <typeparam name="TValue">The singleton value type.</typeparam>
+    internal abstract class FastSingleton<TValue> where TValue : class
+    {
+        // private static fields
+        private static ReaderWriterLockSlim __readerWriterLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+        private static Dictionary<Type, FastSingleton<TValue>> __dictionary = new Dictionary<Type, FastSingleton<TValue>>();
+
+        // public properties
+        /// <summary>
+        /// Gets the singleton value.
+        /// </summary>
+        public abstract TValue Value
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets An optional user-defined object that contains information about the singleton value.
+        /// </summary>
+        public abstract object State
+        {
+            get;
+        }
+
+        // public static methods
+        /// <summary>
+        /// Resolves a nominal type to a singleton instance.
+        /// </summary>
+        /// <param name="nominalType">The nominal type.</param>
+        /// <returns>A singleton instance.</returns>
+        public static FastSingleton<TValue> Lookup(Type nominalType)
+        {
+            FastSingleton<TValue> value;
+
+            __readerWriterLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (__dictionary.TryGetValue(nominalType, out value))
+                {
+                    return value;
+                }
+
+                __readerWriterLock.EnterWriteLock();
+                try
+                {
+                    if (__dictionary.TryGetValue(nominalType, out value))
+                    {
+                        return value;
+                    }
+
+                    var genericType = typeof(FastSingleton<,>).MakeGenericType(typeof(TValue), nominalType);
+
+                    var instancePropertyInfo = genericType.GetProperty(
+                        "Instance",
+                        BindingFlags.Static | BindingFlags.Public);
+
+                    value = (FastSingleton<TValue>)instancePropertyInfo.GetValue(null, null);
+
+                    __dictionary.Add(nominalType, value);
+
+                    return value;
+                }
+                finally
+                {
+                    __readerWriterLock.ExitWriteLock();
+                }
+            }
+            finally
+            {
+                __readerWriterLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        // public methods
+        /// <summary>
+        /// Sets the singleton value.
+        /// </summary>
+        /// <param name="value">The singleton value</param>
+        /// <param name="state">An optional user-defined object that contains information about the singleton value.</param>
+        /// <remarks>Function is atomic.</remarks>
+        /// <returns>true if the singleton value was set; otherwise false.</returns>
+        public abstract bool TrySetValue(TValue value, object state);
+
+        // protected classes
+        /// <summary>
+        /// Groups a singleton value and user-defined object so they can be set atomically.
+        /// </summary>
+        protected class ValueStateTuple
+        {
+            // private fields
+            private readonly TValue value;
+            private readonly object state;
+
+            // constructors
+            /// <summary>
+            /// Initializes a new instance of the Tuple class.
+            /// </summary>
+            /// <param name="value">The singleton value</param>
+            /// <param name="state">An optional user-defined object that contains information about the singleton value.</param>
+            public ValueStateTuple(TValue value, object state)
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                this.value = value;
+                this.state = state;
+            }
+
+            // public properties
+            /// <summary>
+            /// Gets the singleton value.
+            /// </summary>
+            public TValue Value
+            {
+                get
+                {
+                    return this.value;
+                }
+            }
+
+            /// <summary>
+            /// Gets an optional user-defined object that contains information about the singleton value.
+            /// </summary>
+            public object State
+            {
+                get
+                {
+                    return this.state;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fast singleton implementation class
+    /// </summary>
+    /// <typeparam name="TValue">The singleton value type.</typeparam>
+    /// <typeparam name="TNominal">The nominal type associated with the singleton value.</typeparam>
+    internal sealed class FastSingleton<TValue, TNominal> : FastSingleton<TValue> where TValue : class
+    {
+        // private static fields
+        private static readonly FastSingleton<TValue, TNominal> __instance = new FastSingleton<TValue, TNominal>();
+        private static ValueStateTuple __tuple; // volatile accesses
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the FastSingleton&lt;TValue, TNominal&gt; class.
+        /// </summary>
+        /// <remarks>Private because FastSingleton&lt;TValue, TNominal&gt; is a singleton.</remarks>
+        private FastSingleton()
+        {
+        }
+
+        /// <summary>
+        /// Gets the singleton instance of the FastSingleton&lt;TValue, TNominal&gt; type.
+        /// </summary>
+        /// <remarks>Accessed by FastSingleton.Create</remarks>
+        public static FastSingleton<TValue, TNominal> Instance
+        {
+            get
+            {
+                return __instance;
+            }
+        }
+
+        /// <summary>
+        /// Gets the singleton value.
+        /// </summary>
+        public override TValue Value
+        {
+            get
+            {
+                // see implementation of Thread.VolatileRead();
+                var tuple = __tuple;
+
+                Thread.MemoryBarrier();
+
+                if (tuple == null)
+                {
+                    return null;
+                }
+
+                return tuple.Value;
+            }
+        }
+
+        /// <summary>
+        /// Gets An optional user-defined object that contains information about the singleton value.
+        /// </summary>
+        public override object State
+        {
+            get
+            {
+                // see implementation of Thread.VolatileRead();
+                var tuple = __tuple;
+
+                Thread.MemoryBarrier();
+
+                if (tuple == null)
+                {
+                    return null;
+                }
+
+                return tuple.State;
+            }
+        }
+
+        /// <summary>
+        /// Sets the singleton value.
+        /// </summary>
+        /// <param name="value">The singleton value</param>
+        /// <param name="State">An optional user-defined object that contains information about the singleton value.</param>
+        /// <remarks>Function is atomic.</remarks>
+        /// <returns>true if the singleton value was set; otherwise false.</returns>
+        public override bool TrySetValue(TValue value, object State)
+        {
+            var tuple = new ValueStateTuple(value, State);
+
+            var originalTuple = Interlocked.CompareExchange(ref __tuple, tuple, null);
+
+            return originalTuple == null;
+        }
+    }
+}

--- a/Bson/Serialization/BsonClassMapSerializer.cs
+++ b/Bson/Serialization/BsonClassMapSerializer.cs
@@ -23,6 +23,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 
 using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.Options;
 
 namespace MongoDB.Bson.Serialization
@@ -131,7 +132,15 @@ namespace MongoDB.Bson.Serialization
 
                 bsonReader.ReadStartDocument();
                 var missingElementMemberMaps = new HashSet<BsonMemberMap>(classMap.AllMemberMaps); // make a copy!
-                var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(nominalType);
+                IDiscriminatorConvention discriminatorConvention;
+                if (actualType == nominalType)
+                {
+                    discriminatorConvention = classMap.GetDiscriminatorConvention();
+                }
+                else
+                {
+                    discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(nominalType);
+                }
                 while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                 {
                     var elementName = bsonReader.ReadName();
@@ -443,7 +452,7 @@ namespace MongoDB.Bson.Serialization
                 }
                 else
                 {
-                    var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(nominalType);
+                    var discriminatorConvention = memberMap.GetDiscriminatorConvention();
                     actualType = discriminatorConvention.GetActualType(bsonReader, nominalType); // returns nominalType if no discriminator found
                 }
                 var serializer = memberMap.GetSerializer(actualType);

--- a/Bson/Serialization/Serializers/ImageSerializers.cs
+++ b/Bson/Serialization/Serializers/ImageSerializers.cs
@@ -24,6 +24,7 @@ using System.IO;
 
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
 
 namespace MongoDB.Bson.Serialization.Serializers
 {
@@ -71,7 +72,12 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentException(message, "nominalType");
             }
 
-            var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(typeof(Image));
+            var discriminatorConvention = FastSingleton<IDiscriminatorConvention, Image>.Instance.Value;
+            if (discriminatorConvention == null)
+            {
+                // LookupDiscriminatorConvention populates FastSingleton<IDiscriminatorConvention, Image>
+                discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(typeof(Image));
+            }
             var actualType = discriminatorConvention.GetActualType(bsonReader, typeof(Image));
             if (actualType == typeof(Image))
             {

--- a/Bson/Serialization/Serializers/ObjectSerializer.cs
+++ b/Bson/Serialization/Serializers/ObjectSerializer.cs
@@ -22,6 +22,7 @@ using System.IO;
 
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
 
 namespace MongoDB.Bson.Serialization.Serializers
 {
@@ -87,7 +88,12 @@ namespace MongoDB.Bson.Serialization.Serializers
                 }
             }
 
-            var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(typeof(object));
+            var discriminatorConvention = FastSingleton<IDiscriminatorConvention, object>.Instance.Value;
+            if (discriminatorConvention == null)
+            {
+                // LookupDiscriminatorConvention populates FastSingleton<IDiscriminatorConvention, object>
+                discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(typeof(object));
+            }
             var actualType = discriminatorConvention.GetActualType(bsonReader, typeof(object));
             if (actualType == typeof(object))
             {


### PR DESCRIPTION
Deserialization CPU performance was suffering because both LookupDiscriminatorConvention and LookupSerializer were being called for nearly each class member. Both functions take out and release the global config read-lock. Profiling showed that around 25% of all CPU time was being spent in ReaderWriterLockSlim.TryEnterReadLock and ReaderWriterLockSlim.ExitReadLock due to these functions.

Fix makes the BsonClassMap and BsonMemberMap persist references to the appropriate IDiscriminatorConvention and IBsonSerializer singletons.  By doing this, lookups are avoided while maintaining semantic correctness due to the associated BsonClassMap and BsonMemberMap types never changing once constructed.

Also introduced is the FastSingleton class, which extends the existing runtime singleton logic as follows:
1.  Enables more static singleton binding both at compile time and when using generics.
2.  Enables lazy singleton instantiation
3.  Decouples singleton data structure logic from type-specific instantiation logic.
4.  Provides structural performance advantages by isolating runtime binding reader/writer locks and dictionaries by use-case.
Other issues addressed:
1.  DefaultSerializers are now always lazy-bound. This simplified the implementation by ensuring singletons are only set once in the case where a user has specified a custom serializer.
2.  BsonSerializer.Serialize had a bug where a class implementing IBsonSerializable would always be serialized using the IBsonSerializable implemention, even if the implementation was overridden by a registered IBsonSerializer.
