### PR TITLE
Fix for prefix-lookalike fields like Name and NameOfPet

### DIFF
--- a/src/MongoDB.Driver/Linq/Translators/FindProjectionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/FindProjectionTranslator.cs
@@ -192,7 +192,8 @@ namespace MongoDB.Driver.Linq.Translators
                 var referenceGroup = referenceGroups.Dequeue();
                 if (!skippedFields.Contains(referenceGroup.Key))
                 {
-                    var hierarchicalReferenceGroups = referenceGroups.Where(x => x.Key.StartsWith(referenceGroup.Key));
+                    var prefix = referenceGroup.Key + ".";
+                    var hierarchicalReferenceGroups = referenceGroups.Where(x => x.Key.StartsWith(prefix));
                     uniqueFields.AddRange(referenceGroup);
                     skippedFields.AddRange(hierarchicalReferenceGroups.Select(x => x.Key));
                 }


### PR DESCRIPTION
Or Connection and ConnectionType as it was in my case
In case projection looks like 
(item => new Result { Connection =  item.Connection, ConnectionType = item.ConnectionType} )
the method in question returns only one field - Connection
It results in FindProjectionTranslator.VisitField not finding ConnectionType  in fields list and it mistakenly sets _fullDocument = true, wich results in using ProjectingDeserializer that deserializes whole (very large) document and slows our system like x10 times.