### PR TITLE
CSHARP-1999: Support for readonly properties that contain instances

### DIFF
--- a/src/MongoDB.Bson/Serialization/Attributes/BsonUseExistingInstanceAttribute.cs
+++ b/src/MongoDB.Bson/Serialization/Attributes/BsonUseExistingInstanceAttribute.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2010-2014 MongoDB Inc.
+﻿/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/MongoDB.Bson/Serialization/Attributes/BsonUseExistingInstanceAttribute.cs
+++ b/src/MongoDB.Bson/Serialization/Attributes/BsonUseExistingInstanceAttribute.cs
@@ -1,0 +1,36 @@
+﻿/* Copyright 2010-2014 MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace MongoDB.Bson.Serialization.Attributes
+{
+    /// <summary>
+    /// Indicates that a field or property is required.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class BsonUseExistingInstanceAttribute : Attribute, IBsonMemberMapAttribute
+    {
+        // public methods
+        /// <summary>
+        /// Applies a modification to the member map.
+        /// </summary>
+        /// <param name="memberMap">The member map.</param>
+        public void Apply(BsonMemberMap memberMap)
+        {
+            memberMap.SetUseExistingInstance(true);
+        }
+    }
+}

--- a/src/MongoDB.Bson/Serialization/BsonDeserializationArgs.cs
+++ b/src/MongoDB.Bson/Serialization/BsonDeserializationArgs.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using MongoDB.Bson.IO;
 
 namespace MongoDB.Bson.Serialization
 {
@@ -25,13 +24,7 @@ namespace MongoDB.Bson.Serialization
     {
         // private fields
         private Type _nominalType;
-
-        // constructors
-        private BsonDeserializationArgs(
-            Type nominalType)
-        {
-            _nominalType = nominalType;
-        }
+        private object _targetInstance;
 
         // public properties
         /// <summary>
@@ -44,6 +37,18 @@ namespace MongoDB.Bson.Serialization
         {
             get { return _nominalType; }
             set { _nominalType = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the target instance.
+        /// </summary>
+        /// <value>
+        /// The target instance or null.
+        /// </value>
+        public object TargetInstance
+        {
+            get { return _targetInstance; }
+            set { _targetInstance = value; }
         }
     }
 }

--- a/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
@@ -462,7 +462,12 @@ namespace MongoDB.Bson.Serialization
         public BsonMemberMap SetUseExistingInstance(bool useExistingInstance)
         {
             if (_frozen) { ThrowFrozenException(); }
-            if (_memberType.IsValueType)
+#if NETSTANDARD1_5 || NETSTANDARD1_6
+            var type = _memberType.GetTypeInfo();
+#else
+            var type = _memberType;
+#endif
+            if (type.IsValueType)
             {
                 throw new InvalidOperationException($"{nameof(SetUseExistingInstance)} can only be used for reference types");
             }

--- a/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
@@ -462,6 +462,10 @@ namespace MongoDB.Bson.Serialization
         public BsonMemberMap SetUseExistingInstance(bool useExistingInstance)
         {
             if (_frozen) { ThrowFrozenException(); }
+            if (_memberType.IsValueType)
+            {
+                throw new InvalidOperationException($"{nameof(SetUseExistingInstance)} can only be used for reference types");
+            }
             _useExistingInstance = useExistingInstance;
             return this;
         }

--- a/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
@@ -40,6 +40,7 @@ namespace MongoDB.Bson.Serialization
         private volatile IBsonSerializer _serializer;
         private IIdGenerator _idGenerator;
         private bool _isRequired;
+        private bool _useExistingInstance;
         private Func<object, bool> _shouldSerializeMethod;
         private bool _ignoreIfDefault;
         private bool _ignoreIfNull;
@@ -179,6 +180,14 @@ namespace MongoDB.Bson.Serialization
         public bool IsRequired
         {
             get { return _isRequired; }
+        }
+
+        /// <summary>
+        /// Gets whether an existing instance on the target member will get populated during deserialization (true) or whether a new instance will be created (false, default).
+        /// </summary>
+        public bool UseExistingInstance
+        {
+            get { return _useExistingInstance; }
         }
 
         /// <summary>
@@ -326,6 +335,7 @@ namespace MongoDB.Bson.Serialization
             _ignoreIfDefault = false;
             _ignoreIfNull = false;
             _isRequired = false;
+            _useExistingInstance = false;
             _order = int.MaxValue;
             _serializer = null;
             _shouldSerializeMethod = null;
@@ -441,6 +451,18 @@ namespace MongoDB.Bson.Serialization
         {
             if (_frozen) { ThrowFrozenException(); }
             _isRequired = isRequired;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether an existing instance on the target member will get populated during deserialization (true) or whether a new instance will be created (false, default).
+        /// </summary>
+        /// <param name="useExistingInstance">Whether an existing instance on the target member will get populated during deserialization (true) or whether a new instance will be created (false, default).</param>
+        /// <returns>The member map.</returns>
+        public BsonMemberMap SetUseExistingInstance(bool useExistingInstance)
+        {
+            if (_frozen) { ThrowFrozenException(); }
+            _useExistingInstance = useExistingInstance;
             return this;
         }
 

--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 
@@ -25,7 +24,6 @@ using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.IdGenerators;
-using MongoDB.Bson.Serialization.Serializers;
 
 namespace MongoDB.Bson.Serialization
 {
@@ -94,12 +92,13 @@ namespace MongoDB.Bson.Serialization
         /// <typeparam name="TNominalType">The nominal type of the object.</typeparam>
         /// <param name="document">The BsonDocument.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static TNominalType Deserialize<TNominalType>(BsonDocument document, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static TNominalType Deserialize<TNominalType>(BsonDocument document, Action<BsonDeserializationContext.Builder> configurator = null, TNominalType existingInstance = default(TNominalType))
         {
             using (var bsonReader = new BsonDocumentReader(document))
             {
-                return Deserialize<TNominalType>(bsonReader, configurator);
+                return Deserialize(bsonReader, configurator, existingInstance);
             }
         }
 
@@ -109,12 +108,13 @@ namespace MongoDB.Bson.Serialization
         /// <typeparam name="TNominalType">The nominal type of the object.</typeparam>
         /// <param name="bsonReader">The BsonReader.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static TNominalType Deserialize<TNominalType>(IBsonReader bsonReader, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static TNominalType Deserialize<TNominalType>(IBsonReader bsonReader, Action<BsonDeserializationContext.Builder> configurator = null, TNominalType existingInstance = default(TNominalType))
         {
             var serializer = LookupSerializer<TNominalType>();
             var context = BsonDeserializationContext.CreateRoot(bsonReader, configurator);
-            return serializer.Deserialize(context);
+            return serializer.Deserialize(context, existingInstance);
         }
 
         /// <summary>
@@ -123,13 +123,14 @@ namespace MongoDB.Bson.Serialization
         /// <typeparam name="TNominalType">The nominal type of the object.</typeparam>
         /// <param name="bytes">The BSON byte array.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static TNominalType Deserialize<TNominalType>(byte[] bytes, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static TNominalType Deserialize<TNominalType>(byte[] bytes, Action<BsonDeserializationContext.Builder> configurator = null, TNominalType existingInstance = default(TNominalType))
         {
             using (var buffer = new ByteArrayBuffer(bytes, isReadOnly: true))
             using (var stream = new ByteBufferStream(buffer))
             {
-                return Deserialize<TNominalType>(stream, configurator);
+                return Deserialize(stream, configurator, existingInstance);
             }
         }
 
@@ -139,12 +140,13 @@ namespace MongoDB.Bson.Serialization
         /// <typeparam name="TNominalType">The nominal type of the object.</typeparam>
         /// <param name="stream">The BSON Stream.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static TNominalType Deserialize<TNominalType>(Stream stream, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static TNominalType Deserialize<TNominalType>(Stream stream, Action<BsonDeserializationContext.Builder> configurator = null, TNominalType existingInstance = default(TNominalType))
         {
             using (var bsonReader = new BsonBinaryReader(stream))
             {
-                return Deserialize<TNominalType>(bsonReader, configurator);
+                return Deserialize(bsonReader, configurator, existingInstance);
             }
         }
 
@@ -154,12 +156,13 @@ namespace MongoDB.Bson.Serialization
         /// <typeparam name="TNominalType">The nominal type of the object.</typeparam>
         /// <param name="json">The JSON string.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static TNominalType Deserialize<TNominalType>(string json, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static TNominalType Deserialize<TNominalType>(string json, Action<BsonDeserializationContext.Builder> configurator = null, TNominalType existingInstance = default(TNominalType))
         {
             using (var bsonReader = new JsonReader(json))
             {
-                return Deserialize<TNominalType>(bsonReader, configurator);
+                return Deserialize(bsonReader, configurator, existingInstance);
             }
         }
 
@@ -169,12 +172,13 @@ namespace MongoDB.Bson.Serialization
         /// <typeparam name="TNominalType">The nominal type of the object.</typeparam>
         /// <param name="textReader">The JSON TextReader.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static TNominalType Deserialize<TNominalType>(TextReader textReader, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static TNominalType Deserialize<TNominalType>(TextReader textReader, Action<BsonDeserializationContext.Builder> configurator = null, TNominalType existingInstance = default(TNominalType))
         {
             using (var bsonReader = new JsonReader(textReader))
             {
-                return Deserialize<TNominalType>(bsonReader, configurator);
+                return Deserialize(bsonReader, configurator, existingInstance);
             }
         }
 
@@ -184,12 +188,13 @@ namespace MongoDB.Bson.Serialization
         /// <param name="document">The BsonDocument.</param>
         /// <param name="nominalType">The nominal type of the object.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static object Deserialize(BsonDocument document, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static object Deserialize(BsonDocument document, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null, object existingInstance = null)
         {
             using (var bsonReader = new BsonDocumentReader(document))
             {
-                return Deserialize(bsonReader, nominalType, configurator);
+                return Deserialize(bsonReader, nominalType, configurator, existingInstance);
             }
         }
 
@@ -199,12 +204,13 @@ namespace MongoDB.Bson.Serialization
         /// <param name="bsonReader">The BsonReader.</param>
         /// <param name="nominalType">The nominal type of the object.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static object Deserialize(IBsonReader bsonReader, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static object Deserialize(IBsonReader bsonReader, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null, object existingInstance = null)
         {
             var serializer = LookupSerializer(nominalType);
             var context = BsonDeserializationContext.CreateRoot(bsonReader, configurator);
-            return serializer.Deserialize(context);
+            return serializer.Deserialize(context, existingInstance);
         }
 
         /// <summary>
@@ -213,13 +219,14 @@ namespace MongoDB.Bson.Serialization
         /// <param name="bytes">The BSON byte array.</param>
         /// <param name="nominalType">The nominal type of the object.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static object Deserialize(byte[] bytes, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static object Deserialize(byte[] bytes, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null, object existingInstance = null)
         {
             using (var buffer = new ByteArrayBuffer(bytes, isReadOnly: true))
             using (var stream = new ByteBufferStream(buffer))
             {
-                return Deserialize(stream, nominalType, configurator);
+                return Deserialize(stream, nominalType, configurator, existingInstance);
             }
         }
 
@@ -229,12 +236,13 @@ namespace MongoDB.Bson.Serialization
         /// <param name="stream">The BSON Stream.</param>
         /// <param name="nominalType">The nominal type of the object.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static object Deserialize(Stream stream, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static object Deserialize(Stream stream, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null, object existingInstance = null)
         {
             using (var bsonReader = new BsonBinaryReader(stream))
             {
-                return Deserialize(bsonReader, nominalType, configurator);
+                return Deserialize(bsonReader, nominalType, configurator, existingInstance);
             }
         }
 
@@ -244,12 +252,13 @@ namespace MongoDB.Bson.Serialization
         /// <param name="json">The JSON string.</param>
         /// <param name="nominalType">The nominal type of the object.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static object Deserialize(string json, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static object Deserialize(string json, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null, object existingInstance = null)
         {
             using (var bsonReader = new JsonReader(json))
             {
-                return Deserialize(bsonReader, nominalType, configurator);
+                return Deserialize(bsonReader, nominalType, configurator, existingInstance);
             }
         }
 
@@ -259,12 +268,13 @@ namespace MongoDB.Bson.Serialization
         /// <param name="textReader">The JSON TextReader.</param>
         /// <param name="nominalType">The nominal type of the object.</param>
         /// <param name="configurator">The configurator.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static object Deserialize(TextReader textReader, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null)
+        public static object Deserialize(TextReader textReader, Type nominalType, Action<BsonDeserializationContext.Builder> configurator = null, object existingInstance = null)
         {
             using (var bsonReader = new JsonReader(textReader))
             {
-                return Deserialize(bsonReader, nominalType, configurator);
+                return Deserialize(bsonReader, nominalType, configurator, existingInstance);
             }
         }
 

--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Linq;
 using System.Threading;
 
 // don't add using statement for MongoDB.Bson.Serialization.Serializers to minimize dependencies on DefaultSerializer

--- a/src/MongoDB.Bson/Serialization/Conventions/UseExistingInstanceConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/UseExistingInstanceConvention.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2010-2014 MongoDB Inc.
+﻿/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/MongoDB.Bson/Serialization/Conventions/UseExistingInstanceConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/UseExistingInstanceConvention.cs
@@ -13,6 +13,8 @@
 * limitations under the License.
 */
 
