### PR TITLE
SequenceEqual should be usable in LinQ queries

### DIFF
--- a/tests/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
@@ -131,6 +131,16 @@ namespace Tests.MongoDB.Driver.Linq
                 "{ $project: { '__fld0': '$__agg0', '_id': 0 } }");
         }
 
+
+        [Fact]
+        public void SequenceEqual()
+        {
+            var query = CreateQuery()
+                .Where(x => x.M.SequenceEqual(new List<int> { 42, 1337, 420 }));
+
+            Assert(query, 0, "{ $match: { 'M': { '$eq': [42, 1337, 420] } } }");
+        }
+
         [Fact]
         public void Count()
         {


### PR DESCRIPTION
Currently, to filter documents that have a property of type array that matches a specific value, one has to write a query as follows:

```c#
// Assuming .M is an array of ints
var result = collection.AsQueryable().FirstOrDefault(x => x.M == new List<int> { 1, 2, 3 });
```

This is not optimal because it breaks the symmetry of LinQ with the corresponding operation on `Collection` (namely, that `==` applied on lists does not do an element-wise match).

In less philosophical terms, this is a problem because it breaks tests as the mocked result of `.AsQueryable()` (a List) behaves differently, like in this example:

```c#
// using Moq
var myDoc = new Doc { M = new List<int> { 1, 2, 3 }}
mock.Setup(x => x.AsQueryable()).Returns(new List<Doc> { myDoc }).AsQueryable());

// ...in the method that is being tested
var result = collection.AsQueryable().FirstOrDefault(x => x.M == new List<int> { 1, 2, 3 });
Assert.IsNotNull(result) // throws 
```

To make it worse, since `.FirstOrDefault()` is an extension method, it can't be mocked using Moq.

My proposed fix would be to support `.SequenceEqual()` as an alias to `$eq` to restore the symmetry. 
I added a failing test reflecting this.

I'm new to C# so I don't really know if that is the best choice or if it is possible at all.

I'm hoping for a few pointers on how to move this PR forward.

Cheers,
Loris.


