### PR TITLE
CSHARP-752: Method calls that evaluate to booleans can now be the subject of comparison queries in Linq.

### DIFF
--- a/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
+++ b/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
@@ -341,6 +341,18 @@ namespace MongoDB.Driver.Linq
             }
             else
             {
+                var methodCallExpression = variableExpression as MethodCallExpression;
+                if (methodCallExpression != null && value is bool)
+                {
+                    var boolvalue = (bool)value;
+                    var methodresult = this.BuildMethodCallQuery(methodCallExpression);
+
+                    var evaluatesAsEquals = (boolvalue && operatorType == ExpressionType.Equal)
+                                            || (!boolvalue && operatorType == ExpressionType.NotEqual);
+
+                    return evaluatesAsEquals ? methodresult : Query.Not(methodresult);
+                }
+
                 serializationInfo = _serializationInfoHelper.GetSerializationInfo(variableExpression);
             }
 


### PR DESCRIPTION
All unit tests still pass, this solves the bug as experienced by ourselves.
