### PR TITLE
replace GeoNearOptions.null with a null and avoid the compiler warning

### DIFF
--- a/src/MongoDB.Driver/MongoCollection.cs
+++ b/src/MongoDB.Driver/MongoCollection.cs
@@ -1011,7 +1011,7 @@ namespace MongoDB.Driver
         [Obsolete("Use the overload of GeoNearAs that has a GeoNearArgs parameter instead.")]
         public virtual GeoNearResult GeoNearAs(Type documentType, IMongoQuery query, double x, double y, int limit)
         {
-            return GeoNearAs(documentType, query, x, y, limit, GeoNearOptions.Null);
+            return GeoNearAs(documentType, query, x, y, limit, null);
         }
 
         /// <summary>


### PR DESCRIPTION
removed the `IMongoGeoNearOptions.Null` reference as this was causing a "warning as error" result during local build.  Used `null` instead.