### PR TITLE
Small cleanup refactoring follow up for pull request 113

### DIFF
--- a/Bson/ObjectModel/BsonDocumentWrapper.cs
+++ b/Bson/ObjectModel/BsonDocumentWrapper.cs
@@ -63,8 +63,8 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="wrappedNominalType">The nominal type of the wrapped object.</param>
         /// <param name="wrappedObject">The wrapped object.</param>
-        public BsonDocumentWrapper(Type wrappedNominalType, object value)
-            : this(wrappedNominalType, value, false)
+        public BsonDocumentWrapper(Type wrappedNominalType, object wrappedObject)
+            : this(wrappedNominalType, wrappedObject, false)
         {
         }
 

--- a/Bson/Serialization/BsonClassMap.cs
+++ b/Bson/Serialization/BsonClassMap.cs
@@ -1092,7 +1092,6 @@ namespace MongoDB.Bson.Serialization
                 {
                     _declaredMemberMaps.Sort((x, y) => x.Order.CompareTo(y.Order));
                 }
-
             }
         }
 


### PR DESCRIPTION
1. Factored out four branches in BsonTrieNode.GetChild
   a. Eliminated the need to check _isFrozen
   b. Eliminated the need to check _minKeyByte
   c. Eliminated a CLR bounds check on _keyByteIndexes
   d. Eliminated a CLR bounds check on _children
2. Factored out the maxKeyByte member in BsonTrieNode
3. Refactored a foreach into a for in BsonTrie.TryGetValue (for is faster than foreach on arrays due to better CLR support)
4. Made BsonBuffer.DecodeUtf8String static
5. Factored out a branch in BsonBuffer.DecodeUtf8String
   a. Eliminated a CLR bounds check on __asciiStringTable
6. Updated BsonBuffer.ReadCString to use an Int32 instead of an Object for the default type (carries no GC checking overhead and is the default .Net register type)
7. Fixed a comment typo in BsonTrie.TryGetValue
8. Fixed an XML comment error
9. Switched BsonTrieNode._children from List to Array (Lists are slower than Arrays)
