### PR TITLE
add method IsSerializerRegistered to BsonSerializerRegistry

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -75,6 +75,37 @@ namespace MongoDB.Bson.Serialization
         }
 
         /// <summary>
+        /// Determines if a serializer is registered for the specified <paramref name="type" />.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>
+        /// true if the serializer is registered; otherwise false.
+        /// </returns>
+        public bool IsSerializerRegistered(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException("type");
+            }
+
+            var result = _cache.ContainsKey(type);
+            return result;
+        }
+
+        /// <summary>
+        /// Determines if a serializer is registered for the specified <typeparamref name="T" />.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>
+        /// true if the serializer is registered; otherwise false.
+        /// </returns>
+        public bool IsSerializerRegistered<T>()
+        {
+            var result = IsSerializerRegistered(typeof(T));
+            return result;
+        }
+
+        /// <summary>
         /// Registers the serializer.
         /// </summary>
         /// <param name="type">The type.</param>

--- a/src/MongoDB.Bson/Serialization/IBsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/IBsonSerializerRegistry.cs
@@ -35,5 +35,23 @@ namespace MongoDB.Bson.Serialization
         /// <typeparam name="T"></typeparam>
         /// <returns>The serializer.</returns>
         IBsonSerializer<T> GetSerializer<T>();
+
+        /// <summary>
+        /// Determines if a serializer is registered for the specified <paramref name="type" />.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>
+        /// true if the serializer is registered; otherwise false.
+        /// </returns>
+        bool IsSerializerRegistered(Type type);
+
+        /// <summary>
+        /// Determines if a serializer is registered for the specified <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>
+        /// true if the serializer is registered; otherwise false.
+        /// </returns>
+        bool IsSerializerRegistered<T>();
     }
 }


### PR DESCRIPTION
There is no way to determine whether a serialized in registered in the registry.