### PR TITLE
Query is incorrect if type downcasting is present in expression

### DIFF
--- a/src/MongoDB.Driver/Linq/Processors/SerializationBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/SerializationBinder.cs
@@ -218,6 +218,7 @@ namespace MongoDB.Driver.Linq.Processors
                                 return new DocumentExpression(serializer);
                             case ExtensionExpressionType.Field:
                                 return new FieldExpression(
+                                    ((FieldExpression) serializationExpression).Document,
                                     ((FieldExpression)serializationExpression).FieldName,
                                     serializer);
                             case ExtensionExpressionType.FieldAsDocument:

--- a/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
@@ -103,7 +103,8 @@ namespace MongoDB.Driver.Tests.Linq
                 Q = Q.One,
                 R = new DateTime(2013, 1, 2, 3, 4, 5, 6, DateTimeKind.Utc),
                 T = new Dictionary<string, int> { { "one", 1 }, { "two", 2 } },
-                U = 1.23456571661743267789m
+                U = 1.23456571661743267789m,
+                W = new Dictionary<string, object> { { "one", 1 }, { "two", 2 } }
             };
             __collection.InsertOne(root);
         }
@@ -219,6 +220,8 @@ namespace MongoDB.Driver.Tests.Linq
 
             [BsonRepresentation(Bson.BsonType.Double, AllowTruncation = true)]
             public decimal U { get; set; }
+
+            public Dictionary<string, object> W { get; set; }
         }
 
         public class RootDescended : Root

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
@@ -580,6 +580,15 @@ namespace MongoDB.Driver.Tests.Linq.Translators
         }
 
         [Fact]
+        public void DictionaryIndexerWithCasting()
+        {
+            Assert(
+                x => (int) x.W["one"] == 1,
+                1,
+                "{'W.one': 1}");
+        }
+
+        [Fact]
         public void EnumerableCount()
         {
             Assert(
@@ -618,7 +627,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
         [Fact]
         public void Equals_with_non_nullable_field_and_nullable_value()
         {
-            var value = (int?)null;
+            var value = (int?) null;
             Assert(
                 x => x.Id == value,
                 0,


### PR DESCRIPTION
In current project we store additional properties of entity in Dictionary<string, object> 
when try to search through collection with expression for instance: x => (int) x.W["one"] == 1
it's being converted to query: "{'one': 1}"
but should be: "{'W.one': 1}"
The root cause is type casting.

It works on driver's version 2.2.3, but since 2.2.4 we have issue, described above