### PR TITLE
Add strongly typed explain method to LINQ queries.

### DIFF
--- a/MongoDB.Driver/Linq/LinqToMongo.cs
+++ b/MongoDB.Driver/Linq/LinqToMongo.cs
@@ -19,6 +19,8 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver.Linq.QueryPlans;
 
 namespace MongoDB.Driver.Linq
 {
@@ -91,7 +93,29 @@ namespace MongoDB.Driver.Linq
             return projector.Cursor.Explain(verbose);
         }
 
-        /// <summary>
+		/// <summary>
+		/// Returns an explanation of how the query was executed (instead of the results).
+		/// </summary>
+		/// <param name="source">The LINQ query to explain</param>
+		/// <returns>A strongly-typed explanation of how the query was executed.</returns>
+        public static QueryPlan ExplainTyped<T>(this IQueryable<T> source)
+		{
+			return ExplainTyped(source, false);
+		}
+
+		/// <summary>
+		/// Returns an explanation of how the query was executed (instead of the results).
+		/// </summary>
+		/// <param name="source">The LINQ query to explain</param>
+		/// <param name="verbose">Whether the explanation should contain more details.</param>
+		/// <returns>A strongly-typed explanation of how the query was executed.</returns>
+		public static QueryPlan ExplainTyped<T>(this IQueryable<T> source, bool verbose)
+		{
+			BsonDocument doc = source.Explain(verbose);
+			return BsonSerializer.Deserialize<QueryPlan>(doc);
+		}
+
+	    /// <summary>
         /// Determines whether a specified value is contained in a sequence.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements of source.</typeparam>

--- a/MongoDB.Driver/Linq/QueryPlans/ClusterType.cs
+++ b/MongoDB.Driver/Linq/QueryPlans/ClusterType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace MongoDB.Driver.Linq.QueryPlans
+{
+	/// <summary>
+	/// clusteredType is a string that reports the access pattern for shards.
+	/// </summary>
+	public enum ClusterType
+	{
+		/// <summary>
+		/// ParallelSort, if the mongos queries shards in parallel.
+		/// </summary>
+		ParallelSort,
+		/// <summary>
+		/// SerialServer, if the mongos queries shards sequentially.
+		/// </summary>
+		SerialServer
+	}
+}

--- a/MongoDB.Driver/Linq/QueryPlans/CursorType.cs
+++ b/MongoDB.Driver/Linq/QueryPlans/CursorType.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace MongoDB.Driver.Linq.QueryPlans
+{
+	/// <summary>
+	/// Cursor is a string that reports the type of cursor used by the query operation.
+	/// </summary>
+	public enum CursorType
+	{
+		/// <summary>
+		/// Cusor type could not be determined.
+		/// </summary>
+		Unknown,
+		/// <summary>
+		/// BasicCursor indicates a full collection scan.
+		/// </summary>
+		BasicCursor,
+		/// <summary>
+		/// BtreeCursor indicates that the query used an index. The cursor includes name of the index. When a query uses an index, the output of explain() includes indexBounds details.
+		/// </summary>
+		BtreeCursor,
+		/// <summary>
+		/// GeoSearchCursor indicates that the query used a geospatial index.
+		/// </summary>
+		GeoSearchCursor
+	}
+}

