### PR TITLE
SecureString cleanups

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/AuthenticationHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/AuthenticationHelper.cs
@@ -63,11 +63,7 @@ namespace MongoDB.Driver.Core.Authentication
         public static string MongoPasswordDigest(string username, SecureString password)
         {
             var prefixBytes = Utf8Encodings.Strict.GetBytes(username + ":mongo:");
-            return MongoPasswordDigest(prefixBytes, password);
-        }
 
-        public static string MongoPasswordDigest(byte[] prefixBytes, SecureString password)
-        {
             using (var md5 = MD5.Create())
             {
                 var passwordChars = new char[password.Length];

--- a/src/MongoDB.Driver.Core/Core/Authentication/AuthenticationHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/AuthenticationHelper.cs
@@ -64,58 +64,42 @@ namespace MongoDB.Driver.Core.Authentication
         {
             using (var md5 = MD5.Create())
             {
-                var bytes = Utf8Encodings.Strict.GetBytes(username + ":mongo:");
-
+                var prefix = Utf8Encodings.Strict.GetBytes(username + ":mongo:");
+                
                 IntPtr unmanagedPassword = IntPtr.Zero;
+                var passwordChars = new char[password.Length];
                 try
                 {
-                    unmanagedPassword = Marshal.SecureStringToBSTR(password);
-                    var passwordChars = new char[password.Length];
-                    GCHandle passwordCharsHandle = new GCHandle();
+#if NET45
+                    unmanagedPassword = Marshal.SecureStringToGlobalAllocUnicode(password);
+#else
+                    unmanagedPassword = SecureStringMarshal.SecureStringToGlobalAllocUnicode(password);
+#endif
+                    Marshal.Copy(unmanagedPassword, passwordChars, 0, passwordChars.Length);
+                    
+                    var passwordBytesCount = Utf8Encodings.Strict.GetByteCount(passwordChars);
+                    var buffer = new byte[prefix.Length + passwordBytesCount];
                     try
                     {
-                        passwordCharsHandle = GCHandle.Alloc(passwordChars, GCHandleType.Pinned);
-                        Marshal.Copy(unmanagedPassword, passwordChars, 0, passwordChars.Length);
+                        Buffer.BlockCopy(prefix, 0, buffer, 0, prefix.Length);
+                        Utf8Encodings.Strict.GetBytes(passwordChars, 0, passwordChars.Length, buffer, prefix.Length);
 
-                        var byteCount = Utf8Encodings.Strict.GetByteCount(passwordChars);
-                        var passwordBytes = new byte[byteCount];
-                        GCHandle passwordBytesHandle = new GCHandle();
-                        try
-                        {
-                            passwordBytesHandle = GCHandle.Alloc(passwordBytesHandle, GCHandleType.Pinned);
-                            Utf8Encodings.Strict.GetBytes(passwordChars, 0, passwordChars.Length, passwordBytes, 0);
-
-                            var buffer = new byte[bytes.Length + passwordBytes.Length];
-                            Buffer.BlockCopy(bytes, 0, buffer, 0, bytes.Length);
-                            Buffer.BlockCopy(passwordBytes, 0, buffer, bytes.Length, passwordBytes.Length);
-
-                            return BsonUtils.ToHexString(md5.ComputeHash(buffer));
-                        }
-                        finally
-                        {
-                            Array.Clear(passwordBytes, 0, passwordBytes.Length);
-
-                            if (passwordBytesHandle.IsAllocated)
-                            {
-                                passwordBytesHandle.Free();
-                            }
-                        }
+                        return BsonUtils.ToHexString(md5.ComputeHash(buffer));
                     }
                     finally
                     {
-                        Array.Clear(passwordChars, 0, passwordChars.Length);
-
-                        if (passwordCharsHandle.IsAllocated)
-                        {
-                            passwordCharsHandle.Free();
-                        }
+                        // for security reasons
+                        Array.Clear(buffer, 0, buffer.Length);
                     }
                 }
                 finally
                 {
+                    // for security reasons
+                    Array.Clear(passwordChars, 0, passwordChars.Length);
+                    
                     if (unmanagedPassword != IntPtr.Zero)
                     {
-                        Marshal.ZeroFreeBSTR(unmanagedPassword);
+                        Marshal.ZeroFreeGlobalAllocUnicode(unmanagedPassword);
                     }
                 }
             }

--- a/src/MongoDB.Driver.Core/Core/Authentication/UsernamePasswordCredential.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/UsernamePasswordCredential.cs
@@ -99,7 +99,11 @@ namespace MongoDB.Driver.Core.Authentication
             IntPtr unmanagedPassword = IntPtr.Zero;
             try
             {
+#if NET45
                 unmanagedPassword = Marshal.SecureStringToGlobalAllocUnicode(_password);
+#else
+                unmanagedPassword = SecureStringMarshal.SecureStringToGlobalAllocUnicode(_password);
+#endif            
                 return Marshal.PtrToStringUni(unmanagedPassword);
             }
             finally

--- a/src/MongoDB.Driver.Core/Core/Authentication/UsernamePasswordCredential.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/UsernamePasswordCredential.cs
@@ -96,21 +96,20 @@ namespace MongoDB.Driver.Core.Authentication
         /// <returns>The password.</returns>
         public string GetInsecurePassword()
         {
-            IntPtr unmanagedPassword = IntPtr.Zero;
+#if NET45
+            var str = Marshal.SecureStringToGlobalAllocUnicode(_password);
+#else
+            var str = SecureStringMarshal.SecureStringToGlobalAllocUnicode(_password);
+#endif
             try
             {
-#if NET45
-                unmanagedPassword = Marshal.SecureStringToGlobalAllocUnicode(_password);
-#else
-                unmanagedPassword = SecureStringMarshal.SecureStringToGlobalAllocUnicode(_password);
-#endif            
-                return Marshal.PtrToStringUni(unmanagedPassword);
+                return Marshal.PtrToStringUni(str);
             }
             finally
             {
-                if (unmanagedPassword != IntPtr.Zero)
+                if (str != IntPtr.Zero)
                 {
-                    Marshal.ZeroFreeGlobalAllocUnicode(unmanagedPassword);
+                    Marshal.ZeroFreeGlobalAllocUnicode(str);
                 }
             }
         }

--- a/src/MongoDB.Driver/PasswordEvidence.cs
+++ b/src/MongoDB.Driver/PasswordEvidence.cs
@@ -127,7 +127,7 @@ namespace MongoDB.Driver
         /// </summary>
         private static string GenerateDigest(SecureString secureString)
         {
-            using (var sha256 = new SHA256CryptoServiceProvider())
+            using (var sha256 = SHA256.Create())
             {
                 var hash = ComputeHash(sha256, new byte[0], secureString);
                 return BsonUtils.ToHexString(hash);
@@ -136,44 +136,42 @@ namespace MongoDB.Driver
 
         private static byte[] ComputeHash(HashAlgorithm algorithm, byte[] prefixBytes, SecureString secureString)
         {
-            var bstr = Marshal.SecureStringToBSTR(secureString);
+            var passwordChars = new char[secureString.Length];
+#if NET45
+            var unmanagedPassword = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+#else
+            var unmanagedPassword = SecureStringMarshal.SecureStringToGlobalAllocUnicode(secureString);
+#endif
             try
             {
-                var passwordChars = new char[secureString.Length];
-                var passwordCharsHandle = GCHandle.Alloc(passwordChars, GCHandleType.Pinned);
+                Marshal.Copy(unmanagedPassword, passwordChars, 0, passwordChars.Length);
+
+                var passwordBytesCount = Utf8Encodings.Strict.GetByteCount(passwordChars);
+                var buffer = new byte[prefixBytes.Length + passwordBytesCount];
                 try
                 {
-                    Marshal.Copy(bstr, passwordChars, 0, passwordChars.Length);
+                    Buffer.BlockCopy(prefixBytes, 0, buffer, 0, prefixBytes.Length);
+                    Utf8Encodings.Strict.GetBytes(passwordChars, 0, passwordChars.Length, buffer, prefixBytes.Length);
 
-                    var passwordBytes = new byte[secureString.Length * 3]; // worst case for UTF16 to UTF8 encoding
-                    var passwordBytesHandle = GCHandle.Alloc(passwordBytes, GCHandleType.Pinned);
-                    try
-                    {
-                        var encoding = Utf8Encodings.Strict;
-                        var passwordUtf8Length = encoding.GetBytes(passwordChars, 0, passwordChars.Length, passwordBytes, 0);
-                        var buffer = new byte[prefixBytes.Length + passwordUtf8Length];
-                        Buffer.BlockCopy(prefixBytes, 0, buffer, 0, prefixBytes.Length);
-                        Buffer.BlockCopy(passwordBytes, 0, buffer, prefixBytes.Length, passwordUtf8Length);
-                        var hash = algorithm.ComputeHash(buffer);
-                        Array.Clear(buffer, 0, buffer.Length);
-                        return hash;
-                    }
-                    finally
-                    {
-                        Array.Clear(passwordBytes, 0, passwordBytes.Length);
-                        passwordBytesHandle.Free();
-                    }
+                    return algorithm.ComputeHash(buffer);
                 }
                 finally
                 {
-                    Array.Clear(passwordChars, 0, passwordChars.Length);
-                    passwordCharsHandle.Free();
+                    // for security reasons
+                    Array.Clear(buffer, 0, buffer.Length);
                 }
             }
             finally
             {
-                Marshal.ZeroFreeBSTR(bstr);
+                // for security reasons
+                Array.Clear(passwordChars, 0, passwordChars.Length);
+
+                if (unmanagedPassword != IntPtr.Zero)
+                {
+                    Marshal.ZeroFreeGlobalAllocUnicode(unmanagedPassword);
+                }
             }
         }
+
     }
 }


### PR DESCRIPTION
It all started with one block of code in AuthenticationHelper, when I stumbled upon a GCHandle, which was not needed there. 
Then I've seen different encodings (BSTR/Unicode) when marshalling unmanaged strings… and then I just couldn't stop until I refactored it all.