### PR TITLE
Adding support for implicit convert of ObjectId to String

### DIFF
--- a/Bson/ObjectModel/ObjectId.cs
+++ b/Bson/ObjectModel/ObjectId.cs
@@ -61,6 +61,14 @@ namespace MongoDB.Bson
                 __staticPid = 0;
             }
         }
+		
+		/// <summary>
+        /// Allows for implicit conversion of ObjectId to String
+        /// </summary>
+        public static implicit operator String(ObjectId Id)
+        {
+            return Id.ToString();
+        }
 
         // constructors
         /// <summary>


### PR DESCRIPTION
By being able to support conversion to String, you insulate any wrapper/test classes from having to directly reference the BSON assembly.  Your domain class can expose a String property called ObjectId which simply returns the Id property as a string.
