### PR TITLE
CSHARP-750: Fixed array of value type serialization performance issue

### DIFF
--- a/MongoDB.Bson/IO/BsonBinaryWriter.cs
+++ b/MongoDB.Bson/IO/BsonBinaryWriter.cs
@@ -30,6 +30,7 @@ namespace MongoDB.Bson.IO
         private bool _disposeBuffer;
         private BsonBinaryWriterSettings _binaryWriterSettings; // same value as in base class just declared as derived class
         private BsonBinaryWriterContext _context;
+        private readonly UTF8Encoding _encoding = new UTF8Encoding(false, true);
 
         // constructors
         /// <summary>
@@ -724,7 +725,7 @@ namespace MongoDB.Bson.IO
                 name = Name;
             }
 
-            _buffer.WriteCString(new UTF8Encoding(false, true), name); // always use strict encoding for names
+            _buffer.WriteCString(_encoding, name); // always use strict encoding for names
         }
     }
 }


### PR DESCRIPTION
When serializing array of value types there is no need to lookup for serializer for every item, because it is homogeneous. This saves us some cpu cycles but most benefit may be achieved when multiple threads are doing serialization, like in my multi-threaded insert benchmark. The suggested fix allows to avoid extra-contention on ReaderWriterLockSlim inside BsonSerializer.
