### PR TITLE
Implement CSHARP-451 (Improve deserialization performance by ~22%).

### DIFF
--- a/Bson/Serialization/BsonClassMapSerializer.cs
+++ b/Bson/Serialization/BsonClassMapSerializer.cs
@@ -63,7 +63,7 @@ namespace MongoDB.Bson.Serialization
             }
             else
             {
-                var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(nominalType);
+                var discriminatorConvention = _classMap.GetDiscriminatorConvention();
                 var actualType = discriminatorConvention.GetActualType(bsonReader, nominalType);
                 if (actualType != nominalType)
                 {
@@ -131,7 +131,7 @@ namespace MongoDB.Bson.Serialization
 
                 bsonReader.ReadStartDocument();
                 var missingElementMemberMaps = new HashSet<BsonMemberMap>(classMap.AllMemberMaps); // make a copy!
-                var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(nominalType);
+                var discriminatorConvention = classMap.GetDiscriminatorConvention();
                 while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                 {
                     var elementName = bsonReader.ReadName();
@@ -337,7 +337,7 @@ namespace MongoDB.Bson.Serialization
                     // never write out a discriminator for an anonymous class
                     if (!classMap.IsAnonymous)
                     {
-                        var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(nominalType);
+                        var discriminatorConvention = classMap.GetDiscriminatorConvention();
                         var discriminator = discriminatorConvention.GetDiscriminator(nominalType, actualType);
                         if (discriminator != null)
                         {
@@ -443,7 +443,7 @@ namespace MongoDB.Bson.Serialization
                 }
                 else
                 {
-                    var discriminatorConvention = BsonDefaultSerializer.LookupDiscriminatorConvention(nominalType);
+                    var discriminatorConvention = memberMap.GetDiscriminatorConvention();
                     actualType = discriminatorConvention.GetActualType(bsonReader, nominalType); // returns nominalType if no discriminator found
                 }
                 var serializer = memberMap.GetSerializer(actualType);


### PR DESCRIPTION
Deserialization CPU performance was suffering because both LookupDiscriminatorConvention and LookupSerializer were being called for nearly every class member. Both functions take out and release the global config read-lock. Profiling showed that around 22% of all CPU time was being spent in ReaderWriterLockSlim.TryEnterReadLock and ReaderWriterLockSlim.ExitReadLock due to these functions.
Fix makes the BsonClassMap and BsonMemberMap cache references to the appropriate IDiscriminatorConvention and IBsonSerializer instances. By doing this, lookups are avoided while maintaining semantic correctness due to the associated BsonClassMap and BsonMemberMap types never changing once constructed. Incorporated much feedback from discussion with Robert to simplify changes.

Other issues addressed:
1. BsonSerializer.Serialize had a bug where a class implementing IBsonSerializable would always be serialized using the IBsonSerializable implemention, even if the implementation was overridden by a registered IBsonSerializer.
2. Modified BsonSerializer to allow only one custom serializer to be registered. This prevents cache consistency issues when a serializer instance is cached within a BsonMemberMap.
