### PR TITLE
fixed typeInfo properties selection

### DIFF
--- a/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
@@ -39,7 +39,7 @@ namespace MongoDB.Bson.Serialization.Conventions
                 return;
             }
 
-            var properties = typeInfo.GetProperties();
+            var properties = typeInfo.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
             if (properties.Any(p => p.CanWrite))
             {
                 return; // a type that has any writable properties is not immutable


### PR DESCRIPTION
Getting only the public properties of an instance, declared on current hierarchy level.
Otherwise, properties of base class will be selected and mapped, which leads to exception when call AutoMap on inherited classes