### PR TITLE
modify max bson document size to 16M

### DIFF
--- a/MongoDB.Bson/BsonDefaults.cs
+++ b/MongoDB.Bson/BsonDefaults.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Bson
     {
         // private static fields
         private static GuidRepresentation __guidRepresentation = GuidRepresentation.CSharpLegacy;
-        private static int __maxDocumentSize = 4 * 1024 * 1024; // 4MiB
+        private static int __maxDocumentSize = 16 * 1024 * 1024; // 16MiB
         private static int __maxSerializationDepth = 100;
 
         // public static properties


### PR DESCRIPTION
is the max bson document size for mongo db 16MB right now? So in my project i wrote a 4+MB bson file into mongo db but i cannot read it out from the db via C# API.
