### PR TITLE
Support for true "And" and "Or" expressions

### DIFF
--- a/Driver/Linq/Translators/PredicateTranslator.cs
+++ b/Driver/Linq/Translators/PredicateTranslator.cs
@@ -60,8 +60,9 @@ namespace MongoDB.Driver.Linq
 
             switch (expression.NodeType)
             {
+                case ExpressionType.And:
                 case ExpressionType.AndAlso:
-                    query = BuildAndAlsoQuery((BinaryExpression)expression);
+                    query = BuildAndQuery((BinaryExpression)expression);
                     break;
                 case ExpressionType.ArrayIndex:
                     query = BuildBooleanQuery(expression);
@@ -86,8 +87,9 @@ namespace MongoDB.Driver.Linq
                 case ExpressionType.Not:
                     query = BuildNotQuery((UnaryExpression)expression);
                     break;
+                case ExpressionType.Or:
                 case ExpressionType.OrElse:
-                    query = BuildOrElseQuery((BinaryExpression)expression);
+                    query = BuildOrQuery((BinaryExpression)expression);
                     break;
                 case ExpressionType.TypeIs:
                     query = BuildTypeIsQuery((TypeBinaryExpression)expression);
@@ -104,7 +106,7 @@ namespace MongoDB.Driver.Linq
         }
 
         // private methods
-        private IMongoQuery BuildAndAlsoQuery(BinaryExpression binaryExpression)
+        private IMongoQuery BuildAndQuery(BinaryExpression binaryExpression)
         {
             return Query.And(BuildQuery(binaryExpression.Left), BuildQuery(binaryExpression.Right));
         }
@@ -773,7 +775,7 @@ namespace MongoDB.Driver.Linq
             return Query.Not(queryDocument);
         }
 
-        private IMongoQuery BuildOrElseQuery(BinaryExpression binaryExpression)
+        private IMongoQuery BuildOrQuery(BinaryExpression binaryExpression)
         {
             return Query.Or(BuildQuery(binaryExpression.Left), BuildQuery(binaryExpression.Right));
         }


### PR DESCRIPTION
Dear Maintainers,

Please consider following small addition as it is an really blocking issue for one of the projects I'm working on.

Here is some background:

We're implementing RESTful API for our system backed by MongoDB. In fact it is an enhanced OData protocol implementation. One of the crucial OData feature we're trying to benefit of is the querying capabilities which matches very good with what mongo provides. See http://www.odata.org/documentation/uri-conventions#FilterSystemQueryOption for examples.

So we're parsing `$filter` URI parameter and building corresponding `Expression` in order to apply it to queryable mongo collection. And most of the times those expressions are of types `Expression.And` and `Expression.Or` (see MSDN article "ExpressionType Enumeration" at http://msdn.microsoft.com/en-us/library/bb361179). But current mongo C# driver does not support this.

From aforementiond MSDN topic

> **And**: A bitwise or logical AND operation, such as (a & b) in C# and (a And b) in Visual Basic.

while

> **AndAlso**: A conditional AND operation that evaluates the second operand only if the first operand evaluates to true. It corresponds to (a && b) in C# and (a AndAlso b) in Visual Basic.

looks like the first expression type (And) is more semantically correct in most of the cases. (Despite of the fact that in most of the cases `&&` operator will be used by developers from the C# code, what makes sense for in-memory collections but not LINQ providers for databases).

I'd be pleased to provide more details in case you need or contribute in any other way.

Regards,
Igor Toporet
