### PR TITLE
The GroupBy query operator is not supported

### DIFF
--- a/Docs/landing/data/releases.toml
+++ b/Docs/landing/data/releases.toml
@@ -1,6 +1,6 @@
 current = "2.0.1"
 [[versions]]
-  version = "2.1.0-rc1"
+  version = "2.1.0"
   status = "rc"
   docs = "http://mongodb.github.io/mongo-csharp-driver/2.1/"
   api = "http://api.mongodb.org/csharp/2.1"
@@ -22,32 +22,32 @@ current = "2.0.1"
   package = "MongoDB.Driver"
   description = "The driver."
   dependencies = ".NET Core Driver,.NET BSON Library"
-  versions = "2.1.0-rc1,2.0.1"
+  versions = "2.1.0,2.0.1"
 
 [[drivers]]
   name = ".NET GridFS"
   package = "MongoDB.Driver.GridFS"
   description = "The GridFS library."
   dependencies = ".NET Driver,.NET Core Driver,.NET BSON Library"
-  versions = "2.1.0-rc1"
+  versions = "2.1.0"
 
 [[drivers]]
   name = ".NET Core Driver"
   package = "MongoDB.Driver.Core"
   description = "The core driver."
   dependencies = ".NET BSON Library"
-  versions = "2.1.0-rc1,2.0.1"
+  versions = "2.1.0,2.0.1"
 
 [[drivers]]
   name = ".NET BSON Library"
   package = "MongoDB.Bson"
   description = "The BSON library."
   dependencies = ""
-  versions = "2.1.0-rc1,2.0.1"
+  versions = "2.1.0,2.0.1"
 
 [[drivers]]
   name = ".NET Legacy Driver"
   package = "mongocsharpdriver"
   description = "The legacy driver."
   dependencies = ".NET Driver,.NET Core Driver,.NET BSON Library"
-  versions = "2.1.0-rc1,2.0.1,1.10.1"
+  versions = "2.1.0,2.0.1,1.10.1"

--- a/Docs/landing/data/releases.toml
+++ b/Docs/landing/data/releases.toml
@@ -1,6 +1,6 @@
-current = "2.0.1"
+current = "2.1.1"
 [[versions]]
-  version = "2.1.0"
+  version = "2.1.1"
   status = "rc"
   docs = "http://mongodb.github.io/mongo-csharp-driver/2.1/"
   api = "http://api.mongodb.org/csharp/2.1"
@@ -22,32 +22,32 @@ current = "2.0.1"
   package = "MongoDB.Driver"
   description = "The driver."
   dependencies = ".NET Core Driver,.NET BSON Library"
-  versions = "2.1.0,2.0.1"
+  versions = "2.1.1,2.0.1"
 
 [[drivers]]
   name = ".NET GridFS"
   package = "MongoDB.Driver.GridFS"
   description = "The GridFS library."
   dependencies = ".NET Driver,.NET Core Driver,.NET BSON Library"
-  versions = "2.1.0"
+  versions = "2.1.1"
 
 [[drivers]]
   name = ".NET Core Driver"
   package = "MongoDB.Driver.Core"
   description = "The core driver."
   dependencies = ".NET BSON Library"
-  versions = "2.1.0,2.0.1"
+  versions = "2.1.1,2.0.1"
 
 [[drivers]]
   name = ".NET BSON Library"
   package = "MongoDB.Bson"
   description = "The BSON library."
   dependencies = ""
-  versions = "2.1.0,2.0.1"
+  versions = "2.1.1,2.0.1"
 
 [[drivers]]
   name = ".NET Legacy Driver"
   package = "mongocsharpdriver"
   description = "The legacy driver."
   dependencies = ".NET Driver,.NET Core Driver,.NET BSON Library"
-  versions = "2.1.0,2.0.1,1.10.1"
+  versions = "2.1.1,2.0.1,1.10.1"

