### PR TITLE
CSHARP-2275: Skip name on GetCurrentBsonType()

### DIFF
--- a/src/MongoDB.Bson/IO/BsonReader.cs
+++ b/src/MongoDB.Bson/IO/BsonReader.cs
@@ -128,6 +128,11 @@ namespace MongoDB.Bson.IO
             {
                 ReadBsonType();
             }
+            if (_state == BsonReaderState.Name)
+            {
+                // ignore name
+                SkipName();
+            }
             if (_state != BsonReaderState.Value)
             {
                 ThrowInvalidState("GetCurrentBsonType", BsonReaderState.Value);


### PR DESCRIPTION
Either I'm doing something wrong in my custom serializer or this is an appropriate change.

Context: https://jira.mongodb.org/browse/CSHARP-2275