### PR TITLE
Adding in the ability to easily create queries in the format used by MongoDBs console

### DIFF
--- a/MongoDB.Driver/Builders/QueryBuilder.cs
+++ b/MongoDB.Driver/Builders/QueryBuilder.cs
@@ -641,6 +641,25 @@ namespace MongoDB.Driver.Builders
         }
 
         /// <summary>
+        /// Creates a IMongoQuery based on a json string. 
+        /// 
+        /// If the string is invalid, it will throw a FileFormatException.
+        /// </summary>
+        /// <remarks>
+        /// This method is not type safe, and can be vulnerable to injection (either intentional or by
+        /// mistake) if you are creating the query based on user data. It's useful for prototyping
+        /// or confirming that the results you are getting from a IQueryDocument are the same as 
+        /// the raw MongoDB command (consider using .ToJson() for this)
+        /// </remarks>
+        /// <param name="json">A query in the format used in the mongodb console (e.g. { SendId: 4, 'Events.Code' : { $all : [2], $nin : [3] } })</param>
+        /// <returns>An IMongoQuery.</returns>
+        public static IMongoQuery Parse(string json)
+        {
+            var document = BsonDocument.Parse(json);
+            return new QueryDocument(document);
+        }
+
+        /// <summary>
         /// Tests that the size of the named array is equal to some value (see $size).
         /// </summary>
         /// <param name="name">The name of the element to test.</param>

--- a/MongoDB.DriverUnitTests/Builders/QueryBuilderTests.cs
+++ b/MongoDB.DriverUnitTests/Builders/QueryBuilderTests.cs
@@ -21,6 +21,7 @@ using MongoDB.Driver;
 using MongoDB.Driver.Builders;
 using MongoDB.Driver.GeoJsonObjectModel;
 using NUnit.Framework;
+using System.IO;
 
 namespace MongoDB.DriverUnitTests.Builders
 {
@@ -706,6 +707,30 @@ namespace MongoDB.DriverUnitTests.Builders
             var actual = query.ToJson(settings);
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        public void TestParse()
+        {
+            // Check that parsing a string results in the same result when printed to Json
+            var expected = "{ \"name\" : { \"$not\" : { \"$size\" : 1 } } }";
+            var query = Query.Parse(expected);
+            JsonWriterSettings settings = new JsonWriterSettings { OutputMode = JsonOutputMode.JavaScript };
+            var actual = query.ToJson(settings);
+            Assert.AreEqual(expected, actual);
+
+            // Now confirm that adding an invalid string will cause an exception
+            try
+            {
+                // unmatched Quotes
+                expected = "{ name\" : { \"$not\" : { \"$size\" : 1 } } }"; ;
+                query = Query.Parse(expected);
+                Assert.Fail("FileFormatException was not thrown with invalid json string: " + expected);
+            }
+            catch (FileFormatException)
+            {
+            }
+        }
+
 
         [Test]
         public void TestSize()


### PR DESCRIPTION
The question "How do I pass json style queries in to the C# driver" pops up on Stackoverflow quite often. This seems like a reasonably elegant way to add it (perhaps we could look into creating a specific call, to improve error handling for when people get the query wrong though)

e.g. 
http://stackoverflow.com/questions/17220959/c-sharp-mongo-queries-with-json-strings/17221345
http://stackoverflow.com/questions/6120629/can-i-do-a-text-query-with-the-mongodb-c-sharp-driver

Usage:
collection.Find(new JSQueryDocument("{ SendId: 4, 'Events.Code' : { $all : [2], $nin : [3] } }"));

I also ended up writing wrappers around all the MongoCollection methods that take in IQueryDocuments so that you can just provide strings instead - e.g.

collection.Find("{ SendId: 4, 'Events.Code' : { $all : [2], $nin : [3] } }");

See comments below as to why we went with that signature
