### PR TITLE
Fix for Driver fails to reconnect with the server

### DIFF
--- a/MongoDB.Driver/Communication/MongoServerInstance.cs
+++ b/MongoDB.Driver/Communication/MongoServerInstance.cs
@@ -383,7 +383,7 @@ namespace MongoDB.Driver
         {
             lock (_serverInstanceLock)
             {
-                if (_state != MongoServerState.Connected)
+                if (_permanentlyDisconnected)
                 {
                     var message = string.Format("Server instance {0} is no longer connected.", _address);
                     throw new InvalidOperationException(message);


### PR DESCRIPTION
Whenever a ping fails ("MongoServerInstance.Ping"), the connection is set to Disconnected by "SetState(MongoServerState.Disconnected);".

So subsequent "AcquireConnection" calls fails with the message "Server instance {0} is no longer connected." instead of trying to reconnect. So a brief connection problem can stop all future operations...

Problem description:
C# Driver fails to reconnect with the server in some situations when the MongoDb server is slow to respond and the connection times out or momentarily fails to connect to the server due to some temporary cluster unavailability. The error message in most cases is "Server instance {0} is no longer connected.".
