### PR TITLE
CSHARP-1447: Allow serialization of generic IDictionary implementations with non-public constructors when serializing to an interface definition

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/DictionaryInterfaceImplementerSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DictionaryInterfaceImplementerSerializer.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using MongoDB.Bson.Serialization.Options;
@@ -164,7 +165,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         DictionarySerializerBase<TDictionary, TKey, TValue>,
         IChildSerializerConfigurable,
         IDictionaryRepresentationConfigurable<DictionaryInterfaceImplementerSerializer<TDictionary, TKey, TValue>>
-            where TDictionary : class, IDictionary<TKey, TValue>, new()
+            where TDictionary : class, IDictionary<TKey, TValue>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DictionaryInterfaceImplementerSerializer{TDictionary, TKey, TValue}"/> class.
@@ -271,7 +272,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The instance.</returns>
         protected override TDictionary CreateInstance()
         {
-            return new TDictionary();
+            return Activator.CreateInstance<TDictionary>();
         }
 
         // explicit interface implementations


### PR DESCRIPTION
- Fixes regression, now allows serialization of dictionaries that do not have public parameterless constructors
