### PR TITLE
CSHARP-1875: Steer clear of code that needs ntdll.dll

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using MongoDB.Bson;
 
 namespace MongoDB.Driver.Core.Connections
@@ -69,45 +68,56 @@ namespace MongoDB.Driver.Core.Connections
         internal static BsonDocument CreateOSDocument()
         {
             string osType;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            switch (Environment.OSVersion.Platform)
             {
-                osType = "Windows";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                osType = "Linux";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                osType = "macOS";
-            }
-            else
-            {
-                osType = "unknown";
-            }
+                case PlatformID.Win32S:
+                case PlatformID.Win32Windows:
+                case PlatformID.Win32NT:
+                case PlatformID.WinCE:
+                    osType = "Windows";
+                    break;
 
-            var osName = RuntimeInformation.OSDescription.Trim();
+                case PlatformID.Unix:
+                    osType = "Linux";
+                    break;
+
+                case PlatformID.Xbox:
+                    osType = "XBox";
+                    break;
+
+                case PlatformID.MacOSX:
+                    osType = "macOS";
+                    break;
+
+                default:
+                    osType = "Unknown";
+                    break;
+            }
 
             string architecture;
-            switch (RuntimeInformation.ProcessArchitecture)
+            PortableExecutableKinds peKind;
+            ImageFileMachine machine;
+            typeof(object).Module.GetPEKind(out peKind, out machine);
+            switch (machine)
             {
-                case Architecture.Arm: architecture = "arm"; break;
-                case Architecture.Arm64: architecture = "arm64"; break;
-                case Architecture.X64: architecture = "x86_64"; break;
-                case Architecture.X86: architecture = "x86_32"; break;
-                default: architecture = null; break;
+                case ImageFileMachine.I386:
+                    architecture = "x86_32";
+                    break;
+                case ImageFileMachine.IA64:
+                case ImageFileMachine.AMD64:
+                    architecture = "x86_64";
+                    break;
+                case ImageFileMachine.ARM:
+                    architecture = "arm" + (Environment.Is64BitProcess ? "64" : "");
+                    break;
+                default:
+                    architecture = null;
+                    break;
             }
 
-            string osVersion;
-            var match = Regex.Match(osName, @" (?<version>\d+\.\d[^ ]*)");
-            if (match.Success)
-            {
-                osVersion = match.Groups["version"].Value;
-            }
-            else
-            {
-                osVersion = null;
-            }
+            var osName = Environment.OSVersion.VersionString;
+
+            string osVersion = Environment.OSVersion.Version.ToString();
 
             return CreateOSDocument(osType, osName, architecture, osVersion);
         }

--- a/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
@@ -76,7 +76,6 @@ namespace MongoDB.Driver.Core.Connections
 #if NET45
             if (Type.GetType("Mono.Runtime") != null)
             {
-                Console.WriteLine("Hello Mono!!!");
                 switch (Environment.OSVersion.Platform)
                 {
                     case PlatformID.Win32S:


### PR DESCRIPTION
As few changes as possible to accomplish the same functionality without using those parts of System.Runtime.InteropServices.RuntimeInformation that will reference ntdll.dll