### PR TITLE
CSHARP-2162: GridFS MD5 digest must be optional

### DIFF
--- a/src/MongoDB.Driver.GridFS/GridFSBucket.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSBucket.cs
@@ -732,7 +732,8 @@ namespace MongoDB.Driver.GridFS
                 options.Aliases,
                 options.ContentType,
                 chunkSizeBytes,
-                batchSize);
+                batchSize,
+                options.DisableMD5);
 #pragma warning restore
         }
 

--- a/src/MongoDB.Driver.GridFS/GridFSBucketOptions.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSBucketOptions.cs
@@ -25,6 +25,7 @@ namespace MongoDB.Driver.GridFS
     {
         // fields
         private string _bucketName;
+        private bool _disableMD5 = false;
         private int _chunkSizeBytes;
         private ReadConcern _readConcern;
         private ReadPreference _readPreference;
@@ -48,6 +49,7 @@ namespace MongoDB.Driver.GridFS
             Ensure.IsNotNull(other, nameof(other));
             _bucketName = other.BucketName;
             _chunkSizeBytes = other.ChunkSizeBytes;
+            _disableMD5 = other.DisableMD5;
             _readConcern = other.ReadConcern;
             _readPreference = other.ReadPreference;
             _writeConcern = other.WriteConcern;
@@ -62,6 +64,7 @@ namespace MongoDB.Driver.GridFS
             Ensure.IsNotNull(other, nameof(other));
             _bucketName = other.BucketName;
             _chunkSizeBytes = other.ChunkSizeBytes;
+            _disableMD5 = other.DisableMD5;
             _readConcern = other.ReadConcern;
             _readPreference = other.ReadPreference;
             _writeConcern = other.WriteConcern;
@@ -98,6 +101,18 @@ namespace MongoDB.Driver.GridFS
                 Ensure.IsGreaterThanZero(value, nameof(value));
                 _chunkSizeBytes = value;
             }
+        }
+        
+        /// <summary>
+        /// Gets or set whether or not GridFS will compute MD5 checksums of uploaded files.
+        /// </summary>
+        /// <value>
+        /// Whether or not GridFS will compute MD5 checksums of uploaded files.
+        /// </value>
+        public bool DisableMD5
+        {
+            get { return _disableMD5; }
+            set { _disableMD5 = value; }
         }
 
         /// <summary>
@@ -162,6 +177,7 @@ namespace MongoDB.Driver.GridFS
         // fields
         private readonly string _bucketName;
         private readonly int _chunkSizeBytes;
+        private readonly bool _disableMD5 = false;
         private readonly ReadConcern _readConcern;
         private readonly ReadPreference _readPreference;
         private readonly WriteConcern _writeConcern;
