### PR TITLE
CSHARP-2030: Added allowDuplicateElementNames to BsonDocument.Parse

### DIFF
--- a/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
@@ -374,9 +374,20 @@ namespace MongoDB.Bson
         /// <returns>A BsonDocument.</returns>
         public static BsonDocument Parse(string json)
         {
+            return Parse(json, allowDuplicateElementNames: false);
+        }
+
+        /// <summary>
+        /// Parses a JSON string and returns a BsonDocument.
+        /// </summary>
+        /// <param name="json">The JSON string.</param>
+        /// <param name="allowDuplicateElementNames">A value indicating whether to allow duplicate element names.</param>
+        /// <returns>A BsonDocument.</returns>
+        public static BsonDocument Parse(string json, bool allowDuplicateElementNames)
+        {
             using (var jsonReader = new JsonReader(json))
             {
-                var context = BsonDeserializationContext.CreateRoot(jsonReader);
+                var context = BsonDeserializationContext.CreateRoot(jsonReader, b => b.AllowDuplicateElementNames = allowDuplicateElementNames);
                 var document = BsonDocumentSerializer.Instance.Deserialize(context);
                 if (!jsonReader.IsAtEndOfFile())
                 {
@@ -389,14 +400,26 @@ namespace MongoDB.Bson
         /// <summary>
         /// Tries to parse a JSON string and returns a value indicating whether it succeeded or failed.
         /// </summary>
-        /// <param name="s">The JSON string.</param>
+        /// <param name="json">The JSON string.</param>
         /// <param name="result">The result.</param>
         /// <returns>Whether it succeeded or failed.</returns>
-        public static bool TryParse(string s, out BsonDocument result)
+        public static bool TryParse(string json, out BsonDocument result)
+        {
+            return TryParse(json, false, out result);
+        }
+
+        /// <summary>
+        /// Tries to parse a JSON string and returns a value indicating whether it succeeded or failed.
+        /// </summary>
+        /// <param name="json">The JSON string.</param>
+        /// <param name="allowDuplicateElementNames">A value indicating whether to allow duplicate element names.</param>
+        /// <param name="result">The result.</param>
+        /// <returns>Whether it succeeded or failed.</returns>
+        public static bool TryParse(string json, bool allowDuplicateElementNames, out BsonDocument result)
         {
             try
             {
-                result = Parse(s);
+                result = Parse(json, allowDuplicateElementNames);
                 return true;
             }
             catch

--- a/tests/MongoDB.Bson.Tests/ObjectModel/BsonDocumentTests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/BsonDocumentTests.cs
@@ -821,6 +821,14 @@ namespace MongoDB.Bson.Tests
         }
 
         [Fact]
+        public void TestParseWithAllowDuplicateNames()
+        {
+            var json = "{ a : 1, a : 2 }";
+            var document = BsonDocument.Parse(json, allowDuplicateElementNames: true);
+            Assert.Equal(1, document["a"].AsInt32);
+        }
+
+        [Fact]
         public void TestRemove()
         {
             var document = new BsonDocument("x", 1);
@@ -1395,6 +1403,30 @@ namespace MongoDB.Bson.Tests
 
             success.Should().BeFalse();
             result.Should().BeNull();
+        }
+
+        [Fact]
+        public void TestTryParseWithAllowDuplicateNames_failure()
+        {
+            var s = "{ ...";
+            BsonDocument result;
+
+            var success = BsonDocument.TryParse(s, true, out result);
+
+            success.Should().BeFalse();
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void TestTryParseWithAllowDuplicateNames_success()
+        {
+            var s = "{ x : 1, x : 2 }";
+            BsonDocument result;
+
+            var success = BsonDocument.TryParse(s, true, out result);
+
+            success.Should().BeTrue();
+            result.Should().Be(new BsonDocument(allowDuplicateNames: true) {{"x", 1}, {"x", 2}});
         }
 
         private void AssertAreEqual(string expected, byte[] actual)


### PR DESCRIPTION
In this PR I fixed [[CSHARP-2030] Add allowDuplicateElementNames to BsonDocument.Parse](https://jira.mongodb.org/browse/CSHARP-2030).