### PR TITLE
Adding a new BSON serialization provider to be able to determine that…

### DIFF
--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Serialization\CreatorMapDelegateCompiler.cs" />
     <Compile Include="Serialization\ExpressionVisitor.cs" />
     <Compile Include="Serialization\BsonSerializerRegistry.cs" />
+    <Compile Include="Serialization\ForceAsBsonClassMapSerializationProvider.cs" />
     <Compile Include="Serialization\IBsonDictionarySerializer.cs" />
     <Compile Include="Serialization\IBsonPolymorphicSerializer.cs" />
     <Compile Include="Serialization\IBsonSerializerRegistry.cs" />

--- a/src/MongoDB.Bson/Serialization/ForceAsBsonClassMapSerializationProvider.cs
+++ b/src/MongoDB.Bson/Serialization/ForceAsBsonClassMapSerializationProvider.cs
@@ -60,7 +60,7 @@
         {
             if (forcedTypes == null || forcedTypes.Count() == 0)
                 throw new ArgumentException("Cannot configure a forced BSON class map serialization provider which contains no types to be forced as BSON class maps", "forcedTypes");
-            if (forcedTypes.All(type => type.IsClass || type.IsInterface))
+            if (!forcedTypes.All(type => type.IsClass || type.IsInterface))
                 throw new ArgumentException("Forced types must be classes or interfaces");
 
             _forcedTypes = new HashSet<Type>(forcedTypes);

--- a/src/MongoDB.Bson/Serialization/ForceAsBsonClassMapSerializationProvider.cs
+++ b/src/MongoDB.Bson/Serialization/ForceAsBsonClassMapSerializationProvider.cs
@@ -1,0 +1,89 @@
+﻿namespace MongoDB.Bson.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents a BSON serialization provider which defines that some serializable types should be treated
+    /// as BSON class maps.
+    /// </summary>
+    /// <remarks>
+    /// Argumented types to be forced as BSON class maps can be either concrete or also base class and interface ones.
+    /// 
+    /// This serialization provider is useful when a class may implement a collection interface (for example, <see cref="System.Collections.Generic.IList{T}"/>)
+    /// because the domain requires the class to act as a collection, but in terms of serialization, it must be serialized as a regular
+    /// POCO class.
+    /// </remarks>
+    /// <example>
+    /// For example, given the following class:
+    /// 
+    /// <code language="c#">
+    /// public interface ISomeInterface { }
+    /// public class SomeImpl : ISomeInterface { }
+    /// </code>
+    /// 
+    /// This provider can be configured both to force any <codeInline>SomeImpl</codeInline> to be treated as 
+    /// BSON class map and also any implementation of <codeInline>ISomeInterface</codeInline> can be configured as a 
+    /// forced type to let any implementation be serialized as a BSON class map:
+    /// 
+    /// <code language="c#">
+    /// ForceAsBsonClassMapSerializationProvider provider = new ForceAsBsonClassMapSerializationProvider(typeof(SomeImpl));
+    /// 
+    /// // or
+    /// 
+    /// ForceAsBsonClassMapSerializationProvider provider = new ForceAsBsonClassMapSerializationProvider(typeof(ISomeInterface));
+    /// 
+    /// // or even both
+    /// 
+    /// ForceAsBsonClassMapSerializationProvider provider = new ForceAsBsonClassMapSerializationProvider(typeof(SomeImpl), typeof(ISomeInterface));
+    /// </code>
+    /// </example>
+    public sealed class ForceAsBsonClassMapSerializationProvider : BsonSerializationProviderBase
+    {
+        private readonly HashSet<Type> _forcedTypes;
+
+        /// <summary>
+        /// Constructor to give forced types as a type array.
+        /// </summary>
+        /// <param name="forcedTypes">The whole types to be forced as BSON class maps</param>
+        public ForceAsBsonClassMapSerializationProvider(params Type[] forcedTypes)
+            : this((IEnumerable<Type>)forcedTypes)
+        {
+        }
+
+        /// <summary>
+        /// Constructor to give forced types as a sequence of types.
+        /// </summary>
+        /// <param name="forcedTypes">The whole types to be forced as BSON class maps</param>
+        public ForceAsBsonClassMapSerializationProvider(IEnumerable<Type> forcedTypes)
+        {
+            if (forcedTypes == null || forcedTypes.Count() == 0)
+                throw new ArgumentException("Cannot configure a forced BSON class map serialization provider which contains no types to be forced as BSON class maps", "forcedTypes");
+            if (forcedTypes.All(type => type.IsClass || type.IsInterface))
+                throw new ArgumentException("Forced types must be classes or interfaces");
+
+            _forcedTypes = new HashSet<Type>(forcedTypes);
+        }
+
+        /// <summary>
+        /// Gets a set of types to be forced as BSON class maps during their serialization.
+        /// </summary>
+        public HashSet<Type> ForcedTypes { get { return _forcedTypes; } }
+
+        /// <inheritdoc/>
+        public override IBsonSerializer GetSerializer(Type type, IBsonSerializerRegistry serializerRegistry)
+        {
+            // Forcing can happen either if type to be serialized is within forced type set, or if one of forced types
+            // is implemented or inherited by the given type.
+            if (ForcedTypes.Contains(type) || ForcedTypes.Any(forcedType => forcedType.IsAssignableFrom(type)))
+            {
+                BsonClassMapSerializationProvider bsonClassMapProvider = new BsonClassMapSerializationProvider();
+
+                return bsonClassMapProvider.GetSerializer(type);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -142,6 +142,7 @@ namespace MongoDB.Bson.Serialization
                 }
             }
 
+            var docDictionaryImpl = document as IDictionary<string, object>;
             var discriminatorConvention = _classMap.GetDiscriminatorConvention();
             var allMemberMaps = _classMap.AllMemberMaps;
             var extraElementsMemberMapIndex = _classMap.ExtraElementsMemberMapIndex;
@@ -191,6 +192,16 @@ namespace MongoDB.Bson.Serialization
                     }
                     memberMapBitArray[memberMapIndex >> 5] |= 1U << (memberMapIndex & 31);
                 }
