### PR TITLE
Changes to TryMapToBsonValue() method

### DIFF
--- a/Bson/ObjectModel/BsonTypeMapper.cs
+++ b/Bson/ObjectModel/BsonTypeMapper.cs
@@ -443,6 +443,10 @@ namespace MongoDB.Bson
                 return true;
             }
 
+            bsonValue = value as BsonValue;
+            if (bsonValue != null)
+                return true;
+
             var valueType = value.GetType();
             if (valueType.IsEnum)
             {


### PR DESCRIPTION
I faced an issue, when tried to pass _QueryDocument_ as an element of array to **Database.Eval()** method.
Internally it called **BsonArray.Create()**, which in turn called **TryMapToBsonValue()** method for each of array elements.
It failed to convert _QueryDocument_ to _BsonValue_ although it is already a _BsonValue_. So, I added few lines of code to the very beginning of the method to cover that simple case.
