### PR TITLE
Reduction of reflection calls --> minor deserialization performance gain

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -53,6 +53,7 @@ namespace MongoDB.Bson.Serialization
 
         // private fields
         private BsonClassMap _classMap;
+        private bool _isValueType;
 #if NETSTANDARD1_5
         private readonly MethodInfo _beginInitMethodInfo;
         private readonly MethodInfo _endInitMethodInfo;
@@ -80,6 +81,7 @@ namespace MongoDB.Bson.Serialization
             }
 
             _classMap = classMap;
+            _isValueType = _classMap.ClassType.GetTypeInfo().IsValueType;
 #if NETSTANDARD1_5
             CheckForISupportInitializeInterface(out _beginInitMethodInfo, out _endInitMethodInfo);
 #endif
@@ -108,7 +110,7 @@ namespace MongoDB.Bson.Serialization
         {
             var bsonReader = context.Reader;
 
-            if (_classMap.ClassType.GetTypeInfo().IsValueType)
+            if (_isValueType)
             {
                 var message = string.Format("Value class {0} cannot be deserialized.", _classMap.ClassType.FullName);
                 throw new BsonSerializationException(message);


### PR DESCRIPTION
There was some reflection code in the `Deserialize` method which would get called repeatedly. But since the ClassMap is frozen (gets checked in the constructor) it should be sufficient to execute this code once upon construction of the `BsonClassMapSerializer` and then use the cached value.