### PR TITLE
CSHARP-1836: Added additional check for default 'VersionReturned' property value and added unit tests.

### DIFF
--- a/src/MongoDB.Driver.Legacy/MongoCollection.cs
+++ b/src/MongoDB.Driver.Legacy/MongoCollection.cs
@@ -574,7 +574,7 @@ namespace MongoDB.Driver
             var resultSerializer = BsonDocumentSerializer.Instance;
             var messageEncoderSettings = GetMessageEncoderSettings();
             var projection = args.Fields == null ? null : new BsonDocumentWrapper(args.Fields);
-            var returnDocument = args.VersionReturned == FindAndModifyDocumentVersion.Original
+            var returnDocument = !args.VersionReturned.HasValue || args.VersionReturned.Value == FindAndModifyDocumentVersion.Original
                 ? Core.Operations.ReturnDocument.Before
                 : Core.Operations.ReturnDocument.After;
             var sort = args.SortBy == null ? null : new BsonDocumentWrapper(args.SortBy);


### PR DESCRIPTION
The initial problem is that property is nullable.

It could be solved by moving from using nullable fields (not sure why it needs to be nullable).
Almost all overloads of FindAndModify method work properly because specify which version need to be returned.

Obsolete version 'FindAndModifyResult FindAndModify(IMongoQuery query, IMongoSortBy sortBy, IMongoUpdate update)' pretty easy to modify, but it won's solve the problem, because the problem is in 'FindAndModifyArgs' class.