### PR TITLE
add null checks to ClusterBuilder

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilder.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilder.cs
@@ -141,6 +141,8 @@ namespace MongoDB.Driver.Core.Configuration
         /// <returns>A reconfigured cluster builder.</returns>
         public ClusterBuilder ConfigureServer(Func<ServerSettings, ServerSettings> configurator)
         {
+            Ensure.IsNotNull(configurator, "configurator");
+
             _serverSettings = configurator(_serverSettings);
             return this;
         }
@@ -152,6 +154,8 @@ namespace MongoDB.Driver.Core.Configuration
         /// <returns>A reconfigured cluster builder.</returns>
         public ClusterBuilder ConfigureSsl(Func<SslStreamSettings, SslStreamSettings> configurator)
         {
+            Ensure.IsNotNull(configurator, "configurator");
+
             _sslStreamSettings = configurator(_sslStreamSettings ?? new SslStreamSettings());
             return this;
         }


### PR DESCRIPTION
Hello, I'm working an a static analysis tool that can find missing null checks.  It suggested you add these checks.  There are a couple methods in ClusterBuilder that take a function (called configurator) as the argument.  ConfigureServer and ConfigureSsl don't check if configurator is null, but the others do.
