### PR TITLE
add support for specifying the OplogReplay QueryFlag.

### DIFF
--- a/src/MongoDB.Driver/QueryFlags.cs
+++ b/src/MongoDB.Driver/QueryFlags.cs
@@ -36,6 +36,10 @@ namespace MongoDB.Driver
         /// </summary>
         SlaveOk = 4,
         /// <summary>
+        /// Internal replication use only - driver should not set
+        /// </summary>
+        OplogReplay = 8,
+        /// <summary>
         /// Tell the server not to let the cursor timeout.
         /// </summary>
         NoCursorTimeout = 16,


### PR DESCRIPTION
expose the OplogReplay query flag to uses of mongos driver for cases where they want to be able to replicate the oplog.
