### PR TITLE
Added typeconverter to ObjectId

### DIFF
--- a/Bson/Bson.csproj
+++ b/Bson/Bson.csproj
@@ -83,6 +83,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="BsonExtensionMethods.cs" />
+    <Compile Include="ComponentModel\ObjectIdConverter.cs" />
     <Compile Include="IO\BsonDocumentReaderSettings.cs" />
     <Compile Include="IO\BsonDocumentWriterSettings.cs" />
     <Compile Include="IO\BsonReaderSettings.cs" />

--- a/Bson/ComponentModel/ObjectIdConverter.cs
+++ b/Bson/ComponentModel/ObjectIdConverter.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace MongoDB.Bson.ComponentModel
+{
+    /// <summary>
+    /// TypeConverter to convert an ObjectId into a string or DateTime, and from a string into an ObjectId.
+    /// </summary>
+    public class ObjectIdConverter : TypeConverter
+    {
+        /// <summary>
+        /// Gets a value indicating whether this converter can convert an object in the
+        /// given source type to the native type of the converter.
+        /// Supports string only.
+        /// </summary>
+        /// <param name="context">Ignored.</param>
+        /// <param name="sourceType">The source type to evaluate.</param>
+        /// <returns></returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+                return true;
+           
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        /// Converts a string into an ObjectId.
+        /// </summary>
+        /// <param name="context">Ignored.</param>
+        /// <param name="culture">Ignored.</param>
+        /// <param name="value">The value type to convert. Must be string otherwise passed to base implementation.</param>
+        /// <returns>An ObjectId if the value type was string.</returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string)
+                return ObjectId.Parse((string)value);
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this converter can convert an ObjectId to another type.
+        /// Only string or DateTime are supported.
+        /// </summary>
+        /// <param name="context">Ignored.</param>
+        /// <param name="destinationType">Only string or DateTime supported.</param>
+        /// <returns>If conversion is possible, a string or DateTime.</returns>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string) || destinationType == typeof(DateTime))
+                return true;
+
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        /// <summary>
+        /// Converts an ObjectId to a string or DateTime.
+        /// </summary>
+        /// <param name="context">Ignored.</param>
+        /// <param name="culture">Ignored.</param>
+        /// <param name="value">The value to be evaluated.</param>
+        /// <param name="destinationType">Target type, only string or DateTime supported.</param>
+        /// <returns>A string or DateTime if conversion was possible.</returns>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return ((ObjectId) value).ToString();
+            }
+            else if (destinationType == typeof(DateTime))
+            {
+                return ((ObjectId) value).CreationTime;
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/Bson/ObjectModel/ObjectId.cs
+++ b/Bson/ObjectModel/ObjectId.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -22,6 +23,7 @@ using System.Security;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
+using MongoDB.Bson.ComponentModel;
 
 namespace MongoDB.Bson
 {
@@ -29,6 +31,7 @@ namespace MongoDB.Bson
     /// Represents an ObjectId (see also BsonObjectId).
     /// </summary>
     [Serializable]
+    [TypeConverter(typeof(ObjectIdConverter))]
     public struct ObjectId : IComparable<ObjectId>, IEquatable<ObjectId>
     {
         // private static fields

--- a/BsonUnitTests/BsonUnitTests.csproj
+++ b/BsonUnitTests/BsonUnitTests.csproj
@@ -81,6 +81,7 @@
     </Compile>
     <Compile Include="BsonExtensionMethodsTests.cs" />
     <Compile Include="BsonUtilsTests.cs" />
+    <Compile Include="ComponentModel\ObjectIdConverterTests.cs" />
     <Compile Include="DefaultSerializer\Attributes\BsonRepresentationAttributeTests.cs" />
     <Compile Include="DefaultSerializer\BsonClassMapAutoMappingTests.cs" />
     <Compile Include="DefaultSerializer\BsonClassMapTests.cs" />

--- a/BsonUnitTests/ComponentModel/ObjectIdConverterTests.cs
+++ b/BsonUnitTests/ComponentModel/ObjectIdConverterTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using MongoDB.Bson;
+using MongoDB.Bson.ComponentModel;
+using NUnit.Framework;
+
+namespace MongoDB.BsonUnitTests.ComponentModel
+{
+    [TestFixture]
+    public class ObjectIdConverterTests
+    {
+        [Test]
+        public void TestCanGetTypeConverterForObjectId()
+        {
+            TypeConverter res = TypeDescriptor.GetConverter(typeof (ObjectId));
+            Assert.AreEqual(typeof(ObjectIdConverter), res.GetType());
+        }
+
+        #region CanConvertxxx Tests
+
+        [Test]
+        public void TestCanConvertToString()
+        {
+            var converter = new ObjectIdConverter();
+            Assert.IsTrue(converter.CanConvertTo(typeof (string)));
+        }
+
+        [Test]
+        public void TestCanConvertToDateTime()
+        {
+            var converter = new ObjectIdConverter();
+            Assert.IsTrue(converter.CanConvertTo(typeof (DateTime)));
+        }
+
+        [Test]
+        public void TestCanConvertFromString()
+        {
+            var converter = new ObjectIdConverter();
+            Assert.IsTrue(converter.CanConvertFrom(typeof (string)));
+        }
+
+        #endregion
+
+        [Test]
+        public void TestConvertFromObjectIdToString()
+        {
+            var expected = "0102030405060708090a0b0c";
+            var id = new ObjectId(expected);
+            var converter = new ObjectIdConverter();
+
+            var res = converter.ConvertTo(id, typeof(string));
+           
+            Assert.AreEqual(typeof(string), res.GetType());
+            Assert.AreEqual(expected, res);
+        }
+
+        [Test]
+        public void TestConvertFromObjectIdToDateTime()
+        {
+            var expected = new DateTime(2011, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var id = ObjectId.GenerateNewId(expected);
+
+            var converter = new ObjectIdConverter();
+
+            var res = converter.ConvertTo(id, typeof(DateTime));
+
+            Assert.AreEqual(typeof(DateTime), res.GetType());
+            Assert.AreEqual(expected, res);
+        }
+
+        [Test]
+        public void TestConvertFromValidStringToObjectId()
+        {
+            var s = "0102030405060708090a0b0c";
+            var expected = new ObjectId(s);
+            var converter = new ObjectIdConverter();
+
+            var res = converter.ConvertFrom(s);
+
+            Assert.AreEqual(typeof(ObjectId), res.GetType());
+            Assert.AreEqual(expected, res);
+        } 
+    }
+}


### PR DESCRIPTION
A typeconverter allows webapi and mvc to automatically bind HttpRequest parameters/payloads to ObjectIds.
This converter support converting from a string to an ObjectId, and from an ObjectId to a string or DateTime.

This modification needs to be done at the driver level since the 'TypeConverter' attribute needs to be applied to the ObjectId class definition.

These enhancements are accompanied by unit tests.
