### PR TITLE
Fix MongoClientSettings/MongoServerSettings equality comparer

### DIFF
--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -718,7 +718,7 @@ namespace MongoDB.Driver
             var rhs = (MongoServerSettings)obj;
             return
                 _applicationName == rhs._applicationName &&
-                object.ReferenceEquals(_clusterConfigurator, rhs._clusterConfigurator) &&
+                _clusterConfigurator == rhs._clusterConfigurator &&
                _connectionMode == rhs._connectionMode &&
                _connectTimeout == rhs._connectTimeout &&
                _credentials == rhs._credentials &&

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -653,7 +653,7 @@ namespace MongoDB.Driver
             var rhs = (MongoClientSettings)obj;
             return
                 _applicationName == rhs._applicationName &&
-                object.ReferenceEquals(_clusterConfigurator, rhs._clusterConfigurator) &&
+                _clusterConfigurator == rhs._clusterConfigurator &&
                 _connectionMode == rhs._connectionMode &&
                 _connectTimeout == rhs._connectTimeout &&
                 _credentials == rhs._credentials &&
@@ -678,7 +678,7 @@ namespace MongoDB.Driver
                 _verifySslCertificate == rhs._verifySslCertificate &&
                 _waitQueueSize == rhs._waitQueueSize &&
                 _waitQueueTimeout == rhs._waitQueueTimeout &&
-                _writeConcern == rhs._writeConcern &&
+                object.Equals(_writeConcern, rhs._writeConcern) &&
                 object.Equals(_writeEncoding, rhs._writeEncoding);
         }
 

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoServerSettingsTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoServerSettingsTests.cs
@@ -159,11 +159,24 @@ namespace MongoDB.Driver.Tests
             Assert.Equal(WriteConcern.Unacknowledged, settings.WriteConcern);
         }
 
+        private static void ClusterConfigurator(ClusterBuilder clusterBuilder)
+        {
+            clusterBuilder.ToString();
+        }
+
         [Fact]
         public void TestEquals()
         {
             var settings = new MongoServerSettings();
+            settings.ClusterConfigurator = ClusterConfigurator;
+
             var clone = settings.Clone();
+
+            clone.ReadConcern = new ReadConcern(settings.ReadConcern.Level);
+            clone.WriteConcern = new WriteConcern(settings.WriteConcern.W, settings.WriteConcern.WTimeout, settings.WriteConcern.FSync, settings.WriteConcern.Journal);
+            clone.Credentials = settings.Credentials.ToArray();
+            clone.ClusterConfigurator = ClusterConfigurator;
+
             Assert.True(clone.Equals(settings));
 
             clone = settings.Clone();

--- a/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
@@ -149,11 +149,24 @@ namespace MongoDB.Driver.Tests
             Assert.Equal(WriteConcern.Acknowledged, settings.WriteConcern);
         }
 
+        private static void ClusterConfigurator(ClusterBuilder clusterBuilder)
+        {
+            clusterBuilder.ToString();
+        }
+
         [Fact]
         public void TestEquals()
         {
             var settings = new MongoClientSettings();
+            settings.ClusterConfigurator = ClusterConfigurator;
+
             var clone = settings.Clone();
+
+            clone.ReadConcern = new ReadConcern(settings.ReadConcern.Level);
+            clone.WriteConcern = new WriteConcern(settings.WriteConcern.W, settings.WriteConcern.WTimeout, settings.WriteConcern.FSync, settings.WriteConcern.Journal);
+            clone.Credentials = settings.Credentials.ToArray();
+            clone.ClusterConfigurator = ClusterConfigurator;
+
             Assert.True(clone.Equals(settings));
 
             clone = settings.Clone();


### PR DESCRIPTION
This PR should fix an issue where the following code this trigger a MongoException "MongoServer.Create has already created XXX servers which is the maximum number of servers allowed."
The Equals method of MongoClientSettings/MongoServerSettings does return false even if the settings are the same accross several calls.

```cs
class Test
{
    static void ConfigureCluster(ClusterBuilder builder)
    {
        // Do something cool
    }

    void Test()
    {
        for (int i = 0; i < 200; i++)
        {
            var settings = MongoClientSettings.FromUrl(MongoUrl.Create("XXX"));
            settings.ClusterConfigurator = ConfigureCluster;

            var client = new MongoClient(settings);
            var server = client.GetServer();
        }
    }
}
```

## ClusterConfigurator delegate comparison

ClusterConfigurator is a delegate. According to C# spec 7.10.8, the == operator performs some additional checks than ReferenceEquals.
If we use the same static method as callback, Equals should return true.
The sample above illustates this very case.

## WriteConcern comparison

WriteConcern is a class that does not implement == operator.
We should use object.Equals method in order to compare them, just like ReadConcern.

## Testing consideration

The test is faulty here. It does use the Clone function to perform various Equality tests. This Clone method does copy all fields references instead of a deep copy.
Since Clone is part of the public interface, we can't modify it to deep copy as it would change the current behavior.
I added a few lines to deep clone the MongoClientSettings/MongoServerSettings in order to make the first test fail without my PR.