### PR TITLE
Invalid MongoConnectionStringBuilder behaviour

### DIFF
--- a/DriverUnitTests/Core/MongoConnectionStringBuilderTests.cs
+++ b/DriverUnitTests/Core/MongoConnectionStringBuilderTests.cs
@@ -1219,5 +1219,11 @@ namespace MongoDB.DriverUnitTests
 #pragma warning restore
             Assert.AreEqual(connectionString, builder.ToString());
         }
+
+		[Test]
+		public void TestConnectionStringWithParameters()
+		{
+			new MongoConnectionStringBuilder("mongodb://localhost/testDb?safe=true");
+		}
     }
 }


### PR DESCRIPTION
For some reason MongoConnectionStringBuilder can't properly parse connection string that contains '=' (equal) symbol and fails with ArgumentException.

For connection string: mongodb://localhost/testDb?safe=true
It says: System.ArgumentException : Invalid keyword 'mongodb://localhost/testdb?safe'.

I can't find how to create an Issue, so decided to highlight this via pull request.
