### PR TITLE
Preserve element name if its characters are all in capital letters in camel-case convention

### DIFF
--- a/src/MongoDB.Bson/Serialization/Conventions/CamelCaseElementNameConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/CamelCaseElementNameConvention.cs
@@ -23,6 +23,24 @@ namespace MongoDB.Bson.Serialization.Conventions
     /// </summary>
     public class CamelCaseElementNameConvention : ConventionBase, IMemberMapConvention
     {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="skipWhenAllCaps">
+        /// When set to true, this convention will skip members in capital letters (for example: "ALLCAPS")
+        /// in order to preserve acronyms or member names designed to be in upper-case.
+        /// </param>
+        public CamelCaseElementNameConvention(bool skipWhenAllCaps = false)
+        {
+            SkipWhenAllCaps = skipWhenAllCaps;
+        }
+
+        /// <summary>
+        /// Gets if this convention will skip members in capital letters (for example: "ALLCAPS")
+        /// in order to preserve acronyms or member names designed to be in upper-case.
+        /// </summary>
+        private bool SkipWhenAllCaps { get; }
+
         // public methods
         /// <summary>
         /// Applies a modification to the member map.
@@ -42,11 +60,15 @@ namespace MongoDB.Bson.Serialization.Conventions
             {
                 return "";
             }
+            else if (SkipWhenAllCaps && memberName == memberName.ToUpper())
+            {
+                return memberName;
+            }
             else if(memberName.Length == 1)
             {
                 return Char.ToLowerInvariant(memberName[0]).ToString();
             }
-            else 
+            else
             {
                 return Char.ToLowerInvariant(memberName[0]) + memberName.Substring(1);
             }

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/CamelCaseElementNameConventionsTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/CamelCaseElementNameConventionsTests.cs
@@ -27,6 +27,7 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             public int Age { get; set; }
             public string _DumbName { get; set; }
             public string lowerCase { get; set; }
+            public string ALLCAPS { get; set; }
         }
 
         [Fact]
@@ -38,16 +39,43 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             var age = classMap.MapMember(x => x.Age);
             var _dumbName = classMap.MapMember(x => x._DumbName);
             var lowerCase = classMap.MapMember(x => x.lowerCase);
+            var allCaps = classMap.MapMember(x => x.ALLCAPS);
 
             convention.Apply(firstName);
             convention.Apply(age);
             convention.Apply(_dumbName);
             convention.Apply(lowerCase);
+            convention.Apply(allCaps);
 
             Assert.Equal("firstName", firstName.ElementName);
             Assert.Equal("age", age.ElementName);
             Assert.Equal("_DumbName", _dumbName.ElementName);
             Assert.Equal("lowerCase", lowerCase.ElementName);
+            Assert.Equal("aLLCAPS", allCaps.ElementName);
+        }
+
+        [Fact]
+        public void TestCamelCaseElementNameConventionWithSkipAllCaps()
+        {
+            var convention = new CamelCaseElementNameConvention(skipWhenAllCaps: true);
+            var classMap = new BsonClassMap<TestClass>();
+            var firstName = classMap.MapMember(x => x.FirstName);
+            var age = classMap.MapMember(x => x.Age);
+            var _dumbName = classMap.MapMember(x => x._DumbName);
+            var lowerCase = classMap.MapMember(x => x.lowerCase);
+            var allCaps = classMap.MapMember(x => x.ALLCAPS);
+
+            convention.Apply(firstName);
+            convention.Apply(age);
+            convention.Apply(_dumbName);
+            convention.Apply(lowerCase);
+            convention.Apply(allCaps);
+
+            Assert.Equal("firstName", firstName.ElementName);
+            Assert.Equal("age", age.ElementName);
+            Assert.Equal("_DumbName", _dumbName.ElementName);
+            Assert.Equal("lowerCase", lowerCase.ElementName);
+            Assert.Equal("ALLCAPS", allCaps.ElementName);
         }
     }
 }


### PR DESCRIPTION
Hi!

It's a very simple improvement.

Let's say we need to serialize a class like this:

```
public class Customer
{
       public string Id { get; set; }
       public string TIN { get; set; }
}
```

Current `CamelCaseElementNameConvention` will serialize `Customer.TIN` as `tIN` while it should be just `TIN`.

In summary, I would say that if a property is in capital letters **it should mean that it's an *acronym*** (or leaving a property in capital letters is the intended behavior).

## Solution

My proposed solution is a new `else if` in the whole convention code:

```
else if (memberName == memberName.ToUpper())
{
        return memberName;
}
```

---

Thank you in advance and I'll look forward for your comments!