### PR TITLE
Add debug info to exception if deserialization fails

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/DictionarySerializerBase.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DictionarySerializerBase.cs
@@ -618,8 +618,17 @@ namespace MongoDB.Bson.Serialization.Serializers
             while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
             {
                 var key = DeserializeKeyString(bsonReader.ReadName());
-                var value = _lazyValueSerializer.Value.Deserialize(context);
-                dictionary.Add(key, value);
+                try
+                {
+                    var value = _lazyValueSerializer.Value.Deserialize(context);
+                    dictionary.Add(key, value);
+                }
+                catch (FormatException e)
+                {
+                    Exception wrapper = new FormatException("Error while deserializing key " + key, e);
+                    wrapper.Data["Document"] = dictionary;
+                    throw wrapper;
+                }
             }
             bsonReader.ReadEndDocument();
 


### PR DESCRIPTION
In case of an unknown BSON type (for example: Undefined), the driver would crash with no way to debug this case if there're a lot of result records.

This change now provides the (root-)property that failed deserialization and the previously decoded values (mainly _id) of the document to easily find it.