### PR TITLE
CSHARP-5554: Improved ObjectId parsing and ToString() performance

### DIFF
--- a/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Bson.Tests
         [InlineData("-79228162514264337593543950335", "-79228162514264337593543950335")]
         public void Decimal(string valueString, string s)
         {
-            var value = decimal.Parse(valueString);
+            var value = decimal.Parse(valueString, CultureInfo.InvariantCulture);
             var subject = new Decimal128(value);
 
             subject.ToString().Should().Be(s);


### PR DESCRIPTION
While writing an `ObjectId`-like class for another project (where I needed a time-based identifier, but didn't want to bring dependency on a whole `MongoDB.Bson` package just for `ObjectId`), I was curious about performance of my implementation compared to the reference one.

My test was like serializing a million of identifiers (as strings), and then parsing them back. Here are my results:

|  | `ObjectId.ToString()` | `ObjectId.Parse()` |
| --- | --: | --: |
| MongoDB.Bson (v2.3.0) | 3475ms | 897ms |
| My (humble) implementation | 87ms | 81ms |

So this probably looks like a valid reason to make a pull request and improve things a little :) 

I'm not sure if it affects other cases where `ObjectId` is serialized, like performance of database responses' deserialization. But shouldn't hurt at least.
