### PR TITLE
CSHARP-2159: When a MongoNodeIsRecoveringException occurs the server type must be set to Unknown.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Servers/Server.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/Server.cs
@@ -49,6 +49,7 @@ namespace MongoDB.Driver.Core.Servers
         private static readonly List<Type> __invalidatingExceptions = new List<Type>
         {
             typeof(MongoNotPrimaryException),
+            typeof(MongoNodeIsRecoveringException),
             typeof(MongoConnectionException),
             typeof(SocketException),
             typeof(EndOfStreamException),


### PR DESCRIPTION
The fix is trivial.

There is no automated test for this, but I manually verified that I got the same exception as the help ticket:

https://jira.mongodb.org/browse/HELP-6419

And then I verified that the exception no longer occurs after the fix was made.