### PR TITLE
CS-30851:  Adds CreatorClassMapConvention and associated tests

### DIFF
--- a/src/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
+++ b/src/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Serialization\Conventions\CamelCaseElementNameConventionsTests.cs" />
     <Compile Include="Serialization\Conventions\ConventionPackTests.cs" />
     <Compile Include="Serialization\Conventions\ConventionRunnerTests.cs" />
+    <Compile Include="Serialization\Conventions\CreatorClassMapConventionTests.cs" />
     <Compile Include="Serialization\Conventions\DelegateClassMapConventionTests.cs" />
     <Compile Include="Serialization\Conventions\DelegateMemberMapConventionTests.cs" />
     <Compile Include="Serialization\Conventions\DelegatePostProcessingConventionTests.cs" />

--- a/src/MongoDB.Bson.Tests/Serialization/Conventions/CreatorClassMapConventionTests.cs
+++ b/src/MongoDB.Bson.Tests/Serialization/Conventions/CreatorClassMapConventionTests.cs
@@ -1,0 +1,59 @@
+﻿/* Copyright 2010-2014 MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+using NUnit.Framework;
+
+namespace MongoDB.Bson.Tests.Serialization.Conventions
+{
+    [TestFixture]
+    public class CreatorClassMapConventionTests
+    {
+        private class TestClass
+        {
+            public string FirstName { get; set; }
+        }
+
+        
+
+        [Test]
+        public void TestCreatorClassMapConvention()
+        {
+            bool delegateInvoked = false;
+            var convention = new CreatorClassMapConvention("test", (type) =>
+            {
+                return () =>
+                {
+                    delegateInvoked = true;
+                    return Activator.CreateInstance(type);
+                };
+            });
+
+            Assert.AreEqual("test", convention.Name);
+
+            var classMap = new BsonClassMap<TestClass>();
+
+            convention.Apply(classMap);
+
+            classMap.Freeze();
+
+            var obj = classMap.CreateInstance();
+            Assert.AreEqual(obj.GetType(), typeof(TestClass));
+            Assert.AreEqual(delegateInvoked, true);
+        }
+    }
+}

--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Serialization\CollectionsSerializationProvider.cs" />
     <Compile Include="Serialization\Conventions\AttributeConventionPack.cs" />
     <Compile Include="Serialization\Conventions\CamelCaseElementNameConvention.cs" />
+    <Compile Include="Serialization\Conventions\CreatorClassMapConvention.cs" />
     <Compile Include="Serialization\Conventions\NamedParameterCreatorMapConvention.cs" />
     <Compile Include="Serialization\Conventions\ConventionBase.cs" />
     <Compile Include="Serialization\Conventions\ConventionPack.cs" />

--- a/src/MongoDB.Bson/Serialization/Conventions/CreatorClassMapConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/CreatorClassMapConvention.cs
@@ -1,0 +1,53 @@
+﻿/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace MongoDB.Bson.Serialization.Conventions
+{
+    /// <summary>
+    /// A class map convention that wraps a delegate.
+    /// </summary>
+    public class CreatorClassMapConvention : ConventionBase, IClassMapConvention
+    {
+        // private fields
+        private readonly Func<Type, Func<object>> _creator;
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreatorClassMapConvention" /> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="creator">The creator.</param>
+        public CreatorClassMapConvention(string name, Func<Type, Func<object>> creator)
+            : base(name)
+        {
+            if (creator == null)
+            {
+                throw new ArgumentNullException("creator");
+            }
+            _creator = creator;
+        }
+
+        // public methods
+        /// <summary>
+        /// Applies a modification to the class map.
+        /// </summary>
+        /// <param name="classMap">The class map.</param>
+        public void Apply(BsonClassMap classMap)
+        {
+            classMap.SetCreator(_creator(classMap.ClassType));
+        }
+    }
+}


### PR DESCRIPTION
This feature allows consumers of the driver to inject their own object creation mechanism into the BsonClassMap through the ConventionRegistry .  This is useful in scenarios where object creation is delegated to an IOC Container (such as Autofac, etc).  