### PR TITLE
Add a DecimalRepresentationConvention to change the default representation of a decimal

### DIFF
--- a/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/MongoDB.Bson/MongoDB.Bson.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Serialization\BsonDocumentBackedClass.cs" />
     <Compile Include="Serialization\Conventions\AttributeConventionPack.cs" />
     <Compile Include="Serialization\Conventions\CamelCaseElementNameConvention.cs" />
+    <Compile Include="Serialization\Conventions\DecimalRepresentationConvention.cs" />
     <Compile Include="Serialization\Conventions\NamedParameterCreatorMapConvention.cs" />
     <Compile Include="Serialization\Conventions\ConventionBase.cs" />
     <Compile Include="Serialization\Conventions\ConventionPack.cs" />

--- a/MongoDB.Bson/Serialization/Conventions/DecimalRepresentationConvention.cs
+++ b/MongoDB.Bson/Serialization/Conventions/DecimalRepresentationConvention.cs
@@ -1,0 +1,45 @@
+﻿namespace MongoDB.Bson.Serialization.Conventions
+{
+    using System;
+    using Options;
+
+    /// <summary>
+    /// A convention that allows you to set the Decimal serialization representation
+    /// </summary>
+    public class DecimalRepresentationConvention : ConventionBase, IMemberMapConvention
+    {
+        // private fields
+        private readonly BsonType _representation;
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DecimalRepresentationConvention" /> class.
+        /// </summary>
+        /// <param name="representation">The serialization representation.</param>
+        public DecimalRepresentationConvention(BsonType representation)
+        {
+            if (!((representation == BsonType.Array) ||
+                  (representation == BsonType.Double) ||
+                  (representation == BsonType.Int32) ||
+                  (representation == BsonType.Int64) ||
+                  (representation == BsonType.String)))
+            {
+                throw new ArgumentException("Decimals can only be represented as Array, Double, Int32, Int64 or String");
+            }
+            _representation = representation;
+        }
+
+        /// <summary>
+        /// Changes the decimal representation if the member is a decimal
+        /// </summary>
+        /// <param name="memberMap"></param>
+        public void Apply(BsonMemberMap memberMap)
+        {
+            if (memberMap.MemberType != typeof (decimal))
+            {
+                return;
+            }
+            memberMap.SetSerializationOptions(new RepresentationSerializationOptions(_representation));
+        }
+    }
+}

--- a/MongoDB.BsonUnitTests/MongoDB.BsonUnitTests.csproj
+++ b/MongoDB.BsonUnitTests/MongoDB.BsonUnitTests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Serialization\Conventions\CamelCaseElementNameConventionsTests.cs" />
     <Compile Include="Serialization\Conventions\ConventionPackTests.cs" />
     <Compile Include="Serialization\Conventions\ConventionRunnerTests.cs" />
+    <Compile Include="Serialization\Conventions\DecimalRepresentationConventionTests.cs" />
     <Compile Include="Serialization\Conventions\DelegateClassMapConventionTests.cs" />
     <Compile Include="Serialization\Conventions\DelegateMemberMapConventionTests.cs" />
     <Compile Include="Serialization\Conventions\DelegatePostProcessingConventionTests.cs" />

--- a/MongoDB.BsonUnitTests/Serialization/Conventions/DecimalRepresentationConventionTests.cs
+++ b/MongoDB.BsonUnitTests/Serialization/Conventions/DecimalRepresentationConventionTests.cs
@@ -1,0 +1,67 @@
+﻿namespace MongoDB.BsonUnitTests.Serialization.Conventions
+{
+    using System;
+    using Bson;
+    using Bson.Serialization;
+    using Bson.Serialization.Conventions;
+    using Bson.Serialization.Options;
+    using NUnit.Framework;
+
+    public class DecimalRepresentationConventionTests
+    {
+        private class TestClass
+        {
+            public decimal Decimal { get; set; }
+            public string NotDecimal { get; set; }
+        }
+
+        [Test]
+        public void TestDoesNotApplyToANonDecimalType()
+        {
+            var convention = new DecimalRepresentationConvention(BsonType.Double);
+            var classMap = new BsonClassMap<TestClass>();
+            var nonDecimalMemberMap = classMap.MapMember(x => x.NotDecimal);
+
+            convention.Apply(nonDecimalMemberMap);
+
+            Assert.IsNull(nonDecimalMemberMap.SerializationOptions);
+        }
+
+        [Test]
+        [TestCase(BsonType.Array)]
+        [TestCase(BsonType.Double)]
+        [TestCase(BsonType.Int32)]
+        [TestCase(BsonType.Int64)]
+        [TestCase(BsonType.String)]
+        public void TestChangesDecimalRepresentation(BsonType representation)
+        {
+            var convention = new DecimalRepresentationConvention(representation);
+            var classMap = new BsonClassMap<TestClass>();
+            var decimalMemberMap = classMap.MapMember(x => x.Decimal);
+
+            convention.Apply(decimalMemberMap);
+
+            Assert.AreEqual(representation, ((RepresentationSerializationOptions) decimalMemberMap.SerializationOptions).Representation);
+        }
+
+        [Test]
+        public void TestOnlyCreateWithAllowedRepresentations()
+        {
+            foreach (BsonType representation in Enum.GetValues(typeof (BsonType)))
+            {
+                if ((representation == BsonType.Array) ||
+                    (representation == BsonType.Double) ||
+                    (representation == BsonType.Int32) ||
+                    (representation == BsonType.Int64) ||
+                    (representation == BsonType.String))
+                {
+                    new DecimalRepresentationConvention(representation);
+                }
+                else
+                {
+                    Assert.Throws<ArgumentException>(() => { new DecimalRepresentationConvention(representation); });
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
mirrored from EnumRepresentationConvention

Several people have asked for this, although they might want to consider using doubles to avoid mismatch in precision, I figured they might as well have the ability to change it globally if they still want to use decimals.
