### PR TITLE
Enable building Text indexes and setting weight options

### DIFF
--- a/MongoDB.Driver/Builders/IndexKeysBuilder.cs
+++ b/MongoDB.Driver/Builders/IndexKeysBuilder.cs
@@ -81,6 +81,16 @@ namespace MongoDB.Driver.Builders
         {
             return new IndexKeysBuilder().GeoSpatialHaystack(name, additionalName);
         }
+
+        /// <summary>
+        /// Sets one or more key names to index as text.
+        /// </summary>
+        /// <param name="names">One or more key names.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexKeysBuilder Text(params string[] names)
+        {
+            return new IndexKeysBuilder().Text(names);
+        }
     }
 
     /// <summary>
@@ -161,6 +171,28 @@ namespace MongoDB.Driver.Builders
         {
             _document.Add(name, "geoHaystack");
             _document.Add(additionalName, 1, additionalName != null);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets one or more key names to index as text.
+        /// </summary>
+        /// <param name="names">One or more key names.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexKeysBuilder Text(params string[] names)
+        {
+            if (names.Length == 0)
+            {
+                // special case to build text index on *all* string fields
+                _document.Add("$**", "text");
+            }
+            else
+            {
+                foreach (var name in names)
+                {
+                    _document.Add(name, "text");
+                }
+            }
             return this;
         }
 
@@ -257,6 +289,16 @@ namespace MongoDB.Driver.Builders
         {
             return new IndexKeysBuilder<TDocument>().GeoSpatialHaystack(memberExpression, additionalMemberExpression);
         }
+
+        /// <summary>
+        /// Sets one or more key names to index as text.
+        /// </summary>
+        /// <param name="memberExpressions">The member expressions.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexKeysBuilder<TDocument> Text(params Expression<Func<TDocument, object>>[] memberExpressions)
+        {
+            return new IndexKeysBuilder<TDocument>().Text(memberExpressions);
+        }
     }
 
     /// <summary>
@@ -352,6 +394,17 @@ namespace MongoDB.Driver.Builders
             var serializationInfo = _serializationInfoHelper.GetSerializationInfo(memberExpression);
             var additionalSerializationInfo = _serializationInfoHelper.GetSerializationInfo(additionalMemberExpression);
             _indexKeysBuilder = _indexKeysBuilder.GeoSpatialHaystack(serializationInfo.ElementName, additionalSerializationInfo.ElementName);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets one or more key names to index as text.
+        /// </summary>
+        /// <param name="memberExpressions">One or more key names.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexKeysBuilder<TDocument> Text(params Expression<Func<TDocument, object>>[] memberExpressions)
+        {
+            _indexKeysBuilder = _indexKeysBuilder.Text(GetElementNames(memberExpressions).ToArray());
             return this;
         }
 

--- a/MongoDB.Driver/Builders/IndexOptionsBuilder.cs
+++ b/MongoDB.Driver/Builders/IndexOptionsBuilder.cs
@@ -14,10 +14,12 @@
 */
 
 using System;
+using System.Linq.Expressions;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Utils;
 
 namespace MongoDB.Driver.Builders
 {
@@ -115,6 +117,19 @@ namespace MongoDB.Driver.Builders
         public static IndexOptionsBuilder SetUnique(bool value)
         {
             return new IndexOptionsBuilder().SetUnique(value);
+        }
+
+        /// <summary>
+        /// Sets the weight of a field for the text index.
+        /// </summary>
+        /// <param name="name">The name of the field.</param>
+        /// <param name="value">The weight.</param>
+        /// <returns>
+        /// The builder (so method calls can be chained).
+        /// </returns>
+        public static IndexOptionsBuilder SetWeight(string name, int value)
+        {
+            return new IndexOptionsBuilder().SetWeight(name, value);
         }
     }
 
@@ -228,6 +243,23 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Sets the weight of a field for the text index.
+        /// </summary>
+        /// <param name="name">The field name.</param>
+        /// <param name="value">The weight.</param>
+        /// <returns>
+        /// The builder (so method calls can be chained).
+        /// </returns>
+        public IndexOptionsBuilder SetWeight(string name, int value)
+        {
+            if (!_document.Contains("weights"))
+                _document.Add("weights", new BsonDocument());
+
+            _document["weights"][name] = value;
+            return this;
+        }
+
+        /// <summary>
         /// Returns the result of the builder as a BsonDocument.
         /// </summary>
         /// <returns>A BsonDocument.</returns>
