### PR TITLE
Fix CSHARP-637: Fluent Lambda Expressions Don't Resolve Interfaces

### DIFF
--- a/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -1494,10 +1494,42 @@ namespace MongoDB.Bson.Serialization
             switch (memberInfo.MemberType)
             {
                 case MemberTypes.Field:
+                    memberInfo = typeof(TClass).GetField(
+                        memberInfo.Name,
+                        BindingFlags.Instance |
+                        BindingFlags.Public |
+                        BindingFlags.NonPublic);
+                    break;
                 case MemberTypes.Property:
+                    // Handle interfaces and base classes; lambdas always
+                    // call the derived implementation.
+                    if (memberInfo.DeclaringType != typeof(TClass))
+                    {
+                        var memberInfo2 = typeof(TClass).GetProperty(
+                            memberInfo.Name,
+                            BindingFlags.Instance |
+                            BindingFlags.Public |
+                            BindingFlags.NonPublic);
+
+                        // Handle explicit interface implementations.
+                        if (memberInfo2 == null &&
+                            memberInfo.DeclaringType.IsInterface)
+                        {
+                            memberInfo2 = ResolveExplicitProperty(
+                                memberInfo,
+                                typeof(TClass));
+                        }
+
+                        memberInfo = memberInfo2;
+                    }
                     break;
                 default:
-                    throw new BsonSerializationException("Invalid lambda expression");
+                    memberInfo = null;
+                    break;
+            }
+            if (memberInfo == null)
+            {
+                throw new BsonSerializationException("Invalid lambda expression");
             }
             return memberInfo;
         }
@@ -1505,6 +1537,57 @@ namespace MongoDB.Bson.Serialization
         private static string GetMemberNameFromLambda<TMember>(Expression<Func<TClass, TMember>> memberLambda)
         {
             return GetMemberInfoFromLambda(memberLambda).Name;
+        }
+
+        private static PropertyInfo ResolveExplicitProperty(
+            MemberInfo interfaceMemberInfo,
+            Type targetType)
+        {
+            var interfaceType = interfaceMemberInfo.DeclaringType;
+
+            // An interface map must be used because because there is no
+            // other officially documented way to derive the explicitly
+            // implemented property name.
+            var interfaceMap = targetType.GetInterfaceMap(interfaceType);
+
+            var interfacePropertyAccessors =
+                ((PropertyInfo)interfaceMemberInfo).GetAccessors(true);
+
+            var targetPropertyAccessors =
+                interfacePropertyAccessors.Select(accessor =>
+            {
+                var index = Array.IndexOf<MethodInfo>(interfaceMap.InterfaceMethods, accessor);
+
+                return interfaceMap.TargetMethods[index];
+            }).ToArray();
+
+            // Binding must be done by accessor methods because interface
+            // maps only map accessor methods and do not map properties.
+            return targetType.GetProperties(
+                BindingFlags.Instance |
+                BindingFlags.Public |
+                BindingFlags.NonPublic)
+                .Single(propertyInfo =>
+                {
+                    var accessors = propertyInfo.GetAccessors(true);
+
+                    if (accessors.Length != targetPropertyAccessors.Length)
+                    {
+                        return false;
+                    }
+
+                    for (var i = 0; i < accessors.Length; ++i)
+                    {
+                        if (Array.IndexOf<MethodInfo>(
+                            targetPropertyAccessors,
+                            accessors[i]) < 0)
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                });
         }
     }
 }

--- a/MongoDB.BsonUnitTests/Jira/CSharp637Tests.cs
+++ b/MongoDB.BsonUnitTests/Jira/CSharp637Tests.cs
@@ -1,0 +1,79 @@
+﻿/* Copyright 2010-2012 10gen Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using NUnit.Framework;
+
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace MongoDB.BsonUnitTests.Jira.CSharp637
+{
+    [TestFixture]
+    public class CSharp637Tests
+    {
+        public interface IMyInterface
+        {
+            string SomeField1 { get; set; }
+
+            string SomeField2 { get; set; }
+        }
+
+        public class MyClass : IMyInterface
+        {
+            [BsonElement("foo")]
+            public string SomeField1 { get; set; }
+
+            [BsonElement("bar")]
+            string IMyInterface.SomeField2 { get; set; }
+        }
+
+        public static BsonMemberMap MapMyInterface1<T>()
+            where T : IMyInterface
+        {
+            var classMap = new BsonClassMap<T>();
+            classMap.AutoMap();
+            return classMap.MapMember(t => t.SomeField1);
+        }
+
+        public static BsonMemberMap MapMyInterface2<T>()
+            where T : IMyInterface
+        {
+            var classMap = new BsonClassMap<T>();
+            classMap.AutoMap();
+            return classMap.MapMember(t => t.SomeField2);
+        }
+
+        [Test]
+        public void TestMapGenericMember()
+        {
+            var memberMap = MapMyInterface1<MyClass>();
+            Assert.IsNotNull(memberMap);
+            Assert.AreEqual(typeof(MyClass), memberMap.ClassMap.ClassType);
+            Assert.AreEqual("foo", memberMap.ElementName);
+            Assert.AreEqual("SomeField1", memberMap.MemberName);
+        }
+
+        [Test]
+        public void TestMapExplicitGenericMember()
+        {
+            var memberMap = MapMyInterface2<MyClass>();
+            Assert.IsNotNull(memberMap);
+            Assert.AreEqual(typeof(MyClass), memberMap.ClassMap.ClassType);
+            Assert.AreEqual("bar", memberMap.ElementName);
+            Assert.AreEqual("MongoDB.BsonUnitTests.Jira.CSharp637.CSharp637Tests.IMyInterface.SomeField2", memberMap.MemberName);
+        }
+    }
+}

--- a/MongoDB.BsonUnitTests/MongoDB.BsonUnitTests.csproj
+++ b/MongoDB.BsonUnitTests/MongoDB.BsonUnitTests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="BsonExtensionMethodsTests.cs" />
     <Compile Include="BsonUtilsTests.cs" />
     <Compile Include="Jira\CSharp624Tests.cs" />
+    <Compile Include="Jira\CSharp637Tests.cs" />
     <Compile Include="Serialization\Attributes\BsonRepresentationAttributeTests.cs" />
     <Compile Include="Serialization\BsonClassMapAutoMappingTests.cs" />
     <Compile Include="Serialization\BsonClassMapTests.cs" />


### PR DESCRIPTION
Accidental regression from https://github.com/mongodb/mongo-csharp-driver/commit/5a62ca86fba984803e445a1d182bc125a56c7714 caused generic interface member mappings to throw.
