### PR TITLE
CSHARP-1315 Added support for $filter during $project phase of aggreg…

### DIFF
--- a/src/MongoDB.Driver.Tests/Linq/Translators/AggregateProjectionTranslatorTests_Project.cs
+++ b/src/MongoDB.Driver.Tests/Linq/Translators/AggregateProjectionTranslatorTests_Project.cs
@@ -612,6 +612,18 @@ namespace MongoDB.Driver.Tests.Linq.Translators
         }
 
         [Test]
+        [RequiresServer(MinimumVersion = "3.1.3")]
+        public async Task Should_translate_where_to_filter()
+        {
+            var result = await Project(x => new { Result = x.G.Where(c => c.E.F == 33) });
+
+            result.Projection.Should().Be("{ Result: { \"$filter\": { \"input\": \"$G\", \"as\": \"c\", \"cond\": { \"$eq\": [\"$$c.E.F\", 33] } } }, _id: 0 }");
+
+            result.Value.Result.Should().HaveCount(1);
+            result.Value.Result.Single().D.Should().Be("Don't");
+        }
+
+        [Test]
         public async Task Should_translate_string_equals()
         {
             var result = await Project(x => new { Result = x.B.Equals("Balloon") });

--- a/src/MongoDB.Driver/Linq/Processors/SerializationInfoBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/SerializationInfoBinder.cs
@@ -139,6 +139,7 @@ namespace MongoDB.Driver.Linq.Processors
                 case "LongCount":
                 case "Max":
                 case "Min":
+                case "Where":
                 case "Select":
                 case "SelectMany":
                 case "Sum":


### PR DESCRIPTION
…ation pipeline, via Where() +test

Tried to keep implementation as similar in style to existing code as possible; TryBuildFilter() in particular is a close copy of TryBuildMap(), used by Select().  This includes the "// HACK" for adding a single additional $ to the param replacement.

Any questions or problems let me know!
