### PR TITLE
CSHARP-1906: Support for case insensitive search using $in clause in Linq expressions

### DIFF
--- a/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
@@ -332,6 +332,64 @@ namespace MongoDB.Driver.Tests.Linq.Translators
         }
 
         [Fact]
+        public void LocalStringArrayContainsCaseInsensitive()
+        {
+            var local = new[] { "awesome", "amazing", "cool" };
+            Assert(
+                x => local.Contains(x.A.ToLower()),
+                2,
+                "{A: {$in: [/^awesome$/i, /^amazing$/i, /^cool$/i]}}");
+        }
+
+        [Fact]
+        public void LocalStringListContainsCaseInsensitive()
+        {
+            var local = new List<string>() { "awesome", "amazing", "cool" };
+            Assert(
+                x => local.Contains(x.A.ToLower()),
+                2,
+                "{A: {$in: [/^awesome$/i, /^amazing$/i, /^cool$/i]}}");
+        }
+
+        [Fact]
+        public void LocalStringIListContainsCaseInsensitive()
+        {
+            IList<string> local = new[] { "awesome", "amazing", "cool" };
+            Assert(
+                x => local.Contains(x.A.ToLower()),
+                2,
+                "{A: {$in: [/^awesome$/i, /^amazing$/i, /^cool$/i]}}");
+        }
+
+        [Fact]
+        public void LocalStringArrayContainsCaseSensitive()
+        {
+            var local = new[] { "awesome", "amazing", "cool" };
+            Assert(
+                x => local.Contains(x.A),
+                0,
+                "{A: {$in: [\"awesome\", \"amazing\", \"cool\"]}}");
+        }
+
+        [Fact]
+        public void LocalStringListContainsCaseSensitive() {
+            var local = new List<string>() { "awesome", "amazing", "cool" };
+            Assert(
+                x => local.Contains(x.A),
+                0,
+                "{A: {$in: [\"awesome\", \"amazing\", \"cool\"]}}");
+        }
+
+        [Fact]
+        public void LocalStringIListContainsCaseSensitive() {
+            IList<string> local = new[] { "awesome", "amazing", "cool" };
+            Assert(
+                x => local.Contains(x.A),
+                0,
+                "{A: {$in: [\"awesome\", \"amazing\", \"cool\"]}}");
+        }
+
+        [Fact]
         public void ArrayLengthEquals()
         {
             Assert(


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-1906

This pull request adds the support of case insensitive search using $in clause in Linq expressions like it works for general equal clause. For example it might be done in this way:

var goodValues = new string[] { ... }
var query = collection.AsQueryable<T>()
    .Where(i => goodValues.Contains(i.SomeField.ToLower()));

Right now it's only possible to specify general values in the array and is not possible to specify regex values for case insensitive search. General equal clause suports it via ToLower() etc methods, but the driver throw an exception if there is a call of .ToLower() method inside the array.Contains() method in .Where() expression.