--- a/MongoDB.Driver/Linq/QueryPlans/QueryPlan.cs
+++ b/MongoDB.Driver/Linq/QueryPlans/QueryPlan.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace MongoDB.Driver.Linq.QueryPlans
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	[BsonIgnoreExtraElements]
+	public class QueryPlan
+	{
+		/// <summary>
+		/// Cursor is a string that reports the type of cursor used by the query operation.
+		/// </summary>
+		[BsonElement("cursor")]
+		public string Cursor { get; set; }
+
+		/// <summary>
+		/// Cursor is a string that reports the type of cursor used by the query operation.
+		/// </summary>
+		public CursorType CursorType
+		{
+			get
+			{
+				try
+				{
+					var s = Cursor.Split(' ')[0];
+					CursorType result = (CursorType) Enum.Parse(typeof (CursorType), s, true);
+					return result;
+				}
+				catch (Exception)
+				{
+					return CursorType.Unknown;
+				}
+				
+			}
+		}
+
+		/// <summary>
+		/// isMultiKey is a boolean. When true, the query uses a multikey index, where one of the fields in the index holds an array.
+		/// </summary>
+		[BsonElement("isMultiKey")]
+		public bool IsMultiKey { get; set; }
+
+		/// <summary>
+		/// n is a number that reflects the number of documents that match the query selection criteria.
+		/// </summary>
+		[BsonElement("n")]
+		public int DocumentCount { get; set; }
+
+		/// <summary>
+		/// pecifies the total number of documents or index entries scanned during the database operation. You want n and nscanned to be close in value as possible. The nscanned value may be higher than the nscannedObjects value, such as if the index covers a query. See indexOnly.
+		/// </summary>
+		[BsonElement("nscanned")]
+		public int ScannedDocumentCount { get; set; }
+
+		/// <summary>
+		/// nscannedObjectsAllPlans is a number that reflects the total number of documents scanned for all query plans during the database operation.
+		/// </summary>
+		[BsonElement("nscannedObjectsAllPlans")]
+		public int ScannedCount { get; set; }
+
+		/// <summary>
+		/// nscannedAllPlans is a number that reflects the total number of documents or index entries scanned for all query plans during the database operation.
+		/// </summary>
+		[BsonElement("nscannedAllPlans")]
+		public int ScannedDocumentCountAllPlans { get; set; }
+
+		/// <summary>
+		/// Specifies the total number of documents scanned during the query. The nscannedObjects may be lower than nscanned, such as if the index covers a query. See indexOnly. Additionally, the nscannedObjects may be lower than nscanned in the case of multikey index on an array field with duplicate documents.
+		/// </summary>
+		[BsonElement("nscannedObjects")]
+		public int ScannedCountAllPlans { get; set; }
+
+		/// <summary>
+		/// scanAndOrder is a boolean that is true when the query cannot use the order of documents in the index for returning sorted results: MongoDB must sort the documents after it receives the documents from a cursor.
+		///
+		/// If scanAndOrder is false, MongoDB can use the order of the documents in an index to return sorted results.
+		/// </summary>
+		[BsonElement("scanAndOrder")]
+		public bool ScanAndOrder { get; set; }
+
+		/// <summary>
+		/// indexOnly is a boolean value that returns true when the query is covered by the index indicated in the cursor field. When an index covers a query, MongoDB can both match the query conditions and return the results using only the index because:
+		/// * all the fields in the query are part of that index, and
+		/// * all the fields returned in the results set are in the same index.
+		/// </summary>
+		[BsonElement("indexOnly")]
+		public bool IndexOnly { get; set; }
+
+		/// <summary>
+		/// nYields is a number that reflects the number of times this query yielded the read lock to allow waiting writes execute.
+		/// </summary>
+		[BsonElement("nYields")]
+		public int YieldCount { get; set; }
+
+		/// <summary>
+		/// nChunkSkips is a number that reflects the number of documents skipped because of active chunk migrations in a sharded system. Typically this will be zero. A number greater than zero is ok, but indicates a little bit of inefficiency.
+		/// </summary>
+		[BsonElement("nChunkSkips")]
+		public int ChunkSkipCount { get; set; }
+
+		/// <summary>
+		/// millis is a number that reflects the time in milliseconds to complete the query.
+		/// </summary>
+		[BsonElement("millis")]
+		public int Milliseconds { get; set; }
+
+		/// <summary>
+		/// indexBounds is a document that contains the lower and upper index key bounds.
+		/// </summary>
+		[BsonElement("indexBounds")]
+		public Dictionary<string, BsonValue> IndexBounds { get; set; }
+
+		/// <summary>
+		/// server is a string that reports the MongoDB server.
+		/// </summary>
+		[BsonElement("server")]
+		public string Server { get; set; }
+
+		/// <summary>
+		/// allPlans is an array that holds the list of plans the query optimizer runs in order to select the index for the query. Displays only when the verbose parameter to explain() is true or 1.
+		/// </summary>
+		[BsonElement("allPlans")]
+		public QueryPlan[] AllPlans { get; set; }
+
+		/// <summary>
+		/// oldPlan is a document value that contains the previous plan selected by the query optimizer for the query. Displays only when the verbose parameter to explain() is true or 1.
+		/// </summary>
+		[BsonElement("oldPlan")]
+		public QueryPlan OldPlan { get; set; }
+
+		/// <summary>
+		/// clusteredType is a string that reports the access pattern for shards.
+		/// </summary>
+		[BsonElement("clusteredType"), BsonRepresentation(BsonType.String)]
+		public ClusterType? ClusteredType { get; set; }
+
+		/// <summary>
+		/// millisShardTotal is a number that reports the total time in milliseconds for the query to run on the shards.
+		/// </summary>
+		[BsonElement("millisShardTotal")]
+		public int MillisShardTotal { get; set; }
+
+		/// <summary>
+		/// millisShardAvg is a number that reports the average time in millisecond for the query to run on each shard.
+		/// </summary>
+		[BsonElement("millisShardAvg")]
+		public int MillisShardAvg { get; set; }
+
+		/// <summary>
+		/// numQueries is a number that reports the total number of queries executed.
+		/// </summary>
+		[BsonElement("numQueries")]
+		public int NumQueries { get; set; }
+
+		/// <summary>
+		/// numShards is a number that reports the total number of shards queried.
+		/// </summary>
+		[BsonElement("numShards")]
+		public int NumShards { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("filterSet")]
+		public bool FilterSet { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("stats")]
+		public QueryPlanStats Stats { get; set; }
+	}
+}

