### PR TITLE
CSHARP-2071: Using Linq Aggregation to project the root document

### DIFF
--- a/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
@@ -117,6 +117,8 @@ namespace MongoDB.Driver.Linq.Translators
                                 return TranslateArrayIndex((ArrayIndexExpression)node);
                             case ExtensionExpressionType.Concat:
                                 return TranslateConcat((ConcatExpression)node);
+                            case ExtensionExpressionType.Document:
+                                return TranslateDocument((DocumentExpression)node);
                             case ExtensionExpressionType.Except:
                                 return TranslateExcept((ExceptExpression)node);
                             case ExtensionExpressionType.FieldAsDocument:
@@ -249,6 +251,11 @@ namespace MongoDB.Driver.Linq.Translators
             // NOTE: there may be other instances where we should use a literal...
             // but I can't think of any yet.
             return value;
+        }
+
+        private BsonValue TranslateDocument(DocumentExpression node)
+        {
+            return "$$ROOT";
         }
 
         private BsonValue TranslateDocumentWrappedField(FieldAsDocumentExpression expression)

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/AggregateGroupTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/AggregateGroupTranslatorTests.cs
@@ -263,6 +263,14 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             result.Value.Result.Should().Equal(111);
         }
 
+        [Fact]
+        public void Should_translate_push_with_root()
+        {
+            var result = Group(x => x.A, g => new { Result = g.Select(x => x) });
+
+            result.Projection.Should().Be("{ _id: \"$A\", Result: { \"$push\": \"$$ROOT\" } }");
+        }
+
         [SkippableFact]
         public void Should_translate_stdDevPop_with_embedded_projector()
         {


### PR DESCRIPTION
Hello,

Here's a first, naive, change to translate `{document}` to `$$ROOT` for `$push` in a `$group` aggregation stage.
I say "naive" because I'm not sure it doesn't break existing functionality, being new to this part of the code base. I have run all tests in `AggregateGroupTranslatorTests` and they are green.

This is by no means a complete solution. I'd be happy to add tests and extend any dependent functionality if you think this is a the step in the right direction.

Cheers,
Marko

CSHARP-2071