### PR TITLE
Fix to allow Linq queries against properties mapped to a private instance field

### DIFF
--- a/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -329,7 +329,7 @@ namespace MongoDB.Bson.Serialization
         {
             foreach (var memberMap in _classMap.AllMemberMaps)
             {
-                if (memberMap.MemberName == memberName)
+                if (memberMap.MemberName == memberName || memberMap.ElementName == memberName)
                 {
                     var elementName = memberMap.ElementName;
                     var serializer = memberMap.GetSerializer(memberMap.MemberType);


### PR DESCRIPTION
I think I found a missing use case:
1. Map a private instance collection variable, which backs a public read-only collection property
2. Use a linq query against the public read-only collection.

The problem here is that the class map's MemberName equals the instance variable name, and not the public property collection name..

The change here is that I am checking against both the class map's MemberName and Element name values.

This allows you to map an instance field and set the element name as the public property on the class.  This seems to be enough to get the Linq queries to work (Although I'm not sure if there is a more elaborate way to achieve this functionality).  

I know with something like FluentNHibernate, you map the public property, and set the backing field:
Map(x => x.Collection).Access.ReadOnlyPropertyThroughCamelCaseField();

This allows the same functionality if you map the field and set the Element name to be the name of the public property which will be used by Linq.

https://groups.google.com/forum/?fromgroups=#!topic/mongodb-csharp/hnumCgDD9-M