--- a/MongoDB.Driver/Linq/QueryPlans/QueryPlanStats.cs
+++ b/MongoDB.Driver/Linq/QueryPlans/QueryPlanStats.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace MongoDB.Driver.Linq.QueryPlans
+{
+	/// <summary>
+	/// Detailed statistics about the query plan.
+	/// </summary>
+	[BsonIgnoreExtraElements]
+	public class QueryPlanStats
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("type")]
+		public string Type { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("works")]
+		public int Works { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("yields")]
+		public int Yields { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("unyields")]
+		public int Unyields { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("invalidates")]
+		public int Invalidates { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("advanced")]
+		public int Advanced { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("needTime")]
+		public bool NeedTime { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("needFetch")]
+		public bool NeedFetch { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("isEOF")]
+		public bool IsEOF { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("docsTested")]
+		public int DocsTested { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		[BsonElement("children")]
+		public List<QueryPlanStats> Children { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public QueryPlanStats()
+		{
+			this.Children = new List<QueryPlanStats>();
+		}
+	}
+}

--- a/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/MongoDB.Driver/MongoDB.Driver.csproj
@@ -89,6 +89,10 @@
     <Compile Include="Communication\FeatureDetection\AndDependency.cs" />
     <Compile Include="Communication\FeatureDetection\InstanceTypeDependency.cs" />
     <Compile Include="Communication\FeatureDetection\NotDependency.cs" />
+    <Compile Include="Linq\QueryPlans\ClusterType.cs" />
+    <Compile Include="Linq\QueryPlans\CursorType.cs" />
+    <Compile Include="Linq\QueryPlans\QueryPlan.cs" />
+    <Compile Include="Linq\QueryPlans\QueryPlanStats.cs" />
     <Compile Include="Operations\ParallelScanOperation.cs" />
     <Compile Include="ParallelScanArgs.cs" />
     <Compile Include="WriteConcernError.cs" />


### PR DESCRIPTION
Adds strongly typed explain method to LinqToMongo explain methods. Addresses JIRA issue: C# DriverCSHARP-920.

I have added one new method (with two overrides) to LinqToMongo.cs. These return a new object graph of strongly typed objects representing the explain response document.

I have added several unit tests for these methods and I have added as much documentation as I was able to find on the website related to the explain response.

I'm happy to make tweaks if necessary.
