### PR TITLE
Fix for NullReferenceException for seekable download stream:

### DIFF
--- a/src/MongoDB.Driver.GridFS.Tests/GridFSDownloadStreamBaseTests.cs
+++ b/src/MongoDB.Driver.GridFS.Tests/GridFSDownloadStreamBaseTests.cs
@@ -32,6 +32,33 @@ namespace MongoDB.Driver.GridFS.Tests
     {
         // public methods
         [Test]
+        public void Read_should_read(
+           [Values(0.5, 1.0, 1.5, 2.0, 2.5)] double contentSizeMultiple,
+           [Values(false, true)] bool async,
+           [Values(false, true)] bool seekable)
+        {
+            var bucket = CreateBucket(128);
+            var contentSize = (int)(bucket.Options.ChunkSizeBytes * contentSizeMultiple);
+            var content = CreateContent(contentSize);
+            var id = CreateGridFSFile(bucket, content);
+            var options = new GridFSDownloadOptions() { Seekable = seekable };
+            var subject = bucket.OpenDownloadStream(id, options);
+
+            var destination = new byte[contentSize];
+
+            if (async)
+            {
+                subject.ReadAsync(destination, 0, contentSize).GetAwaiter().GetResult();
+            }
+            else
+            {
+                subject.Read(destination, 0, contentSize);
+            }
+
+            destination.Should().Equal(content);
+        }
+
+        [Test]
         public void CopyTo_should_copy_stream(
             [Values(0.0, 0.5, 1.0, 1.5, 2.0, 2.5)] double contentSizeMultiple,
             [Values(null, 128)] int? bufferSize,

--- a/src/MongoDB.Driver.GridFS/GridFSSeekableDownloadStream.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSSeekableDownloadStream.cs
@@ -186,7 +186,7 @@ namespace MongoDB.Driver.GridFS
             var data = document["data"].AsBsonBinaryData.Bytes;
 
             var chunkSizeBytes = FileInfo.ChunkSizeBytes;
-            var lastChunk = 0;
+            var lastChunk = FileInfo.Length / FileInfo.ChunkSizeBytes;
             var expectedChunkSize = n == lastChunk ? FileInfo.Length % chunkSizeBytes : chunkSizeBytes;
             if (data.Length != expectedChunkSize)
             {
@@ -201,7 +201,7 @@ namespace MongoDB.Driver.GridFS
         private ArraySegment<byte> GetSegment(CancellationToken cancellationToken)
         {
             var n = _position / FileInfo.ChunkSizeBytes;
-            if (_n != n)
+            if (_n != n || _chunk == null)
             {
                 GetChunk(n, cancellationToken);
             }
@@ -215,7 +215,7 @@ namespace MongoDB.Driver.GridFS
         private async Task<ArraySegment<byte>> GetSegmentAsync(CancellationToken cancellationToken)
         {
             var n = _position / FileInfo.ChunkSizeBytes;
-            if (_n != n)
+            if (_n != n || _chunk == null)
             {
                 await GetChunkAsync(n, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
Some potential fixes for seekable download stream.
- Checking for _chunk == null before starting.
- added logic for cacluating the the last chunk number.

https://jira.mongodb.org/browse/CSHARP-1489