### PR TITLE
Strategy pattern for BsonClassMapSerializer

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -31,7 +31,7 @@ namespace MongoDB.Bson.Serialization
     public class BsonClassMapSerializer<TClass> : SerializerBase<TClass>, IBsonIdProvider, IBsonDocumentSerializer, IBsonPolymorphicSerializer
     {
         // private fields
-        private BsonClassMap _classMap;
+        private readonly BsonClassMap _classMap;
 
         // constructors
         /// <summary>

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -516,16 +516,23 @@ namespace MongoDB.Bson.Serialization
                 endInitMethodInfo = null;
             }
             #endregion
+
+            #region private static fields
+            private static readonly MethodInfo _beginInitMethodInfo;
+            private static readonly MethodInfo _endInitMethodInfo;
+            #endregion
+
+            // Note: This is inside a generic type so the static constructor will be called on a per type parameter (TClass) basis.
+            static ClassDeserializationStrategy()
+            {
+                CheckForISupportInitializeInterface(out _beginInitMethodInfo, out _endInitMethodInfo);
+            }
 #endif
 
             #region private fields
             private readonly TClass _document;
 #if !NETSTANDARD1_5
             private readonly ISupportInitialize _supportsInitialization;
-#endif
-#if NETSTANDARD1_5
-            private readonly MethodInfo _beginInitMethodInfo;
-            private readonly MethodInfo _endInitMethodInfo;
 #endif
             #endregion
 
@@ -539,7 +546,6 @@ namespace MongoDB.Bson.Serialization
                 _supportsInitialization?.BeginInit();
 #endif
 #if NETSTANDARD1_5
-                CheckForISupportInitializeInterface(out _beginInitMethodInfo, out _endInitMethodInfo);
                 _beginInitMethodInfo?.Invoke(_document, new object[0]);
 #endif
             }

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -86,27 +86,22 @@ namespace MongoDB.Bson.Serialization
                 throw new BsonSerializationException(message);
             }
 
-            if (bsonReader.GetCurrentBsonType() == Bson.BsonType.Null)
+            if (bsonReader.GetCurrentBsonType() == BsonType.Null)
             {
                 bsonReader.ReadNull();
-                return default(TClass);
+                return default;
             }
-            else
+
+            var discriminatorConvention = _classMap.GetDiscriminatorConvention();
+
+            var actualType = discriminatorConvention.GetActualType(bsonReader, args.NominalType);
+            if (actualType == typeof(TClass))
             {
-                var discriminatorConvention = _classMap.GetDiscriminatorConvention();
-
-                var actualType = discriminatorConvention.GetActualType(bsonReader, args.NominalType);
-                if (actualType == typeof(TClass))
-                {
-                    return DeserializeClass(context);
-                }
-                else
-                {
-                    var serializer = BsonSerializer.LookupSerializer(actualType);
-                    return (TClass)serializer.Deserialize(context);
-                }
-
+                return DeserializeClass(context);
             }
+
+            var serializer = BsonSerializer.LookupSerializer(actualType);
+            return (TClass)serializer.Deserialize(context);
         }
 
         /// <summary>
@@ -131,11 +126,8 @@ namespace MongoDB.Bson.Serialization
             {
                 return DeserializeClass(context, bsonReader, new DictionaryDeserializationStrategy(_classMap));
             }
-            else
-            {
 
-                return DeserializeClass(context, bsonReader, new ClassDeserializationStrategy(_classMap));
-            }
+            return DeserializeClass(context, bsonReader, new ClassDeserializationStrategy(_classMap));
         }
 
         private TClass DeserializeClass(BsonDeserializationContext context, IBsonReader bsonReader, IClassDeserializationStrategy deserializationStrategy)
@@ -262,13 +254,11 @@ namespace MongoDB.Bson.Serialization
                 idGenerator = idMemberMap.IdGenerator;
                 return true;
             }
-            else
-            {
-                id = null;
-                idNominalType = null;
-                idGenerator = null;
-                return false;
-            }
+
+            id = null;
+            idNominalType = null;
+            idGenerator = null;
+            return false;
         }
 
         /// <summary>
@@ -546,33 +536,21 @@ namespace MongoDB.Bson.Serialization
 
 #if !NETSTANDARD1_5
                 _supportsInitialization = _document as ISupportInitialize;
-                if (_supportsInitialization != null)
-                {
-                    _supportsInitialization.BeginInit();
-                }
+                _supportsInitialization?.BeginInit();
 #endif
 #if NETSTANDARD1_5
                 CheckForISupportInitializeInterface(out _beginInitMethodInfo, out _endInitMethodInfo);
-                if (_beginInitMethodInfo != null)
-                {
-                    _beginInitMethodInfo.Invoke(_document, new object[0]);
-                }
+                _beginInitMethodInfo?.Invoke(_document, new object[0]);
 #endif
             }
 
             public TClass GetDeserializationResult()
             {
 #if !NETSTANDARD1_5
-                if (_supportsInitialization != null)
-                {
-                    _supportsInitialization.EndInit();
-                }
+                _supportsInitialization?.EndInit();
 #endif
 #if NETSTANDARD1_5
-                if (_endInitMethodInfo != null)
-                {
-                    _endInitMethodInfo.Invoke(_document, new object[0]);
-                }
+                _endInitMethodInfo?.Invoke(_document, new object[0]);
 #endif
                 return _document;
             }
@@ -729,10 +707,7 @@ namespace MongoDB.Bson.Serialization
 
 #if !NETSTANDARD1_5
                 var supportsInitialization = document as ISupportInitialize;
-                if (supportsInitialization != null)
-                {
-                    supportsInitialization.BeginInit();
-                }
+                supportsInitialization?.BeginInit();
 #endif
                 // process any left over values that weren't passed to the creator
                 foreach (var keyValuePair in values)
@@ -748,10 +723,7 @@ namespace MongoDB.Bson.Serialization
                 }
 
 #if !NETSTANDARD1_5
-                if (supportsInitialization != null)
-                {
-                    supportsInitialization.EndInit();
-                }
+                supportsInitialization?.EndInit();
 #endif
 
                 return (TClass)document;


### PR DESCRIPTION
The `BsonClassMapSerializer.DeserializeClass(BsonDeserializationContext context)` method contained code to handle two basic cases depending on the value of `_classMap.HasCreatorMaps`: The deserialization using a `Dictionary<string, object>` and the "standard" deserialization. By introducing a strategy pattern I could reduce branching (minor performance gain in theory but potentially wiped out due to additional method calls, I get varying results...) and refactor the code into a more OO kind of layout.