### PR TITLE
Fix EnumRepresentationConvention with nullable enum properties

### DIFF
--- a/src/MongoDB.Bson/Serialization/Conventions/EnumRepresentationConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/EnumRepresentationConvention.cs
@@ -58,32 +58,7 @@ namespace MongoDB.Bson.Serialization.Conventions
                 memberMap.SetSerializer(reconfiguredSerializer);
             }
         }
-
-        // protected methods
-        /// <summary>
-        /// Reconfigures the specified serializer by applying this attribute to it.
-        /// </summary>
-        /// <param name="serializer">The serializer.</param>
-        /// <returns>A reconfigured serializer.</returns>
-        /// <exception cref="System.NotSupportedException"></exception>
-        protected virtual IBsonSerializer ApplyChild(IBsonSerializer serializer)
-        {
-            // if none of the overrides applied the attribute to the serializer see if it can be applied to a child serializer
-            var childSerializerConfigurable = serializer as IChildSerializerConfigurable;
-            if (childSerializerConfigurable != null)
-            {
-                var childSerializer = childSerializerConfigurable.ChildSerializer;
-                var reconfiguredChildSerializer = Apply(childSerializer);
-                return childSerializerConfigurable.WithChildSerializer(reconfiguredChildSerializer);
-            }
-
-            var message = string.Format(
-                "A serializer of type '{0}' is not configurable using an attribute of type '{1}'.",
-                BsonUtils.GetFriendlyTypeName(serializer.GetType()),
-                BsonUtils.GetFriendlyTypeName(this.GetType()));
-            throw new NotSupportedException(message);
-        }
-
+        
         private IBsonSerializer Apply(IBsonSerializer serializer)
         {
             var representationConfigurable = serializer as IRepresentationConfigurable;
@@ -112,7 +87,20 @@ namespace MongoDB.Bson.Serialization.Conventions
                 }
             }
 
-            return ApplyChild(serializer);
+            // if none of the overrides applied the attribute to the serializer see if it can be applied to a child serializer
+            var childSerializerConfigurable = serializer as IChildSerializerConfigurable;
+            if (childSerializerConfigurable != null)
+            {
+                var childSerializer = childSerializerConfigurable.ChildSerializer;
+                var reconfiguredChildSerializer = Apply(childSerializer);
+                return childSerializerConfigurable.WithChildSerializer(reconfiguredChildSerializer);
+            }
+
+            var message = string.Format(
+                "A serializer of type '{0}' is not configurable using an attribute of type '{1}'.",
+                BsonUtils.GetFriendlyTypeName(serializer.GetType()),
+                BsonUtils.GetFriendlyTypeName(this.GetType()));
+            throw new NotSupportedException(message);
         }
 
         private bool IsEnumType(Type t)

--- a/src/MongoDB.Bson/Serialization/Conventions/EnumRepresentationConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/EnumRepresentationConvention.cs
@@ -49,19 +49,78 @@ namespace MongoDB.Bson.Serialization.Conventions
         /// Applies a modification to the member map.
         /// </summary>
         /// <param name="memberMap">The member map.</param>
-        public void Apply(BsonMemberMap memberMap)
+        public virtual void Apply(BsonMemberMap memberMap)
         {
-            var memberTypeInfo = memberMap.MemberType.GetTypeInfo();
-            if (memberTypeInfo.IsEnum)
+            if (IsEnumType(memberMap.MemberType))
             {
                 var serializer = memberMap.GetSerializer();
-                var representationConfigurableSerializer = serializer as IRepresentationConfigurable;
-                if (representationConfigurableSerializer != null)
-                {
-                    var reconfiguredSerializer = representationConfigurableSerializer.WithRepresentation(_representation);
-                    memberMap.SetSerializer(reconfiguredSerializer);
-                }
+                var reconfiguredSerializer = Apply(serializer);
+                memberMap.SetSerializer(reconfiguredSerializer);
             }
         }