@@ -184,6 +200,7 @@ namespace MongoDB.Driver.GridFS
         {
             Ensure.IsNotNull(other, nameof(other));
             _bucketName = other.BucketName;
+            _disableMD5 = other.DisableMD5;
             _chunkSizeBytes = other.ChunkSizeBytes;
             _readConcern = other.ReadConcern;
             _readPreference = other.ReadPreference;
@@ -212,6 +229,18 @@ namespace MongoDB.Driver.GridFS
         {
             get { return _chunkSizeBytes; }
         }
+        
+        /// <summary>
+        /// Gets or set whether or not GridFS will compute MD5 checksums of uploaded files.
+        /// </summary>
+        /// <value>
+        /// Whether or not GridFS will compute MD5 checksums of uploaded files.
+        /// </value>
+        public bool DisableMD5
+        {
+            get { return _disableMD5; }
+        }
+
 
         /// <summary>
         /// Gets the read concern.

--- a/src/MongoDB.Driver.GridFS/GridFSFileInfoCompat.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSFileInfoCompat.cs
@@ -138,6 +138,7 @@ namespace MongoDB.Driver.GridFS
         /// <value>
         /// The MD5 checksum.
         /// </value>
+        [Obsolete("MD5 support will be removed soon.")]
         public string MD5
         {
             get { return GetValue<string>("MD5", null); }

--- a/src/MongoDB.Driver.GridFS/GridFSUploadOptions.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSUploadOptions.cs
@@ -30,7 +30,9 @@ namespace MongoDB.Driver.GridFS
         private int? _batchSize;
         private int? _chunkSizeBytes;
         private string _contentType;
+        private bool _disableMD5 = false;
         private BsonDocument _metadata;
+        
 
         // properties
         /// <summary>
@@ -84,6 +86,18 @@ namespace MongoDB.Driver.GridFS
         {
             get { return _contentType; }
             set { _contentType = Ensure.IsNullOrNotEmpty(value, nameof(value)); }
+        }
+        
+        /// <summary>
+        /// Gets or sets whether or not MD5 is disabled.
+        /// </summary>
+        /// <value>
+        /// Whether or not MD5 is disabled.
+        /// </value>
+        public bool DisableMD5
+        {
+            get { return _disableMD5; }
+            set { _disableMD5 = value; }
         }
 
         /// <summary>

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSBucketOptionsTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSBucketOptionsTests.cs
@@ -270,6 +270,16 @@ namespace MongoDB.Driver.GridFS.Tests
         }
 
         [Fact]
+        public void DisableMD5_get_and_set_should_return_expected_result()
+        {
+            var subject = new ImmutableGridFSBucketOptions(new GridFSBucketOptions { DisableMD5= true });
+
+            var result = subject.DisableMD5;
+
+            result.Should().Be(true);    
+        }
+
+        [Fact]
         public void ReadConcern_get_should_return_expected_result()
         {
             var subject = new ImmutableGridFSBucketOptions(new GridFSBucketOptions { ReadConcern = ReadConcern.Majority });

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSBucketOptionsTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSBucketOptionsTests.cs
@@ -140,6 +140,16 @@ namespace MongoDB.Driver.GridFS.Tests
         }
 
         [Fact]
+        public void DisableMD5_get_set_should_return_expected_result()
+        {
+            var subject = new GridFSBucketOptions { DisableMD5 = true};
+
+            var result = subject.DisableMD5;
+
+            result.Should().Be(true);
+        }
+
+        [Fact]
         public void ReadPreference_get_should_return_expected_result()
         {
             var subject = new GridFSBucketOptions { ReadPreference = ReadPreference.Secondary };
@@ -225,12 +235,21 @@ namespace MongoDB.Driver.GridFS.Tests
         [Fact]
         public void constructor_with_arguments_should_initialize_instance()
         {
-            var mutable = new GridFSBucketOptions { BucketName = "bucket", ChunkSizeBytes = 123, ReadConcern = ReadConcern.Majority, ReadPreference = ReadPreference.Secondary, WriteConcern = WriteConcern.WMajority };
+            var mutable = new GridFSBucketOptions
+            {
+                BucketName = "bucket", 
+                ChunkSizeBytes = 123, 
+                DisableMD5 = true,
+                ReadConcern = ReadConcern.Majority, 
+                ReadPreference = ReadPreference.Secondary, 
+                WriteConcern = WriteConcern.WMajority
+            };
 
             var result = new ImmutableGridFSBucketOptions(mutable);
 
             result.BucketName.Should().Be("bucket");
             result.ChunkSizeBytes.Should().Be(123);
+            result.DisableMD5.Should().Be(true);
             result.ReadConcern.Should().Be(ReadConcern.Majority);
             result.ReadPreference.Should().Be(ReadPreference.Secondary);
             result.WriteConcern.Should().Be(WriteConcern.WMajority);
@@ -243,6 +262,7 @@ namespace MongoDB.Driver.GridFS.Tests
 
             result.BucketName.Should().Be("fs");
             result.ChunkSizeBytes.Should().Be(255 * 1024);
+            result.DisableMD5.Should().Be(false);
             result.ReadConcern.Should().BeNull();
             result.ReadPreference.Should().BeNull();
             result.WriteConcern.Should().BeNull();
@@ -264,6 +284,7 @@ namespace MongoDB.Driver.GridFS.Tests
 
             result.BucketName.Should().Be("fs");
             result.ChunkSizeBytes.Should().Be(255 * 1024);
+            result.DisableMD5.Should().Be(false);
             result.ReadConcern.Should().BeNull();
             result.ReadPreference.Should().BeNull();
             result.WriteConcern.Should().BeNull();

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSBucketTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSBucketTests.cs
@@ -45,6 +45,7 @@ namespace MongoDB.Driver.GridFS.Tests
             result.Database.Should().BeSameAs(database);
             result.Options.BucketName.Should().Be(options.BucketName);
             result.Options.ChunkSizeBytes.Should().Be(options.ChunkSizeBytes);
+            result.Options.DisableMD5.Should().Be(options.DisableMD5);
             result.Options.ReadPreference.Should().Be(options.ReadPreference);
             result.Options.WriteConcern.Should().Be(options.WriteConcern);
         }
@@ -473,6 +474,7 @@ namespace MongoDB.Driver.GridFS.Tests
 
             result.BucketName.Should().Be(options.BucketName);
             result.ChunkSizeBytes.Should().Be(options.ChunkSizeBytes);
+            result.DisableMD5.Should().Be(options.DisableMD5);
             result.ReadConcern.Should().Be(options.ReadConcern);
             result.ReadPreference.Should().Be(options.ReadPreference);
             result.WriteConcern.Should().Be(options.WriteConcern);

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSFileInfoTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSFileInfoTests.cs
@@ -269,8 +269,10 @@ namespace MongoDB.Driver.GridFS.Tests
             var value = "md5";
             var subject = CreateSubject(md5: value);
 
+#pragma warning disable 
             var result = subject.MD5;
-
+#pragma warning restore
+            
             result.Should().Be(value);
         }
 
@@ -280,8 +282,10 @@ namespace MongoDB.Driver.GridFS.Tests
             var document = CreateFilesCollectionDocument();
 
             var subject = DeserializeFilesCollectionDocument(document);
-
+            
+#pragma warning disable 618
             subject.MD5.Should().Be(document["md5"].AsString);
+#pragma warning restore            
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/GridFSUploadFromBytesTest.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/GridFSUploadFromBytesTest.cs
@@ -99,6 +99,10 @@ namespace MongoDB.Driver.GridFS.Tests.Specifications.gridfs
                         _options.ContentType = option.Value.AsString;
 #pragma warning restore
                         break;
+                    
+                    case "disableMD5":
+                        _options.DisableMD5 = option.Value.AsBoolean;
+                        break;
 
                     case "metadata":
                         _options.Metadata = option.Value.AsBsonDocument;

--- a/tests/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/tests/upload.json
+++ b/tests/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/tests/upload.json
@@ -1,11 +1,7 @@
 {
   "data": {
-    "files": [
-
-    ],
-    "chunks": [
-
-    ]
+    "files": [],
+    "chunks": []
   },
   "tests": [
     {

--- a/tests/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/tests/upload.json
+++ b/tests/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/tests/upload.json
@@ -386,6 +386,39 @@
           }
         ]
       }
+    },
+    {
+      "description": "Upload when length is 0 sans MD5",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": ""
+          },
+          "options": {
+            "chunkSizeBytes": 4,
+            "disableMD5": true
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 0,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "filename": "filename"
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/tests/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/tests/upload.yml
+++ b/tests/MongoDB.Driver.GridFS.Tests/Specifications/gridfs/tests/upload.yml
@@ -156,3 +156,18 @@ tests:
                     { insert : "expected.chunks", documents : [
                         { _id : "*actual", files_id : "*result", n : 0, data : { $hex : "11" } }
                     ] }
+    -
+        description: "Upload when length is 0 sans MD5"
+        act:
+            operation: upload
+            arguments:
+                filename: "filename"
+                source: { $hex : "" }
+                options: { chunkSizeBytes : 4, disableMD5: true }
+        assert:
+            result: "&result"
+            data:
+                -   
+                    { insert : "expected.files", documents : [
+                        { _id : "*result",  length : 0, chunkSize : 4, uploadDate : "*actual", filename : "filename" }
+                    ] }                


### PR DESCRIPTION
Add disableMD5 flag and associated tests while deprecating the checksum field