### PR TITLE
CSHARP-554 - Implemented CopyDatabase on MongoServer

### DIFF
--- a/MongoDB.Driver/MongoServer.cs
+++ b/MongoDB.Driver/MongoServer.cs
@@ -513,7 +513,6 @@ namespace MongoDB.Driver
             _serverProxy.Connect(timeout, _settings.ReadPreference);
         }
 
-        // TODO: fromHost parameter?
         /// <summary>
         /// Copies a database.
         /// </summary>
@@ -521,7 +520,22 @@ namespace MongoDB.Driver
         /// <param name="to">The name of the new database.</param>
         public virtual void CopyDatabase(string from, string to)
         {
-            throw new NotImplementedException();
+            var adminCredentials = _settings.GetCredentials("admin");
+            CopyDatabase(from, to, adminCredentials);
+        }
+
+        /// <summary>
+        /// Copies a database.
+        /// </summary>
+        /// <param name="from">The name of an existing database.</param>
+        /// <param name="to">The name of the new database.</param>
+        /// <param name="adminCredentials">Credentials for the admin database.</param>
+        public virtual void CopyDatabase(string from, string to, MongoCredentials adminCredentials)
+        {
+            var adminDatabase = GetDatabase("admin", adminCredentials);
+            var command = new CommandDocument("copydb", 1) { { "fromdb", from }, { "todb", to } };
+
+            adminDatabase.RunCommand(command);
         }
 
         /// <summary>

--- a/MongoDB.DriverUnitTests/MongoServerTests.cs
+++ b/MongoDB.DriverUnitTests/MongoServerTests.cs
@@ -58,6 +58,21 @@ namespace MongoDB.DriverUnitTests
         }
 
         [Test]
+        public void TestCopyDatabase()
+        {
+            if (_isMasterSlavePair) return;
+            const string copied = "copied";
+            _server.DropDatabase(copied);
+
+            _collection.Insert(new BsonDocument());
+            Assert.IsTrue(_server.DatabaseExists(_database.Name));
+
+            _server.CopyDatabase(_database.Name, copied, null);
+            Assert.IsTrue(_server.DatabaseExists(_database.Name));
+            Assert.IsTrue(_server.DatabaseExists(copied));
+        }
+
+        [Test]
         public void TestCreateMongoServerSettings()
         {
 #pragma warning disable 618


### PR DESCRIPTION
This is a relatively simple update.

Implemented CSHARP-554 - CopyDatabase in MongoServer. Did not include a fromHost parameter for now, as I figured we could add an overload in the future. To do that, we'd need a way to handle authentication on the host server of the original database. I added a test to the MongoServerTests.

Sorry about the previous aborted request - I needed to rebase my repo.
