### PR TITLE
Removing support for MongoDB 2.6 in v2.5 release notes

### DIFF
--- a/Release Notes/Release Notes v2.5.0.md
+++ b/Release Notes/Release Notes v2.5.0.md
@@ -22,3 +22,5 @@ https://jira.mongodb.org/issues/?jql=project%20%3D%20CSHARP%20AND%20fixVersion%2
 Upgrading
 
 We believe there are only minor breaking changes in classes that normally would not be directly used by applications.
+
+MongoDB server versions below version 2.6 are no longer supported.


### PR DESCRIPTION
As part of https://jira.mongodb.org/browse/DRIVERS-407, support for server versions below 2.6 was removed in https://github.com/mongodb/mongo-csharp-driver/commit/c1f4e87edb410862f87976231bb0aac58de09856. 

I thought it might be helpful to also add this to the release notes, as it seems to be a breaking change.