### PR TITLE
Fix for CSHARP-610

### DIFF
--- a/Driver/Core/MongoServerAddress.cs
+++ b/Driver/Core/MongoServerAddress.cs
@@ -71,7 +71,7 @@ namespace MongoDB.Driver
             }
             else
             {
-                throw new FormatException("'{0}' is not a valid server address.");
+                throw new FormatException(String.Format("'{0}' is not a valid server address.", value));
             }
         }
 

--- a/DriverUnitTests/Core/MongoServerAddressTests.cs
+++ b/DriverUnitTests/Core/MongoServerAddressTests.cs
@@ -87,5 +87,21 @@ namespace MongoDB.DriverUnitTests
             Assert.AreEqual("host", credentials.Host);
             Assert.AreEqual(123, credentials.Port);
         }
+
+        [Test]
+        [ExpectedException(ExpectedException = typeof(FormatException),
+                           ExpectedMessage = "'' is not a valid server address.")]
+        public void TestParseNullParam()
+        {
+            MongoServerAddress.Parse(null);
+        }
+
+        [Test]
+        [ExpectedException(ExpectedException = typeof(FormatException),
+                           ExpectedMessage = "'' is not a valid server address.")]
+        public void TestParseEmptyParam()
+        {
+            MongoServerAddress.Parse(String.Empty);
+        }
     }
 }


### PR DESCRIPTION
Fixes the FormatException message in the path in
MongoServerAddress::Parse where the provided 'url' does not pass
the ::TryParse criteria for correctness. The intent was to provide
the offending value in the message, but the developer forgot to
fill in the {0} placeholder.

MongoServerAddress::{Parse,TryParse} could use some more hardening
and testing but that should be a separate improvement I suppose.
