### PR TITLE
README.md: Fix typo in filter creation for "Deleting Documents"

### DIFF
--- a/Docs/reference/content/getting_started/quick_tour.md
+++ b/Docs/reference/content/getting_started/quick_tour.md
@@ -341,7 +341,7 @@ The update methods return an [`UpdateResult`]({{< apiref "T_MongoDB_Driver_Updat
 To delete at most 1 document (may be 0 if none match the filter) use the [`DeleteOne`]({{< apiref "M_MongoDB_Driver_IMongoCollection_1_DeleteOne" >}}) or [`DeleteOneAsync`]({{< apiref "M_MongoDB_Driver_IMongoCollection_1_DeleteOneAsync" >}}) methods:
 
 ```csharp
-var filter = Builders<BsonDocument>.Filter.Eq("i", 110));
+var filter = Builders<BsonDocument>.Filter.Eq("i", 110);
 ```
 ```csharp
 collection.DeleteOne(filter);
@@ -353,7 +353,7 @@ await collection.DeleteOneAsync(filter);
 To delete all documents matching the filter use the [`DeleteMany`]({{< apiref "M_MongoDB_Driver_IMongoCollection_1_DeleteMany" >}}) or [`DeleteManyAsync`]({{< apiref "M_MongoDB_Driver_IMongoCollection_1_DeleteManyAsync" >}}) methods. Here we delete all documents where `i >= 100`:
 
 ```csharp
-var filter = Builders<BsonDocument>.Filter.Gte("i", 100));
+var filter = Builders<BsonDocument>.Filter.Gte("i", 100);
 ```
 ```csharp
 var result = collection.DeleteMany(filter);


### PR DESCRIPTION
Remove an extra ")" in the commands to create filters for DeleteOne and DeleteMany, which causes syntax errors.