### PR TITLE
CSHARP-586: InsertBatch with empty enumerable

### DIFF
--- a/MongoDB.Driver/MongoCollection.cs
+++ b/MongoDB.Driver/MongoCollection.cs
@@ -1117,6 +1117,15 @@ namespace MongoDB.Driver
                 throw new ArgumentNullException("options");
             }
 
+            var writeConcern = options.WriteConcern ?? _settings.WriteConcern;
+            
+            var documentsCollection = documents as ICollection;
+
+            if (documentsCollection != null && documentsCollection.Count == 0)
+            {
+                return (writeConcern.Enabled) ? new List<WriteConcernResult>() : null;
+            }
+
             var readerSettings = new BsonBinaryReaderSettings
             {
                 Encoding = _settings.ReadEncoding ?? MongoDefaults.ReadEncoding,
@@ -1134,7 +1143,7 @@ namespace MongoDB.Driver
                 _name,
                 readerSettings,
                 writerSettings,
-                options.WriteConcern ?? _settings.WriteConcern,
+                writeConcern,
                 _settings.AssignIdOnInsert,
                 options.CheckElementNames,
                 nominalType,

--- a/MongoDB.DriverUnitTests/MongoCollectionTests.cs
+++ b/MongoDB.DriverUnitTests/MongoCollectionTests.cs
@@ -1326,6 +1326,26 @@ namespace MongoDB.DriverUnitTests
         }
 
         [Test]
+        public void TestInsertBatchWriteConcernEnabledEmptyDocumentsReturnsEmptyWriteConcernResults()
+        {
+            var collectionName = Configuration.TestCollection.Name;
+            var collection = Configuration.TestDatabase.GetCollection(collectionName);
+            var options = new MongoInsertOptions { WriteConcern = WriteConcern.Acknowledged };
+
+            Assert.AreEqual(0, collection.InsertBatch(new List<object>(), options).Count());
+        }
+
+        [Test]
+        public void TestInsertBatchWriteConcernDisabledEmptyDocumentsReturnsNull()
+        {
+            var collectionName = Configuration.TestCollection.Name;
+            var collection = Configuration.TestDatabase.GetCollection(collectionName);
+            var options = new MongoInsertOptions { WriteConcern = WriteConcern.Unacknowledged };
+
+            Assert.IsNull(collection.InsertBatch(new List<object>(), options));
+        }
+
+        [Test]
         public void TestIsCappedFalse()
         {
             var collection = _database.GetCollection("notcappedcollection");


### PR DESCRIPTION
If the enumerable is an ICollection, then test if it's empty before executing the insert operation.  Before this change, the exception "Message contains no documents" is thrown.  See the JIRA issue for details.  Unit tests included.