+
+        // protected methods
+        /// <summary>
+        /// Reconfigures the specified serializer by applying this attribute to it.
+        /// </summary>
+        /// <param name="serializer">The serializer.</param>
+        /// <returns>A reconfigured serializer.</returns>
+        /// <exception cref="System.NotSupportedException"></exception>
+        protected virtual IBsonSerializer ApplyChild(IBsonSerializer serializer)
+        {
+            // if none of the overrides applied the attribute to the serializer see if it can be applied to a child serializer
+            var childSerializerConfigurable = serializer as IChildSerializerConfigurable;
+            if (childSerializerConfigurable != null)
+            {
+                var childSerializer = childSerializerConfigurable.ChildSerializer;
+                var reconfiguredChildSerializer = Apply(childSerializer);
+                return childSerializerConfigurable.WithChildSerializer(reconfiguredChildSerializer);
+            }
+
+            var message = string.Format(
+                "A serializer of type '{0}' is not configurable using an attribute of type '{1}'.",
+                BsonUtils.GetFriendlyTypeName(serializer.GetType()),
+                BsonUtils.GetFriendlyTypeName(this.GetType()));
+            throw new NotSupportedException(message);
+        }
+
+        private IBsonSerializer Apply(IBsonSerializer serializer)
+        {
+            var representationConfigurable = serializer as IRepresentationConfigurable;
+            if (representationConfigurable != null)
+            {
+                var reconfiguredSerializer = representationConfigurable.WithRepresentation(_representation);
+
+                var converterConfigurable = reconfiguredSerializer as IRepresentationConverterConfigurable;
+                if (converterConfigurable != null)
+                {
+                    var converter = new RepresentationConverter(false, false);
+                    reconfiguredSerializer = converterConfigurable.WithConverter(converter);
+                }
+
+                return reconfiguredSerializer;
+            }
+
+            // for backward compatibility representations of Array and Document are mapped to DictionaryRepresentations if possible
+            var dictionaryRepresentationConfigurable = serializer as IDictionaryRepresentationConfigurable;
+            if (dictionaryRepresentationConfigurable != null)
+            {
+                if (_representation == BsonType.Array || _representation == BsonType.Document)
+                {
+                    var dictionaryRepresentation = (_representation == BsonType.Array) ? DictionaryRepresentation.ArrayOfArrays : DictionaryRepresentation.Document;
+                    return dictionaryRepresentationConfigurable.WithDictionaryRepresentation(dictionaryRepresentation);
+                }
+            }
+
+            return ApplyChild(serializer);
+        }
+
+        private bool IsEnumType(Type t)
+        {
+            if (t.IsEnum) return true;
+            Type u = Nullable.GetUnderlyingType(t);
+            return (u != null) && u.IsEnum;
+        }
+
     }
 }

--- a/src/MongoDB.Bson/Serialization/Conventions/EnumRepresentationConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/EnumRepresentationConvention.cs
@@ -105,9 +105,9 @@ namespace MongoDB.Bson.Serialization.Conventions
 
         private bool IsEnumType(Type t)
         {
-            if (t.IsEnum) return true;
+            if (t.GetTypeInfo().IsEnum) return true;
             Type u = Nullable.GetUnderlyingType(t);
-            return (u != null) && u.IsEnum;
+            return (u != null) && u.GetTypeInfo().IsEnum;
         }
 
     }

--- a/src/MongoDB.Bson/Serialization/Conventions/EnumRepresentationConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/EnumRepresentationConvention.cs
@@ -49,7 +49,7 @@ namespace MongoDB.Bson.Serialization.Conventions
         /// Applies a modification to the member map.
         /// </summary>
         /// <param name="memberMap">The member map.</param>
-        public virtual void Apply(BsonMemberMap memberMap)
+        public void Apply(BsonMemberMap memberMap)
         {
             if (IsEnumType(memberMap.MemberType))
             {

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/EnumRepresentationConventionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/EnumRepresentationConventionTests.cs
@@ -38,6 +38,13 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             public WorkDays ChangedRepresentationEnum { get; set; }
         }
 
+        private class TestClassNullable
+        {
+            public string NonEnum { get; set; }
+            public WorkDays? DefaultEnum { get; set; }
+            public WorkDays? ChangedRepresentationEnum { get; set; }
+        }
+
         [Theory]
         [InlineData(0)]
         [InlineData(BsonType.Int32)]
@@ -53,6 +60,23 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             convention.Apply(nonEnumMemberMap);
             convention.Apply(changedEnumMemberMap);
             Assert.Equal(value, ((IRepresentationConfigurable)(changedEnumMemberMap.GetSerializer())).Representation);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(BsonType.Int32)]
+        [InlineData(BsonType.Int64)]
+        [InlineData(BsonType.String)]
+        public void TestConventionNullable(BsonType value)
+        {
+            var convention = new EnumRepresentationConvention(value);
+            var classMap = new BsonClassMap<TestClassNullable>();
+            var nonEnumMemberMap = classMap.MapMember(x => x.NonEnum);
+            classMap.MapMember(x => x.DefaultEnum);
+            var changedEnumMemberMap = classMap.MapMember(x => x.ChangedRepresentationEnum);
+            convention.Apply(nonEnumMemberMap);
+            convention.Apply(changedEnumMemberMap);
+            Assert.Equal(value, ((IRepresentationConfigurable)((IChildSerializerConfigurable)(changedEnumMemberMap.GetSerializer())).ChildSerializer).Representation);
         }
 
         [Fact]


### PR DESCRIPTION
This fix ensures the EnumRepresentationConvention works as expected onNullable enum properties.

Ref: https://jira.mongodb.org/browse/CSHARP-1839