+                else if(docDictionaryImpl != null)
+                {
+                    // If the document itself implements IDictionary<TKey, TValue>, document to serialize could
+                    // contain extra elements as document properties...
+                    docDictionaryImpl.Add
+                    (
+                        elementName, 
+                        BsonTypeMapper.MapToDotNetValue(BsonValueSerializer.Instance.Deserialize(context))
+                    );
+                }
                 else
                 {
                     if (elementName == discriminatorConvention.ElementName)
@@ -202,7 +213,9 @@ namespace MongoDB.Bson.Serialization
                     if (extraElementsMemberMapIndex >= 0)
                     {
                         var extraElementsMemberMap = _classMap.ExtraElementsMemberMap;
-                        if (document != null)
+                        var documentDictionaryImpl = document as IDictionary<string, object>;
+
+                        if (document != null || documentDictionaryImpl != null)
                         {
                             DeserializeExtraElementMember(context, document, elementName, extraElementsMemberMap);
                         }
@@ -450,6 +463,31 @@ namespace MongoDB.Bson.Serialization
             return (TClass)document;
         }
 
+        private void X(BsonMemberMap extraElementsMemberMap,  object obj)
+        {
+
+            //var extraElements = (IDictionary<string, object>)extraElementsMemberMap.Getter(obj);
+
+            //if (extraElements == null)
+            //    extraElements = obj as IDictionary<string, object>;
+
+            //if (extraElements == null)
+            //{
+            //    if (extraElementsMemberMap.MemberType == typeof(IDictionary<string, object>))
+            //    {
+            //        extraElements = new Dictionary<string, object>();
+            //    }
+            //    else
+            //    {
+            //        extraElements = (IDictionary<string, object>)Activator.CreateInstance(extraElementsMemberMap.MemberType);
+            //    }
+            //    extraElementsMemberMap.Setter(obj, extraElements);
+            //}
+
+            //var bsonValue = BsonValueSerializer.Instance.Deserialize(context);
+            //extraElements[elementName] = BsonTypeMapper.MapToDotNetValue(bsonValue);
+        }
+
         private void DeserializeExtraElementMember(
             BsonDeserializationContext context,
             object obj,
@@ -564,6 +602,7 @@ namespace MongoDB.Bson.Serialization
             var bsonWriter = context.Writer;
 
             var remainingMemberMaps = _classMap.AllMemberMaps.ToList();
+            HashSet<string> classElementNames = new HashSet<string>(remainingMemberMaps.Select(map => map.MemberName));
 
             bsonWriter.WriteStartDocument();
 
@@ -591,7 +630,28 @@ namespace MongoDB.Bson.Serialization
                 SerializeMember(context, document, memberMap);
             }
 
+
+            // It might happen that a class implements IDictionary<TKey, TValue>, so 
+            // the keys can be also extra elements.
+            SerializeDictionary(context, document as IDictionary<string, object>, classElementNames);
+
             bsonWriter.WriteEndDocument();
+        }
+
+        private void SerializeDictionary(BsonSerializationContext context, IDictionary<string, object> extraElements, HashSet<string> classElementNames = null)
+        {
+            if (extraElements != null && extraElements.Count > 0)
+            {
+                foreach (var key in classElementNames == null ?
+                                           extraElements.Keys : extraElements.Keys.Where(key => !classElementNames.Contains(key)))
+                                   
+                {
+                    context.Writer.WriteName(key);
+                    var value = extraElements[key];
+                    var bsonValue = BsonTypeMapper.MapToBsonValue(value);
+                    BsonValueSerializer.Instance.Serialize(context, bsonValue);
+                }
+            }
         }
 
         private void SerializeExtraElements(BsonSerializationContext context, object obj, BsonMemberMap extraElementsMemberMap)
