### PR TITLE
The query builder was generating invalid queries when ANDing two or more

### DIFF
--- a/src/MongoDB.Driver/Builders/QueryBuilder.cs
+++ b/src/MongoDB.Driver/Builders/QueryBuilder.cs
@@ -893,7 +893,7 @@ namespace MongoDB.Driver.Builders
                     }
                     else
                     {
-                        query.Add(clause);
+                        PromoteQueryToDollarAndForm(query, clause);
                     }
                 }
             }


### PR DESCRIPTION
conditions that both exist in a in an array of objects.

Assuming a document like this
{
    _objectid:...,
    Item:555,
    MetaData: [{
        Foo: Bar
    },
    {
        Baz: Bat
    }]...
}
Query.And with two conditons in that array would generate invalid syntax.
I found the solution was to promote to $and everytime. There is certainly
a more elegant solution, but this solved my immediate problem with no ill
effects.