### PR TITLE
CSHARP-2114: MongoIndexManager reads list of indexes not only from primary

### DIFF
--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -1192,7 +1192,7 @@ namespace MongoDB.Driver
             {
                 Ensure.IsNotNull(session, nameof(session));
                 var operation = CreateListIndexesOperation();
-                return _collection.ExecuteReadOperation(session, operation, ReadPreference.Primary, cancellationToken);
+                return _collection.ExecuteReadOperation(session, operation, cancellationToken);
             }
 
             public override Task<IAsyncCursor<BsonDocument>> ListAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -1204,7 +1204,7 @@ namespace MongoDB.Driver
             {
                 Ensure.IsNotNull(session, nameof(session));
                 var operation = CreateListIndexesOperation();
-                return _collection.ExecuteReadOperationAsync(session, operation, ReadPreference.Primary, cancellationToken);
+                return _collection.ExecuteReadOperationAsync(session, operation, cancellationToken);
             }
 
             // private methods


### PR DESCRIPTION
Issue: https://jira.mongodb.org/browse/CSHARP-2114.

[Indexes_List_should_execute_a_ListIndexesOperation](https://github.com/mongodb/mongo-csharp-driver/blob/1c20602fb9e95e393c452e91109caa467c541c84/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs#L1721) (test that checks "list indexes" operation) works after my changes.