### PR TITLE
CSHARP-1503: Mark IMongoQueryProvider as public

### DIFF
--- a/src/MongoDB.Driver/Linq/IMongoQueryProvider.cs
+++ b/src/MongoDB.Driver/Linq/IMongoQueryProvider.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Driver.Linq
     /// <summary>
     /// An implementation of <see cref="IQueryProvider" /> for MongoDB.
     /// </summary>
-    internal interface IMongoQueryProvider : IQueryProvider
+    public interface IMongoQueryProvider : IQueryProvider
     {
         /// <summary>
         /// Gets the collection namespace.


### PR DESCRIPTION
Would it be possible to have the [IMongoQueryProvider interface ](https://github.com/mongodb/mongo-csharp-driver/blob/v2.2.0/src/MongoDB.Driver/Linq/IMongoQueryProvider.cs) marked as public?

We are building a Framework that has built-in Async LINQ support, and for our mongodb data adapter it would make for extremely cleaner code if we could access ExecuteAsync<T> directly, instead of having to rewrite all the CountAsync, SumAsync etc (that are already coded inside the core of our framework).

This interface is well documented, and does not have any properties of types that are not exposed, so it seems to me that it can be easily changed to public. Of course that means keeping backwards compatibility on the API from now on, but I think it can be useful for users of the C# driver in general to have access to it.