### PR TITLE
CSHARP-1972: Further performance optimization of the Hex conversion methods in BsonUtils

### DIFF
--- a/src/MongoDB.Bson/BsonUtils.cs
+++ b/src/MongoDB.Bson/BsonUtils.cs
@@ -82,8 +82,8 @@ namespace MongoDB.Bson
         /// <returns>An array that maps all potential hex characters (0-F) to the byte values (0-255) to a uint that represents the two hex chars for each byte key.</returns>
         private static char[] CreateLookupNibbleToHexChar()
         {
-            var lookup = new char[15];
-            for (var i = 0; i < 15; i++)
+            var lookup = new char[16];
+            for (var i = 0; i < 16; i++)
             {
                 lookup[i] = (char)(i + (i < 10 ? '0' : 'a' - 10));
             }


### PR DESCRIPTION
May I suggest another performance optimization around the hex string to byte array (and back) conversion methods in `BsonUtils`.

This change introduces some precalculated jump tables that cost a tiny little bit of memory but give an dramatic boost in performance.

I have put together a demo solution using Benchmark.NET that proves the correctness and shows the performance improvement here: https://github.com/dnickless/BsonUtilsHexConversionPerformance