+using System.Reflection;
+
 namespace MongoDB.Bson.Serialization.Conventions
 {
     /// <summary>
@@ -39,7 +41,12 @@ namespace MongoDB.Bson.Serialization.Conventions
         /// <param name="memberMap">The member map.</param>
         public void Apply(BsonMemberMap memberMap)
         {
-            if (!memberMap.MemberType.IsValueType)
+#if NETSTANDARD1_5 || NETSTANDARD1_6
+            var type = memberMap.MemberType.GetTypeInfo();
+#else
+            var type = memberMap.MemberType;
+#endif
+            if (!type.IsValueType)
             {
                 memberMap.SetUseExistingInstance(_useExistingInstance);
             }

--- a/src/MongoDB.Bson/Serialization/Conventions/UseExistingInstanceConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/UseExistingInstanceConvention.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson.Serialization.Conventions
     public class UseExistingInstanceConvention : ConventionBase, IMemberMapConvention
     {
         // private fields
-        private bool _useExistingInstance;
+        private readonly bool _useExistingInstance;
 
         // constructors
         /// <summary>
@@ -39,7 +39,10 @@ namespace MongoDB.Bson.Serialization.Conventions
         /// <param name="memberMap">The member map.</param>
         public void Apply(BsonMemberMap memberMap)
         {
-            memberMap.SetUseExistingInstance(_useExistingInstance);
+            if (!memberMap.MemberType.IsValueType)
+            {
+                memberMap.SetUseExistingInstance(_useExistingInstance);
+            }
         }
     }
 }

--- a/src/MongoDB.Bson/Serialization/Conventions/UseExistingInstanceConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/UseExistingInstanceConvention.cs
@@ -1,0 +1,45 @@
+﻿/* Copyright 2010-2014 MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Bson.Serialization.Conventions
+{
+    /// <summary>
+    /// A convention that sets whether to use an existing instance during deserialization.
+    /// </summary>
+    public class UseExistingInstanceConvention : ConventionBase, IMemberMapConvention
+    {
+        // private fields
+        private bool _useExistingInstance;
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IgnoreIfNullConvention" /> class.
+        /// </summary>
+        /// <param name="useExistingInstance">Whether to use and existing instance during deserialization.</param>
+        public UseExistingInstanceConvention(bool useExistingInstance)
+        {
+            _useExistingInstance = useExistingInstance;
+        }
+
+        /// <summary>
+        /// Applies a modification to the member map.
+        /// </summary>
+        /// <param name="memberMap">The member map.</param>
+        public void Apply(BsonMemberMap memberMap)
+        {
+            memberMap.SetUseExistingInstance(_useExistingInstance);
+        }
+    }
+}

--- a/src/MongoDB.Bson/Serialization/IBsonSerializerExtensions.cs
+++ b/src/MongoDB.Bson/Serialization/IBsonSerializerExtensions.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System;
 using MongoDB.Bson.IO;
 
 namespace MongoDB.Bson.Serialization
@@ -29,10 +28,11 @@ namespace MongoDB.Bson.Serialization
         /// </summary>
         /// <param name="serializer">The serializer.</param>
         /// <param name="context">The deserialization context.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static object Deserialize(this IBsonSerializer serializer, BsonDeserializationContext context)
+        public static object Deserialize(this IBsonSerializer serializer, BsonDeserializationContext context, object existingInstance = null)
         {
-            var args = new BsonDeserializationArgs { NominalType = serializer.ValueType };
+            var args = new BsonDeserializationArgs { NominalType = serializer.ValueType, TargetInstance = existingInstance };
             return serializer.Deserialize(context, args);
         }
 
@@ -42,10 +42,11 @@ namespace MongoDB.Bson.Serialization
         /// <typeparam name="TValue">The type that this serializer knows how to serialize.</typeparam>
         /// <param name="serializer">The serializer.</param>
         /// <param name="context">The deserialization context.</param>
+        /// <param name="existingInstance">An existing target instance or null.</param>
         /// <returns>A deserialized value.</returns>
-        public static TValue Deserialize<TValue>(this IBsonSerializer<TValue> serializer, BsonDeserializationContext context)
+        public static TValue Deserialize<TValue>(this IBsonSerializer<TValue> serializer, BsonDeserializationContext context, object existingInstance = null)
         {
-            var args = new BsonDeserializationArgs { NominalType = serializer.ValueType };
+            var args = new BsonDeserializationArgs { NominalType = serializer.ValueType, TargetInstance = existingInstance };
             return serializer.Deserialize(context, args);
         }
 

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonDocumentSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonDocumentSerializer.cs
@@ -59,12 +59,19 @@ namespace MongoDB.Bson.Serialization.Serializers
             var bsonReader = context.Reader;
 
             bsonReader.ReadStartDocument();
-            var document = new BsonDocument(allowDuplicateNames: context.AllowDuplicateElementNames);
+            var document = (BsonDocument)args.TargetInstance ?? new BsonDocument(allowDuplicateNames: context.AllowDuplicateElementNames);
             while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
             {
                 var name = bsonReader.ReadName();
                 var value = BsonValueSerializer.Instance.Deserialize(context);
-                document.Add(name, value);
+                if (args.TargetInstance != null)
+                {
+                    document.Set(name, value);
+                }
+                else
+                {
+                    document.Add(name, value);
+                }
             }
             bsonReader.ReadEndDocument();
 

--- a/src/MongoDB.Bson/Serialization/Serializers/DictionarySerializerBase.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DictionarySerializerBase.cs
@@ -516,9 +516,9 @@ namespace MongoDB.Bson.Serialization.Serializers
             switch (bsonType)
             {
                 case BsonType.Array:
-                    return DeserializeArrayRepresentation(context);
+                    return DeserializeArrayRepresentation(context, args.TargetInstance);
                 case BsonType.Document:
-                    return DeserializeDocumentRepresentation(context);
+                    return DeserializeDocumentRepresentation(context, args.TargetInstance);
                 default:
                     throw CreateCannotDeserializeFromBsonTypeException(bsonType);
             }
@@ -591,10 +591,11 @@ namespace MongoDB.Bson.Serialization.Serializers
         }
 
         // private methods
-        private TDictionary DeserializeArrayRepresentation(BsonDeserializationContext context)
+        private TDictionary DeserializeArrayRepresentation(BsonDeserializationContext context, object targetInstance)
         {
+            var accumulator = (ICollection<KeyValuePair<TKey, TValue>>)targetInstance ?? CreateAccumulator();
+            accumulator.Clear();
 
-            var accumulator = CreateAccumulator();
             var bsonReader = context.Reader;
             bsonReader.ReadStartArray();
             while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
@@ -636,9 +637,10 @@ namespace MongoDB.Bson.Serialization.Serializers
             return FinalizeAccumulator(accumulator);
         }
 
-        private TDictionary DeserializeDocumentRepresentation(BsonDeserializationContext context)
+        private TDictionary DeserializeDocumentRepresentation(BsonDeserializationContext context, object targetInstance)
         {
-            var accumulator = CreateAccumulator();
+            var accumulator = (ICollection<KeyValuePair<TKey, TValue>>)targetInstance ?? CreateAccumulator();
+            accumulator.Clear();
 
             var bsonReader = context.Reader;
             bsonReader.ReadStartDocument();

--- a/src/MongoDB.Bson/Serialization/Serializers/QueueSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/QueueSerializer.cs
@@ -80,6 +80,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The accumulator.</returns>
         protected override object CreateAccumulator()
         {
+            if (TargetInstance != null)
+            {
+                TargetInstance.Clear();
+                return TargetInstance;
+            }
+
             return new Queue();
         }
 
@@ -100,6 +106,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The result.</returns>
         protected override Queue FinalizeResult(object accumulator)
         {
+            if (TargetInstance != null)
+            {
+                // TargetInstance has already been cleared and populated so just return it
+                return TargetInstance;
+            }
+
             return (Queue)accumulator;
         }
 
@@ -178,6 +190,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The accumulator.</returns>
         protected override object CreateAccumulator()
         {
+            if (TargetInstance != null)
+            {
+                TargetInstance.Clear();
+                return TargetInstance;
+            }
+
             return new Queue<TItem>();
         }
 
@@ -198,6 +216,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The result.</returns>
         protected override Queue<TItem> FinalizeResult(object accumulator)
         {
+            if (TargetInstance != null)
+            {
+                // TargetInstance has already been cleared and populated so just return it
+                return TargetInstance;
+            }
+
             return (Queue<TItem>)accumulator;
         }
 

--- a/src/MongoDB.Bson/Serialization/Serializers/ReadOnlyCollectionSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ReadOnlyCollectionSerializer.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -69,6 +70,11 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The accumulator.</returns>
         protected override object CreateAccumulator()
         {
+            if (TargetInstance != null)
+            {
+                throw new NotSupportedException($"An existing readonly collection instance can not be deserialized into.");
+            }
+
             return new List<TItem>();
         }
 

--- a/src/MongoDB.Bson/Serialization/Serializers/ReadOnlyCollectionSubclassSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ReadOnlyCollectionSubclassSerializer.cs
@@ -59,6 +59,11 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The accumulator.</returns>
         protected override object CreateAccumulator()
         {
+            if (TargetInstance != null)
+            {
+                throw new NotSupportedException($"An existing readonly collection instance can not be deserialized into.");
+            }
+
             return new List<TItem>();
         }
 

--- a/src/MongoDB.Bson/Serialization/Serializers/StackSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/StackSerializer.cs
@@ -84,6 +84,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The accumulator.</returns>
         protected override object CreateAccumulator()
         {
+            if (TargetInstance != null)
+            {
+                TargetInstance.Clear();
+                return TargetInstance;
+            }
+
             return new Stack();
         }
 
@@ -104,6 +110,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The result.</returns>
         protected override Stack FinalizeResult(object accumulator)
         {
+            if (TargetInstance != null)
+            {
+                // TargetInstance has already been cleared and populated so just return it
+                return TargetInstance;
+            }
+
             return (Stack)accumulator;
         }
 
@@ -182,6 +194,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The accumulator.</returns>
         protected override object CreateAccumulator()
         {
+            if (TargetInstance != null)
+            {
+                TargetInstance.Clear();
+                return TargetInstance;
+            }
+
             return new Stack<TItem>();
         }
 
@@ -202,6 +220,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <returns>The result.</returns>
         protected override Stack<TItem> FinalizeResult(object accumulator)
         {
+            if (TargetInstance != null)
+            {
+                // TargetInstance has already been cleared and populated so just return it
+                return TargetInstance;
+            }
+
             return (Stack<TItem>)accumulator;
         }
 

--- a/tests/MongoDB.Bson.Tests/Serialization/Attributes/BsonAttributeTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Attributes/BsonAttributeTests.cs
@@ -58,6 +58,10 @@ namespace MongoDB.Bson.Tests.Serialization.Attributes
             public string Required { get; set; }
             public string NotRequired { get; set; }
 
+            [BsonUseExistingInstance]
+            public string UseExistingInstance { get; set; }
+            public string DoNotUseExistingInstance { get; set; }
+
             [BsonElement("notordered")]
             public string NotOrdered { get; set; }
             [BsonElement("ordered", Order = 1)]
@@ -162,6 +166,18 @@ namespace MongoDB.Bson.Tests.Serialization.Attributes
 
             var notRequired = classMap.GetMemberMap("NotRequired");
             Assert.Equal(false, notRequired.IsRequired);
+        }
+
+        [Fact]
+        public void TestUseExistingInstance()
+        {
+            var classMap = BsonClassMap.LookupClassMap(typeof(Test));
+
+            var useExistingInstance = classMap.GetMemberMap("UseExistingInstance");
+            Assert.Equal(true, useExistingInstance.UseExistingInstance);
+
+            var doNotUseExistingInstance = classMap.GetMemberMap("DoNotUseExistingInstance");
+            Assert.Equal(false, doNotUseExistingInstance.UseExistingInstance);
         }
 
         [Fact]

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonMemberMapTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonMemberMapTests.cs
@@ -273,6 +273,7 @@ namespace MongoDB.Bson.Tests.Serialization
             memberMap.SetIdGenerator(new GuidGenerator());
             memberMap.SetIgnoreIfDefault(true);
             memberMap.SetIsRequired(true);
+            memberMap.SetUseExistingInstance(true);
             memberMap.SetOrder(21);
             memberMap.SetSerializer(originalSerializer);
             memberMap.SetShouldSerializeMethod(o => false);
@@ -285,6 +286,7 @@ namespace MongoDB.Bson.Tests.Serialization
             Assert.False(memberMap.IgnoreIfDefault);
             Assert.False(memberMap.IgnoreIfNull);
             Assert.False(memberMap.IsRequired);
+            Assert.False(memberMap.UseExistingInstance);
             Assert.Equal(int.MaxValue, memberMap.Order);
             Assert.NotSame(originalSerializer, memberMap.GetSerializer());
             Assert.Null(memberMap.ShouldSerializeMethod);

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/UseExistingInstanceConventionTest.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/UseExistingInstanceConventionTest.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2010-2014 MongoDB Inc.
+﻿/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/UseExistingInstanceConventionTest.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/UseExistingInstanceConventionTest.cs
@@ -1,0 +1,44 @@
+﻿/* Copyright 2010-2014 MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+using Xunit;
+
+namespace MongoDB.Bson.Tests.Serialization.Conventions
+{
+    public class UseExistingInstanceConventionTest
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TestApply(bool value)
+        {
+            var subject = new UseExistingInstanceConvention(value);
+            var classMap = new BsonClassMap<TestClass>();
+            var memberMap = classMap.MapMember(x => x.Id);
+
+            subject.Apply(memberMap);
+
+            Assert.Equal(value, memberMap.UseExistingInstance);
+        }
+
+        private class TestClass
+        {
+            public ObjectId Id { get; set; }
+        }
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/UseExistingInstanceSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/UseExistingInstanceSerializerTests.cs
@@ -345,7 +345,7 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         public Test<TCollection> DoNotUseExistingInstanceWritableInnerInstance { get; set; }
 
         // hack so we can set the collection initializer from the outside in order to allow for a default constructor (called during deserialization) that still populates the collections
-        public static Func<TCollection> CollectionFactory;
+        internal static Func<TCollection> CollectionFactory;
 
         // this will be called by the deserializer
         public Test() : this(true)

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/UseExistingInstanceSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/UseExistingInstanceSerializerTests.cs
@@ -1,0 +1,370 @@
+/* Copyright 2015 MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Conventions;
+using Xunit;
+
+namespace MongoDB.Bson.Tests.Serialization.Serializers
+{
+    public class UseExistingInstanceSerializerTests
+    {
+        [Fact]
+        public void TestSetExistingInstanceAttributeOnValueTypePropertyThrowsException()
+        {
+            Assert.Throws<InvalidOperationException>(() => BsonClassMap.RegisterClassMap<TestValueTypeWithAttribute>(map => map.AutoMap()));
+        }
+
+        [Fact]
+        public void TestManuallyConfiguringSetExistingInstanceOnValueTypePropertyThrowsException()
+        {
+            Assert.Throws<InvalidOperationException>(() => BsonClassMap.RegisterClassMap<TestValueTypeWithoutAttribute>(map => map.MapField(t => t.ValueType).SetUseExistingInstance(true)));
+        }
+
+        [Fact]
+        public void TestUsingSetExistingInstanceConventionOnValueTypePropertyDoesNotThrowException()
+        {
+            ConventionRegistry.Register("Global use existing instance convention", new ConventionPack { new UseExistingInstanceConvention(true) }, t => t == typeof(TestValueTypeWithoutAttribute));
+            BsonClassMap.RegisterClassMap<TestValueTypeWithoutAttribute>();
+        }
+
+        [Fact]
+        public void TestDeserializationWithExistingBsonDocument()
+        {
+            var existingDocument = new BsonDocument { { "existingValue", new BsonInt32(1) } };
+            var documentToDeserialize = new BsonDocument { { "newValue", new BsonInt32(2) } };
+
+            var expectedDocument = new BsonDocument
+            {
+                { "existingValue", new BsonInt32(1) },
+                { "newValue", new BsonInt32(2) }
+            };
+
+            using (var bsonReader = new BsonDocumentReader(documentToDeserialize))
+            {
+                var rehydrated = Deserialize(bsonReader, existingDocument);
+                Assert.True(expectedDocument.Equals(rehydrated));
+            }
+        }
+
+        [Fact]
+        public void TestDeserializationWithExistingBsonDocumentAndSameFields()
+        {
+            var existingDocument = new BsonDocument { { "field", new BsonInt32(1) } };
+            var documentToDeserialize = new BsonDocument { { "field", new BsonInt32(2) } };
+
+            var expectedDocument = new BsonDocument
+            {
+                { "field", new BsonInt32(2) }
+            };
+
+            using (var bsonReader = new BsonDocumentReader(documentToDeserialize))
+            {
+                var rehydrated = Deserialize(bsonReader, existingDocument);
+                Assert.True(expectedDocument.Equals(rehydrated));
+            }
+        }
+
+        [Fact]
+        public void TestDeserializationWithExistingEmptyBsonDocument()
+        {
+            var document = new BsonDocument { { "newValue", new BsonInt32(2) } };
+
+            var expectedDocument = new BsonDocument
+            {
+                { "newValue", new BsonInt32(2) }
+            };
+
+            using (var bsonReader = new BsonDocumentReader(document))
+            {
+                var rehydrated = Deserialize(bsonReader, new BsonDocument());
+                Assert.True(expectedDocument.Equals(rehydrated));
+            }
+        }
+
+        [Fact]
+        public void TestDeserializationWithoutExistingBsonDocument()
+        {
+            var document = new BsonDocument { { "newValue", new BsonInt32(2) } };
+
+            var expectedDocument = new BsonDocument
+            {
+                { "newValue", new BsonInt32(2) }
+            };
+
+            using (var bsonReader = new BsonDocumentReader(document))
+            {
+                var rehydrated = Deserialize(bsonReader, (BsonDocument)null);
+                Assert.True(expectedDocument.Equals(rehydrated));
+            }
+        }
+
+        [Fact]
+        public void TestExistingObjectWithReadOnlyCollection()
+        {
+            Assert.Throws<FormatException>(() => TestExistingObjectWithCollectionOfType<ReadOnlyCollection<int>, int>(() => new List<int>(new[] { 0, 1, 2 }).AsReadOnly(), new List<int> { 3, 4 }.AsReadOnly()));
+        }
+
+        [Fact]
+        public void TestExistingObjectWithList()
+        {
+            TestExistingObjectWithCollectionOfType<List<int>, int>(() => new List<int>(new[] { 0, 1, 2 }), new List<int>(new[] { 3, 4 }));
+            TestExistingObjectWithCollectionOfType<List<int>, int>(() => (List<int>)null, new List<int>(new[] { 3, 4 }));
+        }
+
+        [Fact]
+        public void TestExistingObjectWithStack()
+        {
+            TestExistingObjectWithCollectionOfType<Stack<int>, int>(() => new Stack<int>(new[] { 0, 1, 2 }), new Stack<int>(new[] { 3, 4 }), expectResultsReversed: true);
+            TestExistingObjectWithCollectionOfType<Stack<int>, int>(() => null as Stack<int>, new Stack<int>(new[] { 3, 4 }), expectResultsReversed: true);
+        }
+
+        [Fact]
+        public void TestExistingObjectWithQueue()
+        {
+            TestExistingObjectWithCollectionOfType<Queue<int>, int>(() => new Queue<int>(new[] { 0, 1, 2 }), new Queue<int>(new[] { 3, 4 }));
+            TestExistingObjectWithCollectionOfType<Queue<int>, int>(() => null as Queue<int>, new Queue<int>(new[] { 3, 4 }));
+        }
+
+        [Fact]
+        public void TestExistingObjectWithArray()
+        {
+            TestExistingObjectWithCollectionOfType<int[], int>(() => new[] { 0, 1, 2 }, new[] { 3, 4 }, expectExcessItemsToBeTrimmed: false);
+            TestExistingObjectWithCollectionOfType<int[], int>(() => null, new[] { 3, 4 }, expectExcessItemsToBeTrimmed: false);
+        }
+
+        [Fact]
+        public void TestExistingObjectWithDictionary()
+        {
+            TestExistingObjectWithCollectionOfType<Dictionary<string, int>, KeyValuePair<string, int>>(() => new Dictionary<string, int> { { "0", 0 }, { "1", 1 }, { "2", 2 } }, new Dictionary<string, int> { { "3", 3 }, { "4", 4 } });
+            TestExistingObjectWithCollectionOfType<Dictionary<string, int>, KeyValuePair<string, int>>(() => null, new Dictionary<string, int> { { "3", 3 }, { "4", 4 } });
+        }
+
+        [Fact]
+        public void TestExistingObjectWithArrayAndTooMuchDeserializedData()
+        {
+            Assert.Throws<FormatException>(() => TestExistingObjectWithCollectionOfType<int[], int>(() => new int[] { 0, 1, 2 }, new int[] { 3, 4, 5, 6 }));
+        }
+
+        private void TestExistingObjectWithCollectionOfType<TCollection, TValue>(Func<TCollection> collectionFactory, TCollection valuesToBeDeserialized, bool expectExcessItemsToBeTrimmed = true, bool expectResultsReversed = false) where TCollection : IEnumerable<TValue>
+        {
+            if (!BsonClassMap.IsClassMapRegistered(typeof(Test<TCollection>)))
+            {
+                BsonClassMap.RegisterClassMap<Test<TCollection>>(cm =>
+                {
+                    cm.AutoMap();
+                    // map all readonly properties
+                    cm.MapProperty(c => c.UseExistingInstanceReadOnlyCollection);
+                    cm.MapProperty(c => c.DoNotUseExistingInstanceReadOnlyCollection);
+                    cm.MapProperty(c => c.UseExistingInstanceReadOnlyInnerInstance);
+                    cm.MapProperty(c => c.DoNotUseExistingInstanceReadOnlyInnerInstance);
+                });
+            }
+
+            Test<TCollection>.CollectionFactory = () => valuesToBeDeserialized;
+            Test<TCollection> test = new Test<TCollection>();
+
+            var bsonDocument = test.ToBsonDocument();
+
+            // 1. first test without a top level document
+            Test<TCollection> doc = null;
+            // hack which allows us to have the deserializer call the default constructor and still populate the collections
+            Test<TCollection>.CollectionFactory = collectionFactory;
+            TestUsingTopLevelInstance<TCollection, TValue>(collectionFactory, valuesToBeDeserialized, expectExcessItemsToBeTrimmed, bsonDocument, doc);
+
+            // 2. then test with an existing top level instance
+            doc = new Test<TCollection>(true);
+
+            // we capture the current properties locally in order to check for instance identity after deserialization
+            var useExistingInstanceReadOnlyCollection = doc.UseExistingInstanceReadOnlyCollection;
+            var doNotUseExistingInstanceReadOnlyCollection = doc.DoNotUseExistingInstanceReadOnlyCollection;
+            var useExistingInstanceWritableCollection = doc.UseExistingInstanceWritableCollection;
+            var doNotUseExistingInstanceWritableCollection = doc.DoNotUseExistingInstanceWritableCollection;
+            var useExistingInstanceReadOnlyInnerInstance = doc.UseExistingInstanceReadOnlyInnerInstance;
+            var doNotUseExistingInstanceReadOnlyInnerInstance = doc.DoNotUseExistingInstanceReadOnlyInnerInstance;
+            var useExistingInstanceWritableInnerInstance = doc.UseExistingInstanceWritableInnerInstance;
+            var doNotUseExistingInstanceWritableInnerInstance = doc.DoNotUseExistingInstanceWritableInnerInstance;
+
+            var rehydrated = TestUsingTopLevelInstance<TCollection, TValue>(collectionFactory, valuesToBeDeserialized, expectExcessItemsToBeTrimmed, bsonDocument, doc);
+
+            // we expect the original document instance that we pass into the deserializer to be the same as the one that gets returned from the deserializer
+            Assert.Same(doc, rehydrated);
+
+            // we expect all readonly properties that *are* marked with the UseExistingInstance attribute to be identical to the ones returned from the deserializer
+            Assert.Same(useExistingInstanceReadOnlyCollection, rehydrated.UseExistingInstanceReadOnlyCollection);
+            Assert.Same(useExistingInstanceReadOnlyInnerInstance, rehydrated.UseExistingInstanceReadOnlyInnerInstance);
+
+            // we expect all writable properties that *are* marked with the UseExistingInstance attribute to be identical to the ones returned from the deserializer
+            // unless the existing instance is null in which case we expect them to be different
+            AssertSameIfNotNullOtherwiseAssertNotSame(useExistingInstanceWritableCollection, rehydrated.UseExistingInstanceWritableCollection);
+            AssertSameIfNotNullOtherwiseAssertNotSame(useExistingInstanceWritableInnerInstance, rehydrated.UseExistingInstanceWritableInnerInstance);
+
+            // we expect all writable properties that are *not* marked with the UseExistingInstance attribute to be different from the ones returned from the deserializer
+            Assert.NotSame(doNotUseExistingInstanceWritableCollection, rehydrated.DoNotUseExistingInstanceWritableInnerInstance);
+            Assert.NotSame(doNotUseExistingInstanceWritableInnerInstance, rehydrated.DoNotUseExistingInstanceWritableInnerInstance);
+
+            // we expect all readonly properties that are *not* marked with the UseExistingInstance attribute to be identical to the the ones returned from the deserializer
+            Assert.Same(doNotUseExistingInstanceReadOnlyCollection, rehydrated.DoNotUseExistingInstanceReadOnlyCollection);
+            Assert.Same(doNotUseExistingInstanceReadOnlyInnerInstance, rehydrated.DoNotUseExistingInstanceReadOnlyInnerInstance);
+        }
+
+        private static void AssertSameIfNotNullOtherwiseAssertNotSame<TCollection>(TCollection originalCollection, TCollection rehydratedCollection)
+        {
+            if (originalCollection != null)
+            {
+                Assert.Same(originalCollection, rehydratedCollection);
+            }
+            else
+            {
+                Assert.NotSame(originalCollection, rehydratedCollection);
+            }
+        }
+
+        private Test<TCollection> TestUsingTopLevelInstance<TCollection, TValue>(Func<TCollection> collectionFactory, TCollection valuesToBeDeserialized, bool expectExcessItemsToBeTrimmed, BsonDocument document, Test<TCollection> doc)
+            where TCollection : IEnumerable<TValue>
+        {
+            using (var bsonReader = new BsonDocumentReader(document))
+            {
+                var rehydrated = Deserialize(bsonReader, doc);
+                IEnumerable<TValue> expectedResults = valuesToBeDeserialized;
+
+                // we expect all writable properties that are *not* marked with the UseExistingInstance attribute to contain our new data
+                // that's the default behaviour before the UseExistingInstance attribute even got created...
+                Assert.True(expectedResults.SequenceEqual(rehydrated.DoNotUseExistingInstanceWritableCollection));
+                Assert.True(expectedResults.SequenceEqual(rehydrated.UseExistingInstanceReadOnlyInnerInstance.DoNotUseExistingInstanceWritableCollection));
+                Assert.True(expectedResults.SequenceEqual(rehydrated.UseExistingInstanceWritableInnerInstance.DoNotUseExistingInstanceWritableCollection));
+                Assert.True(expectedResults.SequenceEqual(rehydrated.DoNotUseExistingInstanceWritableInnerInstance.DoNotUseExistingInstanceWritableCollection));
+
+                TCollection collection = collectionFactory();
+
+                if (!expectExcessItemsToBeTrimmed && !Equals(collection, default(TCollection)))
+                {
+                    // for all collections, other than list, the number of items in the collection will be equal to the number of deserialized items
+                    // for arrays, however, the size will be the same as on the original instance since we reuse the existing array
+                    expectedResults = expectedResults.Concat(Enumerable.Repeat(default(TValue), collection.Count() - valuesToBeDeserialized.Count())).ToList();
+                }
+
+                // we expect all writable properties that *are* marked with the UseExistingInstance attribute to contain our new data
+                Assert.True(expectedResults.SequenceEqual(rehydrated.UseExistingInstanceWritableCollection));
+                Assert.True(expectedResults.SequenceEqual(rehydrated.UseExistingInstanceReadOnlyInnerInstance.UseExistingInstanceWritableCollection));
+                Assert.True(expectedResults.SequenceEqual(rehydrated.UseExistingInstanceWritableInnerInstance.UseExistingInstanceWritableCollection));
+                Assert.True(expectedResults.SequenceEqual(rehydrated.DoNotUseExistingInstanceWritableInnerInstance.UseExistingInstanceWritableCollection));
+
+                // we expect all readonly properties that *are* marked with the UseExistingInstance attribute to contain our new data unless the existing instance is null
+                if (collection != null)
+                {
+                    Assert.True(expectedResults.SequenceEqual(rehydrated.UseExistingInstanceReadOnlyCollection));
+                    Assert.True(expectedResults.SequenceEqual(rehydrated.UseExistingInstanceReadOnlyInnerInstance.UseExistingInstanceReadOnlyCollection));
+                    Assert.True(expectedResults.SequenceEqual(rehydrated.UseExistingInstanceWritableInnerInstance.UseExistingInstanceReadOnlyCollection));
+                    Assert.True(expectedResults.SequenceEqual(rehydrated.DoNotUseExistingInstanceWritableInnerInstance.UseExistingInstanceReadOnlyCollection));
+                }
+                else
+                {
+                    Assert.Null(rehydrated.UseExistingInstanceReadOnlyCollection);
+                    Assert.Null(rehydrated.UseExistingInstanceReadOnlyInnerInstance.UseExistingInstanceReadOnlyCollection);
+                    Assert.Null(rehydrated.UseExistingInstanceWritableInnerInstance.UseExistingInstanceReadOnlyCollection);
+                    Assert.Null(rehydrated.DoNotUseExistingInstanceWritableInnerInstance.UseExistingInstanceReadOnlyCollection);
+                }
+
+                // we expect all readonly properties that are *not* marked with the UseExistingInstance attribute to be unchanged.
+                Assert.Equal(collection, rehydrated.DoNotUseExistingInstanceReadOnlyCollection);
+                Assert.Equal(collection, rehydrated.UseExistingInstanceReadOnlyInnerInstance.DoNotUseExistingInstanceReadOnlyCollection);
+                Assert.Equal(collection, rehydrated.UseExistingInstanceWritableInnerInstance.DoNotUseExistingInstanceReadOnlyCollection);
+                Assert.Equal(collection, rehydrated.DoNotUseExistingInstanceWritableInnerInstance.DoNotUseExistingInstanceReadOnlyCollection);
+
+                // we expect all properties that sit inside a nested readonly type that's exposed by a readonly property that is *not* marked with the UseExistingInstance attribute to be unchanged.
+                Assert.Equal(collection, rehydrated.DoNotUseExistingInstanceReadOnlyInnerInstance.DoNotUseExistingInstanceReadOnlyCollection);
+                Assert.Equal(collection, rehydrated.DoNotUseExistingInstanceReadOnlyInnerInstance.DoNotUseExistingInstanceWritableCollection);
+                Assert.Equal(collection, rehydrated.DoNotUseExistingInstanceReadOnlyInnerInstance.UseExistingInstanceWritableCollection);
+                Assert.Equal(collection, rehydrated.DoNotUseExistingInstanceReadOnlyInnerInstance.UseExistingInstanceReadOnlyCollection);
+
+                return rehydrated;
+            }
+        }
+
+        private static T Deserialize<T>(IBsonReader bsonReader, T existingInstance = default(T))
+        {
+            return BsonSerializer.Deserialize(bsonReader, existingInstance: existingInstance);
+        }
+    }
+
+    public class TestValueTypeWithAttribute
+    {
+        [BsonUseExistingInstance]
+        public int ValueType { get; set; }
+    }
+
+    public class TestValueTypeWithoutAttribute
+    {
+        public int ValueType { get; set; }
+    }
+
+    public class Test<TCollection> where TCollection : IEnumerable
+    {
+        // readonly collection properties
+        [BsonUseExistingInstance]
+        public TCollection UseExistingInstanceReadOnlyCollection { get; }
+
+        public TCollection DoNotUseExistingInstanceReadOnlyCollection { get; }
+
+        // writable collection properties
+        [BsonUseExistingInstance]
+        public TCollection UseExistingInstanceWritableCollection { get; set; }
+
+        public TCollection DoNotUseExistingInstanceWritableCollection { get; set; }
+
+        // readonly nested classes
+        [BsonUseExistingInstance]
+        public Test<TCollection> UseExistingInstanceReadOnlyInnerInstance { get; }
+
+        public Test<TCollection> DoNotUseExistingInstanceReadOnlyInnerInstance { get; }
+
+        // writable nested classes
+        [BsonUseExistingInstance]
+        public Test<TCollection> UseExistingInstanceWritableInnerInstance { get; set; }
+
+        public Test<TCollection> DoNotUseExistingInstanceWritableInnerInstance { get; set; }
+
+        // hack so we can set the collection initializer from the outside in order to allow for a default constructor (called during deserialization) that still populates the collections
+        public static Func<TCollection> CollectionFactory;
+
+        // this will be called by the deserializer
+        public Test() : this(true)
+        {
+        }
+
+        public Test(bool createInnerInstance)
+        {
+            UseExistingInstanceReadOnlyCollection = CollectionFactory();
+            DoNotUseExistingInstanceReadOnlyCollection = CollectionFactory();
+            UseExistingInstanceWritableCollection = CollectionFactory();
+            DoNotUseExistingInstanceWritableCollection = CollectionFactory();
+            if (createInnerInstance)
+            {
+                UseExistingInstanceReadOnlyInnerInstance = new Test<TCollection>(false);
+                DoNotUseExistingInstanceReadOnlyInnerInstance = new Test<TCollection>(false);
+                UseExistingInstanceWritableInnerInstance = new Test<TCollection>(false);
+                DoNotUseExistingInstanceWritableInnerInstance = new Test<TCollection>(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR implements https://jira.mongodb.org/browse/CSHARP-1999.

´BsonMemberMap´ now supports a `SetUseExistingInstance(bool useExistingInstance)` method (there's also a convention and an attribute) which can be used in order to tell the driver to deserialize a document directly into an existing instance (either straight from the root level or individually for a configured property).

This allows for some greater level of flexibility around entity design:

- Readonly auto-initialized properties can now be populated by the driver which wasn't possible before:
  - `public List<int> Foo { get; } = new List<int>();`
  - `public SomeType Bar { get; } = new SomeType();`)
- Also, in cases of heavy constructors where the instantiation of an entity type `A` through the driver would immediately trigger the creation of some contained nested instances `B` (and `C` and so on...) as part of a top-level constructor call, superfluous constructor calls can be avoided by reusing the already created instances.
- As a side-product of the implementation, existing instances can now be partially/incrementally populated by the driver (e.g. through `BsonSerializer.Deserialize(bsonReader, existingInstance: existingInstance);`) which may be an interesting feature in some slightly more arcane scenarios:
  - e.g. for entities that need to hold data from multiple source (read: collections/queries)
  - or when a user should be able to populate an entity partially which, however, then needs to be enriched with some fields that are stored in the database.