### PR TITLE
CSHARP-1460: added UseLocalTime option in JsonWriterSettings

### DIFF
--- a/src/MongoDB.Bson.Tests/Jira/CSharp1460Tests.cs
+++ b/src/MongoDB.Bson.Tests/Jira/CSharp1460Tests.cs
@@ -1,0 +1,58 @@
+﻿/* Copyright 2010-2014 MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using NUnit.Framework;
+
+namespace MongoDB.Bson.Tests.Jira
+{
+    [TestFixture]
+    public class CSharp1460Tests
+    {
+        [Test]
+        public void TestJsonWriterLocalDateTimeSetting()
+        {
+            var testDateTime = DateTime.ParseExact("2015-10-28T00:00:00Z", "yyyy-MM-ddTHH:mm:ss.FFFZ", System.Globalization.CultureInfo.InvariantCulture).ToUniversalTime();
+            var document = new BsonDocument();
+            document.Add("DateTimeField", testDateTime);
+            var json = document.ToJson(new Bson.IO.JsonWriterSettings() { UseLocalTime = true });
+            var expected = ("{ 'DateTimeField' : ISODate('" + testDateTime.ToLocalTime().ToString("yyyy-MM-ddTHH:mm:ss.FFFzzz") + "') }").Replace("'", "\"");
+            Assert.AreEqual(expected, json);
+
+            var bson = document.ToBson();
+            var rehydrated = BsonDocument.Parse(json);
+            Assert.IsTrue(bson.SequenceEqual(rehydrated.ToBson()));
+
+            //test without settings, should work as before
+            json = document.ToJson();
+            expected = ("{ 'DateTimeField' : ISODate('" + testDateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ") + "') }").Replace("'", "\"");
+            Assert.AreEqual(expected, json);
+            bson = document.ToBson();
+            rehydrated = BsonDocument.Parse(json);
+            Assert.IsTrue(bson.SequenceEqual(rehydrated.ToBson()));
+
+            //test with parameter, with no setting specified, should work as before
+            json = document.ToJson(new Bson.IO.JsonWriterSettings());
+            expected = ("{ 'DateTimeField' : ISODate('" + testDateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ") + "') }").Replace("'", "\"");
+            Assert.AreEqual(expected, json);
+            bson = document.ToBson();
+            rehydrated = BsonDocument.Parse(json);
+            Assert.IsTrue(bson.SequenceEqual(rehydrated.ToBson()));
+        }
+    }
+}

--- a/src/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
+++ b/src/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="IO\OutputBufferChunkSourceTests.cs" />
     <Compile Include="IO\SingleChunkBufferTests.cs" />
     <Compile Include="IO\TrieNameDecoderTests.cs" />
+    <Compile Include="Jira\CSharp1460Tests.cs" />
     <Compile Include="Jira\CSharp728Tests.cs" />
     <Compile Include="Jira\CSharp708Tests.cs" />
     <Compile Include="Jira\CSharp476Tests.cs" />

--- a/src/MongoDB.Bson/IO/JsonWriter.cs
+++ b/src/MongoDB.Bson/IO/JsonWriter.cs
@@ -191,8 +191,16 @@ namespace MongoDB.Bson.IO
                     if (value >= BsonConstants.DateTimeMinValueMillisecondsSinceEpoch &&
                         value <= BsonConstants.DateTimeMaxValueMillisecondsSinceEpoch)
                     {
-                        var utcDateTime = BsonUtils.ToDateTimeFromMillisecondsSinceEpoch(value);
-                        _textWriter.Write("ISODate(\"{0}\")", utcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ"));
+                        if (_jsonWriterSettings.UseLocalTime)
+                        {
+                            var localDateTime = BsonUtils.ToDateTimeFromMillisecondsSinceEpoch(value).ToLocalTime();
+                            _textWriter.Write("ISODate(\"{0}\")", localDateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFzzz"));
+                        }
+                        else
+                        {
+                            var utcDateTime = BsonUtils.ToDateTimeFromMillisecondsSinceEpoch(value);
+                            _textWriter.Write("ISODate(\"{0}\")", utcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ"));
+                        }
                     }
                     else
                     {

--- a/src/MongoDB.Bson/IO/JsonWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/JsonWriterSettings.cs
@@ -34,6 +34,7 @@ namespace MongoDB.Bson.IO
         private string _newLineChars = "\r\n";
         private JsonOutputMode _outputMode = JsonOutputMode.Shell;
         private Version _shellVersion;
+        private bool _useLocalTime = false;
 
         // constructors
         /// <summary>
@@ -140,6 +141,20 @@ namespace MongoDB.Bson.IO
             }
         }
 
+        /// <summary>
+        /// Gets or sets whether to serialize DateTime fields as UTC or local time.
+        /// </summary>
+        public bool UseLocalTime
+        {
+            get { return _useLocalTime; }
+            set
+            {
+                if (IsFrozen) { throw new InvalidOperationException("JsonWriterSettings is frozen."); }
+                _useLocalTime = value;
+            }
+        }
+
+
         // public methods
         /// <summary>
         /// Creates a clone of the settings.
@@ -168,7 +183,8 @@ namespace MongoDB.Bson.IO
                 MaxSerializationDepth = MaxSerializationDepth,
                 NewLineChars = _newLineChars,
                 OutputMode = _outputMode,
-                ShellVersion = _shellVersion
+                ShellVersion = _shellVersion,
+                UseLocalTime = _useLocalTime
             };
             return clone;
         }


### PR DESCRIPTION
I added an option on JsonWriterSettings, to serialize DateTimeFields using LocalTime instead of UTC. I wrote a unit test to make sure it doesn't break anything and seems ok.

https://jira.mongodb.org/browse/CSHARP-1460
