### PR TITLE
CSHARP-1914 Remove cloning of the certificates

### DIFF
--- a/src/MongoDB.Driver/SslSettings.cs
+++ b/src/MongoDB.Driver/SslSettings.cs
@@ -63,11 +63,11 @@ namespace MongoDB.Driver
         /// </summary>
         public IEnumerable<X509Certificate> ClientCertificates
         {
-            get { return (_clientCertificateCollection == null) ? null : ((IEnumerable)_clientCertificateCollection).Cast<X509Certificate>().Select(c => CloneCertificate(c)); }
+            get { return (_clientCertificateCollection == null) ? null : ((IEnumerable)_clientCertificateCollection).Cast<X509Certificate>(); }
             set
             {
                 if (_isFrozen) { throw new InvalidOperationException("SslSettings is frozen."); }
-                _clientCertificateCollection = (value == null) ? null : new X509CertificateCollection(value.Select(c => CloneCertificate(c)).ToArray());
+                _clientCertificateCollection = (value == null) ? null : new X509CertificateCollection(value.ToArray());
             }
         }
 
@@ -250,21 +250,7 @@ namespace MongoDB.Driver
 
             return string.Format("{{{0}}}", string.Join(",", parts.ToArray()));
         }
-
-        // private methods
-        private X509Certificate CloneCertificate(X509Certificate certificate)
-        {
-            var certificate2 = certificate as X509Certificate2;
-            if (certificate2 != null)
-            {
-                return new X509Certificate2(certificate2.RawData);
-            }
-            else
-            {
-                return new X509Certificate(certificate.Export(X509ContentType.Cert));
-            }
-        }
-
+        
         // nested classes
         private class X509CertificateCollectionEqualityComparer : IEqualityComparer<X509CertificateCollection>
         {

--- a/tests/MongoDB.Driver.Tests/SslSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/SslSettingsTests.cs
@@ -69,11 +69,11 @@ namespace MongoDB.Driver.Tests
 
             var certificateFileName = GetTestCertificateFileName();
             var clientCertificates = new[] { new X509Certificate2(certificateFileName, "password"), new X509Certificate2(certificateFileName, "password") };
+            Assert.True(clientCertificates.All(cert => cert.HasPrivateKey));
             settings.ClientCertificates = clientCertificates;
             Assert.True(clientCertificates.SequenceEqual(settings.ClientCertificates));
-            Assert.NotSame(clientCertificates[0], settings.ClientCertificates.ElementAt(0));
-            Assert.NotSame(clientCertificates[1], settings.ClientCertificates.ElementAt(1));
-
+            Assert.True(settings.ClientCertificates.Cast<X509Certificate2>().All(cert => cert.HasPrivateKey));
+            
             settings.Freeze();
             Assert.True(clientCertificates.SequenceEqual(settings.ClientCertificates));
             Assert.Throws<InvalidOperationException>(() => { settings.ClientCertificates = clientCertificates; });


### PR DESCRIPTION
Remove cloning of the certificates, as this was problematic as the private key is not included in the RawData of a cert and a cert cannot always be cloned in a deep manner (if it is non exportable)