### PR TITLE
Improve Bson Deserialization Performance by 10-15% (Refactor Discriminator Code)

### DIFF
--- a/Bson/Bson.csproj
+++ b/Bson/Bson.csproj
@@ -150,6 +150,9 @@
     <Compile Include="Serialization\BsonSerializationInfo.cs" />
     <Compile Include="Serialization\Serializers\CollectionGenericSerializers.cs" />
     <Compile Include="Serialization\Serializers\CollectionSerializers.cs" />
+    <Compile Include="Serialization\Serializers\NullSerializer.cs" />
+    <Compile Include="Serialization\Serializers\SerializerHolder.cs" />
+    <Compile Include="Serialization\Serializers\DiscriminatorSerializer.cs" />
     <Compile Include="Serialization\Serializers\KeyValuePairSerializer.cs" />
     <Compile Include="Serialization\Serializers\DictionaryGenericSerializer.cs" />
     <Compile Include="Serialization\Serializers\DictionarySerializer.cs" />

--- a/Bson/Serialization/Attributes/BsonSerializationOptionsAttribute.cs
+++ b/Bson/Serialization/Attributes/BsonSerializationOptionsAttribute.cs
@@ -20,6 +20,7 @@ using System.Text;
 
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Options;
+using MongoDB.Bson.Serialization.Serializers;
 
 namespace MongoDB.Bson.Serialization.Attributes
 {
@@ -43,7 +44,8 @@ namespace MongoDB.Bson.Serialization.Attributes
         /// <param name="memberMap">The member map.</param>
         public virtual void Apply(BsonMemberMap memberMap)
         {
-            var memberSerializer = memberMap.GetSerializer(memberMap.MemberType);
+            var memberSerializer = memberMap.GetSerializer();
+            memberSerializer = DiscriminatorSerializer.Unwrap(memberSerializer);
             var memberSerializationOptions = memberMap.SerializationOptions;
             if (memberSerializationOptions == null)
             {

--- a/Bson/Serialization/Serializers/ArraySerializer.cs
+++ b/Bson/Serialization/Serializers/ArraySerializer.cs
@@ -32,6 +32,9 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// <typeparam name="T">The type of the elements.</typeparam>
     public class ArraySerializer<T> : BsonBaseSerializer, IBsonArraySerializer
     {
+        // private static fields
+        private static SerializerHolder __elementHolder = new SerializerHolder(typeof(T));
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the ArraySerializer class.
@@ -67,14 +70,12 @@ namespace MongoDB.Bson.Serialization.Serializers
                     bsonReader.ReadNull();
                     return null;
                 case BsonType.Array:
+                    var elementSerializer = __elementHolder.Value;
                     bsonReader.ReadStartArray();
-                    var discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(typeof(T));
                     var list = new List<T>();
                     while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                     {
-                        var elementType = discriminatorConvention.GetActualType(bsonReader, typeof(T));
-                        var serializer = BsonSerializer.LookupSerializer(elementType);
-                        var element = (T)serializer.Deserialize(bsonReader, typeof(T), elementType, itemSerializationOptions);
+                        var element = (T)elementSerializer.Deserialize(bsonReader, typeof(T), itemSerializationOptions);
                         list.Add(element);
                     }
                     bsonReader.ReadEndArray();
@@ -141,10 +142,11 @@ namespace MongoDB.Bson.Serialization.Serializers
                 var arraySerializationOptions = EnsureSerializationOptions<ArraySerializationOptions>(options);
                 var itemSerializationOptions = arraySerializationOptions.ItemSerializationOptions;
 
+                var elementSerializer = __elementHolder.Value;
                 bsonWriter.WriteStartArray();
                 for (int index = 0; index < array.Length; index++)
                 {
-                    BsonSerializer.Serialize(bsonWriter, typeof(T), array[index], itemSerializationOptions);
+                    elementSerializer.Serialize(bsonWriter, typeof(T), array[index], itemSerializationOptions);
                 }
                 bsonWriter.WriteEndArray();
             }
@@ -157,6 +159,9 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// <typeparam name="T">The type of the elements.</typeparam>
     public class TwoDimensionalArraySerializer<T> : BsonBaseSerializer
     {
+        // private static fields
+        private static SerializerHolder __elementHolder = new SerializerHolder(typeof(T));
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the TwoDimensionalArraySerializer class.
@@ -193,8 +198,8 @@ namespace MongoDB.Bson.Serialization.Serializers
                     bsonReader.ReadNull();
                     return null;
                 case BsonType.Array:
+                    var elementSerializer = __elementHolder.Value;
                     bsonReader.ReadStartArray();
-                    var discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(typeof(T));
                     var outerList = new List<List<T>>();
                     while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                     {
@@ -202,9 +207,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                         var innerList = new List<T>();
                         while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                         {
-                            var elementType = discriminatorConvention.GetActualType(bsonReader, typeof(T));
-                            var serializer = BsonSerializer.LookupSerializer(elementType);
-                            var element = (T)serializer.Deserialize(bsonReader, typeof(T), elementType, itemSerializationOptions);
+                            var element = (T)elementSerializer.Deserialize(bsonReader, typeof(T), itemSerializationOptions);
                             innerList.Add(element);
                         }
                         bsonReader.ReadEndArray();
@@ -279,6 +282,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 var arraySerializationOptions = EnsureSerializationOptions<ArraySerializationOptions>(options);
                 var itemSerializationOptions = arraySerializationOptions.ItemSerializationOptions;
 
+                var elementSerializer = __elementHolder.Value;
                 bsonWriter.WriteStartArray();
                 var length1 = array.GetLength(0);
                 var length2 = array.GetLength(1);
@@ -287,7 +291,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                     bsonWriter.WriteStartArray();
                     for (int j = 0; j < length2; j++)
                     {
-                        BsonSerializer.Serialize(bsonWriter, typeof(T), array[i, j], itemSerializationOptions);
+                        elementSerializer.Serialize(bsonWriter, typeof(T), array[i, j], itemSerializationOptions);
                     }
                     bsonWriter.WriteEndArray();
                 }
@@ -302,6 +306,9 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// <typeparam name="T">The type of the elements.</typeparam>
     public class ThreeDimensionalArraySerializer<T> : BsonBaseSerializer
     {
+        // private static fields
+        private static SerializerHolder __elementHolder = new SerializerHolder(typeof(T));
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the ThreeDimensionalArraySerializer class.
@@ -338,6 +345,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                     bsonReader.ReadNull();
                     return null;
                 case BsonType.Array:
+                    var elementSerializer = __elementHolder.Value;
                     bsonReader.ReadStartArray();
                     var discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(typeof(T));
                     var outerList = new List<List<List<T>>>();
@@ -351,9 +359,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                             var innerList = new List<T>();
                             while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                             {
-                                var elementType = discriminatorConvention.GetActualType(bsonReader, typeof(T));
-                                var serializer = BsonSerializer.LookupSerializer(elementType);
-                                var element = (T)serializer.Deserialize(bsonReader, typeof(T), elementType, itemSerializationOptions);
+                                var element = (T)elementSerializer.Deserialize(bsonReader, typeof(T), itemSerializationOptions);
                                 innerList.Add(element);
                             }
                             bsonReader.ReadEndArray();
@@ -441,6 +447,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 var arraySerializationOptions = EnsureSerializationOptions<ArraySerializationOptions>(options);
                 var itemSerializationOptions = arraySerializationOptions.ItemSerializationOptions;
 
+                var elementSerializer = __elementHolder.Value;
                 bsonWriter.WriteStartArray();
                 var length1 = array.GetLength(0);
                 var length2 = array.GetLength(1);
@@ -453,7 +460,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                         bsonWriter.WriteStartArray();
                         for (int k = 0; k < length3; k++)
                         {
-                            BsonSerializer.Serialize(bsonWriter, typeof(T), array[i, j, k], itemSerializationOptions);
+                            elementSerializer.Serialize(bsonWriter, typeof(T), array[i, j, k], itemSerializationOptions);
                         }
                         bsonWriter.WriteEndArray();
                     }

--- a/Bson/Serialization/Serializers/CollectionGenericSerializers.cs
+++ b/Bson/Serialization/Serializers/CollectionGenericSerializers.cs
@@ -32,6 +32,9 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// <typeparam name="T">The type of the elements.</typeparam>
     public class EnumerableSerializer<T> : BsonBaseSerializer, IBsonArraySerializer
     {
+        // private static fields
+        private static SerializerHolder __elementHolder = new SerializerHolder(typeof(T));
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the EnumerableSerializer class.
@@ -66,14 +69,13 @@ namespace MongoDB.Bson.Serialization.Serializers
                     bsonReader.ReadNull();
                     return null;
                 case BsonType.Array:
+                    var elementSerializer = __elementHolder.Value;
                     bsonReader.ReadStartArray();
                     var collection = CreateInstance(actualType);
                     var discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(typeof(T));
                     while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                     {
-                        var elementType = discriminatorConvention.GetActualType(bsonReader, typeof(T));
-                        var serializer = BsonSerializer.LookupSerializer(elementType);
-                        var element = (T)serializer.Deserialize(bsonReader, typeof(T), elementType, itemSerializationOptions);
+                        var element = (T)elementSerializer.Deserialize(bsonReader, typeof(T), itemSerializationOptions);
                         collection.Add(element);
                     }
                     bsonReader.ReadEndArray();
@@ -98,7 +100,8 @@ namespace MongoDB.Bson.Serialization.Serializers
         public BsonSerializationInfo GetItemSerializationInfo()
         {
             string elementName = null;
-            var serializer = BsonSerializer.LookupSerializer(typeof(T));
+            var serializer = __elementHolder.Value;
+            serializer = DiscriminatorSerializer.Unwrap(serializer);
             var nominalType = typeof(T);
             IBsonSerializationOptions serializationOptions = null;
             return new BsonSerializationInfo(elementName, serializer, nominalType, serializationOptions);
@@ -138,10 +141,11 @@ namespace MongoDB.Bson.Serialization.Serializers
                 var arraySerializationOptions = EnsureSerializationOptions<ArraySerializationOptions>(options);
                 var itemSerializationOptions = arraySerializationOptions.ItemSerializationOptions;
 
+                var elementSerializer = __elementHolder.Value;
                 bsonWriter.WriteStartArray();
                 foreach (var item in items)
                 {
-                    BsonSerializer.Serialize(bsonWriter, typeof(T), item, itemSerializationOptions);
+                    elementSerializer.Serialize(bsonWriter, typeof(T), item, itemSerializationOptions);
                 }
                 bsonWriter.WriteEndArray();
             }
@@ -190,6 +194,9 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// <typeparam name="T">The type of the elements.</typeparam>
     public class QueueSerializer<T> : BsonBaseSerializer, IBsonArraySerializer
     {
+        // private static fields
+        private static SerializerHolder __elementHolder = new SerializerHolder(typeof(T));
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the QueueSerializer class.
@@ -224,14 +231,13 @@ namespace MongoDB.Bson.Serialization.Serializers
                     bsonReader.ReadNull();
                     return null;
                 case BsonType.Array:
+                    var elementSerializer = __elementHolder.Value;
                     bsonReader.ReadStartArray();
                     var queue = new Queue<T>();
                     var discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(typeof(T));
                     while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                     {
-                        var elementType = discriminatorConvention.GetActualType(bsonReader, typeof(T));
-                        var serializer = BsonSerializer.LookupSerializer(elementType);
-                        var element = (T)serializer.Deserialize(bsonReader, typeof(T), elementType, itemSerializationOptions);
+                        var element = (T)elementSerializer.Deserialize(bsonReader, typeof(T), itemSerializationOptions);
                         queue.Enqueue(element);
                     }
                     bsonReader.ReadEndArray();
@@ -256,7 +262,8 @@ namespace MongoDB.Bson.Serialization.Serializers
         public BsonSerializationInfo GetItemSerializationInfo()
         {
             string elementName = null;
-            var serializer = BsonSerializer.LookupSerializer(typeof(T));
+            var serializer = __elementHolder.Value;
+            serializer = DiscriminatorSerializer.Unwrap(serializer);
             var nominalType = typeof(T);
             IBsonSerializationOptions serializationOptions = null;
             return new BsonSerializationInfo(elementName, serializer, nominalType, serializationOptions);
@@ -296,10 +303,11 @@ namespace MongoDB.Bson.Serialization.Serializers
                 var arraySerializationOptions = EnsureSerializationOptions<ArraySerializationOptions>(options);
                 var itemSerializationOptions = arraySerializationOptions.ItemSerializationOptions;
 
+                var elementSerializer = __elementHolder.Value;
                 bsonWriter.WriteStartArray();
                 foreach (var item in items)
                 {
-                    BsonSerializer.Serialize(bsonWriter, typeof(T), item, itemSerializationOptions);
+                    elementSerializer.Serialize(bsonWriter, typeof(T), item, itemSerializationOptions);
                 }
                 bsonWriter.WriteEndArray();
             }
@@ -312,6 +320,9 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// <typeparam name="T">The type of the elements.</typeparam>
     public class StackSerializer<T> : BsonBaseSerializer, IBsonArraySerializer
     {
+        // private static fields
+        private static SerializerHolder __elementHolder = new SerializerHolder(typeof(T));
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the StackSerializer class.
@@ -346,14 +357,13 @@ namespace MongoDB.Bson.Serialization.Serializers
                     bsonReader.ReadNull();
                     return null;
                 case BsonType.Array:
+                    var elementSerializer = __elementHolder.Value;
                     bsonReader.ReadStartArray();
                     var stack = new Stack<T>();
                     var discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(typeof(T));
                     while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                     {
-                        var elementType = discriminatorConvention.GetActualType(bsonReader, typeof(T));
-                        var serializer = BsonSerializer.LookupSerializer(elementType);
-                        var element = (T)serializer.Deserialize(bsonReader, typeof(T), elementType, itemSerializationOptions);
+                        var element = (T)elementSerializer.Deserialize(bsonReader, typeof(T), itemSerializationOptions);
                         stack.Push(element);
                     }
                     bsonReader.ReadEndArray();
@@ -378,7 +388,8 @@ namespace MongoDB.Bson.Serialization.Serializers
         public BsonSerializationInfo GetItemSerializationInfo()
         {
             string elementName = null;
-            var serializer = BsonSerializer.LookupSerializer(typeof(T));
+            var serializer = __elementHolder.Value;
+            serializer = DiscriminatorSerializer.Unwrap(serializer);
             var nominalType = typeof(T);
             IBsonSerializationOptions serializationOptions = null;
             return new BsonSerializationInfo(elementName, serializer, nominalType, serializationOptions);
@@ -419,10 +430,11 @@ namespace MongoDB.Bson.Serialization.Serializers
                 var itemSerializationOptions = arraySerializationOptions.ItemSerializationOptions;
 
                 // serialize first pushed item first (reverse of enumeration order)
+                var elementSerializer = __elementHolder.Value;
                 bsonWriter.WriteStartArray();
                 for (var i = items.Length - 1; i >= 0; i--)
                 {
-                    BsonSerializer.Serialize(bsonWriter, typeof(T), items[i], itemSerializationOptions);
+                    elementSerializer.Serialize(bsonWriter, typeof(T), items[i], itemSerializationOptions);
                 }
                 bsonWriter.WriteEndArray();
             }

--- a/Bson/Serialization/Serializers/DictionaryGenericSerializer.cs
+++ b/Bson/Serialization/Serializers/DictionaryGenericSerializer.cs
@@ -109,7 +109,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                         bsonReader,
                         typeof(KeyValuePair<TKey, TValue>),
                         keyValuePairSerializationOptions);
-                    dictionary.Add(keyValuePair);
+                    dictionary.Add(keyValuePair.Key, keyValuePair.Value);
                 }
                 bsonReader.ReadEndArray();
 

--- a/Bson/Serialization/Serializers/DiscriminatorSerializer.cs
+++ b/Bson/Serialization/Serializers/DiscriminatorSerializer.cs
@@ -1,0 +1,164 @@
+﻿/* Copyright 2010-2012 10gen Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace MongoDB.Bson.Serialization.Serializers
+{
+    /// <summary>
+    /// Represents a wrapper for serializers with discriminators.
+    /// </summary>
+    public class DiscriminatorSerializer : IBsonSerializer
+    {
+        // private fields
+        private readonly Type _nominalType;
+        private readonly IDiscriminatorConvention _discriminatorConvention;
+        private readonly IBsonSerializer _serializer;
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the KeyValuePairSerializer class.
+        /// </summary>
+        private DiscriminatorSerializer(
+            Type nominalType,
+            IBsonSerializer serializer)
+        {
+            _nominalType = nominalType;
+            _discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(nominalType);
+            _serializer = serializer;
+        }
+
+        // public static methods
+        /// <summary>
+        /// Creates a DiscriminatorSerializer for a Type if the type is discriminated.
+        /// </summary>
+        /// <param name="type">The Type.</param>
+        /// <returns>A serializer for the Type.</returns>
+        public static IBsonSerializer Create(Type type)
+        {
+            var serializer = BsonSerializer.LookupSerializer(type);
+            // no discriminator required if the type cannot be inherrited
+            if ((!type.IsClass && !type.IsInterface) || type.IsSealed)
+            {
+                return serializer;
+            }
+            return new DiscriminatorSerializer(type, serializer);
+        }
+
+        /// <summary>
+        /// Unwraps the inner serializer if a serializer is a DiscriminatorSerializer.
+        /// </summary>
+        /// <param name="serializer">The serializer.</param>
+        /// <returns>The inner serializer.</returns>
+        public static IBsonSerializer Unwrap(IBsonSerializer serializer)
+        {
+            var discriminatorSerializer = serializer as DiscriminatorSerializer;
+            return discriminatorSerializer != null ? discriminatorSerializer._serializer : serializer;
+        }
+
+        // public methods
+        /// <summary>
+        /// Deserializes an object from a BsonReader.
+        /// </summary>
+        /// <param name="bsonReader">The BsonReader.</param>
+        /// <param name="nominalType">The nominal type of the object.</param>
+        /// <param name="options">The serialization options.</param>
+        /// <returns>An object.</returns>
+        public object Deserialize(BsonReader bsonReader, Type nominalType, IBsonSerializationOptions options)
+        {
+            VerifyType(nominalType);
+
+            var actualType = _discriminatorConvention.GetActualType(bsonReader, nominalType);
+            var serializer = actualType == _nominalType ?
+                _serializer : BsonSerializer.LookupSerializer(actualType);
+            return serializer.Deserialize(bsonReader, _nominalType, actualType, options);
+        }
+
+        /// <summary>
+        /// Deserializes an object from a BsonReader.
+        /// </summary>
+        /// <param name="bsonReader">The BsonReader.</param>
+        /// <param name="nominalType">The nominal type of the object.</param>
+        /// <param name="actualType">The actual type of the object.</param>
+        /// <param name="options">The serialization options.</param>
+        /// <returns>An object.</returns>
+        public object Deserialize(
+            BsonReader bsonReader,
+            Type nominalType,
+            Type actualType,
+            IBsonSerializationOptions options)
+        {
+            return _serializer.Deserialize(bsonReader, nominalType, actualType, options);
+        }
+
+        /// <summary>
+        /// Gets the default serialization options for this serializer.
+        /// </summary>
+        /// <returns>The default serialization options for this serializer.</returns>
+        public IBsonSerializationOptions GetDefaultSerializationOptions()
+        {
+            return _serializer.GetDefaultSerializationOptions();
+        }
+
+        /// <summary>
+        /// Serializes an object to a BsonWriter.
+        /// </summary>
+        /// <param name="bsonWriter">The BsonWriter.</param>
+        /// <param name="nominalType">The nominal type.</param>
+        /// <param name="value">The object.</param>
+        /// <param name="options">The serialization options.</param>
+        public void Serialize(
+            BsonWriter bsonWriter,
+            Type nominalType,
+            object value,
+            IBsonSerializationOptions options)
+        {
+            VerifyNominalType(nominalType);
+
+            var actualType = value != null ? value.GetType() : nominalType;
+            var serializer = actualType == _nominalType ?
+                _serializer : BsonSerializer.LookupSerializer(actualType);
+            serializer.Serialize(bsonWriter, _nominalType, value, options);
+        }
+
+        // private methods
+        private void VerifyType(Type type)
+        {
+            if (type != _nominalType)
+            {
+                var message = string.Format(
+                    "DiscriminatorSerializer for type {0} cannot be used with type {1}.",
+                    _nominalType,
+                    type.FullName);
+                throw new BsonSerializationException(message);
+            }
+        }
+
+        private void VerifyNominalType(Type nominalType)
+        {
+            if (nominalType != _nominalType && !_nominalType.IsAssignableFrom(nominalType))
+            {
+                var message = string.Format(
+                    "DiscriminatorSerializer for type {0} cannot be used with type {1}.",
+                    _nominalType,
+                    nominalType.FullName);
+                throw new BsonSerializationException(message);
+            }
+        }
+    }
+}

--- a/Bson/Serialization/Serializers/KeyValuePairSerializer.cs
+++ b/Bson/Serialization/Serializers/KeyValuePairSerializer.cs
@@ -34,12 +34,8 @@ namespace MongoDB.Bson.Serialization.Serializers
     {
         // private static fields
         private static readonly BsonTrie<bool> __bsonTrie = BuildBsonTrie();
-
-        // private fields
-        private volatile IDiscriminatorConvention _cachedKeyDiscriminatorConvention;
-        private volatile IDiscriminatorConvention _cachedValueDiscriminatorConvention;
-        private volatile IBsonSerializer _cachedKeySerializer;
-        private volatile IBsonSerializer _cachedValueSerializer;
+        private static SerializerHolder __keyHolder = new SerializerHolder(typeof(TKey));
+        private static SerializerHolder __valueHolder = new SerializerHolder(typeof(TValue));
 
         // constructors
         /// <summary>
@@ -77,23 +73,19 @@ namespace MongoDB.Bson.Serialization.Serializers
             VerifyTypes(nominalType, actualType, typeof(KeyValuePair<TKey, TValue>));
             var keyValuePairSerializationOptions = EnsureSerializationOptions<KeyValuePairSerializationOptions>(options);
 
-            var keyDiscriminatorConvention = GetKeyDiscriminatorConvention();
-            var valueDiscriminatorConvention = GetValueDiscriminatorConvention();
             TKey key;
-            TValue value;            
+            TValue value;
 
+            var keySerializer = __keyHolder.Value;
+            var valueSerializer = __valueHolder.Value;
             var bsonType = bsonReader.GetCurrentBsonType();
             if (bsonType == BsonType.Array)
             {
                 bsonReader.ReadStartArray();
                 bsonReader.ReadBsonType();
-                var keyType = keyDiscriminatorConvention.GetActualType(bsonReader, typeof(TKey));
-                var keySerializer = GetKeySerializer(keyType);
-                key = (TKey)keySerializer.Deserialize(bsonReader, typeof(TKey), keyType, keyValuePairSerializationOptions.KeySerializationOptions);
+                key = (TKey)keySerializer.Deserialize(bsonReader, typeof(TKey), keyValuePairSerializationOptions.KeySerializationOptions);
                 bsonReader.ReadBsonType();
-                var valueType = valueDiscriminatorConvention.GetActualType(bsonReader, typeof(TValue));
-                var valueSerializer = GetValueSerializer(valueType);
-                value = (TValue)valueSerializer.Deserialize(bsonReader, typeof(TValue), valueType, keyValuePairSerializationOptions.ValueSerializationOptions);
+                value = (TValue)valueSerializer.Deserialize(bsonReader, typeof(TValue), keyValuePairSerializationOptions.ValueSerializationOptions);
                 bsonReader.ReadEndArray();
             }
             else if (bsonType == BsonType.Document)
@@ -111,16 +103,12 @@ namespace MongoDB.Bson.Serialization.Serializers
                     {
                         if (elementIsKey)
                         {
-                            var keyType = keyDiscriminatorConvention.GetActualType(bsonReader, typeof(TKey));
-                            var keySerializer = GetValueSerializer(keyType);
-                            key = (TKey)keySerializer.Deserialize(bsonReader, typeof(TKey), keyType, keyValuePairSerializationOptions.KeySerializationOptions);
+                            key = (TKey)keySerializer.Deserialize(bsonReader, typeof(TKey), keyValuePairSerializationOptions.KeySerializationOptions);
                             keyFound = true;
                         }
                         else
                         {
-                            var valueType = valueDiscriminatorConvention.GetActualType(bsonReader, typeof(TValue));
-                            var valueSerializer = GetValueSerializer(valueType);
-                            value = (TValue)valueSerializer.Deserialize(bsonReader, typeof(TValue), valueType, keyValuePairSerializationOptions.ValueSerializationOptions);
+                            value = (TValue)valueSerializer.Deserialize(bsonReader, typeof(TValue), keyValuePairSerializationOptions.ValueSerializationOptions);
                             valueFound = true;
                         }
                     }
@@ -169,8 +157,8 @@ namespace MongoDB.Bson.Serialization.Serializers
             var keyValuePair = (KeyValuePair<TKey, TValue>)value;
             var keyValuePairSerializationOptions = EnsureSerializationOptions<KeyValuePairSerializationOptions>(options);
 
-            var keySerializer = GetKeySerializer(keyValuePair.Key.GetType());
-            var valueSerializer = GetValueSerializer(keyValuePair.Value.GetType());
+            var keySerializer = __keyHolder.Value;
+            var valueSerializer = __valueHolder.Value;
             switch (keyValuePairSerializationOptions.Representation)
             {
                 case BsonType.Array:
@@ -207,91 +195,6 @@ namespace MongoDB.Bson.Serialization.Serializers
             bsonTrie.Add("k", true); // is key
             bsonTrie.Add("v", false);
             return bsonTrie;
-        }
-
-        // private methods
-        /// <summary>
-        /// Gets the discriminator convention for keys.
-        /// </summary>
-        /// <returns>The discriminator convention for the class.</returns>
-        private IDiscriminatorConvention GetKeyDiscriminatorConvention()
-        {
-            // return a cached discriminator convention when possible
-            var discriminatorConvention = _cachedKeyDiscriminatorConvention;
-            if (discriminatorConvention == null)
-            {
-                // it's possible but harmless for multiple threads to do the initial lookup at the same time
-                discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(typeof(TKey));
-                _cachedKeyDiscriminatorConvention = discriminatorConvention;
-            }
-            return discriminatorConvention;
-        }
-
-        /// <summary>
-        /// Gets the key serializer.
-        /// </summary>
-        /// <param name="actualType">The actual type of the key.</param>
-        /// <returns>The serializer for the key type.</returns>
-        private IBsonSerializer GetKeySerializer(Type actualType)
-        {
-            // return a cached serializer when possible
-            if (actualType == typeof(TKey))
-            {
-                var serializer = _cachedKeySerializer;
-                if (serializer == null)
-                {
-                    // it's possible but harmless for multiple threads to do the initial lookup at the same time
-                    serializer = BsonSerializer.LookupSerializer(typeof(TKey));
-                    _cachedKeySerializer = serializer;
-                }
-                return serializer;
-            }
-            else
-            {
-                return BsonSerializer.LookupSerializer(actualType);
-            }
-        }
-
-        /// <summary>
-        /// Gets the discriminator convention for values.
-        /// </summary>
-        /// <returns>The discriminator convention for the class.</returns>
-        private IDiscriminatorConvention GetValueDiscriminatorConvention()
-        {
-            // return a cached discriminator convention when possible
-            var discriminatorConvention = _cachedValueDiscriminatorConvention;
-            if (discriminatorConvention == null)
-            {
-                // it's possible but harmless for multiple threads to do the initial lookup at the same time
-                discriminatorConvention = BsonSerializer.LookupDiscriminatorConvention(typeof(TValue));
-                _cachedValueDiscriminatorConvention = discriminatorConvention;
-            }
-            return discriminatorConvention;
-        }
-
-        /// <summary>
-        /// Gets the value serializer.
-        /// </summary>
-        /// <param name="actualType">The actual type of the value.</param>
-        /// <returns>The serializer for the value type.</returns>
-        private IBsonSerializer GetValueSerializer(Type actualType)
-        {
-            // return a cached serializer when possible
-            if (actualType == typeof(TValue))
-            {
-                var serializer = _cachedValueSerializer;
-                if (serializer == null)
-                {
-                    // it's possible but harmless for multiple threads to do the initial lookup at the same time
-                    serializer = BsonSerializer.LookupSerializer(typeof(TValue));
-                    _cachedValueSerializer = serializer;
-                }
-                return serializer;
-            }
-            else
-            {
-                return BsonSerializer.LookupSerializer(actualType);
-            }
         }
     }
 }

--- a/Bson/Serialization/Serializers/NullSerializer.cs
+++ b/Bson/Serialization/Serializers/NullSerializer.cs
@@ -1,0 +1,136 @@
+﻿/* Copyright 2010-2012 10gen Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+using MongoDB.Bson.IO;
+
+namespace MongoDB.Bson.Serialization.Serializers
+{
+    /// <summary>
+    /// Represents a placeholder serializer for null values.
+    /// </summary>
+    public class NullSerializer : IBsonSerializer
+    {
+        // private fields
+        private readonly Type _nominalType;
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the KeyValuePairSerializer class.
+        /// </summary>
+        /// <param name="nominalType">The Type.</param>
+        public NullSerializer(
+            Type nominalType)
+        {
+            _nominalType = nominalType;
+        }
+
+        // public methods
+        /// <summary>
+        /// Deserializes an object from a BsonReader.
+        /// </summary>
+        /// <param name="bsonReader">The BsonReader.</param>
+        /// <param name="nominalType">The nominal type of the object.</param>
+        /// <param name="options">The serialization options.</param>
+        /// <returns>An object.</returns>
+        public object Deserialize(BsonReader bsonReader, Type nominalType, IBsonSerializationOptions options)
+        {
+            return this.Deserialize(bsonReader, nominalType, nominalType, options);
+        }
+
+        /// <summary>
+        /// Deserializes an object from a BsonReader.
+        /// </summary>
+        /// <param name="bsonReader">The BsonReader.</param>
+        /// <param name="nominalType">The nominal type of the object.</param>
+        /// <param name="actualType">The actual type of the object.</param>
+        /// <param name="options">The serialization options.</param>
+        /// <returns>An object.</returns>
+        public object Deserialize(
+            BsonReader bsonReader,
+            Type nominalType,
+            Type actualType,
+            IBsonSerializationOptions options)
+        {
+            VerifyType(nominalType);
+
+            var bsonType = bsonReader.GetCurrentBsonType();
+            if (bsonType != BsonType.Null)
+            {
+                var message = string.Format("BsonType {0} is unsupported.", bsonType);
+                throw new BsonSerializationException(message);
+            }
+            bsonReader.ReadNull();
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the default serialization options for this serializer.
+        /// </summary>
+        /// <returns>The default serialization options for this serializer.</returns>
+        public IBsonSerializationOptions GetDefaultSerializationOptions()
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Serializes an object to a BsonWriter.
+        /// </summary>
+        /// <param name="bsonWriter">The BsonWriter.</param>
+        /// <param name="nominalType">The nominal type.</param>
+        /// <param name="value">The object.</param>
+        /// <param name="options">The serialization options.</param>
+        public void Serialize(
+            BsonWriter bsonWriter,
+            Type nominalType,
+            object value,
+            IBsonSerializationOptions options)
+        {
+            VerifyNominalType(nominalType);
+
+            if (value != null)
+            {
+                throw new BsonSerializationException("value is not null.");
+            }
+            bsonWriter.WriteNull();
+        }
+
+        // private methods
+        private void VerifyType(Type type)
+        {
+            if (type != _nominalType)
+            {
+                var message = string.Format(
+                    "NullSerializer for type {0} cannot be used with type {1}.",
+                    _nominalType.FullName,
+                    type.FullName);
+                throw new BsonSerializationException(message);
+            }
+        }
+
+        private void VerifyNominalType(Type nominalType)
+        {
+            if (nominalType != _nominalType && !_nominalType.IsAssignableFrom(nominalType))
+            {
+                var message = string.Format(
+                    "NullSerializer for type {0} cannot be used with type {1}.",
+                    _nominalType.FullName,
+                    nominalType.FullName);
+                throw new BsonSerializationException(message);
+            }
+        }
+    }
+}

--- a/Bson/Serialization/Serializers/SerializerHolder.cs
+++ b/Bson/Serialization/Serializers/SerializerHolder.cs
@@ -1,0 +1,64 @@
+﻿/* Copyright 2010-2012 10gen Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization.Options;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace MongoDB.Bson.Serialization.Serializers
+{
+    /// <summary>
+    /// Represents a cached delay-resolved IBsonSerializer.
+    /// </summary>
+    internal sealed class SerializerHolder
+    {
+        // private fields
+        private readonly Type _serializerType;
+        private volatile IBsonSerializer _cachedSerializer;
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the SerializerHolder structure.
+        /// </summary>
+        /// <param name="serializerType">The serializer type.</param>
+        public SerializerHolder(Type serializerType)
+        {
+            _serializerType = serializerType;
+            _cachedSerializer = null;
+        }
+
+        // public properties
+        public IBsonSerializer Value
+        {
+            get
+            {
+                var serializer = _cachedSerializer;
+                if (serializer == null)
+                {
+                    // it's possible but harmless for multiple threads to do the initial lookup at the same time
+                    serializer = DiscriminatorSerializer.Create(_serializerType);
+                    _cachedSerializer = serializer;
+                }
+                return serializer;
+            }
+        }
+    }
+}

--- a/BsonUnitTests/Jira/CSharp270Tests.cs
+++ b/BsonUnitTests/Jira/CSharp270Tests.cs
@@ -49,7 +49,7 @@ namespace MongoDB.BsonUnitTests.Jira.CSharp270
         public void TestBogusElement()
         {
             var document = new BsonDocument("bogus", 0);
-            var message = "Element 'bogus' does not match any field or property of class MongoDB.BsonUnitTests.Jira.CSharp270.C.";
+            var message = "An error occurred while deserializing class MongoDB.BsonUnitTests.Jira.CSharp270.C: Element 'bogus' does not match any field or property of class MongoDB.BsonUnitTests.Jira.CSharp270.C.";
             var ex = Assert.Throws<FileFormatException>(() => { BsonSerializer.Deserialize<C>(document); });
             Assert.AreEqual(message, ex.Message);
         }

--- a/Driver/Core/MongoCollection.cs
+++ b/Driver/Core/MongoCollection.cs
@@ -1451,7 +1451,7 @@ namespace MongoDB.Driver
                     {
                         var classMap = BsonClassMap.LookupClassMap(documentType);
                         var idMemberMap = classMap.IdMemberMap;
-                        var idSerializer = idMemberMap.GetSerializer(id.GetType());
+                        var idSerializer = idMemberMap.GetSerializer();
                         // we only care about the serialized _id value but we need a dummy document to serialize it into
                         var bsonDocument = new BsonDocument();
                         var bsonDocumentWriterSettings = new BsonDocumentWriterSettings


### PR DESCRIPTION
1. Ongoing profiling of the driver revealed that refactoring discriminator handling code was a strong candidate for performance improvement.
    * A fair bit of time was being spent in Type verification, DiscriminatorConvention lookup, Serializer lookup, and the associated locking code.
    * Of note, discriminator code was being executed during deserialization regardless of whether it was appropriate for the Type.
        * Specifically, only unsealed class types can have useful discriminators in .Net as only these types can be inherited.
        * Additionally, the implementation of the StandardDiscriminator was always evaluating for primitive types, however the only nominal type that is assignable at the CLR layer is System.Object, making much of the computation unnecessary.
2. To achieve performance and maintainability improvements the following was done:
    * Factor out discriminator code into a DiscriminatorSerializer wrapper serializer.
    * Only wrap serializers that can be discriminated.
    * Factored out previous performance related serializer caching work into a SerializerHolder class
        * Replaced lots of duplicate discriminator lookup -> serializer lookup -> serializer caching code with this class.
        * Also applied this class to generic collections that had been missed in previous rounds of performance improvement as they were not covered by benchmarks.
        * In several cases this reduced class size as these holders could be made static relative to the generic class types.
3. To improve the performance of discriminator lookups the following was done:
    * Combine BsonSerializer.__discriminatedTypes and BsonSerializer.__typesWithRegisteredKnownTypes into a single dictionary.
    * Make accesses to the new dictionary only require a lock for updating
4. Another minor performance improvement to reduce the overhead of BsonClassMapSerializer.DeserializeMember (one of the hottest methods)
    * Move the try/catch setup to outside the member loop in BsonClassMapSerializer.Deserialize, this way the try/catch only needs to be setup once per instance rather than once per member.
5. Another minor performance improvement to reduce the overhead of DictionaryGenericSerializer
    * Call dictionary.Add(key, value) instead of .Add(keyValuePair) as the second requires cloning a struct on the stack as the struct is passed by value
6. Net is that classes with primitive properties (i.e. almost all) benefit from this, as well as all generic collection types.
7. Finally, care was taken not to disturb any publicly facing APIs, as the aim was to make improvements turnkey.

Raw profiling data, I can provide hard VS profiler results and benchmark code as well if needed.

Iterations	master	optimiz3	Improvement
25000	10.3441722	9.3571325	10%
25000	10.4369589	9.4071719	10%
25000	10.5356442	9.4646407	10%
25000	10.4389251	9.409648367	10%
