### PR TITLE
Fix CSHARP-541: Make BsonClassMap<TClass>.MapMember Typesafe

### DIFF
--- a/BsonUnitTests/DefaultSerializer/BsonClassMapTests.cs
+++ b/BsonUnitTests/DefaultSerializer/BsonClassMapTests.cs
@@ -114,7 +114,9 @@ namespace MongoDB.BsonUnitTests.Serialization
         [Test]
         public void TestMapField()
         {
+#pragma warning disable 618 // MapField is obsolete
             var classMap = new BsonClassMap<C>(cm => cm.MapField("f"));
+#pragma warning restore
             var memberMap = classMap.GetMemberMap("f");
             Assert.IsNotNull(memberMap);
             Assert.AreEqual("f", memberMap.ElementName);
@@ -124,7 +126,9 @@ namespace MongoDB.BsonUnitTests.Serialization
         [Test]
         public void TestMapIdField()
         {
+#pragma warning disable 618 // MapIdField is obsolete
             var classMap = new BsonClassMap<C>(cm => cm.MapIdField("f"));
+#pragma warning restore
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
             Assert.AreEqual("_id", idMemberMap.ElementName);
@@ -145,7 +149,9 @@ namespace MongoDB.BsonUnitTests.Serialization
         [Test]
         public void TestMapIdProperty()
         {
+#pragma warning disable 618 // MapIdProperty is obsolete
             var classMap = new BsonClassMap<C>(cm => cm.MapIdProperty("p"));
+#pragma warning restore
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
             Assert.AreEqual("_id", idMemberMap.ElementName);
@@ -166,7 +172,9 @@ namespace MongoDB.BsonUnitTests.Serialization
         [Test]
         public void TestMapProperty()
         {
+#pragma warning disable 618 // MapIdProperty is obsolete
             var classMap = new BsonClassMap<C>(cm => cm.MapProperty("p"));
+#pragma warning restore
             var memberMap = classMap.GetMemberMap("p");
             Assert.IsNotNull(memberMap);
             Assert.AreEqual("p", memberMap.ElementName);
@@ -188,7 +196,9 @@ namespace MongoDB.BsonUnitTests.Serialization
         [Test]
         public void TestMapField()
         {
+#pragma warning disable 618 // MapField is obsolete
             var classMap = new BsonClassMap<C>(cm => cm.MapField(c => c.F));
+#pragma warning restore
             var memberMap = classMap.GetMemberMap("F");
             Assert.IsNotNull(memberMap);
             Assert.AreEqual("F", memberMap.ElementName);
@@ -198,7 +208,9 @@ namespace MongoDB.BsonUnitTests.Serialization
         [Test]
         public void TestMapIdField()
         {
+#pragma warning disable 618 // MapIdField is obsolete
             var classMap = new BsonClassMap<C>(cm => cm.MapIdField(c => c.F));
+#pragma warning restore
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
             Assert.AreEqual("_id", idMemberMap.ElementName);
@@ -218,7 +230,9 @@ namespace MongoDB.BsonUnitTests.Serialization
         [Test]
         public void TestMapIdProperty()
         {
+#pragma warning disable 618 // MapIdProperty is obsolete
             var classMap = new BsonClassMap<C>(cm => cm.MapIdProperty(c => c.P));
+#pragma warning restore
             var idMemberMap = classMap.IdMemberMap;
             Assert.IsNotNull(idMemberMap);
             Assert.AreEqual("_id", idMemberMap.ElementName);
@@ -238,7 +252,9 @@ namespace MongoDB.BsonUnitTests.Serialization
         [Test]
         public void TestMapProperty()
         {
+#pragma warning disable 618 // MapProperty is obsolete
             var classMap = new BsonClassMap<C>(cm => cm.MapProperty(c => c.P));
+#pragma warning restore
             var memberMap = classMap.GetMemberMap("P");
             Assert.IsNotNull(memberMap);
             Assert.AreEqual("P", memberMap.ElementName);
@@ -266,11 +282,13 @@ namespace MongoDB.BsonUnitTests.Serialization
             {
                 cm.AutoMap();
                 cm.SetIdMember(cm.GetMemberMap("Id"));
+#pragma warning disable 618 // UnmapField and UnmapProperty are obsolete
                 cm.UnmapField("Id");
                 cm.UnmapField("FieldUnmappedByName");
                 cm.UnmapField(c => c.FieldUnmappedByLambda);
                 cm.UnmapProperty("PropertyUnmappedByName");
                 cm.UnmapProperty(c => c.PropertyUnmappedByLambda);
+#pragma warning restore
             });
             classMap.Freeze();
             Assert.IsNull(classMap.IdMemberMap);

--- a/BsonUnitTests/DefaultSerializer/BsonSerializerTests.cs
+++ b/BsonUnitTests/DefaultSerializer/BsonSerializerTests.cs
@@ -71,11 +71,11 @@ namespace MongoDB.BsonUnitTests.Serialization
             {
                 BsonClassMap.RegisterClassMap<Employee>(cm =>
                 {
-                    cm.MapIdProperty(e => e.EmployeeId);
-                    cm.MapProperty(e => e.FirstName).SetElementName("fn");
-                    cm.MapProperty(e => e.LastName).SetElementName("ln");
-                    cm.MapProperty(e => e.DateOfBirth).SetElementName("dob").SetSerializer(new DateOfBirthSerializer());
-                    cm.MapProperty(e => e.Age).SetElementName("age");
+                    cm.MapIdMember(e => e.EmployeeId);
+                    cm.MapMember(e => e.FirstName).SetElementName("fn");
+                    cm.MapMember(e => e.LastName).SetElementName("ln");
+                    cm.MapMember(e => e.DateOfBirth).SetElementName("dob").SetSerializer(new DateOfBirthSerializer());
+                    cm.MapMember(e => e.Age).SetElementName("age");
                 });
             }
 


### PR DESCRIPTION
Fix for CSHARP-541: Make BsonClassMap<TClass>.MapMember Typesafe
- Rebased on top latest changes from master
- Added a strongly typed BsonMemberMap
- Made MapMember variants return a strongly typed BsonMemberMap
  - This made it simpler to write member mapping code
    - Before: BsonClassMap.RegisterClassMap<MyType>(classMap => { classMap.AutoMap(); classMap.MapMember(myType => myType.MyField).SetShouldSerializeMethod(obj => !((MyType)obj).MyField != null); });
    - After: BsonClassMap.RegisterClassMap<MyType>(classMap => { classMap.AutoMap(); classMap.MapMember(myType => myType.MyField).SetShouldSerializeMethod(myType => myType.MyField != null); });
- Deprecated MapField, MapProperty, MapIdField, MapIdProperty, MapExtraElementsField, MapExtraElementsProperty, UnmapField, and UnmapProperty
  - In .Net it is forbidden to have have a property and field with the same name; having both *Field and *Property versions when the API was capable of determining what to do needlessly complicated the API.
  - The lambda versions were semantically incorrect as they were calling MapMember, which does not distinguish between fields and properties.
  - All of this code was refactored to a few small versions, which reduced bloat (for example, all versions called MapMember, which performs argument validation and freeze checking).
- Fixed a small validation bug in SetSerializeDefaultValue
- Eliminated the custom GetDefaultValue code in BsonMemberMap and replaced it with default(TMember)
