### PR TITLE
fix BsonTypeMapper to use custom type mappers for enums

### DIFF
--- a/Bson/ObjectModel/BsonTypeMapper.cs
+++ b/Bson/ObjectModel/BsonTypeMapper.cs
@@ -444,6 +444,15 @@ namespace MongoDB.Bson
             }
 
             var valueType = value.GetType();
+
+            // we check the custom type mappers here because the user
+            // could have defined a type mapper for an enum
+            ICustomBsonTypeMapper customTypeMapper;
+            if (__customTypeMappers.TryGetValue(valueType, out customTypeMapper))
+            {
+                return customTypeMapper.TryMapToBsonValue(value, out bsonValue);
+            }
+
             if (valueType.IsEnum)
             {
                 valueType = Enum.GetUnderlyingType(valueType);
@@ -486,12 +495,6 @@ namespace MongoDB.Bson
             {
                 bsonValue = new BsonArray((IEnumerable)value);
                 return true;
-            }
-
-            ICustomBsonTypeMapper customTypeMapper;
-            if (__customTypeMappers.TryGetValue(valueType, out customTypeMapper))
-            {
-                return customTypeMapper.TryMapToBsonValue(value, out bsonValue);
             }
 
             bsonValue = null;

--- a/BsonUnitTests/ObjectModel/BsonTypeMapperTests.cs
+++ b/BsonUnitTests/ObjectModel/BsonTypeMapperTests.cs
@@ -640,5 +640,31 @@ namespace MongoDB.BsonUnitTests
             Assert.AreEqual(true, BsonTypeMapper.TryMapToBsonValue(customDateTime, out bsonValue));
             Assert.AreEqual(utcNowTruncated, bsonValue.AsDateTime);
         }
+
+        // used by TestCustomTypeMapperEnum
+        public enum CustomEnum : int
+        {
+            V = 1
+        }
+
+        [Test]
+        public void TestCustomTypeMapperEnum()
+        {
+            BsonTypeMapper.RegisterCustomTypeMapper(typeof(CustomEnum), new CustomEnumMapper());
+
+            var enumValue = CustomEnum.V;
+            BsonValue bsonValue;
+            Assert.AreEqual(true, BsonTypeMapper.TryMapToBsonValue(enumValue, out bsonValue));
+            Assert.AreEqual(enumValue.ToString(), bsonValue.AsString);
+        }
+
+        public class CustomEnumMapper : ICustomBsonTypeMapper
+        {
+            public bool TryMapToBsonValue(object value, out BsonValue bsonValue)
+            {
+                bsonValue = new BsonString(((CustomEnum)value).ToString());
+                return true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi there,

this is a small fix to the BsonTypeMapper to accept custom type mappers for enum types. I added a unit test for this scenario as well.

Cheers,
Gregor
