### PR TITLE
CSHARP-1378 BulkWrite enumerates requests argument multiple times

### DIFF
--- a/src/MongoDB.Driver/BulkWriteResult.cs
+++ b/src/MongoDB.Driver/BulkWriteResult.cs
@@ -113,10 +113,10 @@ namespace MongoDB.Driver
         /// <param name="processedRequests">The processed requests.</param>
         protected BulkWriteResult(
             int requestCount,
-            IEnumerable<WriteModel<TDocument>> processedRequests)
+            List<WriteModel<TDocument>> processedRequests)
             : base(requestCount)
         {
-            _processedRequests = processedRequests.ToList();
+            _processedRequests = processedRequests;
         }
 
         // public properties
@@ -148,7 +148,7 @@ namespace MongoDB.Driver
                 result.ProcessedRequests.Select(r => WriteModel<TDocument>.FromCore(r)));
         }
 
-        internal static BulkWriteResult<TDocument> FromCore(Core.Operations.BulkWriteOperationResult result, IEnumerable<WriteModel<TDocument>> requests)
+        internal static BulkWriteResult<TDocument> FromCore(Core.Operations.BulkWriteOperationResult result, List<WriteModel<TDocument>> requests)
         {
             if (result.IsAcknowledged)
             {
@@ -201,6 +201,23 @@ namespace MongoDB.Driver
                 long insertedCount,
                 long? modifiedCount,
                 IEnumerable<WriteModel<TDocument>> processedRequests,
+                IEnumerable<BulkWriteUpsert> upserts)
+                : base(requestCount, processedRequests.ToList())
+            {
+                _matchedCount = matchedCount;
+                _deletedCount = deletedCount;
+                _insertedCount = insertedCount;
+                _modifiedCount = modifiedCount;
+                _upserts = upserts.ToList();
+            }
+
+            internal Acknowledged(
+                int requestCount,
+                long matchedCount,
+                long deletedCount,
+                long insertedCount,
+                long? modifiedCount,
+                List<WriteModel<TDocument>> processedRequests,
                 IEnumerable<BulkWriteUpsert> upserts)
                 : base(requestCount, processedRequests)
             {
@@ -279,6 +296,13 @@ namespace MongoDB.Driver
             public Unacknowledged(
                 int requestCount,
                 IEnumerable<WriteModel<TDocument>> processedRequests)
+                : base(requestCount, processedRequests.ToList())
+            {
+            }
+
+            internal Unacknowledged(
+                int requestCount,
+                List<WriteModel<TDocument>> processedRequests)
                 : base(requestCount, processedRequests)
             {
             }

--- a/src/MongoDB.Driver/MongoBulkWriteException.cs
+++ b/src/MongoDB.Driver/MongoBulkWriteException.cs
@@ -223,7 +223,8 @@ namespace MongoDB.Driver
             var processedRequests = ex.Result.ProcessedRequests
                 .Select(r => new { CorrelationId = r.CorrelationId.Value, Request = requests[r.CorrelationId.Value] })
                 .OrderBy(x => x.CorrelationId)
-                .Select(x => x.Request);
+                .Select(x => x.Request)
+                .ToList();
 
             var unprocessedRequests = ex.UnprocessedRequests
                 .Select(r => new { CorrelationId = r.CorrelationId.Value, Request = requests[r.CorrelationId.Value] })

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -169,21 +169,24 @@ namespace MongoDB.Driver
         {
             Ensure.IsNotNull(session, nameof(session));
             Ensure.IsNotNull(requests, nameof(requests));
-            if (!requests.Any())
+
+            var requestList = requests.ToList();
+
+            if (requestList.Count==0)
             {
                 throw new ArgumentException("Must contain at least 1 request.", "requests");
             }
             options = options ?? new BulkWriteOptions();
 
-            var operation = CreateBulkWriteOperation(requests, options);
+            var operation = CreateBulkWriteOperation(requestList, options);
             try
             {
                 var result = ExecuteWriteOperation(session, operation, cancellationToken);
-                return BulkWriteResult<TDocument>.FromCore(result, requests);
+                return BulkWriteResult<TDocument>.FromCore(result, requestList);
             }
             catch (MongoBulkWriteOperationException ex)
             {
-                throw MongoBulkWriteException<TDocument>.FromCore(ex, requests.ToList());
+                throw MongoBulkWriteException<TDocument>.FromCore(ex, requestList);
             }
         }
 
@@ -196,21 +199,24 @@ namespace MongoDB.Driver
         {
             Ensure.IsNotNull(session, nameof(session));
             Ensure.IsNotNull(requests, nameof(requests));
-            if (!requests.Any())
+
+            var requestList = requests.ToList();
+
+            if (requestList.Count==0)
             {
                 throw new ArgumentException("Must contain at least 1 request.", "requests");
             }
             options = options ?? new BulkWriteOptions();
 
-            var operation = CreateBulkWriteOperation(requests, options);
+            var operation = CreateBulkWriteOperation(requestList, options);
             try
             {
                 var result = await ExecuteWriteOperationAsync(session, operation, cancellationToken).ConfigureAwait(false);
-                return BulkWriteResult<TDocument>.FromCore(result, requests);
+                return BulkWriteResult<TDocument>.FromCore(result, requestList);
             }
             catch (MongoBulkWriteOperationException ex)
             {
-                throw MongoBulkWriteException<TDocument>.FromCore(ex, requests.ToList());
+                throw MongoBulkWriteException<TDocument>.FromCore(ex, requestList);
             }
         }
 

--- a/tests/MongoDB.Driver.Tests/BulkWriteResultTests.cs
+++ b/tests/MongoDB.Driver.Tests/BulkWriteResultTests.cs
@@ -42,7 +42,7 @@ namespace MongoDB.Driver.Tests
                 processedRequests: new[] { new InsertRequest(new BsonDocument("b", 1)) },
                 upserts: new List<BulkWriteOperationUpsert>());
 
-            var models = new[] 
+            var models = new List<WriteModel<BsonDocument>>
             {
                 new InsertOneModel<BsonDocument>(new BsonDocument("a", 1))
             };
@@ -70,7 +70,7 @@ namespace MongoDB.Driver.Tests
                 requestCount: 1,
                 processedRequests: new[] { new InsertRequest(new BsonDocument("b", 1)) });
 
-            var models = new[] 
+            var models = new List<WriteModel<BsonDocument>>
             {
                 new InsertOneModel<BsonDocument>(new BsonDocument("a", 1))
             };


### PR DESCRIPTION
`BulkWrite` currently enumerates its `requests` param 3 times:
- to check whether it is empty
- to build the bulkwrite operation
- to copy `requests` into the result object

That behaviour can be very costly if `requests` represents e.g. a remote db table.

This pull requests contains 2 commits:

- **CSHARP-1378 enumerate bulkwrite request list once**: Simply copies the enumerable to a list once and uses that list everywhere the enumerable was used. Includes a unit test that fails for the case where `BulkWrite`/`BulkWriteAsync` enumerates the enumerable multiple times. 

- **CSHARP-1378 remove extra list copy**: With the above commit `BulkWrite` does one more list copy than in the baseline case. This second commit optimizes that extra copy away because I don't want to worsen performance for cases where `requests` is cheap to enumerate. I put it in a separate commit because you might find avoiding the extra list copy not worth the hassle because "computers are fast now".

Some tests fail in my ad-hoc environment, but then they also fail there without these changes, so that should be ok.