### PR TITLE
Workaround Xamarin compiler errors by adding explicit type parameters

### DIFF
--- a/src/MongoDB.Driver.Tests/GeoJsonObjectModel/GeoJsonMultiPolygonTests.cs
+++ b/src/MongoDB.Driver.Tests/GeoJsonObjectModel/GeoJsonMultiPolygonTests.cs
@@ -25,9 +25,9 @@ namespace MongoDB.Driver.Tests.GeoJsonObjectModel
         [Test]
         public void TestExampleFromSpec()
         {
-            var multiPolygon = GeoJson.MultiPolygon(
+            var multiPolygon = GeoJson.MultiPolygon<GeoJson2DCoordinates>(
                 GeoJson.PolygonCoordinates(GeoJson.Position(102.0, 2.0), GeoJson.Position(103.0, 2.0), GeoJson.Position(103.0, 3.0), GeoJson.Position(102.0, 3.0), GeoJson.Position(102.0, 2.0)),
-                GeoJson.PolygonCoordinates(
+                GeoJson.PolygonCoordinates<GeoJson2DCoordinates>(
                     GeoJson.LinearRingCoordinates(GeoJson.Position(102.0, 2.0), GeoJson.Position(103.0, 2.0), GeoJson.Position(103.0, 3.0), GeoJson.Position(102.0, 3.0), GeoJson.Position(102.0, 2.0)),
                     GeoJson.LinearRingCoordinates(GeoJson.Position(102.0, 2.0), GeoJson.Position(103.0, 2.0), GeoJson.Position(103.0, 3.0), GeoJson.Position(102.0, 3.0), GeoJson.Position(102.0, 2.0))));
 

--- a/src/MongoDB.Driver.Tests/GeoJsonObjectModel/GeoJsonPolygonTests.cs
+++ b/src/MongoDB.Driver.Tests/GeoJsonObjectModel/GeoJsonPolygonTests.cs
@@ -39,7 +39,7 @@ namespace MongoDB.Driver.Tests.GeoJsonObjectModel
         public void TestExampleFromSpecWithHoles()
         {
             var polygon = GeoJson.Polygon(
-                GeoJson.PolygonCoordinates(
+                GeoJson.PolygonCoordinates<GeoJson2DCoordinates>(
                     // exterior
                     GeoJson.LinearRingCoordinates(
                         GeoJson.Position(100.0, 0.0),


### PR DESCRIPTION
Per Robert's suggestion, adding explicit type parameters made the Xamarin compiler stop complaining.