--- a/Docs/reference/content/what_is_new.md
+++ b/Docs/reference/content/what_is_new.md
@@ -25,6 +25,6 @@ The 2.1 driver ships with a number of new features. The most notable are discuss
 Simply use the new [`AsQueryable`]({{< apiref "M_MongoDB_Driver_IMongoCollectionExtensions_AsQueryable__1" >}}) method to work with LINQ.
 
 
-## Eventing Implementation
+## Eventing
 
 [CSHARP-1374](https://jira.mongodb.org/browse/CSHARP-1374) - An eventing API has been added allowing a user to subscribe to one or more events from the core driver for insight into server discovery, server selection, connection pooling, and commands.

--- a/Release Notes/Release Notes v2.1.0.md
+++ b/Release Notes/Release Notes v2.1.0.md
@@ -1,6 +1,4 @@
-# .NET Driver Version 2.1.0-rc1 Release Notes
-
-(Preliminary)
+# .NET Driver Version 2.1.0 Release Notes
 
 This is a minor release which supports all MongoDB server versions since 2.4.
 

--- a/Release Notes/Release Notes v2.1.1.md
+++ b/Release Notes/Release Notes v2.1.1.md
@@ -1,0 +1,25 @@
+# .NET Driver Version 2.1.1 Release Notes
+
+This is a minor release which supports all MongoDB server versions since 2.4.
+
+An online version of these release notes is available at:
+
+https://github.com/mongodb/mongo-csharp-driver/blob/master/Release%20Notes/Release%20Notes%20v2.1.1.md
+
+The full list of JIRA issues resolved in this release is available at:
+
+{TODO}
+
+Documentation on the .NET driver can be found at:
+
+http://mongodb.github.io/mongo-csharp-driver/
+
+
+## Notable Fixes
+
+Notable fixes are listed below. For a full list, see the full list of JIRA issues linked above.
+
+
+## Upgrading
+
+There are no known backwards breaking changes in this release.

--- a/Release Notes/Release Notes v2.1.1.md
+++ b/Release Notes/Release Notes v2.1.1.md
@@ -4,20 +4,15 @@ This is a minor release which supports all MongoDB server versions since 2.4.
 
 An online version of these release notes is available at:
 
-https://github.com/mongodb/mongo-csharp-driver/blob/master/Release%20Notes/Release%20Notes%20v2.1.1.md
+https://github.com/mongodb/mongo-csharp-driver/blob/v2.1.x/Release%20Notes/Release%20Notes%20v2.1.1.md
 
 The full list of JIRA issues resolved in this release is available at:
 
-{TODO}
+https://jira.mongodb.org/browse/CSHARP-1468?filter=18754
 
 Documentation on the .NET driver can be found at:
 
 http://mongodb.github.io/mongo-csharp-driver/
-
-
-## Notable Fixes
-
-Notable fixes are listed below. For a full list, see the full list of JIRA issues linked above.
 
 
 ## Upgrading

--- a/Release Notes/Release Notes v2.1.2.md
+++ b/Release Notes/Release Notes v2.1.2.md
@@ -1,0 +1,20 @@
+# .NET Driver Version 2.1.2 Release Notes
+
+This is a minor release which supports all MongoDB server versions since 2.4.
+
+An online version of these release notes is available at:
+
+https://github.com/mongodb/mongo-csharp-driver/blob/v2.1.x/Release%20Notes/Release%20Notes%20v2.1.1.md
+
+The full list of JIRA issues resolved in this release is available at:
+
+https://jira.mongodb.org/browse/CSHARP-1468?filter=18754
+
+Documentation on the .NET driver can be found at:
+
+http://mongodb.github.io/mongo-csharp-driver/
+
+
+## Upgrading
+
+There are no known backwards breaking changes in this release.

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -4,7 +4,7 @@ open Fake
 open Fake.AssemblyInfoFile
 
 let config = getBuildParamOrDefault "config" "Release"
-let baseVersion = getBuildParamOrDefault "baseVersion" "2.1.1"
+let baseVersion = getBuildParamOrDefault "baseVersion" "2.1.2"
 let preRelease = getBuildParamOrDefault "preRelease" "local"
 let getComputedBuildNumber() = 
     let result = Git.CommandHelper.runSimpleGitCommand currentDirectory "describe HEAD^1 --tags --long --match \"v[0-9].[0-9].[0-9]\""

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -4,7 +4,7 @@ open Fake
 open Fake.AssemblyInfoFile
 
 let config = getBuildParamOrDefault "config" "Release"
-let baseVersion = getBuildParamOrDefault "baseVersion" "2.1.0"
+let baseVersion = getBuildParamOrDefault "baseVersion" "2.1.1"
 let preRelease = getBuildParamOrDefault "preRelease" "local"
 let getComputedBuildNumber() = 
     let result = Git.CommandHelper.runSimpleGitCommand currentDirectory "describe HEAD^1 --tags --long --match \"v[0-9].[0-9].[0-9]\""

--- a/src/MongoDB.Driver.Core.Tests/Core/Helpers/MessageHelper.cs
+++ b/src/MongoDB.Driver.Core.Tests/Core/Helpers/MessageHelper.cs
@@ -155,6 +155,24 @@ namespace MongoDB.Driver.Core.Helpers
                 false);
         }
 
