### PR TITLE
CSHARP-1080: fix unexpected change non id field name in BSON document

### DIFF
--- a/MongoDB.Bson/Serialization/Conventions/NamedIdMemberConvention.cs
+++ b/MongoDB.Bson/Serialization/Conventions/NamedIdMemberConvention.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2010-2014 MongoDB Inc.
+/* Copyright 2010-2014 MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,13 +109,21 @@ namespace MongoDB.Bson.Serialization.Conventions
 
                 if (member != null)
                 {
-                    if (IsValidIdMember(classMap, member))
+                    if (IsValidIdMember(classMap, member) &&
+                        !ConflictWithBsonElementAttribute(member))
                     {
                         classMap.MapIdMember(member);
                         return;
                     }
                 }
             }
+        }
+
+        private bool ConflictWithBsonElementAttribute(MemberInfo member)
+        {
+            return member.GetCustomAttributes(typeof(MongoDB.Bson.Serialization.Attributes.BsonElementAttribute), true)
+                .Cast<MongoDB.Bson.Serialization.Attributes.BsonElementAttribute>()
+                .Any(_ => _.ElementName != null && _.ElementName != "_id");
         }
 
         private bool IsValidIdMember(BsonClassMap classMap, MemberInfo member)
@@ -142,7 +150,8 @@ namespace MongoDB.Bson.Serialization.Conventions
             foreach (string name in _names)
             {
                 var memberInfo = type.GetMember(name).SingleOrDefault(x => x.MemberType == MemberTypes.Field || x.MemberType == MemberTypes.Property);
-                if (memberInfo != null)
+                if (memberInfo != null &&
+                    !ConflictWithBsonElementAttribute(memberInfo))
                 {
                     return name;
                 }

--- a/MongoDB.BsonUnitTests/Serialization/Attributes/BsonAttributeTests.cs
+++ b/MongoDB.BsonUnitTests/Serialization/Attributes/BsonAttributeTests.cs
@@ -66,6 +66,12 @@ namespace MongoDB.BsonUnitTests.Serialization.Attributes
             public string NoElement { get; set; }
         }
 
+        public class TestModel_CustomNotId
+        {
+            [BsonElement("id")]
+            public ObjectId Id { get; set; }
+        }
+
         [Test]
         public void TestDiscriminator()
         {
@@ -115,6 +121,16 @@ namespace MongoDB.BsonUnitTests.Serialization.Attributes
             var isNotId = classMap.GetMemberMap("IsNotId");
             Assert.AreEqual("IsNotId", isNotId.ElementName);
             Assert.AreNotSame(classMap.IdMemberMap, isNotId);
+        }
+
+        [Test]
+        public void TestCustomNotId()
+        {
+            var classMap = BsonClassMap.LookupClassMap(typeof(TestModel_CustomNotId));
+
+            var id = classMap.GetMemberMap("Id");
+            Assert.AreEqual("id", id.ElementName);
+            Assert.IsNull(classMap.IdMemberMap);
         }
 
         [Test]


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-1080

I want to serialize following class:

``` csharp
public class TestModel_CustomNotId
{
    [BsonElement("id")]
    public ObjectId Id { get; set; }
}
```

I expected Id field to be serialized as "id",
but the result BSON document is containing "_id" field.
