### PR TITLE
BsonType.Timestamp support in ObjectSerializer

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/ObjectSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ObjectSerializer.cs
@@ -129,6 +129,9 @@ namespace MongoDB.Bson.Serialization.Serializers
                 case BsonType.String:
                     return bsonReader.ReadString();
 
+                case BsonType.Timestamp:
+                    return bsonReader.ReadTimestamp();
+
                 default:
                     var message = string.Format("ObjectSerializer does not support BSON type '{0}'.", bsonType);
                     throw new FormatException(message);


### PR DESCRIPTION
### Scenario

Calling `IMongoDatabase.RunCommandAsync<object>` fails when response contains values with BSON type *Timestamp*. This happens at every request when using replica sets.

A `FormatException` is thrown saying: *ObjectSerializer does not support BSON type Timestamp*.  
Specialized serializers (like `BsonTimestampSerializer`) can't be used here, because the anonymous response type doesn't allow class mapping.

### Solution

Add an entry to `ObjectSerializer` type recognition code, in order to support *Timestamp* deserialization.

That's already done for other BSON types (binary, int, decimal, array, string, objectId, etc.)

### Notes

[CSHARP-1162](https://jira.mongodb.org/browse/CSHARP-1162) says that Timestamp class is for internal use only, this may be the reason why it's not supported. This PR does not aim to change that.

Nevertheless, `RunCommandAsync` (and possibly other methods) just fail with collections that contain a Timestamp value. This is often out of programmers control, and the proposed change may be a painless solution.