### PR TITLE
CSHARP-837: Add support for CompareTo in the legacy predicate translator

### DIFF
--- a/src/MongoDB.Driver.Legacy/Linq/Translators/PredicateTranslator.cs
+++ b/src/MongoDB.Driver.Legacy/Linq/Translators/PredicateTranslator.cs
@@ -288,6 +288,12 @@ namespace MongoDB.Driver.Linq
                 return query;
             }
 
+            query = BuildCompareToQuery(variableExpression, operatorType, constantExpression);
+            if (query != null)
+            {
+                return query;
+            }
+
             query = BuildStringIndexOfQuery(variableExpression, operatorType, constantExpression);
             if (query != null)
             {
@@ -319,6 +325,28 @@ namespace MongoDB.Driver.Linq
             }
 
             return BuildComparisonQuery(variableExpression, operatorType, constantExpression);
+        }
+
+        private IMongoQuery BuildCompareToQuery(Expression variableExpression, ExpressionType operatorType, ConstantExpression constantExpression)
+        {
+            if (constantExpression.Type != typeof (int) || ((int) constantExpression.Value) != 0)
+            {
+                return null;
+            }
+
+            var call = variableExpression as MethodCallExpression;
+            if (call == null || call.Object == null || call.Method.Name != "CompareTo" || call.Arguments.Count != 1)
+            {
+                return null;
+            }
+
+            constantExpression = call.Arguments[0] as ConstantExpression;
+            if (constantExpression == null)
+            {
+                return null;
+            }
+
+            return BuildComparisonQuery(call.Object, operatorType, constantExpression);
         }
 
         private IMongoQuery BuildComparisonQuery(Expression variableExpression, ExpressionType operatorType, ConstantExpression constantExpression)

--- a/src/MongoDB.Driver.Tests/Linq/Translators/LegacyPredicateTranslatorTests.cs
+++ b/src/MongoDB.Driver.Tests/Linq/Translators/LegacyPredicateTranslatorTests.cs
@@ -1162,6 +1162,43 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert<C>(c => !(c.X != 1), 1, "{ \"x\" : 1 }");
         }
 
+        [Test]
+        public void CompareTo_equal()
+        {
+            Assert<C>(x => x.S.CompareTo("abc") == 0, 1, "{\"s\": \"abc\" }");
+        }
+
+        [Test]
+        public void CompareTo_greater_than()
+        {
+            Assert<C>(
+                x => x.S.CompareTo("Around") > 0, 1, "{\"s\": { $gt: \"Around\" } }");
+        }
+
+        [Test]
+        public void CompareTo_greater_than_or_equal()
+        {
+            Assert<C>(x => x.S.CompareTo("Around") >= 0, 1, "{\"s\": { $gte: \"Around\" } }");
+        }
+
+        [Test]
+        public void CompareTo_less_than()
+        {
+            Assert<C>(x => x.S.CompareTo("Around") < 0, 1, "{\"s\": { $lt: \"Around\" } }");
+        }
+
+        [Test]
+        public void CompareTo_less_than_or_equal()
+        {
+            Assert<C>(x => x.S.CompareTo("Around") <= 0, 1, "{\"s\": { $lte: \"Around\" } }");
+        }
+
+        [Test]
+        public void CompareTo_not_equal()
+        {
+            Assert<C>(x => x.S.CompareTo("abc") != 0, 4, "{\"s\": { $ne: \"abc\" } }");
+        }
+
         public void Assert<TDocument>(Expression<Func<TDocument, bool>> filter, int expectedCount, string expectedFilter)
         {
             var serializer = BsonSerializer.SerializerRegistry.GetSerializer<TDocument>();


### PR DESCRIPTION
I'm aware that [CSHARP-837](https://jira.mongodb.org/browse/CSHARP-837) has already closed, but I would like to add it to the legacy version of the driver since it's useful not just to `string`, but also to all types that use `CompareTo`, e.g. `Guid`.
