### PR TITLE
CSHARP-1478: BsonClassMap.Reset() is not consistent with default constructor

### DIFF
--- a/src/MongoDB.Bson.Tests/Serialization/Attributes/BsonAttributeTests.cs
+++ b/src/MongoDB.Bson.Tests/Serialization/Attributes/BsonAttributeTests.cs
@@ -14,7 +14,6 @@
 */
 
 using System.Linq;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.IdGenerators;
@@ -26,7 +25,6 @@ namespace MongoDB.Bson.Tests.Serialization.Attributes
     public class BsonAttributeTests
     {
         [BsonDiscriminator("discriminator", Required = true)]
-        [BsonIgnoreExtraElements(false)]
         public class Test
         {
             [BsonDefaultValue("default1")]
@@ -66,6 +64,16 @@ namespace MongoDB.Bson.Tests.Serialization.Attributes
             public string NoElement { get; set; }
         }
 
+        [BsonIgnoreExtraElements(true)]
+        public class TestIgnoredByAttribute
+        {
+        }
+
+        [BsonIgnoreExtraElements(false)]
+        public class TestNotIgnoredByAttribute
+        {
+        }
+
         [Test]
         public void TestDiscriminator()
         {
@@ -79,6 +87,12 @@ namespace MongoDB.Bson.Tests.Serialization.Attributes
         {
             var classMap = BsonClassMap.LookupClassMap(typeof(Test));
             Assert.AreEqual(false, classMap.IgnoreExtraElements);
+
+            var ignoredClassMap = BsonClassMap.LookupClassMap(typeof(TestIgnoredByAttribute));
+            Assert.AreEqual(true, ignoredClassMap.IgnoreExtraElements);
+
+            var notIgnoredClassMap = BsonClassMap.LookupClassMap(typeof(TestNotIgnoredByAttribute));
+            Assert.AreEqual(false, notIgnoredClassMap.IgnoreExtraElements);
         }
 
         [Test]

--- a/src/MongoDB.Bson.Tests/Serialization/BsonClassMapTests.cs
+++ b/src/MongoDB.Bson.Tests/Serialization/BsonClassMapTests.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
 using NUnit.Framework;
@@ -428,16 +427,20 @@ namespace MongoDB.Bson.Tests.Serialization
 
             classMap.Freeze();
 
+            var defaultClassMap = new BsonClassMap<TestClass>();
+
+            defaultClassMap.Freeze();
+
             Assert.DoesNotThrow(() => classMap.CreateInstance());
-            Assert.AreEqual(0, classMap.DeclaredMemberMaps.Count());
-            Assert.AreEqual("TestClass", classMap.Discriminator);
-            Assert.IsFalse(classMap.DiscriminatorIsRequired);
-            Assert.IsNull(classMap.ExtraElementsMemberMap);
-            Assert.IsNull(classMap.IdMemberMap);
-            Assert.IsTrue(classMap.IgnoreExtraElements);
-            Assert.IsFalse(classMap.IgnoreExtraElementsIsInherited);
-            Assert.IsFalse(classMap.IsRootClass);
-            Assert.AreEqual(0, classMap.KnownTypes.Count());
+            Assert.AreEqual(defaultClassMap.DeclaredMemberMaps.Count(), classMap.DeclaredMemberMaps.Count());
+            Assert.AreEqual(defaultClassMap.Discriminator, classMap.Discriminator);
+            Assert.AreEqual(defaultClassMap.DiscriminatorIsRequired, classMap.DiscriminatorIsRequired);
+            Assert.AreEqual(defaultClassMap.ExtraElementsMemberMap, classMap.ExtraElementsMemberMap);
+            Assert.AreEqual(defaultClassMap.IdMemberMap, classMap.IdMemberMap);
+            Assert.AreEqual(defaultClassMap.IgnoreExtraElements, classMap.IgnoreExtraElements);
+            Assert.AreEqual(defaultClassMap.IgnoreExtraElementsIsInherited, classMap.IgnoreExtraElementsIsInherited);
+            Assert.AreEqual(defaultClassMap.IsRootClass, classMap.IsRootClass);
+            Assert.AreEqual(defaultClassMap.KnownTypes.Count(), classMap.KnownTypes.Count());
         }
 
         private class TestClass

--- a/src/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -915,7 +915,7 @@ namespace MongoDB.Bson.Serialization
             _discriminatorIsRequired = false;
             _extraElementsMemberMap = null;
             _idMemberMap = null;
-            _ignoreExtraElements = true; // TODO: should this really be false?
+            _ignoreExtraElements = false; // TODO: should this really be false?
             _ignoreExtraElementsIsInherited = false;
             _isRootClass = false;
             _knownTypes.Clear();

--- a/src/MongoDB.Driver/Linq/Processors/SerializerBuilder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/SerializerBuilder.cs
@@ -20,6 +20,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Linq.Expressions;
+using MongoDB.Bson.Serialization.Conventions;
 
 namespace MongoDB.Driver.Linq.Processors
 {
@@ -151,6 +152,9 @@ namespace MongoDB.Driver.Linq.Processors
                 baseClassMap.Freeze();
             }
             var classMap = new BsonClassMap(type, baseClassMap);
+
+            // Ignore extra elements, as the projection expression will likely not be complete
+            classMap.SetIgnoreExtraElements(true);
 
             foreach (var memberMapping in mapping.Members.Where(x => x.Member.DeclaringType == type))
             {


### PR DESCRIPTION
- fixed BsonClassMap.Reset() method to reflect default constructor behavior regarding IgnoreExtraElements property.
- updated associated test to compare results of the Reset() method with a fresh instance, rather than predefined results.
