### PR TITLE
$maxscan should be spelled as $maxScan

### DIFF
--- a/src/MongoDB.Driver/MongoCursor.cs
+++ b/src/MongoDB.Driver/MongoCursor.cs
@@ -473,7 +473,7 @@ namespace MongoDB.Driver
         public virtual MongoCursor SetMaxScan(int maxScan)
         {
             if (_isFrozen) { ThrowFrozen(); }
-            SetOption("$maxscan", maxScan);
+            SetOption("$maxScan", maxScan);
             return this;
         }
 


### PR DESCRIPTION
SetMaxScan method added $maxscan option instead of $maxScan option which resulted in that option being ignored by mongod.
