### PR TITLE
Small changes in MongoUtils.cs

### DIFF
--- a/src/MongoDB.Driver/MongoUtils.cs
+++ b/src/MongoDB.Driver/MongoUtils.cs
@@ -35,7 +35,7 @@ namespace MongoDB.Driver
         public static string Hash(string text)
         {
             MD5 md5 = MD5.Create();
-            bytes[] bytes = md5.ComputeHash(Encoding.UTF8.GetBytes(text));
+            byte[] bytes = md5.ComputeHash(Encoding.UTF8.GetBytes(text));
             return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
         }
 


### PR DESCRIPTION
Changes:

I've changed the var's, because is not good regarding the performance use var, because you know perfectly what thos functions are returning, so there is no need to let the program, to infere. And return that directly, there is no need to store the hash in a string and then return.

About the CamelCase, is the string value was an empty string, the program will crash with an ArgumentOutOfRangeException, so a simple check will fix that part.

And at the end, only to standarized, it's cleaner to standarized all the "" to String.Empty.