@@ -246,6 +278,260 @@ namespace MongoDB.Driver.Builders
         protected override void Serialize(BsonWriter bsonWriter, Type nominalType, IBsonSerializationOptions options)
         {
             BsonDocumentSerializer.Instance.Serialize(bsonWriter, nominalType, _document, options);
+        }
+    }
+
+    /// <summary>
+    /// A builder for the options used when creating an index
+    /// </summary>
+    /// <typeparam name="TDocument">The type of the document.</typeparam>
+    public static class IndexOptions<TDocument>
+    {
+        // public static methods
+        /// <summary>
+        /// Sets whether to build the index in the background.
+        /// </summary>
+        /// <param name="value">Whether to build the index in the background.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexOptionsBuilder<TDocument> SetBackground(bool value)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetBackground(value);
+        }
+
+        /// <summary>
+        /// Sets the bucket size for geospatial haystack indexes.
+        /// </summary>
+        /// <param name="value">The bucket size.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexOptionsBuilder<TDocument> SetBucketSize(double value)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetBucketSize(value);
+        }
+
+        /// <summary>
+        /// Sets whether duplicates should be dropped.
+        /// </summary>
+        /// <param name="value">Whether duplicates should be dropped.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexOptionsBuilder<TDocument> SetDropDups(bool value)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetDropDups(value);
+        }
+
+        /// <summary>
+        /// Sets the geospatial range.
+        /// </summary>
+        /// <param name="min">The min value of the range.</param>
+        /// <param name="max">The max value of the range.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexOptionsBuilder<TDocument> SetGeoSpatialRange(double min, double max)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetGeoSpatialRange(min, max);
+        }
+
+        /// <summary>
+        /// Sets the name of the index.
+        /// </summary>
+        /// <param name="value">The name of the index.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexOptionsBuilder<TDocument> SetName(string value)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetName(value);
+        }
+
+        /// <summary>
+        /// Sets whether the index is a sparse index.
+        /// </summary>
+        /// <param name="value">Whether the index is a sparse index.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexOptionsBuilder<TDocument> SetSparse(bool value)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetSparse(value);
+        }
+
+        /// <summary>
+        /// Sets the time to live value.
+        /// </summary>
+        /// <param name="timeToLive">The time to live.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexOptionsBuilder<TDocument> SetTimeToLive(TimeSpan timeToLive)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetTimeToLive(timeToLive);
+        }
+
+        /// <summary>
+        /// Sets whether the index enforces unique values.
+        /// </summary>
+        /// <param name="value">Whether the index enforces unique values.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexOptionsBuilder<TDocument> SetUnique(bool value)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetUnique(value);
+        }
+
+        /// <summary>
+        /// Sets the weight of a field for the text index.
+        /// </summary>
+        /// <typeparam name="TMember">The type of the member.</typeparam>
+        /// <param name="memberExpression">The member expression.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The builder (so method calls can be chained).
+        /// </returns>
+        public static IndexOptionsBuilder<TDocument> SetWeight<TMember>(Expression<Func<TDocument, TMember>> memberExpression, int value)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetWeight(memberExpression, value);
+        }
+    }
+
+    /// <summary>
+    /// A builder for the options used when creating an index.
+    /// </summary>
+    /// <typeparam name="TDocument">The type of the document.</typeparam>
+    [Serializable]
+    public class IndexOptionsBuilder<TDocument> : BuilderBase, IMongoIndexOptions
+    {
+        // private fields
+        private readonly BsonSerializationInfoHelper _serializationInfoHelper;
+        private IndexOptionsBuilder _indexOptionsBuilder;
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the IndexKeysBuilder class.
+        /// </summary>
+        public IndexOptionsBuilder()
+        {
+            _serializationInfoHelper = new BsonSerializationInfoHelper();
+            _indexOptionsBuilder = new IndexOptionsBuilder();
+        }
+
+        // public methods
+        /// <summary>
+        /// Sets whether to build the index in the background.
+        /// </summary>
+        /// <param name="value">Whether to build the index in the background.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexOptionsBuilder<TDocument> SetBackground(bool value)
+        {
+            _indexOptionsBuilder = _indexOptionsBuilder.SetBackground(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the bucket size for geospatial haystack indexes.
+        /// </summary>
+        /// <param name="value">The bucket size.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexOptionsBuilder<TDocument> SetBucketSize(double value)
+        {
+            _indexOptionsBuilder = _indexOptionsBuilder.SetBucketSize(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether duplicates should be dropped.
+        /// </summary>
+        /// <param name="value">Whether duplicates should be dropped.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexOptionsBuilder<TDocument> SetDropDups(bool value)
+        {
+            _indexOptionsBuilder = _indexOptionsBuilder.SetDropDups(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the geospatial range.
+        /// </summary>
+        /// <param name="min">The min value of the range.</param>
+        /// <param name="max">The max value of the range.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexOptionsBuilder<TDocument> SetGeoSpatialRange(double min, double max)
+        {
+            _indexOptionsBuilder = _indexOptionsBuilder.SetGeoSpatialRange(min, max);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the name of the index.
+        /// </summary>
+        /// <param name="value">The name of the index.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexOptionsBuilder<TDocument> SetName(string value)
+        {
+            _indexOptionsBuilder = _indexOptionsBuilder.SetName(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether the index is a sparse index.
+        /// </summary>
+        /// <param name="value">Whether the index is a sparse index.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexOptionsBuilder<TDocument> SetSparse(bool value)
+        {
+            _indexOptionsBuilder = _indexOptionsBuilder.SetSparse(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the time to live value.
+        /// </summary>
+        /// <param name="timeToLive">The time to live.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexOptionsBuilder<TDocument> SetTimeToLive(TimeSpan timeToLive)
+        {
+            _indexOptionsBuilder = _indexOptionsBuilder.SetTimeToLive(timeToLive);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether the index enforces unique values.
+        /// </summary>
+        /// <param name="value">Whether the index enforces unique values.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexOptionsBuilder<TDocument> SetUnique(bool value)
+        {
+            _indexOptionsBuilder = _indexOptionsBuilder.SetUnique(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the weight of a field for the text index.
+        /// </summary>
+        /// <typeparam name="TMember">The type of the member.</typeparam>
+        /// <param name="memberExpression">The member expression.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The builder (so method calls can be chained).
+        /// </returns>
+        public IndexOptionsBuilder<TDocument> SetWeight<TMember>(Expression<Func<TDocument, TMember>> memberExpression, int value)
+        {
+            var serializationInfo = _serializationInfoHelper.GetSerializationInfo(memberExpression);
+            _indexOptionsBuilder = _indexOptionsBuilder.SetWeight(serializationInfo.ElementName, value);
+            return this;
+        }
+
+        /// <summary>
+        /// Converts this object to a BsonDocument.
+        /// </summary>
+        /// <returns>
+        /// A BsonDocument.
+        /// </returns>
+        public override BsonDocument ToBsonDocument()
+        {
+            return _indexOptionsBuilder.ToBsonDocument();
+        }
+
+        // protected methods
+        /// <summary>
+        /// Serializes the result of the builder to a BsonWriter.
+        /// </summary>
+        /// <param name="bsonWriter">The writer.</param>
+        /// <param name="nominalType">The nominal type.</param>
+        /// <param name="options">The serialization options.</param>
+        protected override void Serialize(BsonWriter bsonWriter, Type nominalType, IBsonSerializationOptions options)
+        {
+            ((IBsonSerializable)_indexOptionsBuilder).Serialize(bsonWriter, nominalType, options);
         }
     }
 }

--- a/MongoDB.DriverUnitTests/Builders/IndexKeysBuilderTests.cs
+++ b/MongoDB.DriverUnitTests/Builders/IndexKeysBuilderTests.cs
@@ -207,5 +207,53 @@ namespace MongoDB.DriverUnitTests.Builders
             string expected = "{ \"a\" : 1, \"b\" : \"2d\" }";
             Assert.AreEqual(expected, keys.ToJson());
         }
+
+        [Test]
+        public void TestText()
+        {
+            var keys = IndexKeys.Text("a");
+            string expected = "{ \"a\" : \"text\" }";
+            Assert.AreEqual(expected, keys.ToJson());
+        }
+
+        [Test]
+        public void TestMultipleText()
+        {
+            var keys = IndexKeys.Text("a", "b");
+            string expected = "{ \"a\" : \"text\", \"b\" : \"text\" }";
+            Assert.AreEqual(expected, keys.ToJson());
+        }
+
+        [Test]
+        public void TestTextAll()
+        {
+            var keys = IndexKeys.Text();
+            string expected = "{ \"$**\" : \"text\" }";
+            Assert.AreEqual(expected, keys.ToJson());
+        }
+
+        [Test]
+        public void TestText_Typed()
+        {
+            var keys = IndexKeys<Test>.Text(x => x.A);
+            string expected = "{ \"a\" : \"text\" }";
+            Assert.AreEqual(expected, keys.ToJson());
+        }
+
+        [Test]
+        public void TestMultipleText_Typed()
+        {
+            var keys = IndexKeys<Test>.Text(x => x.A, x => x.B);
+            string expected = "{ \"a\" : \"text\", \"b\" : \"text\" }";
+            Assert.AreEqual(expected, keys.ToJson());
+        }
+         
+        [Test]
+        public void TestTextAll_Typed()
+        {
+            var keys = IndexKeys<Test>.Text();
+            string expected = "{ \"$**\" : \"text\" }";
+            Assert.AreEqual(expected, keys.ToJson());
+        }
     }
 }

--- a/MongoDB.DriverUnitTests/Builders/IndexOptionsBuilderTests.cs
+++ b/MongoDB.DriverUnitTests/Builders/IndexOptionsBuilderTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Builders;
 using NUnit.Framework;
 
@@ -23,6 +24,15 @@ namespace MongoDB.DriverUnitTests.Builders
     [TestFixture]
     public class IndexOptionsBuilderTests
     {
+        private class Test
+        {
+            [BsonElement("a")]
+            public string A { get; set; }
+
+            [BsonElement("b")]
+            public string B { get; set; }
+        }
+
         [Test]
         public void TestBackground()
         {
@@ -44,6 +54,38 @@ namespace MongoDB.DriverUnitTests.Builders
         {
             var options = IndexOptions.SetGeoSpatialRange(1.1, 2.2);
             string expected = "{ \"min\" : 1.1, \"max\" : 2.2 }";
+            Assert.AreEqual(expected, options.ToJson());
+        }
+
+        [Test]
+        public void TestWeight()
+        {
+            var options = IndexOptions.SetWeight("a", 2);
+            string expected = "{ \"weights\" : { \"a\" : 2 } }";
+            Assert.AreEqual(expected, options.ToJson());
+        }
+
+        [Test]
+        public void TestWeight_Typed()
+        {
+            var options = IndexOptions<Test>.SetWeight(x => x.A, 2);
+            string expected = "{ \"weights\" : { \"a\" : 2 } }";
+            Assert.AreEqual(expected, options.ToJson());
+        }
+
+        [Test]
+        public void TestMultipleWeights()
+        {
+            var options = IndexOptions.SetWeight("a", 2).SetWeight("b", 10);
+            string expected = "{ \"weights\" : { \"a\" : 2, \"b\" : 10 } }";
+            Assert.AreEqual(expected, options.ToJson());
+        }
+
+        [Test]
+        public void TestMultipleWeights_Typed()
+        {
+            var options = IndexOptions<Test>.SetWeight(x => x.A, 2).SetWeight(x => x.B, 10);
+            string expected = "{ \"weights\" : { \"a\" : 2, \"b\" : 10 } }";
             Assert.AreEqual(expected, options.ToJson());
         }
 


### PR DESCRIPTION
This is to support creation of the text indexes as per:
http://docs.mongodb.org/manual/release-notes/2.4/#text-indexes

I used the same pattern from `IndexKeysBuilder` to implement `IndexOptions<TDocument>` and `IndexOptionsBuilder<TDocument>` to allow specifying the text weights using plain string names or strongly-typed expressions.
