### PR TITLE
CSHARP-1029: Making properties virtual for easier testing

### DIFF
--- a/src/MongoDB.Bson/IO/BsonReader.cs
+++ b/src/MongoDB.Bson/IO/BsonReader.cs
@@ -53,7 +53,7 @@ namespace MongoDB.Bson.IO
         /// <summary>
         /// Gets the current BsonType.
         /// </summary>
-        public BsonType CurrentBsonType
+        public virtual BsonType CurrentBsonType
         {
             get { return _currentBsonType; }
             protected set { _currentBsonType = value; }
@@ -70,7 +70,7 @@ namespace MongoDB.Bson.IO
         /// <summary>
         /// Gets the current state of the reader.
         /// </summary>
-        public BsonReaderState State
+        public virtual BsonReaderState State
         {
             get { return _state; }
             protected set { _state = value; }

--- a/src/MongoDB.Bson/IO/BsonWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonWriter.cs
@@ -90,7 +90,7 @@ namespace MongoDB.Bson.IO
         /// <summary>
         /// Gets the current state of the writer.
         /// </summary>
-        public BsonWriterState State
+        public virtual BsonWriterState State
         {
             get { return _state; }
             protected set { _state = value; }


### PR DESCRIPTION
Make properties virtual, so they can be mocked for unit testing IBsonSerializer implementation.