### PR TITLE
Typo fix in BsonClassMap.cs documentation

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -1476,10 +1476,10 @@ namespace MongoDB.Bson.Serialization
         }
 
         /// <summary>
-        /// Creates a member map for the Id property and adds it to the class map.
+        /// Creates a member map for the property and adds it to the class map.
         /// </summary>
         /// <typeparam name="TMember">The member type.</typeparam>
-        /// <param name="propertyLambda">A lambda expression specifying the Id property.</param>
+        /// <param name="propertyLambda">A lambda expression specifying the property.</param>
         /// <returns>The member map.</returns>
         public BsonMemberMap MapProperty<TMember>(Expression<Func<TClass, TMember>> propertyLambda)
         {


### PR DESCRIPTION
Removed typo in MapProperty method xmldoc.