### PR TITLE
Add an overload of BulkWriteOperation's Execute to not take a WriteConcern

### DIFF
--- a/MongoDB.Driver/Operations/BulkWriteOperation.cs
+++ b/MongoDB.Driver/Operations/BulkWriteOperation.cs
@@ -25,14 +25,23 @@ namespace MongoDB.Driver
     {
         // private fields
         private readonly MongoCollection _collection;
-        private readonly bool _isOrdered;
+        private readonly BulkWriteArgs _arguments = new BulkWriteArgs();
         private readonly List<WriteRequest> _requests = new List<WriteRequest>();
+
+        // public properties
+        /// <summary>
+        /// The arguments for this bulk operation.
+        /// </summary>
+        public BulkWriteArgs Arguments
+        {
+            get { return _arguments; }
+        }
 
         // constructors
         internal BulkWriteOperation(MongoCollection collection, bool isOrdered)
         {
             _collection = collection;
-            _isOrdered = isOrdered;
+            _arguments.IsOrdered = isOrdered;
         }
 
         // public methods
@@ -42,7 +51,7 @@ namespace MongoDB.Driver
         /// <returns>A BulkWriteResult.</returns>
         public BulkWriteResult Execute()
         {
-            return Execute(null);
+            return _collection.BulkWrite(_arguments, _requests);
         }
 
         /// <summary>
@@ -52,12 +61,8 @@ namespace MongoDB.Driver
         /// <returns>A BulkWriteResult.</returns>
         public BulkWriteResult Execute(WriteConcern writeConcern)
         {
-            var args = new BulkWriteArgs
-            {
-                IsOrdered = _isOrdered,
-                WriteConcern = writeConcern
-            };
-            return _collection.BulkWrite(args, _requests);
+            _arguments.WriteConcern = writeConcern;
+            return _collection.BulkWrite(_arguments, _requests);
         }
 
         /// <summary>

--- a/MongoDB.DriverUnitTests/MongoCollectionTests.cs
+++ b/MongoDB.DriverUnitTests/MongoCollectionTests.cs
@@ -1321,6 +1321,22 @@ namespace MongoDB.DriverUnitTests
             Assert.AreEqual(0, _collection.Count());
         }
 
+        [Test]
+        public void TestInitializeOrderedBulkOperationSetsOrderedInArgumentsToTrue()
+        {
+            var bulk = _collection.InitializeOrderedBulkOperation();
+
+            Assert.IsTrue(bulk.Arguments.IsOrdered.Value);
+        }
+
+        [Test]
+        public void TestInitializeUnorderedBulkOperationSetsOrderedInArgumentsToFalse()
+        {
+            var bulk = _collection.InitializeUnorderedBulkOperation();
+
+            Assert.IsFalse(bulk.Arguments.IsOrdered.Value);
+        }
+
 #pragma warning disable 649 // never assigned to
         private class Place
         {


### PR DESCRIPTION
Should help consumer code readability.

https://jira.mongodb.org/browse/CSHARP-797
