### PR TITLE
Bugfix CreateCollection doesn't return and throws NullReferenceException

### DIFF
--- a/src/MongoDB.Driver/MongoDatabaseImpl.cs
+++ b/src/MongoDB.Driver/MongoDatabaseImpl.cs
@@ -73,12 +73,14 @@ namespace MongoDB.Driver
             if (options == null)
             {
                 CreateCollectionHelper<BsonDocument>(name, null, cancellationToken);
+                return;
             }
 
             if (options.GetType() == typeof(CreateCollectionOptions))
             {
                 var genericOptions = CreateCollectionOptions<BsonDocument>.CoercedFrom(options);
                 CreateCollectionHelper<BsonDocument>(name, genericOptions, cancellationToken);
+                return;
             }
 
             var genericMethodDefinition = typeof(MongoDatabaseImpl).GetMethod("CreateCollectionHelper", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
`CreateCollectionAsync` returns a `Task` in these cases.
I guess when creating the sync version the return was dropped as there's no longer anything to return.
This causes a `NullReferenceException` when `options == null`