### PR TITLE
Fixing method summaries to be coherent

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -40,7 +40,8 @@ namespace MongoDB.Bson.Serialization
 
         // public methods
         /// <summary>
-        /// Gets the serializer (explicitly registered or default) for the specified <paramref name="type" />.
+        /// Gets the serializer for the specified <paramref name="type" />.
+        /// If none is already registered, the serialization providers will be used to create a serializer and it will be automatically registered.
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>
@@ -63,7 +64,8 @@ namespace MongoDB.Bson.Serialization
         }
 
         /// <summary>
-        /// Gets the serializer (explicitly registered or default) for the specified <typeparamref name="T" />.
+        /// Gets the serializer for the specified <typeparamref name="T" />.
+        /// If none is already registered, the serialization providers will be used to create a serializer and it will be automatically registered.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns>
@@ -109,7 +111,7 @@ namespace MongoDB.Bson.Serialization
         }
 
         /// <summary>
-        /// Registers the serialization provider. This behaves like a stack, so the 
+        /// Registers the serialization provider. This behaves like a stack, so the
         /// last provider registered is the first provider consulted.
         /// </summary>
         /// <param name="serializationProvider">The serialization provider.</param>

--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -40,8 +40,7 @@ namespace MongoDB.Bson.Serialization
 
         // public methods
         /// <summary>
-        /// Gets the serializer for the specified <paramref name="type" />,
-        /// or adds it when it was not registered yet.
+        /// Gets the serializer (explicitly registered or default) for the specified <paramref name="type" />.
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>
@@ -64,8 +63,7 @@ namespace MongoDB.Bson.Serialization
         }
 
         /// <summary>
-        /// Gets the serializer for the specified <typeparamref name="T" />,
-        /// or adds it when it was not registered yet.
+        /// Gets the serializer (explicitly registered or default) for the specified <typeparamref name="T" />.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns>

--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -40,7 +40,8 @@ namespace MongoDB.Bson.Serialization
 
         // public methods
         /// <summary>
-        /// Gets the serializer for the specified <paramref name="type" />.
+        /// Gets the serializer for the specified <paramref name="type" />,
+        /// or adds it when it was not registered yet.
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>
@@ -63,7 +64,8 @@ namespace MongoDB.Bson.Serialization
         }
 
         /// <summary>
-        /// Gets the serializer for the specified <typeparamref name="T" />.
+        /// Gets the serializer for the specified <typeparamref name="T" />,
+        /// or adds it when it was not registered yet.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns>


### PR DESCRIPTION
Fixing the summary of both "GetSerializer" methods to be coherent with what they actually do. 
They not only gets a registered serializer, but they also ADDs it when it wasn't registered before (behavior I disagree BTW). And it took me a while to find out this was the problem I was facing.