### PR TITLE
CSHARP-1316: Dictionary key comparison linq query support

### DIFF
--- a/MongoDB.Bson/Serialization/Serializers/DictionarySerializer.cs
+++ b/MongoDB.Bson/Serialization/Serializers/DictionarySerializer.cs
@@ -65,6 +65,16 @@ namespace MongoDB.Bson.Serialization.Serializers
             get { return __instance; }
         }
 
+        /// <summary>
+        /// Gets the value serializer.
+        /// </summary>
+        /// <param name="actualType">The actual type of the value.</param>
+        /// <returns>The serializer for the value type.</returns>
+        public IBsonSerializer GetValueSerializer(Type actualType)
+        {
+            return _keyValuePairSerializer.GetValueSerializer(actualType);
+        }
+
         // public methods
         /// <summary>
         /// Deserializes an object from a BsonReader.

--- a/MongoDB.Bson/Serialization/Serializers/KeyValuePairSerializer.cs
+++ b/MongoDB.Bson/Serialization/Serializers/KeyValuePairSerializer.cs
@@ -274,7 +274,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// </summary>
         /// <param name="actualType">The actual type of the value.</param>
         /// <returns>The serializer for the value type.</returns>
-        private IBsonSerializer GetValueSerializer(Type actualType)
+        internal IBsonSerializer GetValueSerializer(Type actualType)
         {
             // return a cached serializer when possible
             if (actualType == typeof(TValue))

--- a/MongoDB.Driver/Linq/Utils/BsonSerializationInfoFinder.cs
+++ b/MongoDB.Driver/Linq/Utils/BsonSerializationInfoFinder.cs
@@ -282,6 +282,21 @@ namespace MongoDB.Driver.Linq.Utils
                 return CombineSerializationInfo(serializationInfo, memberSerializationInfo);
             }
 
+            var dictionarySerializer = serializationInfo.Serializer as MongoDB.Bson.Serialization.Serializers.DictionarySerializer;
+            if (dictionarySerializer != null)
+            {
+                DictionarySerializationOptions dictionarySerializationOptions = serializationInfo.SerializationOptions as DictionarySerializationOptions;
+                if (dictionarySerializationOptions != null)
+                {
+                    var memberSerializationInfo = new BsonSerializationInfo(
+                            indexName,
+                            dictionarySerializer.GetValueSerializer(indexExpression.Value.GetType()),
+                            indexExpression.Value.GetType(),
+                            dictionarySerializationOptions.KeyValuePairSerializationOptions.ValueSerializationOptions);
+                    return CombineSerializationInfo(serializationInfo, memberSerializationInfo);
+                }
+            }
+
             return null;
         }
 

--- a/MongoDB.DriverUnitTests/Linq/SelectDictionaryTests.cs
+++ b/MongoDB.DriverUnitTests/Linq/SelectDictionaryTests.cs
@@ -240,6 +240,30 @@ namespace MongoDB.DriverUnitTests.Linq
         }
 
         [Test]
+        public void TestWhereHHasXEqualToSomeInt()
+        {
+            object someInt = 42;
+            var query = from c in _collection.AsQueryable<C>()
+                        where c.H["x"] == someInt
+                        select c;
+
+            var translatedQuery = MongoQueryTranslator.Translate(query);
+            Assert.IsInstanceOf<SelectQuery>(translatedQuery);
+            Assert.AreSame(_collection, translatedQuery.Collection);
+            Assert.AreSame(typeof(C), translatedQuery.DocumentType);
+
+            var selectQuery = (SelectQuery)translatedQuery;
+            Assert.AreEqual("(C c) => (c.H.get_Item(\"x\") == 42)", ExpressionFormatter.ToString(selectQuery.Where));
+            Assert.IsNull(selectQuery.OrderBy);
+            Assert.IsNull(selectQuery.Projection);
+            Assert.IsNull(selectQuery.Skip);
+            Assert.IsNull(selectQuery.Take);
+
+            Assert.AreEqual("{ \"H.x\" : 42 }", selectQuery.BuildQuery().ToJson());
+            Assert.AreEqual(0, query.ToList().Count());
+        }
+
+        [Test]
         public void TestWhereHContainsKeyZ()
         {
             var query = from c in _collection.AsQueryable<C>()


### PR DESCRIPTION
CSHARP-1316
added DictionarySerializer support in
BsonSerializationInfoFinder.VisitGetItem
added public GetValueSerializer to DictionarySerializer
