### PR TITLE
Fix for Issue[CSHARP-2033] and Issue[CSHARP-2016]

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -36,9 +36,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MongoDB.Driver.Core/packages.config
+++ b/src/MongoDB.Driver.Core/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
MongoDB.Driver.Core has a dependency on System.Runtime.InteropServices.RuntimeInformation. Updating the Nuget package for the dependency makes it so that MongoDB.Driver.Core will work with Azure Functions.

This fixes this issue: https://jira.mongodb.org/projects/CSHARP/issues/CSHARP-2033?filter=allopenissues