### PR TITLE
Performance: Some more caching and reduced null checks on hot path in BsonSerializer

### DIFF
--- a/src/MongoDB.Bson/BsonUtils.cs
+++ b/src/MongoDB.Bson/BsonUtils.cs
@@ -42,7 +42,7 @@ namespace MongoDB.Bson
 
             var sb = new StringBuilder();
             sb.AppendFormat("{0}<", Regex.Replace(type.Name, @"\`\d+$", ""));
-            foreach (var typeParameter in type.GetTypeInfo().GetGenericArguments())
+            foreach (var typeParameter in typeInfo.GetGenericArguments())
             {
                 sb.AppendFormat("{0}, ", GetFriendlyTypeName(typeParameter));
             }

--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -360,8 +360,6 @@ namespace MongoDB.Bson.Serialization
         /// <returns>A discriminator convention.</returns>
         public static IDiscriminatorConvention LookupDiscriminatorConvention(Type type)
         {
-            var typeInfo = type.GetTypeInfo();
-
             __configLock.EnterReadLock();
             try
             {
@@ -382,6 +380,7 @@ namespace MongoDB.Bson.Serialization
                 IDiscriminatorConvention convention;
                 if (!__discriminatorConventions.TryGetValue(type, out convention))
                 {
+                    var typeInfo = type.GetTypeInfo();
                     if (type == typeof(object))
                     {
                         // if there is no convention registered for object register the default one
@@ -398,8 +397,8 @@ namespace MongoDB.Bson.Serialization
                     {
                         // inherit the discriminator convention from the closest parent (that isn't object) that has one
                         // otherwise default to the standard hierarchical convention
-                        Type parentType = type.GetTypeInfo().BaseType;
-                        while (convention == null)
+                        Type parentType = typeInfo.BaseType;
+                        while (true)
                         {
                             if (parentType == typeof(object))
                             {
@@ -438,7 +437,6 @@ namespace MongoDB.Bson.Serialization
         /// <returns>An IdGenerator for the Id type.</returns>
         public static IIdGenerator LookupIdGenerator(Type type)
         {
-            var typeInfo = type.GetTypeInfo();
             __configLock.EnterReadLock();
             try
             {
@@ -459,6 +457,7 @@ namespace MongoDB.Bson.Serialization
                 IIdGenerator idGenerator;
                 if (!__idGenerators.TryGetValue(type, out idGenerator))
                 {
+                    var typeInfo = type.GetTypeInfo();
                     if (typeInfo.IsValueType && __useZeroIdChecker)
                     {
                         var iEquatableDefinition = typeof(IEquatable<>);
@@ -539,7 +538,7 @@ namespace MongoDB.Bson.Serialization
                     hashSet.Add(type);
 
                     // mark all base types as discriminated (so we know that it's worth reading a discriminator)
-                    for (var baseType = type.GetTypeInfo().BaseType; baseType != null; baseType = baseType.GetTypeInfo().BaseType)
+                    for (var baseType = typeInfo.BaseType; baseType != null; baseType = baseType.GetTypeInfo().BaseType)
                     {
                         __discriminatedTypes.Add(baseType);
                     }

--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -300,11 +300,12 @@ namespace MongoDB.Bson.Serialization
                 Type actualType = null;
 
                 HashSet<Type> hashSet;
+                var nominalTypeInfo = nominalType.GetTypeInfo();
                 if (__discriminators.TryGetValue(discriminator, out hashSet))
                 {
                     foreach (var type in hashSet)
                     {
-                        if (nominalType.GetTypeInfo().IsAssignableFrom(type))
+                        if (nominalTypeInfo.IsAssignableFrom(type))
                         {
                             if (actualType == null)
                             {
@@ -336,7 +337,7 @@ namespace MongoDB.Bson.Serialization
                     throw new BsonSerializationException(message);
                 }
 
-                if (!nominalType.GetTypeInfo().IsAssignableFrom(actualType))
+                if (!nominalTypeInfo.IsAssignableFrom(actualType))
                 {
                     string message = string.Format(
                         "Actual type {0} is not assignable to expected type {1}.",

--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -25,7 +25,6 @@ using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.IdGenerators;
-using MongoDB.Bson.Serialization.Serializers;
 
 namespace MongoDB.Bson.Serialization
 {
@@ -318,9 +317,15 @@ namespace MongoDB.Bson.Serialization
                             }
                         }
                     }
+
+                    // no need for additional checks, we found the right type
+                    if (actualType != null)
+                    {
+                        return actualType;
+                    }
                 }
 
-                if (actualType == null && discriminator.IsString)
+                if (discriminator.IsString)
                 {
                     actualType = TypeNameDiscriminator.GetActualType(discriminator.AsString); // see if it's a Type name
                 }

--- a/src/MongoDB.Bson/Serialization/CollectionsSerializationProvider.cs
+++ b/src/MongoDB.Bson/Serialization/CollectionsSerializationProvider.cs
@@ -76,7 +76,7 @@ namespace MongoDB.Bson.Serialization
                 Type serializerTypeDefinition;
                 if (__serializerTypes.TryGetValue(type.GetGenericTypeDefinition(), out serializerTypeDefinition))
                 {
-                    return CreateGenericSerializer(serializerTypeDefinition, type.GetTypeInfo().GetGenericArguments(), serializerRegistry);
+                    return CreateGenericSerializer(serializerTypeDefinition, typeInfo.GetGenericArguments(), serializerRegistry);
                 }
             }
 
@@ -253,9 +253,10 @@ namespace MongoDB.Bson.Serialization
 
         private List<Type> GetImplementedInterfaces(Type type)
         {
-            return type.GetTypeInfo().IsInterface
-                ? type.GetTypeInfo().GetInterfaces().Concat(new Type[] { type }).ToList()
-                : type.GetTypeInfo().GetInterfaces().ToList();
+            var typeInfo = type.GetTypeInfo();
+            return typeInfo.IsInterface
+                ? typeInfo.GetInterfaces().Concat(new Type[] { type }).ToList()
+                : typeInfo.GetInterfaces().ToList();
         }
 
         private IBsonSerializer GetReadOnlyDictionarySerializer(Type type, IBsonSerializerRegistry serializerRegistry)

--- a/src/MongoDB.Bson/Serialization/Conventions/AttributeConventionPack.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/AttributeConventionPack.cs
@@ -120,8 +120,10 @@ namespace MongoDB.Bson.Serialization.Conventions
 
             private void OptInMembersWithBsonCreatorMapModifierAttribute(BsonClassMap classMap)
             {
+                TypeInfo classTypeInfo = classMap.ClassType.GetTypeInfo();
+
                 // let other constructors opt-in if they have any IBsonCreatorMapAttribute attributes
-                foreach (var constructorInfo in classMap.ClassType.GetTypeInfo().GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                foreach (var constructorInfo in classTypeInfo.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
                 {
                     var hasAttribute = constructorInfo.GetCustomAttributes(inherit: false).OfType<IBsonCreatorMapAttribute>().Any();
                     if (hasAttribute)
@@ -131,7 +133,7 @@ namespace MongoDB.Bson.Serialization.Conventions
                 }
 
                 // let other static factory methods opt-in if they have any IBsonCreatorMapAttribute attributes
-                foreach (var methodInfo in classMap.ClassType.GetTypeInfo().GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                foreach (var methodInfo in classTypeInfo.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
                 {
                     var hasAttribute = methodInfo.GetCustomAttributes(inherit: false).OfType<IBsonCreatorMapAttribute>().Any();
                     if (hasAttribute)
@@ -143,8 +145,10 @@ namespace MongoDB.Bson.Serialization.Conventions
 
             private void OptInMembersWithBsonMemberMapModifierAttribute(BsonClassMap classMap)
             {
+                var classTypeInfo = classMap.ClassType.GetTypeInfo();
+
                 // let other fields opt-in if they have any IBsonMemberMapAttribute attributes
-                foreach (var fieldInfo in classMap.ClassType.GetTypeInfo().GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                foreach (var fieldInfo in classTypeInfo.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
                 {
                     var hasAttribute = fieldInfo.GetCustomAttributes(inherit: false).OfType<IBsonMemberMapAttribute>().Any();
                     if (hasAttribute)
@@ -154,7 +158,7 @@ namespace MongoDB.Bson.Serialization.Conventions
                 }
 
                 // let other properties opt-in if they have any IBsonMemberMapAttribute attributes
-                foreach (var propertyInfo in classMap.ClassType.GetTypeInfo().GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                foreach (var propertyInfo in classTypeInfo.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
                 {
                     var hasAttribute = propertyInfo.GetCustomAttributes(inherit: false).OfType<IBsonMemberMapAttribute>().Any();
                     if (hasAttribute)

--- a/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
@@ -126,10 +126,11 @@ namespace MongoDB.Bson.Serialization.Conventions
             }
 
             // also map properties that match some constructor parameter that might be called by a derived class
-            var constructors = GetUsableConstructors(classMap.ClassType.GetTypeInfo());
+            var classTypeInfo = classMap.ClassType.GetTypeInfo();
+            var constructors = GetUsableConstructors(classTypeInfo);
             foreach (var constructorInfo in constructors)
             {
-                if (classMap.ClassType.GetTypeInfo().IsAbstract || 
+                if (classTypeInfo.IsAbstract || 
                     constructorInfo.IsFamily || // protected
                     constructorInfo.IsFamilyOrAssembly) // protected internal
                 {

--- a/src/MongoDB.Bson/Serialization/PrimitiveSerializationProvider.cs
+++ b/src/MongoDB.Bson/Serialization/PrimitiveSerializationProvider.cs
@@ -98,7 +98,7 @@ namespace MongoDB.Bson.Serialization
                 Type serializerTypeDefinition;
                 if (__serializersTypes.TryGetValue(type.GetGenericTypeDefinition(), out serializerTypeDefinition))
                 {
-                    return CreateGenericSerializer(serializerTypeDefinition, type.GetTypeInfo().GetGenericArguments(), serializerRegistry);
+                    return CreateGenericSerializer(serializerTypeDefinition, typeInfo.GetGenericArguments(), serializerRegistry);
                 }
             }
 

--- a/src/MongoDB.Bson/Serialization/TypeMappingSerializationProvider.cs
+++ b/src/MongoDB.Bson/Serialization/TypeMappingSerializationProvider.cs
@@ -62,7 +62,7 @@ namespace MongoDB.Bson.Serialization
                 Type serializerTypeDefinition;
                 if (_serializerTypes.TryGetValue(type.GetGenericTypeDefinition(), out serializerTypeDefinition))
                 {
-                    return CreateGenericSerializer(serializerTypeDefinition, type.GetTypeInfo().GetGenericArguments(), serializerRegistry);
+                    return CreateGenericSerializer(serializerTypeDefinition, typeInfo.GetGenericArguments(), serializerRegistry);
                 }
             }
 
@@ -96,7 +96,7 @@ namespace MongoDB.Bson.Serialization
                 {
                     throw new ArgumentException("A generic type must either have all or none of the type parameters assigned.");
                 }
-                if (type.GetTypeInfo().GetGenericArguments().Length != serializerType.GetTypeInfo().GetGenericArguments().Length)
+                if (typeInfo.GetGenericArguments().Length != serializerTypeInfo.GetGenericArguments().Length)
                 {
                     throw new ArgumentException("The type and the serializerType must have the same number of type parameters.");
                 }

--- a/src/MongoDB.Bson/Serialization/TypeNameDiscriminator.cs
+++ b/src/MongoDB.Bson/Serialization/TypeNameDiscriminator.cs
@@ -108,7 +108,7 @@ namespace MongoDB.Bson.Serialization
             if (typeInfo.IsGenericType)
             {
                 var typeArgumentNames = "";
-                foreach (var typeArgument in type.GetTypeInfo().GetGenericArguments())
+                foreach (var typeArgument in typeInfo.GetGenericArguments())
                 {
                     var typeArgumentName = GetDiscriminator(typeArgument);
                     if (typeArgumentName.IndexOf(',') != -1)
@@ -128,7 +128,7 @@ namespace MongoDB.Bson.Serialization
                 typeName = type.FullName;
             }
 
-            var assembly = type.GetTypeInfo().Assembly;
+            var assembly = typeInfo.Assembly;
             string assemblyName = null;
             if (!__wellKnownAssemblies.Contains(assembly))
             {

--- a/src/MongoDB.Driver.Legacy/Linq/Translators/SelectQuery.cs
+++ b/src/MongoDB.Driver.Legacy/Linq/Translators/SelectQuery.cs
@@ -222,8 +222,9 @@ namespace MongoDB.Driver.Linq
             {
                 var lambdaType = projection.GetType();
                 var delegateType = lambdaType.GetTypeInfo().GetGenericArguments()[0];
-                var sourceType = delegateType.GetTypeInfo().GetGenericArguments()[0];
-                var resultType = delegateType.GetTypeInfo().GetGenericArguments()[1];
+                var delegateTypeInfo = delegateType.GetTypeInfo();
+                var sourceType = delegateTypeInfo.GetGenericArguments()[0];
+                var resultType = delegateTypeInfo.GetGenericArguments()[1];
                 var projectorType = typeof(Projector<,>).MakeGenericType(sourceType, resultType);
                 var compiledProjection = projection.Compile();
                 projector = (IProjector)Activator.CreateInstance(projectorType, cursor, compiledProjection);

--- a/src/MongoDB.Driver/Linq/Processors/Transformers/CollectionConstructorTransformer.cs
+++ b/src/MongoDB.Driver/Linq/Processors/Transformers/CollectionConstructorTransformer.cs
@@ -34,7 +34,8 @@ namespace MongoDB.Driver.Linq.Processors.Transformers
 
         public Expression Transform(NewExpression node)
         {
-            var isGenericType = node.Type.GetTypeInfo().IsGenericType;
+            var nodeTypeInfo = node.Type.GetTypeInfo();
+            var isGenericType = nodeTypeInfo.IsGenericType;
 
             if (isGenericType &&
                 node.Type.GetGenericTypeDefinition() == typeof(HashSet<>) &&
@@ -43,7 +44,7 @@ namespace MongoDB.Driver.Linq.Processors.Transformers
                 return Expression.Call(
                     typeof(MongoEnumerable),
                     "ToHashSet",
-                    node.Type.GetTypeInfo().GetGenericArguments(),
+                    nodeTypeInfo.GetGenericArguments(),
                     node.Arguments.ToArray());
             }
 
@@ -54,7 +55,7 @@ namespace MongoDB.Driver.Linq.Processors.Transformers
                 return Expression.Call(
                     typeof(Enumerable),
                     "ToList",
-                    node.Type.GetTypeInfo().GetGenericArguments(),
+                    nodeTypeInfo.GetGenericArguments(),
                     node.Arguments.ToArray());
             }
 

--- a/src/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
@@ -530,8 +530,9 @@ namespace MongoDB.Driver.Linq.Translators
         private FilterDefinition<BsonDocument> TranslateContainsKey(MethodCallExpression methodCallExpression)
         {
             var dictionaryType = methodCallExpression.Object.Type;
-            var implementedInterfaces = new List<Type>(dictionaryType.GetTypeInfo().GetInterfaces());
-            if (dictionaryType.GetTypeInfo().IsInterface)
+            var dictionaryTypeInfo = dictionaryType.GetTypeInfo();
+            var implementedInterfaces = new List<Type>(dictionaryTypeInfo.GetInterfaces());
+            if (dictionaryTypeInfo.IsInterface)
             {
                 implementedInterfaces.Add(dictionaryType);
             }

--- a/src/MongoDB.Driver/Support/ReflectionExtensions.cs
+++ b/src/MongoDB.Driver/Support/ReflectionExtensions.cs
@@ -126,7 +126,7 @@ namespace MongoDB.Driver.Support
 
             if (seqTypeInfo.IsGenericType)
             {
-                foreach (Type arg in seqType.GetTypeInfo().GetGenericArguments())
+                foreach (Type arg in seqTypeInfo.GetGenericArguments())
                 {
                     Type ienum = typeof(IEnumerable<>).MakeGenericType(arg);
                     if (ienum.GetTypeInfo().IsAssignableFrom(seqType))


### PR DESCRIPTION
Again just some algorithmic optimization to make things faster. Mind you, this will have a really tiny effect only... I just avoided some checks that weren't required in the LookupActualType method and cached one reflection call.