### PR TITLE
added drop extension methods for IMongoDatabase and IMongoCollection

### DIFF
--- a/src/MongoDB.Driver/MongoCollectionExtensions.cs
+++ b/src/MongoDB.Driver/MongoCollectionExtensions.cs
@@ -1,0 +1,39 @@
+﻿/* Copyright 2010-2014 MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MongoDB.Driver
+{
+    /// <summary>
+    /// Holds the extensions for <see cref="IMongoCollection{TDocument}" />.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class MongoCollectionExtensions
+    {
+        /// <summary>
+        /// Drops the referenced collection.
+        /// </summary>
+        /// <param name="collection">The collection reference to drop.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task</returns>
+        public static Task DropAsync<TDocument>(this IMongoCollection<TDocument> collection, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return collection.Database.DropCollectionAsync(collection.CollectionNamespace.CollectionName, cancellationToken);
+        }
+    }
+}

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -150,6 +150,8 @@
     <Compile Include="Linq\Translators\AggregateLanguageTranslator.cs" />
     <Compile Include="Linq\QueryableExecutionModelBuilder.cs" />
     <Compile Include="Linq\Translators\PredicateTranslator.cs" />
+    <Compile Include="MongoCollectionExtensions.cs" />
+    <Compile Include="MongoDatabaseExtensions.cs" />
     <Compile Include="PipelineStageDefinition.cs" />
     <Compile Include="PipelineDefinition.cs" />
     <Compile Include="BulkWriteError.cs" />

--- a/src/MongoDB.Driver/MongoDatabaseExtensions.cs
+++ b/src/MongoDB.Driver/MongoDatabaseExtensions.cs
@@ -1,0 +1,39 @@
+﻿/* Copyright 2010-2014 MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MongoDB.Driver
+{
+    /// <summary>
+    /// Holds the extensions for <see cref="IMongoDatabase" />.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class MongoDatabaseExtensions
+    {
+        /// <summary>
+        /// Drops the referenced database.
+        /// </summary>
+        /// <param name="database">The database reference to drop.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task</returns>
+        public static Task DropAsync(this IMongoDatabase database, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return database.Client.DropDatabaseAsync(database.DatabaseNamespace.DatabaseName, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
Added `DropAsync` extensions methods for both `IMongoDatabase` and `IMongoCollection` to make it easy to reach them. Not sure if this is the desired but I keep having this in my projects as it's easier to type.
