### PR TITLE
added AllClassMaps static method to BsonClassMap

### DIFF
--- a/Bson/Serialization/BsonClassMap.cs
+++ b/Bson/Serialization/BsonClassMap.cs
@@ -288,6 +288,14 @@ namespace MongoDB.Bson.Serialization
         }
 
         /// <summary>
+        /// Returns all registered class maps.
+        /// </summary>
+        public static IEnumerable<BsonClassMap> AllClassMaps()
+        {
+            return __classMaps.Values;
+        }
+
+        /// <summary>
         /// Looks up a class map (will AutoMap the class if no class map is registered).
         /// </summary>
         /// <param name="classType">The class type.</param>

--- a/BsonUnitTests/DefaultSerializer/BsonClassMapTests.cs
+++ b/BsonUnitTests/DefaultSerializer/BsonClassMapTests.cs
@@ -310,6 +310,48 @@ namespace MongoDB.BsonUnitTests.Serialization
     }
 
     [TestFixture]
+    public class BsonClassMapAllClassMapTests
+    {
+        private static bool __testAlreadyRan;
+
+        public class C
+        {
+            public ObjectId Id;
+            public int X;
+        }
+
+        public class D
+        {
+            public ObjectId Id;
+            public string Y;
+        }
+
+        [Test]
+        public void TestAllClassMaps()
+        {
+            // test can only be run once
+            if (__testAlreadyRan)
+            {
+                return;
+            }
+
+            __testAlreadyRan = true;
+
+            Assert.IsFalse(BsonClassMap.IsClassMapRegistered(typeof(C)));
+            Assert.IsFalse(BsonClassMap.IsClassMapRegistered(typeof(D)));
+            BsonClassMap.RegisterClassMap<C>(cm => cm.AutoMap());
+            BsonClassMap.RegisterClassMap<D>(cm => cm.AutoMap());
+
+            var classMaps = BsonClassMap.AllClassMaps();
+            var classMapTypes = classMaps.Select(x => x.ClassType).ToList();
+
+            Assert.IsTrue(BsonClassMap.IsClassMapRegistered(typeof(C)));
+            Assert.Contains(typeof(C), classMapTypes);
+            Assert.Contains(typeof(D), classMapTypes);
+        }
+    }
+
+    [TestFixture]
     public class BsonShouldSerializeTests
     {
         public class ClassA


### PR DESCRIPTION
Allows us to get all class maps out of BsonClassMap.
