### PR TITLE
Adjust collection and index read preference

### DIFF
--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -883,13 +883,13 @@ namespace MongoDB.Driver
             public override IAsyncCursor<BsonDocument> List(CancellationToken cancellationToken = default(CancellationToken))
             {
                 var operation = CreateListIndexesOperation();
-                return _collection.ExecuteReadOperation(operation, ReadPreference.Primary, cancellationToken);
+                return _collection.ExecuteReadOperation(operation, _collection._settings.ReadPreference ?? ReadPreference.Primary, cancellationToken);
             }
 
             public override Task<IAsyncCursor<BsonDocument>> ListAsync(CancellationToken cancellationToken = default(CancellationToken))
             {
                 var operation = CreateListIndexesOperation();
-                return _collection.ExecuteReadOperationAsync(operation, ReadPreference.Primary, cancellationToken);
+                return _collection.ExecuteReadOperationAsync(operation, _collection._settings.ReadPreference ?? ReadPreference.Primary, cancellationToken);
             }
 
             // private methods

--- a/src/MongoDB.Driver/MongoDatabaseImpl.cs
+++ b/src/MongoDB.Driver/MongoDatabaseImpl.cs
@@ -161,14 +161,14 @@ namespace MongoDB.Driver
         {
             options = options ?? new ListCollectionsOptions();
             var operation = CreateListCollectionsOperation(options);
-            return ExecuteReadOperation(operation, ReadPreference.Primary, cancellationToken);
+            return ExecuteReadOperation(operation, _settings.ReadPreference ?? ReadPreference.Primary, cancellationToken);
         }
 
         public override Task<IAsyncCursor<BsonDocument>> ListCollectionsAsync(ListCollectionsOptions options, CancellationToken cancellationToken)
         {
             options = options ?? new ListCollectionsOptions();
             var operation = CreateListCollectionsOperation(options);
-            return ExecuteReadOperationAsync(operation, ReadPreference.Primary, cancellationToken);
+            return ExecuteReadOperationAsync(operation, _settings.ReadPreference ?? ReadPreference.Primary, cancellationToken);
         }
 
         public override void RenameCollection(string oldName, string newName, RenameCollectionOptions options, CancellationToken cancellationToken)


### PR DESCRIPTION
The default readprefence is primary so that I list collections and indexs on slave database and collection will be fail.
I think collection and index list operation could be just read operation that can be special setting. please consider it, thank you so much.