### PR TITLE
CSHARP-2290: Add 4.0 server to Evergreen matrix

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -353,6 +353,10 @@ axes:
         display_name: "latest"
         variables:
            VERSION: "latest"
+      - id: "4.0"
+        display_name: "4.0"
+        variables:
+           VERSION: "4.0"
       - id: "3.6"
         display_name: "3.6"
         variables:


### PR DESCRIPTION
Patch build is green: https://evergreen.mongodb.com/version/5b1951a6e3c33120750e352e