+        public static ReplyMessage<T> BuildQueryFailedReply<T>(
+            BsonDocument queryFailureDocument,
+            int responseTo = 0)
+        {
+            return new ReplyMessage<T>(
+                false,
+                0,
+                false,
+                null,
+                1,
+                true,
+                queryFailureDocument,
+                0,
+                responseTo,
+                BsonSerializer.SerializerRegistry.GetSerializer<T>(),
+                0);
+        }
+
         public static ReplyMessage<T> BuildReply<T>(
             T document,
             IBsonSerializer<T> serializer = null,

--- a/src/MongoDB.Driver.Core/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/CommandEventHelper.cs
@@ -599,7 +599,7 @@ namespace MongoDB.Driver.Core.Connections
             }
             finally
             {
-                if (disposeOfDocuments)
+                if (disposeOfDocuments && replyMessage.Documents != null)
                 {
                     replyMessage.Documents.ForEach(d => d.Dispose());
                 }

--- a/src/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/GridFSDownloadAsBytesAsyncTest.cs
+++ b/src/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/GridFSDownloadAsBytesAsyncTest.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Driver.GridFS.Tests.Specifications.gridfs
     {
         // fields
         protected ObjectId _id;
-        protected GridFSDownloadOptions _options = new GridFSDownloadOptions();
+        protected GridFSDownloadOptions _options = null;
 
         // constructors
         public GridFSDownloadAsyncTestBase(BsonDocument data, BsonDocument testDefinition)
@@ -70,6 +70,7 @@ namespace MongoDB.Driver.GridFS.Tests.Specifications.gridfs
         {
             foreach (var option in options.Elements)
             {
+                _options = _options ?? new GridFSDownloadOptions();
                 switch (option.Name)
                 {
                     case "checkMD5":

--- a/src/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/GridFSDownloadAsBytesByNameAsyncTest.cs
+++ b/src/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/GridFSDownloadAsBytesByNameAsyncTest.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Driver.GridFS.Tests.Specifications.gridfs
     {
         // fields
         protected string _filename;
-        protected GridFSDownloadByNameOptions _options = new GridFSDownloadByNameOptions();
+        protected GridFSDownloadByNameOptions _options = null;
 
         // constructors
         public GridFSGetByNameAsyncTestBase(BsonDocument data, BsonDocument testDefinition)
@@ -70,6 +70,7 @@ namespace MongoDB.Driver.GridFS.Tests.Specifications.gridfs
         {
             foreach (var option in options.Elements)
             {
+                _options = _options ?? new GridFSDownloadByNameOptions();
                 switch (option.Name)
                 {
                     case "checkMD5":

--- a/src/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/GridFSUploadFromBytesAsyncTest.cs
+++ b/src/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/GridFSUploadFromBytesAsyncTest.cs
@@ -26,7 +26,7 @@ namespace MongoDB.Driver.GridFS.Tests.Specifications.gridfs
     {
         // fields
         protected string _filename;
-        protected GridFSUploadOptions _options = new GridFSUploadOptions();
+        protected GridFSUploadOptions _options = null;
         protected byte[] _source;
 
         // constructors
@@ -76,6 +76,7 @@ namespace MongoDB.Driver.GridFS.Tests.Specifications.gridfs
         {
             foreach (var option in options.Elements)
             {
+                _options = _options ?? new GridFSUploadOptions();
                 switch (option.Name)
                 {
                     case "aliases":

--- a/src/MongoDB.Driver.GridFS/GridFSBucket.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSBucket.cs
@@ -100,12 +100,14 @@ namespace MongoDB.Driver.GridFS
         public Task<byte[]> DownloadAsBytesAsync(BsonValue id, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.IsNotNull(id, nameof(id));
+            options = options ?? new GridFSDownloadOptions();
             return DownloadAsBytesHelperAsync(id, options, cancellationToken);
         }
 
         /// <inheritdoc />
         public Task<byte[]> DownloadAsBytesAsync(ObjectId id, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            options = options ?? new GridFSDownloadOptions();
             return DownloadAsBytesHelperAsync(new BsonObjectId(id), options, cancellationToken);
         }
 
@@ -135,6 +137,7 @@ namespace MongoDB.Driver.GridFS
         {
             Ensure.IsNotNull(id, nameof(id));
             Ensure.IsNotNull(destination, nameof(destination));
+            options = options ?? new GridFSDownloadOptions();
             return DownloadToStreamHelperAsync(id, destination, options, cancellationToken);
         }
 
@@ -142,6 +145,7 @@ namespace MongoDB.Driver.GridFS
         public Task DownloadToStreamAsync(ObjectId id, Stream destination, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.IsNotNull(destination, nameof(destination));
+            options = options ?? new GridFSDownloadOptions();
             return DownloadToStreamHelperAsync(new BsonObjectId(id), destination, options, cancellationToken);
         }
 
@@ -220,12 +224,14 @@ namespace MongoDB.Driver.GridFS
         public Task<GridFSDownloadStream> OpenDownloadStreamAsync(BsonValue id, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.IsNotNull(id, nameof(id));
+            options = options ?? new GridFSDownloadOptions();
             return OpenDownloadStreamHelperAsync(id, options, cancellationToken);
         }
 
         /// <inheritdoc />
         public Task<GridFSDownloadStream> OpenDownloadStreamAsync(ObjectId id, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            options = options ?? new GridFSDownloadOptions();
             return OpenDownloadStreamHelperAsync(new BsonObjectId(id), options, cancellationToken);
         }
 
@@ -366,7 +372,7 @@ namespace MongoDB.Driver.GridFS
             await operation.ExecuteAsync(binding, cancellationToken).ConfigureAwait(false);
         }
 
-        private GridFSDownloadStream CreateDownloadStream(IReadBindingHandle binding, GridFSFileInfo fileInfo, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        private GridFSDownloadStream CreateDownloadStream(IReadBindingHandle binding, GridFSFileInfo fileInfo, GridFSDownloadOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             var checkMD5 = options.CheckMD5 ?? false;
             var seekable = options.Seekable ?? false;
@@ -423,7 +429,7 @@ namespace MongoDB.Driver.GridFS
             }
         }
 
-        private async Task<byte[]> DownloadAsBytesHelperAsync(BsonValue id, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<byte[]> DownloadAsBytesHelperAsync(BsonValue id, GridFSDownloadOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var binding = await GetSingleServerReadBindingAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -446,7 +452,7 @@ namespace MongoDB.Driver.GridFS
             }
         }
 
-        private async Task DownloadToStreamHelperAsync(IReadBindingHandle binding, GridFSFileInfo fileInfo, Stream destination, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task DownloadToStreamHelperAsync(IReadBindingHandle binding, GridFSFileInfo fileInfo, Stream destination, GridFSDownloadOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             var checkMD5 = options.CheckMD5 ?? false;
 
@@ -467,7 +473,7 @@ namespace MongoDB.Driver.GridFS
             }
         }
 
-        private async Task DownloadToStreamHelperAsync(BsonValue id, Stream destination, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task DownloadToStreamHelperAsync(BsonValue id, Stream destination, GridFSDownloadOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var binding = await GetSingleServerReadBindingAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -617,10 +623,8 @@ namespace MongoDB.Driver.GridFS
             return true;
         }
 
-        private async Task<GridFSDownloadStream> OpenDownloadStreamHelperAsync(BsonValue id, GridFSDownloadOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<GridFSDownloadStream> OpenDownloadStreamHelperAsync(BsonValue id, GridFSDownloadOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
-            options = options ?? new GridFSDownloadByNameOptions();
-
             using (var binding = await GetSingleServerReadBindingAsync(cancellationToken).ConfigureAwait(false))
             {
                 var fileInfo = await GetFileInfoAsync(binding, id, cancellationToken).ConfigureAwait(false);

--- a/src/MongoDB.Driver.Tests/FilterDefinitionBuilderTests.cs
+++ b/src/MongoDB.Driver.Tests/FilterDefinitionBuilderTests.cs
@@ -824,6 +824,19 @@ namespace MongoDB.Driver.Tests
             Assert(subject.Type("FirstName", BsonType.String), "{fn: {$type: 2}}");
         }
 
+        [Test]
+        public void Generic_type_constraint_causing_base_class_conversion()
+        {
+            var filter = TypeConstrainedFilter<Twin>(21);
+
+            Assert(filter, "{ age: 21 }");
+        }
+
+        private FilterDefinition<T> TypeConstrainedFilter<T>(int age) where T : Person
+        {
+            return CreateSubject<T>().Eq(x => x.Age, age);
+        }
+
         private void Assert<TDocument>(FilterDefinition<TDocument> filter, string expected)
         {
             Assert(filter, BsonDocument.Parse(expected));

--- a/src/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
+++ b/src/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
@@ -124,6 +124,14 @@ namespace MongoDB.Driver.Tests.Linq
         }
 
         [Test]
+        public void Count_with_no_matches()
+        {
+            var result = CreateQuery().Count(x => x.C.E.F == 13151235);
+
+            result.Should().Be(0);
+        }
+
+        [Test]
         public async Task CountAsync()
         {
             var result = await CreateQuery().CountAsync();
@@ -137,6 +145,14 @@ namespace MongoDB.Driver.Tests.Linq
             var result = await CreateQuery().CountAsync(x => x.C.E.F == 11);
 
             result.Should().Be(1);
+        }
+
+        [Test]
+        public async Task CountAsync_with_no_matches()
+        {
+            var result = await CreateQuery().CountAsync(x => x.C.E.F == 123412523);
+
+            result.Should().Be(0);
         }
 
         [Test]
@@ -365,6 +381,14 @@ namespace MongoDB.Driver.Tests.Linq
         }
 
         [Test]
+        public void LongCount_with_no_results()
+        {
+            var result = CreateQuery().LongCount(x => x.C.E.F == 123452135);
+
+            result.Should().Be(0);
+        }
+
+        [Test]
         public async Task LongCountAsync()
         {
             var result = await CreateQuery().LongCountAsync();
@@ -378,6 +402,14 @@ namespace MongoDB.Driver.Tests.Linq
             var result = await CreateQuery().LongCountAsync(x => x.C.E.F == 11);
 
             result.Should().Be(1);
+        }
+
+        [Test]
+        public async Task LongCountAsync_with_no_results()
+        {
+            var result = await CreateQuery().LongCountAsync(x => x.C.E.F == 12351235);
+
+            result.Should().Be(0);
         }
 
         [Test]
@@ -923,6 +955,14 @@ namespace MongoDB.Driver.Tests.Linq
         }
 
         [Test]
+        public void Sum_with_no_results()
+        {
+            var result = CreateQuery().Where(x => x.C.E.F == 12341235).Sum(x => x.C.E.F);
+
+            result.Should().Be(0);
+        }
+
+        [Test]
         public async Task SumAsync()
         {
             var result = await CreateQuery().Select(x => x.C.E.F).SumAsync();
@@ -936,6 +976,14 @@ namespace MongoDB.Driver.Tests.Linq
             var result = await CreateQuery().SumAsync(x => x.C.E.F);
 
             result.Should().Be(122);
+        }
+
+        [Test]
+        public async Task SumAsync_with_no_results()
+        {
+            var result = await CreateQuery().Where(x => x.C.E.F == 21341235).SumAsync(x => x.C.E.F);
+
+            result.Should().Be(0);
         }
 
         [Test]

--- a/src/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
+++ b/src/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
@@ -865,6 +865,29 @@ namespace MongoDB.Driver.Tests.Linq
         }
 
         [Test]
+        public void SelectMany_followed_by_a_group()
+        {
+            var first = from x in CreateQuery()
+                        from y in x.G
+                        select y;
+
+            var query = from f in first
+                        group f by f.D into g
+                        select new
+                        {
+                            g.Key,
+                            SumF = g.Sum(x => x.E.F)
+                        };
+
+            Assert(query,
+                4,
+                "{ $unwind: '$G' }",
+                "{ $project: { G: 1, _id: 0 } }",
+                "{ $group: { _id: '$G.D', __agg0: { $sum : '$G.E.F' } } }",
+                "{ $project: { Key: '$_id', SumF: '$__agg0', _id: 0 } }");
+        }
+
+        [Test]
         public void Single()
         {
             var result = CreateQuery().Where(x => x.Id == 10).Select(x => x.C.E.F).Single();

--- a/src/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
+++ b/src/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
@@ -749,6 +749,7 @@ namespace MongoDB.Driver.Tests
         [TestCase(new string[] { "host1", "host2" }, new object[] { 27018, null }, "mongodb://host1:27018,host2")]
         [TestCase(new string[] { "host1", "host2" }, new object[] { 27018, 27017 }, "mongodb://host1:27018,host2")]
         [TestCase(new string[] { "host1", "host2" }, new object[] { 27018, 27018 }, "mongodb://host1:27018,host2:27018")]
+        [TestCase(new string[] { "[::1]", "host2" }, new object[] { 27018, 27018 }, "mongodb://[::1]:27018,host2:27018")]
         public void TestServers(string[] hosts, object[] ports, string connectionString)
         {
             var servers = (hosts == null) ? null : new List<MongoServerAddress>();

--- a/src/MongoDB.Driver/ClusterRegistry.cs
+++ b/src/MongoDB.Driver/ClusterRegistry.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using MongoDB.Driver.Core.Authentication;
 using MongoDB.Driver.Core.Clusters;
@@ -79,7 +80,7 @@ namespace MongoDB.Driver
 
         private ClusterSettings ConfigureCluster(ClusterSettings settings, ClusterKey clusterKey)
         {
-            var endPoints = clusterKey.Servers.Select(s => (EndPoint)new DnsEndPoint(s.Host, s.Port));
+            var endPoints = clusterKey.Servers.Select(s => EndPointHelper.Parse(s.ToString()));
             return settings.With(
                 connectionMode: clusterKey.ConnectionMode.ToCore(),
                 endPoints: Optional.Enumerable(endPoints),
@@ -140,6 +141,11 @@ namespace MongoDB.Driver
 
         private TcpStreamSettings ConfigureTcp(TcpStreamSettings settings, ClusterKey clusterKey)
         {
+            if (clusterKey.IPv6)
+            {
+                settings = settings.With(addressFamily: AddressFamily.InterNetworkV6);
+            }
+
             return settings.With(
                 connectTimeout: clusterKey.ConnectTimeout,
                 readTimeout: clusterKey.SocketTimeout,

--- a/src/MongoDB.Driver/Linq/Expressions/ResultOperators/CountResultOperator.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/ResultOperators/CountResultOperator.cs
@@ -40,12 +40,12 @@ namespace MongoDB.Driver.Linq.Expressions.ResultOperators
 
         public LambdaExpression CreateAggregator(Type sourceType)
         {
-            return ResultTransformerHelper.CreateAggregator("Single", sourceType);
+            return ResultTransformerHelper.CreateAggregator("SingleOrDefault", sourceType);
         }
 
         public LambdaExpression CreateAsyncAggregator(Type sourceType)
         {
-            return ResultTransformerHelper.CreateAsyncAggregator("SingleAsync", sourceType);
+            return ResultTransformerHelper.CreateAsyncAggregator("SingleOrDefaultAsync", sourceType);
         }
     }
 }

--- a/src/MongoDB.Driver/Linq/Expressions/ResultOperators/SumResultOperator.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/ResultOperators/SumResultOperator.cs
@@ -40,12 +40,12 @@ namespace MongoDB.Driver.Linq.Expressions.ResultOperators
 
         public LambdaExpression CreateAggregator(Type sourceType)
         {
-            return ResultTransformerHelper.CreateAggregator("Single", sourceType);
+            return ResultTransformerHelper.CreateAggregator("SingleOrDefault", sourceType);
         }
 
         public LambdaExpression CreateAsyncAggregator(Type sourceType)
         {
-            return ResultTransformerHelper.CreateAsyncAggregator("SingleAsync", sourceType);
+            return ResultTransformerHelper.CreateAsyncAggregator("SingleOrDefaultAsync", sourceType);
         }
     }
 }

--- a/src/MongoDB.Driver/Linq/MongoQueryProviderImpl.cs
+++ b/src/MongoDB.Driver/Linq/MongoQueryProviderImpl.cs
@@ -79,7 +79,14 @@ namespace MongoDB.Driver.Linq
                 Translate(expression));
 
             var lambda = Expression.Lambda(executionPlan);
-            return lambda.Compile().DynamicInvoke(null);
+            try
+            {
+                return lambda.Compile().DynamicInvoke(null);
+            }
+            catch (TargetInvocationException tie)
+            {
+                throw tie.InnerException;
+            }
         }
 
         public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/MongoDB.Driver/Linq/Processors/EmbeddedPipeline/EmbeddedPipelineBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/EmbeddedPipeline/EmbeddedPipelineBinder.cs
@@ -85,9 +85,18 @@ namespace MongoDB.Driver.Linq.Processors.EmbeddedPipeline
                 BsonSerializationInfo itemSerializationInfo;
                 if (arraySerializer != null && arraySerializer.TryGetItemSerializationInfo(out itemSerializationInfo))
                 {
-                    return new PipelineExpression(
-                        node,
-                        new DocumentExpression(itemSerializationInfo.Serializer));
+                    if (itemSerializationInfo.ElementName == null)
+                    {
+                        return new PipelineExpression(
+                            node,
+                            new DocumentExpression(itemSerializationInfo.Serializer));
+                    }
+                    else
+                    {
+                        return new PipelineExpression(
+                            node,
+                            new FieldExpression(itemSerializationInfo.ElementName, itemSerializationInfo.Serializer));
+                    }
                 }
             }
             else if (node.NodeType == ExpressionType.Constant)

--- a/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/GroupByBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/GroupByBinder.cs
@@ -62,13 +62,17 @@ namespace MongoDB.Driver.Linq.Processors.Pipeline.MethodCallBinders
 
         private Expression BuildProjector(PipelineBindingContext bindingContext, Expression idSelector, Expression elementSelector)
         {
+            var elementSerializer = bindingContext.GetSerializer(elementSelector.Type, elementSelector);
+            var elementFieldName = (elementSelector as IFieldExpression)?.FieldName;
+
             var serializerType = typeof(GroupingDeserializer<,>).MakeGenericType(
                 idSelector.Type,
                 elementSelector.Type);
             var serializer = (IBsonSerializer)Activator.CreateInstance(
                 serializerType,
                 bindingContext.GetSerializer(idSelector.Type, idSelector),
-                bindingContext.GetSerializer(elementSelector.Type, elementSelector));
+                bindingContext.GetSerializer(elementSelector.Type, elementSelector),
+                elementFieldName);
 
             return new DocumentExpression(serializer);
         }
@@ -100,13 +104,15 @@ namespace MongoDB.Driver.Linq.Processors.Pipeline.MethodCallBinders
 
         private class GroupingDeserializer<TKey, TElement> : SerializerBase<IGrouping<TKey, TElement>>, IBsonDocumentSerializer, IBsonArraySerializer
         {
+            private readonly string _elementFieldName;
             private readonly IBsonSerializer _elementSerializer;
             private readonly IBsonSerializer _idSerializer;
 
-            public GroupingDeserializer(IBsonSerializer idSerializer, IBsonSerializer elementSerializer)
+            public GroupingDeserializer(IBsonSerializer idSerializer, IBsonSerializer elementSerializer, string elementFieldName)
             {
                 _idSerializer = idSerializer;
                 _elementSerializer = elementSerializer;
+                _elementFieldName = elementFieldName;
             }
 
             public override IGrouping<TKey, TElement> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
@@ -144,7 +150,7 @@ namespace MongoDB.Driver.Linq.Processors.Pipeline.MethodCallBinders
 
             public bool TryGetItemSerializationInfo(out BsonSerializationInfo serializationInfo)
             {
-                serializationInfo = new BsonSerializationInfo(null, _elementSerializer, typeof(TElement));
+                serializationInfo = new BsonSerializationInfo(_elementFieldName, _elementSerializer, typeof(TElement));
                 return true;
             }
         }

--- a/src/MongoDB.Driver/Linq/Processors/SerializationBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/SerializationBinder.cs
@@ -161,6 +161,20 @@ namespace MongoDB.Driver.Linq.Processors
             return base.VisitMethodCall(node);
         }
 
+        protected override Expression VisitUnary(UnaryExpression node)
+        {
+            var newNode = (UnaryExpression)base.VisitUnary(node);
+            if (newNode.NodeType == ExpressionType.Convert || newNode.NodeType == ExpressionType.ConvertChecked)
+            {
+                if (newNode.Method == null && !newNode.IsLiftedToNull && newNode.Type.IsAssignableFrom(newNode.Operand.Type))
+                {
+                    return newNode.Operand;
+                }
+            }
+
+            return newNode;
+        }
+
         // private methods
         private Expression BindElementAt(MethodCallExpression node)
         {

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -594,7 +594,12 @@ namespace MongoDB.Driver
                 }
                 else if ((ipEndPoint = endPoint as IPEndPoint) != null)
                 {
-                    return new MongoServerAddress(ipEndPoint.Address.ToString(), ipEndPoint.Port);
+                    var address = ipEndPoint.Address.ToString();
+                    if (ipEndPoint.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
+                    {
+                        address = "[" + address + "]";
+                    }
+                    return new MongoServerAddress(address, ipEndPoint.Port);
                 }
                 else
                 {


### PR DESCRIPTION
Exception error： MongoDB.Driver.Legacy.dll 
The GroupBy query operator is not supported.

my code:
 public void TestMethod1()
        {
            var db = new MongoDbContext();
            var query = (from c in db.GetCollection<UserLoginLog>().AsQueryable()
                select c).GroupBy(c => c);
            var list = query.ToList(); // execute query
        }

It's why?