@@ -599,6 +659,10 @@ namespace MongoDB.Bson.Serialization
             var bsonWriter = context.Writer;
 
             var extraElements = extraElementsMemberMap.Getter(obj);
+
+            if (extraElements == null)
+                extraElements = obj as IDictionary<string, object>;
+
             if (extraElements != null)
             {
                 if (extraElementsMemberMap.MemberType == typeof(BsonDocument))
@@ -612,14 +676,7 @@ namespace MongoDB.Bson.Serialization
                 }
                 else
                 {
-                    var dictionary = (IDictionary<string, object>)extraElements;
-                    foreach (var key in dictionary.Keys)
-                    {
-                        bsonWriter.WriteName(key);
-                        var value = dictionary[key];
-                        var bsonValue = BsonTypeMapper.MapToBsonValue(value);
-                        BsonValueSerializer.Instance.Serialize(context, bsonValue);
-                    }
+                    SerializeDictionary(context, (IDictionary<string, object>)extraElements);
                 }
             }
         }


### PR DESCRIPTION
Because some requirements in my project, I had to create a base class derived by some domain objects which implement `IDictionary<TKey, TValue>`, but these domain objects are still POCOs and I want them to be serialized using regular BSON class map serializer. 

When I ran some test I found some issue: my domain object wasn't getting an auto-assigned GUID. After clonning the driver source code, I debugged the code step by step and I found that my domain objects were serialized as collections rather than POCOs, because they inherit a base class which implements `IDictionary<TKey, TValue>` as I mentioned above.

Then, I thought, *what about a way to configure that certain types must be serialized as class maps to solve my issue?*, and I implemented a serialization provider `ForceAsBsonClassMapSerializationProvider` to fix my problem.

For example, this new provider may be used as follows:

    public class SomeImpl : IDictionary<string, object> 
    {
        // Imagine that I've implemented all IDictionary<string, object> members
    }

    BsonSerializer.RegisterSerializationProvider(new ForceAsBsonClassMapSerializationProvider(typeof(IDictionary<string, object>)));

It can be also registered a concrete type to be forced as a BSON class map:

    BsonSerializer.RegisterSerializationProvider(new ForceAsBsonClassMapSerializationProvider(typeof(SomeImpl)));

Or also both:

    // Order doesn't matter...
    BsonSerializer.RegisterSerializationProvider(new ForceAsBsonClassMapSerializationProvider(typeof(IDictionary<string, object>), typeof(SomeImpl)));

Because I feel that other developers might encounter the same limitation, I believe that it would be a good point merging this simple serialization provider. 

Thank you in advance and I'll look forward for your comments, suggestions...!