### PR TITLE
CSHARP-1991: Add support for OP_COMPRESSED

### DIFF
--- a/src/MongoDB.Driver.Core.Dotnet/MongoDB.Driver.Core.Dotnet.csproj
+++ b/src/MongoDB.Driver.Core.Dotnet/MongoDB.Driver.Core.Dotnet.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>2.7.0</VersionPrefix>
     <VersionSuffix>beta1</VersionSuffix>
@@ -13,11 +12,9 @@
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\MongoDB.Driver.Core\**\*.cs;..\MongoDB.Shared\ApplicationNameHelper.cs;..\MongoDB.Shared\Hasher.cs;..\MongoDB.Shared\MaxTimeHelper.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
   </ItemGroup>
@@ -25,7 +22,6 @@
   <ItemGroup>
     <ProjectReference Include="..\MongoDB.Bson.Dotnet\MongoDB.Bson.Dotnet.csproj" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
@@ -34,5 +30,7 @@
     <PackageReference Include="System.Security.SecureString" Version="4.0.0" />
     <PackageReference Include="DnsClient" Version="1.0.7" />
   </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="SharpCompress" Version="0.21.1" />
+  </ItemGroup>
 </Project>

--- a/src/MongoDB.Driver.Core/Core/Compression/CompressorId.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/CompressorId.cs
@@ -8,14 +8,14 @@
 		/// <summary>
 		/// No compression.
 		/// </summary>
-		noop,
-		/// <summary>
-		/// Compression using snappy algorithm.
-		/// </summary>
-		snappy,
+		noop = 0,
+		///// <summary>
+		///// Compression using snappy algorithm. NOT SUPPORTED YET.
+		///// </summary>
+		//snappy = 1, 
 		/// <summary>
 		/// Compression using zlib algorithm. 
 		/// </summary>
-		zlib
+		zlib = 2
 	}
 }

--- a/src/MongoDB.Driver.Core/Core/Compression/CompressorId.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/CompressorId.cs
@@ -1,0 +1,21 @@
+﻿namespace MongoDB.Driver.Core.Compression
+{
+	/// <summary>
+	/// Represents the compressor id.
+	/// </summary>
+	public enum CompressorId
+	{
+		/// <summary>
+		/// No compression.
+		/// </summary>
+		noop,
+		/// <summary>
+		/// Compression using snappy algorithm.
+		/// </summary>
+		snappy,
+		/// <summary>
+		/// Compression using zlib algorithm. 
+		/// </summary>
+		zlib
+	}
+}

--- a/src/MongoDB.Driver.Core/Core/Compression/ICompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ICompressor.cs
@@ -1,4 +1,19 @@
-﻿namespace MongoDB.Driver.Core.Compression
+﻿/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Core.Compression
 {
 	/// <summary>
 	/// Represents a compressor.

--- a/src/MongoDB.Driver.Core/Core/Compression/ICompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ICompressor.cs
@@ -1,0 +1,31 @@
+﻿namespace MongoDB.Driver.Core.Compression
+{
+	/// <summary>
+	/// Represents a compressor.
+	/// </summary>
+	public interface ICompressor
+	{
+		/// <summary>
+		/// Gets the name of the compressor.
+		/// </summary>
+		string Name { get; }
+		
+		/// <summary>
+		/// Gets the id of the compressor
+		/// </summary>
+		CompressorId Id { get; }
+
+		/// <summary>
+		/// Compresses the specified byte array with a given offset.
+		/// </summary>
+		/// <param name="bytesToCompress">Bytes to compress.</param>
+		/// <param name="offset">Offset of the bytes.</param>
+		byte[] Compress(byte[] bytesToCompress, int offset);
+
+		/// <summary>
+		/// Decompresses the specified byte array.
+		/// </summary>
+		/// <param name="bytesToDecompress">Bytes to decompress.</param>
+		byte[] Decompress(byte[] bytesToDecompress);
+	}
+}

--- a/src/MongoDB.Driver.Core/Core/Compression/MessageCompressionHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/MessageCompressionHelper.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using MongoDB.Bson.IO;
+using MongoDB.Driver.Core.WireProtocol.Messages;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
+
+namespace MongoDB.Driver.Core.Compression
+{
+	internal sealed class MessageCompressionHelper
+	{
+		private readonly IDictionary<CompressorId, ICompressor> _compressorDictionary;
+		private readonly MessageEncoderSettings _messageEncoderSettings;
+
+		public MessageCompressionHelper(IDictionary<CompressorId, ICompressor> compressorDictionary, MessageEncoderSettings messageEncoderSettings)
+		{
+			_compressorDictionary = compressorDictionary;
+			_messageEncoderSettings = messageEncoderSettings;
+		}
+
+		public bool IsCompressedMessage(Stream stream)
+		{
+			var bsonStream = GetBsonStream(stream);
+			
+			var position = stream.Position;
+			
+			// Skip header to opcode
+			bsonStream.ReadInt32();
+			bsonStream.ReadInt32();
+			bsonStream.ReadInt32();
+			var isCompressed = bsonStream.ReadInt32() == (int)Opcode.Compressed;
+
+			stream.Position = position;
+               
+			return isCompressed;
+		}
+
+		public Stream UncompressMessage(Stream stream)
+		{
+			var bsonStream = GetBsonStream(stream);
+			return ReadCompressedStream(bsonStream);
+		}
+
+		public ResponseMessage ReadCompressedResponseMessage(Stream stream, IMessageEncoderSelector encoderSelector)
+		{
+			var bsonStream = GetBsonStream(stream);
+			using (var uncompressedStream = ReadCompressedStream(bsonStream))
+			{
+				return (ResponseMessage) ReadMessage(uncompressedStream, encoderSelector);
+			}
+		}
+
+		private static BsonStream GetBsonStream(Stream stream)
+		{
+			return stream as BsonStream ?? new BsonStreamAdapter(stream);
+		}
+		
+		[SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
+		private ByteBufferStream ReadCompressedStream(BsonStream stream)
+		{
+			var compressedMessageLength = stream.ReadInt32();
+			var requestId = stream.ReadInt32();
+			var responseTo = stream.ReadInt32();
+			stream.ReadInt32(); //OP_COMPRESSED
+
+			var originalOpCode = (Opcode) stream.ReadInt32();
+			var originalMessageSize = stream.ReadInt32();
+			var compressorId = (CompressorId) stream.ReadByte();
+			var compressor = GetCompressor(compressorId);
+
+			var compressedBytes = stream.ReadBytes(compressedMessageLength - (int) stream.Position);
+
+			var uncompressedBytes = compressor.Decompress(compressedBytes);
+
+			using (var memStream = new MemoryStream())
+			{
+				using (var writer = new BinaryWriter(memStream, Encoding.Default, true))
+				{
+					writer.Write(originalMessageSize + 16);
+					writer.Write(requestId);
+					writer.Write(responseTo);
+					writer.Write((int)originalOpCode);
+                        
+					writer.Write(uncompressedBytes);
+				}
+
+				var buffer = new ByteArrayBuffer(memStream.ToArray());
+				buffer.MakeReadOnly();
+				return new ByteBufferStream(buffer);
+			}
+		}
+
+		private ICompressor GetCompressor(CompressorId compressorId)
+		{
+			ICompressor compressor;
+
+			if (_compressorDictionary.TryGetValue(compressorId, out compressor))
+				return compressor;
+                
+			throw new MongoClientException($"Unsupported compressor with identifier {(int)compressorId}");
+		}
+
+		private MongoDBMessage ReadMessage(ByteBufferStream stream, IMessageEncoderSelector encoderSelector)
+		{
+			var encoderFactory = new BinaryMessageEncoderFactory(stream, _messageEncoderSettings);
+			var encoder = encoderSelector.GetEncoder(encoderFactory);
+			return encoder.ReadMessage();
+		}
+	}
+}

--- a/src/MongoDB.Driver.Core/Core/Compression/MessageCompressionHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/MessageCompressionHelper.cs
@@ -11,6 +11,7 @@ namespace MongoDB.Driver.Core.Compression
 {
 	internal sealed class MessageCompressionHelper
 	{
+		private const int MessageHeaderLength = 16;
 		private readonly IDictionary<CompressorId, ICompressor> _compressorDictionary;
 		private readonly MessageEncoderSettings _messageEncoderSettings;
 
@@ -78,7 +79,7 @@ namespace MongoDB.Driver.Core.Compression
 			{
 				using (var writer = new BinaryWriter(memStream, Encoding.Default, true))
 				{
-					writer.Write(originalMessageSize + 16);
+					writer.Write(originalMessageSize + MessageHeaderLength);
 					writer.Write(requestId);
 					writer.Write(responseTo);
 					writer.Write((int)originalOpCode);

--- a/src/MongoDB.Driver.Core/Core/Compression/MessageCompressionHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/MessageCompressionHelper.cs
@@ -1,4 +1,19 @@
-﻿using System.Collections.Generic;
+﻿/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
@@ -77,7 +92,7 @@ namespace MongoDB.Driver.Core.Compression
 
 			using (var memStream = new MemoryStream())
 			{
-				using (var writer = new BinaryWriter(memStream, Encoding.Default, true))
+				using (var writer = new BinaryWriter(memStream, Encoding.UTF8, true))
 				{
 					writer.Write(originalMessageSize + MessageHeaderLength);
 					writer.Write(requestId);

--- a/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Driver.Core.Compression
 {
 	/// <summary>
 	/// Compressors using zlib algorithm
-	/// </summary>
+	/// </summary> 
 	public sealed class ZlibCompressor : ICompressor
 	{
 		private readonly CompressionLevel _compressionLevel;

--- a/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
@@ -45,6 +45,7 @@ namespace MongoDB.Driver.Core.Compression
 		}
 
 		/// <inheritdoc />
+		[SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
 		public byte[] Decompress(byte[] bytesToDecompress)
 		{
 			using (var memoryStream = new MemoryStream())

--- a/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
@@ -1,7 +1,22 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using CompressionLevel = Ionic.Zlib.CompressionLevel;
-using CompressionMode = Ionic.Zlib.CompressionMode;
+using SharpCompress.Compressors;
+using SharpCompress.Compressors.Deflate;
 
 namespace MongoDB.Driver.Core.Compression
 {
@@ -33,7 +48,7 @@ namespace MongoDB.Driver.Core.Compression
 		{
 			using (var memoryStream = new MemoryStream())
 			{
-				using (var zlibStream = new Ionic.Zlib.ZlibStream(memoryStream, CompressionMode.Compress, _compressionLevel))
+				using (var zlibStream = new ZlibStream(memoryStream, CompressionMode.Compress, _compressionLevel))
 				{
 					zlibStream.Write(bytesToCompress, offset, bytesToCompress.Length - offset);
 				}
@@ -48,7 +63,7 @@ namespace MongoDB.Driver.Core.Compression
 		{
 			using (var memoryStream = new MemoryStream())
 			{
-				using (var zlibStream = new Ionic.Zlib.ZlibStream(memoryStream, CompressionMode.Decompress))
+				using (var zlibStream = new ZlibStream(memoryStream, CompressionMode.Decompress))
 				{
 					zlibStream.Write(bytesToDecompress, 0, bytesToDecompress.Length);
 				}

--- a/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
@@ -1,0 +1,72 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Configuration;
+using CompressionLevel = Ionic.Zlib.CompressionLevel;
+using CompressionMode = Ionic.Zlib.CompressionMode;
+
+namespace MongoDB.Driver.Core.Compression
+{
+	/// <summary>
+	/// Compressors using zlib algorithm
+	/// </summary>
+	public sealed class ZlibCompressor : ICompressor
+	{
+		private readonly int _compressionLevel;
+
+		/// <inheritdoc />
+		public string Name => "zlib";
+
+		/// <inheritdoc />
+		public CompressorId Id => CompressorId.zlib;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ZlibCompressor" /> class.
+		/// </summary>
+		/// <param name="compressionLevel">The compression level.</param>
+		public ZlibCompressor(int compressionLevel = -1)
+		{
+			_compressionLevel = compressionLevel;
+		}
+
+		/// <inheritdoc />
+		[SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
+		public byte[] Compress(byte[] bytesToCompress, int offset)
+		{
+			using (var memoryStream = new MemoryStream())
+			{
+				using (var zlibStream = new Ionic.Zlib.ZlibStream(memoryStream, CompressionMode.Compress, GetCompressionLevel()))
+				{
+					zlibStream.Write(bytesToCompress, offset, bytesToCompress.Length - offset);
+				}
+				
+				return memoryStream.ToArray();
+			}
+		}
+
+		/// <inheritdoc />
+		public byte[] Decompress(byte[] bytesToDecompress)
+		{
+			using (var memoryStream = new MemoryStream())
+			{
+				using (var zlibStream = new Ionic.Zlib.ZlibStream(memoryStream, CompressionMode.Decompress))
+				{
+					zlibStream.Write(bytesToDecompress, 0, bytesToDecompress.Length);
+				}
+				
+				return memoryStream.ToArray();
+			}
+		}
+
+		private CompressionLevel GetCompressionLevel()
+		{
+			if (_compressionLevel < 0)
+				return CompressionLevel.Default;
+
+			if (_compressionLevel > 9)
+				return CompressionLevel.BestCompression;
+
+			return (CompressionLevel) _compressionLevel;
+		}
+	}
+}

--- a/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Driver.Core.Compression
 		/// Initializes a new instance of the <see cref="ZlibCompressor" /> class.
 		/// </summary>
 		/// <param name="compressionLevel">The compression level.</param>
-		public ZlibCompressor(int compressionLevel = -1)
+		public ZlibCompressor(int compressionLevel)
 		{
 			_compressionLevel = compressionLevel;
 		}

--- a/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ZlibCompressor.cs
@@ -1,7 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.IO.Compression;
-using System.Net.Configuration;
 using CompressionLevel = Ionic.Zlib.CompressionLevel;
 using CompressionMode = Ionic.Zlib.CompressionMode;
 
@@ -12,7 +10,7 @@ namespace MongoDB.Driver.Core.Compression
 	/// </summary>
 	public sealed class ZlibCompressor : ICompressor
 	{
-		private readonly int _compressionLevel;
+		private readonly CompressionLevel _compressionLevel;
 
 		/// <inheritdoc />
 		public string Name => "zlib";
@@ -26,7 +24,7 @@ namespace MongoDB.Driver.Core.Compression
 		/// <param name="compressionLevel">The compression level.</param>
 		public ZlibCompressor(int compressionLevel)
 		{
-			_compressionLevel = compressionLevel;
+			_compressionLevel = GetCompressionLevel(compressionLevel);
 		}
 
 		/// <inheritdoc />
@@ -35,7 +33,7 @@ namespace MongoDB.Driver.Core.Compression
 		{
 			using (var memoryStream = new MemoryStream())
 			{
-				using (var zlibStream = new Ionic.Zlib.ZlibStream(memoryStream, CompressionMode.Compress, GetCompressionLevel()))
+				using (var zlibStream = new Ionic.Zlib.ZlibStream(memoryStream, CompressionMode.Compress, _compressionLevel))
 				{
 					zlibStream.Write(bytesToCompress, offset, bytesToCompress.Length - offset);
 				}
@@ -59,15 +57,15 @@ namespace MongoDB.Driver.Core.Compression
 			}
 		}
 
-		private CompressionLevel GetCompressionLevel()
+		private static CompressionLevel GetCompressionLevel(int compressionLevel)
 		{
-			if (_compressionLevel < 0)
+			if (compressionLevel < 0)
 				return CompressionLevel.Default;
 
-			if (_compressionLevel > 9)
+			if (compressionLevel > 9)
 				return CompressionLevel.BestCompression;
 
-			return (CompressionLevel) _compressionLevel;
+			return (CompressionLevel) compressionLevel;
 		}
 	}
 }

--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilderExtensions.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilderExtensions.cs
@@ -120,6 +120,10 @@ namespace MongoDB.Driver.Core.Configuration
             {
                 builder = builder.ConfigureConnection(s => s.With(maxLifeTime: connectionString.MaxLifeTime.Value));
             }
+            if (connectionString.Compressors != null)
+            {
+                builder = builder.ConfigureConnection(s => s.With(compressors: Optional.Enumerable(connectionString.Compressors)));
+            }
 
             // Connection Pool
             if (connectionString.MaxPoolSize != null)

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionSettings.cs
@@ -37,7 +37,7 @@ namespace MongoDB.Driver.Core.Configuration
         private readonly IReadOnlyList<IAuthenticator> _authenticators;
         private readonly TimeSpan _maxIdleTime;
         private readonly TimeSpan _maxLifeTime;
-        private readonly IEnumerable<string> _compressors;
+        private readonly IEnumerable<MongoCompressor> _compressors;
 
         // constructors
         /// <summary>
@@ -50,13 +50,13 @@ namespace MongoDB.Driver.Core.Configuration
         /// <param name="applicationName">The application name.</param>
         public ConnectionSettings(
             Optional<IEnumerable<IAuthenticator>> authenticators = default(Optional<IEnumerable<IAuthenticator>>),
-            Optional<IEnumerable<string>> compressors = default(Optional<IEnumerable<string>>),
+            Optional<IEnumerable<MongoCompressor>> compressors = default(Optional<IEnumerable<MongoCompressor>>),
             Optional<TimeSpan> maxIdleTime = default(Optional<TimeSpan>),
             Optional<TimeSpan> maxLifeTime = default(Optional<TimeSpan>),
             Optional<string> applicationName = default(Optional<string>))
         {
             _authenticators = Ensure.IsNotNull(authenticators.WithDefault(__noAuthenticators), "authenticators").ToList();
-            _compressors = Ensure.IsNotNull(compressors.WithDefault(Enumerable.Empty<string>()), nameof(compressors)).ToList();
+            _compressors = Ensure.IsNotNull(compressors.WithDefault(Enumerable.Empty<MongoCompressor>()), nameof(compressors)).ToList();
             _maxIdleTime = Ensure.IsGreaterThanZero(maxIdleTime.WithDefault(TimeSpan.FromMinutes(10)), "maxIdleTime");
             _maxLifeTime = Ensure.IsGreaterThanZero(maxLifeTime.WithDefault(TimeSpan.FromMinutes(30)), "maxLifeTime");
             _applicationName = ApplicationNameHelper.EnsureApplicationNameIsValid(applicationName.WithDefault(null), nameof(applicationName));
@@ -110,7 +110,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// <summary>
         /// The compressors
         /// </summary>
-        public IEnumerable<string> Compressors
+        public IEnumerable<MongoCompressor> Compressors
         {
             get { return _compressors; }
         }
@@ -127,7 +127,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// <returns>A new ConnectionSettings instance.</returns>
         public ConnectionSettings With(
             Optional<IEnumerable<IAuthenticator>> authenticators = default(Optional<IEnumerable<IAuthenticator>>),
-            Optional<IEnumerable<string>> compressors = default(Optional<IEnumerable<string>>),
+            Optional<IEnumerable<MongoCompressor>> compressors = default(Optional<IEnumerable<MongoCompressor>>),
             Optional<TimeSpan> maxIdleTime = default(Optional<TimeSpan>),
             Optional<TimeSpan> maxLifeTime = default(Optional<TimeSpan>),
             Optional<string> applicationName = default(Optional<string>))

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionSettings.cs
@@ -37,22 +37,26 @@ namespace MongoDB.Driver.Core.Configuration
         private readonly IReadOnlyList<IAuthenticator> _authenticators;
         private readonly TimeSpan _maxIdleTime;
         private readonly TimeSpan _maxLifeTime;
+        private readonly IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionSettings" /> class.
         /// </summary>
         /// <param name="authenticators">The authenticators.</param>
+        /// <param name="compressors">The compressors</param>
         /// <param name="maxIdleTime">The maximum idle time.</param>
         /// <param name="maxLifeTime">The maximum life time.</param>
         /// <param name="applicationName">The application name.</param>
         public ConnectionSettings(
             Optional<IEnumerable<IAuthenticator>> authenticators = default(Optional<IEnumerable<IAuthenticator>>),
+            Optional<IEnumerable<string>> compressors = default(Optional<IEnumerable<string>>),
             Optional<TimeSpan> maxIdleTime = default(Optional<TimeSpan>),
             Optional<TimeSpan> maxLifeTime = default(Optional<TimeSpan>),
             Optional<string> applicationName = default(Optional<string>))
         {
             _authenticators = Ensure.IsNotNull(authenticators.WithDefault(__noAuthenticators), "authenticators").ToList();
+            _compressors = Ensure.IsNotNull(compressors.WithDefault(Enumerable.Empty<string>()), nameof(compressors)).ToList();
             _maxIdleTime = Ensure.IsGreaterThanZero(maxIdleTime.WithDefault(TimeSpan.FromMinutes(10)), "maxIdleTime");
             _maxLifeTime = Ensure.IsGreaterThanZero(maxLifeTime.WithDefault(TimeSpan.FromMinutes(30)), "maxLifeTime");
             _applicationName = ApplicationNameHelper.EnsureApplicationNameIsValid(applicationName.WithDefault(null), nameof(applicationName));
@@ -103,23 +107,34 @@ namespace MongoDB.Driver.Core.Configuration
             get { return _maxLifeTime; }
         }
 
+        /// <summary>
+        /// The compressors
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get { return _compressors; }
+        }
+
         // methods
         /// <summary>
         /// Returns a new ConnectionSettings instance with some settings changed.
         /// </summary>
         /// <param name="authenticators">The authenticators.</param>
+        /// <param name="compressors">The compressors.</param>
         /// <param name="maxIdleTime">The maximum idle time.</param>
         /// <param name="maxLifeTime">The maximum life time.</param>
         /// <param name="applicationName">The application name.</param>
         /// <returns>A new ConnectionSettings instance.</returns>
         public ConnectionSettings With(
             Optional<IEnumerable<IAuthenticator>> authenticators = default(Optional<IEnumerable<IAuthenticator>>),
+            Optional<IEnumerable<string>> compressors = default(Optional<IEnumerable<string>>),
             Optional<TimeSpan> maxIdleTime = default(Optional<TimeSpan>),
             Optional<TimeSpan> maxLifeTime = default(Optional<TimeSpan>),
             Optional<string> applicationName = default(Optional<string>))
         {
             return new ConnectionSettings(
                 authenticators: Optional.Enumerable(authenticators.WithDefault(_authenticators)),
+                compressors: Optional.Enumerable(compressors.WithDefault(_compressors)),
                 maxIdleTime: maxIdleTime.WithDefault(_maxIdleTime),
                 maxLifeTime: maxLifeTime.WithDefault(_maxLifeTime),
                 applicationName: applicationName.WithDefault(_applicationName));

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -712,9 +712,7 @@ namespace MongoDB.Driver.Core.Configuration
                     _authSource = value;
                     break;
                 case "compressors":
-                {
                     _compressors = value.Split(',');
-                }
                     break;
                 case "connect":
                     _connect = ParseClusterConnectionMode(name, value);
@@ -872,6 +870,11 @@ namespace MongoDB.Driver.Core.Configuration
                     _unknownOptions.Add(name, value);
                     break;
             }
+        }
+
+        private static IEnumerable<string> ParseCompressors(string value)
+        {
+            return value.Split(',');
         }
 
         // private static methods

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -712,7 +712,9 @@ namespace MongoDB.Driver.Core.Configuration
                     _authSource = value;
                     break;
                 case "compressors":
-                    _compressors = ParseCompressors(value);
+                {
+                    _compressors = value.Split(',');
+                }
                     break;
                 case "connect":
                     _connect = ParseClusterConnectionMode(name, value);
@@ -870,11 +872,6 @@ namespace MongoDB.Driver.Core.Configuration
                     _unknownOptions.Add(name, value);
                     break;
             }
-        }
-
-        private static IEnumerable<string> ParseCompressors(string value)
-        {
-            return value.Split(',');
         }
 
         // private static methods

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -872,11 +872,6 @@ namespace MongoDB.Driver.Core.Configuration
             }
         }
 
-        private static IEnumerable<string> ParseCompressors(string value)
-        {
-            return value.Split(',');
-        }
-
         // private static methods
         private static IEnumerable<KeyValuePair<string, string>> GetAuthMechanismProperties(string name, string value)
         {

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -639,7 +639,7 @@ namespace MongoDB.Driver.Core.Configuration
                 return;
             }
 
-            _compressors = new List<MongoCompressor>();
+            var compressors = new List<MongoCompressor>();
             
             foreach (var compressor in _compressorNames)
             {
@@ -650,13 +650,17 @@ namespace MongoDB.Driver.Core.Configuration
                     throw new MongoConfigurationException($"Unsupported compressor '{compressor}'.");
                 }
 
-                var mongoCompressor = new MongoCompressor { Name = compressor.ToLowerInvariant() };
+                var mongoCompressor = new MongoCompressor(compressor.ToLowerInvariant());
                 
-                if (id == CompressorId.zlib)
+                if (id == CompressorId.zlib && _zlibCompressionLevel.HasValue)
                 {
-                    mongoCompressor.Properties.Add(MongoCompressor.Level, _zlibCompressionLevel.GetValueOrDefault(-1));
+                    mongoCompressor.Properties.Add(MongoCompressor.Level, _zlibCompressionLevel.Value);
                 }
+
+                compressors.Add(mongoCompressor);
             }
+
+            _compressors = compressors;
         }
 
         private void ExtractUsernameAndPassword(Match match)

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -99,6 +99,7 @@ namespace MongoDB.Driver.Core.Configuration
         private TimeSpan? _waitQueueTimeout;
         private WriteConcern.WValue _w;
         private TimeSpan? _wTimeout;
+        private IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>
@@ -431,6 +432,14 @@ namespace MongoDB.Driver.Core.Configuration
             get { return _wTimeout; }
         }
 
+        /// <summary>
+        /// Gets the compressors that should be requested.
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get { return _compressors; }
+        }
+
         // public methods
         /// <summary>
         /// Gets the option.
@@ -702,6 +711,9 @@ namespace MongoDB.Driver.Core.Configuration
                 case "authsource":
                     _authSource = value;
                     break;
+                case "compressors":
+                    _compressors = ParseCompressors(value);
+                    break;
                 case "connect":
                     _connect = ParseClusterConnectionMode(name, value);
                     break;
@@ -858,6 +870,11 @@ namespace MongoDB.Driver.Core.Configuration
                     _unknownOptions.Add(name, value);
                     break;
             }
+        }
+
+        private static IEnumerable<string> ParseCompressors(string value)
+        {
+            return value.Split(',');
         }
 
         // private static methods

--- a/src/MongoDB.Driver.Core/Core/Configuration/MongoCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/MongoCompressor.cs
@@ -8,6 +8,16 @@ namespace MongoDB.Driver.Core.Configuration
 	public sealed class MongoCompressor
 	{
 		/// <summary>
+		/// Initializes an instance of <see cref="MongoCompressor"/>.
+		/// </summary>
+		/// <param name="name">Name of the compressor.</param>
+		public MongoCompressor(string name)
+		{
+			Name = name;
+			Properties = new Dictionary<string, object>();
+		}
+
+		/// <summary>
 		/// Key for the compression level
 		/// </summary>
 		public const string Level = "Level";
@@ -15,11 +25,11 @@ namespace MongoDB.Driver.Core.Configuration
 		/// <summary>
 		/// Name of the compressor
 		/// </summary>
-		public string Name { get; set; }
+		public string Name { get; }
 		
 		/// <summary>
 		/// Properties of the compressor
 		/// </summary>
-		public IDictionary<string, object> Properties { get; set; }
+		public IDictionary<string, object> Properties { get; }
 	}
 }

--- a/src/MongoDB.Driver.Core/Core/Configuration/MongoCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/MongoCompressor.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace MongoDB.Driver.Core.Configuration
+{
+	/// <summary>
+	/// Describes a compressor.
+	/// </summary>
+	public sealed class MongoCompressor
+	{
+		/// <summary>
+		/// Key for the compression level
+		/// </summary>
+		public const string Level = "Level";
+		
+		/// <summary>
+		/// Name of the compressor
+		/// </summary>
+		public string Name { get; set; }
+		
+		/// <summary>
+		/// Properties of the compressor
+		/// </summary>
+		public IDictionary<string, object> Properties { get; set; }
+	}
+}

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -20,10 +20,15 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Driver.Core.Async;
+using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
@@ -73,8 +78,12 @@ namespace MongoDB.Driver.Core.Connections
         private readonly Action<ConnectionSentMessagesEvent> _sentMessagesEventHandler;
         private readonly Action<ConnectionSendingMessagesFailedEvent> _failedSendingMessagesEvent;
 
+        protected IDictionary<CompressorId, ICompressor> _compressorDictionary;
+        
+        private ICompressor _sendCompressor;
+        
         // constructors
-        public BinaryConnection(ServerId serverId, EndPoint endPoint, ConnectionSettings settings, IStreamFactory streamFactory, IConnectionInitializer connectionInitializer, IEventSubscriber eventSubscriber)
+        public BinaryConnection(ServerId serverId, EndPoint endPoint, ConnectionSettings settings, IStreamFactory streamFactory, IConnectionInitializer connectionInitializer, IEventSubscriber eventSubscriber, IEnumerable<string> compressors)
         {
             Ensure.IsNotNull(serverId, nameof(serverId));
             _endPoint = Ensure.IsNotNull(endPoint, nameof(endPoint));
@@ -91,6 +100,8 @@ namespace MongoDB.Driver.Core.Connections
             _sendLock = new SemaphoreSlim(1);
             _state = new InterlockedInt32(State.Initial);
 
+            _compressorDictionary = CreateCompressorDictionary(compressors);
+            
             _commandEventHelper = new CommandEventHelper(eventSubscriber);
             eventSubscriber.TryGetEventHandler(out _failedEventHandler);
             eventSubscriber.TryGetEventHandler(out _closingEventHandler);
@@ -216,6 +227,37 @@ namespace MongoDB.Driver.Core.Connections
             }
         }
 
+        private IDictionary<CompressorId, ICompressor> CreateCompressorDictionary(IEnumerable<string> compressors)
+        {
+            var dictionary = new Dictionary<CompressorId, ICompressor>();
+            foreach (string compressor in compressors)
+            {
+                // TODO: Add compressionlevel
+                if (compressor == CompressorId.zlib.ToString())
+                {
+                    dictionary.Add(CompressorId.zlib, new ZlibCompressor());
+                }
+                
+
+                // TODO: throw exception when unsupported compressor
+            }
+
+            return dictionary;
+        }
+        
+        private ICompressor FindCompressor(IEnumerable<string> compression)
+        {
+            var firstCompressorName = compression.First();
+
+            foreach (var compressor in _compressorDictionary.Values)
+            {
+                if (compressor.Name == firstCompressorName)
+                    return compressor;
+            }
+
+            throw new MongoInternalException($"Unexpected compressor negotiated: {firstCompressorName}");
+        }
+        
         public void Open(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
@@ -277,6 +319,7 @@ namespace MongoDB.Driver.Core.Connections
                 _stream = _streamFactory.CreateStream(_endPoint, cancellationToken);
                 helper.InitializingConnection();
                 _description = _connectionInitializer.InitializeConnection(this, cancellationToken);
+                _sendCompressor = FindCompressor(_description.Compression);
                 helper.OpenedConnection();
             }
             catch (Exception ex)
@@ -296,6 +339,7 @@ namespace MongoDB.Driver.Core.Connections
                 _stream = await _streamFactory.CreateStreamAsync(_endPoint, cancellationToken).ConfigureAwait(false);
                 helper.InitializingConnection();
                 _description = await _connectionInitializer.InitializeConnectionAsync(this, cancellationToken).ConfigureAwait(false);
+                _sendCompressor = FindCompressor(_description.Compression);
                 helper.OpenedConnection();
             }
             catch (Exception ex)
@@ -437,7 +481,7 @@ namespace MongoDB.Driver.Core.Connections
             Ensure.IsNotNull(encoderSelector, nameof(encoderSelector));
             ThrowIfDisposedOrNotOpen();
 
-            var helper = new ReceiveMessageHelper(this, responseTo, messageEncoderSettings);
+            var helper = new ReceiveMessageHelper(this, responseTo, messageEncoderSettings, _compressorDictionary);
             try
             {
                 helper.ReceivingMessage();
@@ -464,7 +508,7 @@ namespace MongoDB.Driver.Core.Connections
             Ensure.IsNotNull(encoderSelector, nameof(encoderSelector));
             ThrowIfDisposedOrNotOpen();
 
-            var helper = new ReceiveMessageHelper(this, responseTo, messageEncoderSettings);
+            var helper = new ReceiveMessageHelper(this, responseTo, messageEncoderSettings, _compressorDictionary);
             try
             {
                 helper.ReceivingMessage();
@@ -545,7 +589,7 @@ namespace MongoDB.Driver.Core.Connections
             Ensure.IsNotNull(messages, nameof(messages));
             ThrowIfDisposedOrNotOpen();
 
-            var helper = new SendMessagesHelper(this, messages, messageEncoderSettings);
+            var helper = new SendMessagesHelper(this, messages, messageEncoderSettings, _sendCompressor);
             try
             {
                 helper.EncodingMessages();
@@ -568,7 +612,7 @@ namespace MongoDB.Driver.Core.Connections
             Ensure.IsNotNull(messages, nameof(messages));
             ThrowIfDisposedOrNotOpen();
 
-            var helper = new SendMessagesHelper(this, messages, messageEncoderSettings);
+            var helper = new SendMessagesHelper(this, messages, messageEncoderSettings, _sendCompressor);
             try
             {
                 helper.EncodingMessages();
@@ -747,15 +791,17 @@ namespace MongoDB.Driver.Core.Connections
             private readonly BinaryConnection _connection;
             private TimeSpan _deserializationDuration;
             private readonly MessageEncoderSettings _messageEncoderSettings;
+            private readonly IDictionary<CompressorId, ICompressor> _compressorDictionary;
             private TimeSpan _networkDuration;
             private int _responseTo;
             private Stopwatch _stopwatch;
 
-            public ReceiveMessageHelper(BinaryConnection connection, int responseTo, MessageEncoderSettings messageEncoderSettings)
+            public ReceiveMessageHelper(BinaryConnection connection, int responseTo, MessageEncoderSettings messageEncoderSettings, IDictionary<CompressorId, ICompressor> compressorDictionary)
             {
                 _connection = connection;
                 _responseTo = responseTo;
                 _messageEncoderSettings = messageEncoderSettings;
+                _compressorDictionary = compressorDictionary;
             }
 
             public ResponseMessage DecodeMessage(IByteBuffer buffer, IMessageEncoderSelector encoderSelector, CancellationToken cancellationToken)
@@ -769,14 +815,84 @@ namespace MongoDB.Driver.Core.Connections
                 _stopwatch.Restart();
                 using (var stream = new ByteBufferStream(buffer, ownsBuffer: false))
                 {
-                    var encoderFactory = new BinaryMessageEncoderFactory(stream, _messageEncoderSettings);
-                    var encoder = encoderSelector.GetEncoder(encoderFactory);
-                    message = (ResponseMessage)encoder.ReadMessage();
+                    if (IsCompressedResponse(stream))
+                    {
+                        message = ReadCompressedResponseMessage(encoderSelector, stream);
+                    }
+                    else
+                    {
+                        message = ReadResponseMessage(encoderSelector, stream);
+                    }
                 }
                 _stopwatch.Stop();
                 _deserializationDuration = _stopwatch.Elapsed;
 
                 return message;
+            }
+
+            private ResponseMessage ReadCompressedResponseMessage(IMessageEncoderSelector encoderSelector, ByteBufferStream stream)
+            {
+                var compressedMessageLength = stream.ReadInt32();
+                var requestId = stream.ReadInt32();
+                var responseTo = stream.ReadInt32();
+                stream.ReadInt32(); //OP_COMPRESSED
+
+                var originalOpCode = (Opcode) stream.ReadInt32();
+                var originalMessageSize = stream.ReadInt32();
+                var compressorId = (CompressorId) stream.ReadByte();
+
+                var compressor = GetCompressor(compressorId);
+                
+                var compressedBytes = stream.ReadBytes(compressedMessageLength - (int) stream.Position);
+
+                var uncompressedBytes = compressor.Decompress(compressedBytes);
+
+                using (var memStream = new MemoryStream())
+                {
+                    using (var writer = new BinaryWriter(memStream, Encoding.Default, true))
+                    {
+                        writer.Write(originalMessageSize + 16);
+                        writer.Write(requestId);
+                        writer.Write(responseTo);
+                        writer.Write((int)originalOpCode);
+                        
+                        writer.Write(uncompressedBytes);
+                    }
+
+                    var buffer = new ByteArrayBuffer(memStream.ToArray());
+                    buffer.MakeReadOnly();
+                    return ReadResponseMessage(encoderSelector, new ByteBufferStream(buffer));
+                }
+            }
+
+            private ICompressor GetCompressor(CompressorId compressorId)
+            {
+                ICompressor compressor;
+
+                if (_compressorDictionary.TryGetValue(compressorId, out compressor))
+                    return compressor;
+                
+                throw new MongoClientException($"Unsupported compressor with identifier {(int)compressorId}");
+            }
+
+            private bool IsCompressedResponse(BsonStream stream)
+            {
+                // Skip header to opcode
+                stream.ReadInt32();
+                stream.ReadInt32();
+                stream.ReadInt32();
+                var isCompressed = stream.ReadInt32() == (int)Opcode.Compressed;
+
+                stream.Position = 0;
+                
+                return isCompressed;
+            }
+
+            private ResponseMessage ReadResponseMessage(IMessageEncoderSelector encoderSelector, ByteBufferStream stream)
+            {
+                var encoderFactory = new BinaryMessageEncoderFactory(stream, _messageEncoderSettings);
+                var encoder = encoderSelector.GetEncoder(encoderFactory);
+                return (ResponseMessage) encoder.ReadMessage();
             }
 
             public void FailedReceivingMessage(Exception exception)
@@ -821,19 +937,35 @@ namespace MongoDB.Driver.Core.Connections
 
         private class SendMessagesHelper
         {
+            private static readonly HashSet<string> SecuritySensitiveCommands = new HashSet<string>
+            {
+                "isMaster",
+                "saslStart",
+                "saslContinue",
+                "getnonce",
+                "authenticate",
+                "createUser",
+                "updateUser",
+                "copydbsaslstart",
+                "copydbgetnonce",
+                "copydb"
+            }; 
+            
             private readonly Stopwatch _commandStopwatch;
             private readonly BinaryConnection _connection;
             private readonly MessageEncoderSettings _messageEncoderSettings;
+            private readonly ICompressor _sendCompressor;
             private readonly List<RequestMessage> _messages;
             private Lazy<List<int>> _requestIds;
             private TimeSpan _serializationDuration;
             private Stopwatch _networkStopwatch;
 
-            public SendMessagesHelper(BinaryConnection connection, IEnumerable<RequestMessage> messages, MessageEncoderSettings messageEncoderSettings)
+            public SendMessagesHelper(BinaryConnection connection, IEnumerable<RequestMessage> messages, MessageEncoderSettings messageEncoderSettings, ICompressor sendCompressor)
             {
                 _connection = connection;
                 _messages = messages.ToList();
                 _messageEncoderSettings = messageEncoderSettings;
+                _sendCompressor = sendCompressor;
 
                 _commandStopwatch = Stopwatch.StartNew();
                 _requestIds = new Lazy<List<int>>(() => _messages.Select(m => m.RequestId).ToList());
@@ -851,18 +983,21 @@ namespace MongoDB.Driver.Core.Connections
                     var encoderFactory = new BinaryMessageEncoderFactory(stream, _messageEncoderSettings);
                     foreach (var message in _messages)
                     {
-                        if (message.ShouldBeSent == null || message.ShouldBeSent())
+                        if (_sendCompressor == null || !MessageCanBeCompressed(message))
                         {
-                            var encoder = message.GetEncoder(encoderFactory);
-                            encoder.WriteMessage(message);
-                            message.WasSent = true;
+                            EncodeMessage(message, encoderFactory);
                         }
-
+                        else
+                        {
+                            EncodeMessageWithCompression(message, encoderFactory);
+                        }
+                        
                         // Encoding messages includes serializing the
                         // documents, so encoding message could be expensive
                         // and worthy of us honoring cancellation here.
                         cancellationToken.ThrowIfCancellationRequested();
                     }
+
                     buffer.Length = (int)stream.Length;
                     buffer.MakeReadOnly();
                 }
@@ -870,6 +1005,68 @@ namespace MongoDB.Driver.Core.Connections
                 _serializationDuration = serializationStopwatch.Elapsed;
 
                 return buffer;
+            }
+
+            private void EncodeMessageWithCompression(RequestMessage message, IMessageEncoderFactory encoderFactory)
+            {
+                if (message.ShouldBeSent != null
+                    && !message.ShouldBeSent())
+                {
+                    return;
+                }
+                
+                var compressedMessage = new CompressedMessage(message, _sendCompressor);
+                var encoder = compressedMessage.GetEncoder(encoderFactory);
+                encoder.WriteMessage(compressedMessage);
+                
+                message.WasSent = true;
+            }
+
+            private bool MessageCanBeCompressed(RequestMessage message)
+            {
+                if (IsLegacyRequestMessage(message))
+                {
+                    return false;
+                }
+
+                if (IsSecuritySensitiveCommand((CommandRequestMessage) message))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            private bool IsSecuritySensitiveCommand(CommandRequestMessage message)
+            {
+                var section = message.WrappedMessage.Sections.OfType<Type0CommandMessageSection<BsonDocument>>().First();
+
+                var firstKey = section.Document.First().Name;
+
+                if (SecuritySensitiveCommands.Contains(firstKey))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            private static bool IsLegacyRequestMessage(RequestMessage message)
+            {
+                return !(message is CommandRequestMessage);
+            }
+
+            private static void EncodeMessage(RequestMessage message, IMessageEncoderFactory encoderFactory)
+            {
+                if (message.ShouldBeSent != null
+                    && !message.ShouldBeSent())
+                {
+                    return;
+                }
+                
+                var encoder = message.GetEncoder(encoderFactory);
+                encoder.WriteMessage(message);
+                message.WasSent = true;
             }
 
             public void EncodingMessages()

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -78,12 +78,12 @@ namespace MongoDB.Driver.Core.Connections
         private readonly Action<ConnectionSentMessagesEvent> _sentMessagesEventHandler;
         private readonly Action<ConnectionSendingMessagesFailedEvent> _failedSendingMessagesEvent;
 
-        protected IDictionary<CompressorId, ICompressor> _compressorDictionary;
+        private readonly IDictionary<CompressorId, ICompressor> _compressorDictionary;
         
         private ICompressor _sendCompressor;
         
         // constructors
-        public BinaryConnection(ServerId serverId, EndPoint endPoint, ConnectionSettings settings, IStreamFactory streamFactory, IConnectionInitializer connectionInitializer, IEventSubscriber eventSubscriber, IEnumerable<MongoCompressor> compressors)
+        public BinaryConnection(ServerId serverId, EndPoint endPoint, ConnectionSettings settings, IStreamFactory streamFactory, IConnectionInitializer connectionInitializer, IEventSubscriber eventSubscriber)
         {
             Ensure.IsNotNull(serverId, nameof(serverId));
             _endPoint = Ensure.IsNotNull(endPoint, nameof(endPoint));
@@ -100,7 +100,7 @@ namespace MongoDB.Driver.Core.Connections
             _sendLock = new SemaphoreSlim(1);
             _state = new InterlockedInt32(State.Initial);
 
-            _compressorDictionary = CreateCompressorDictionary(compressors);
+            _compressorDictionary = CreateCompressorDictionary(settings.Compressors);
             
             _commandEventHelper = new CommandEventHelper(eventSubscriber, _compressorDictionary);
             eventSubscriber.TryGetEventHandler(out _failedEventHandler);

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -250,7 +250,7 @@ namespace MongoDB.Driver.Core.Connections
                 return new ZlibCompressor(zlibCompressionLevel ?? -1);
             }
             
-            throw new MongoInternalException($"Unsupported compressor: {compressor.Name}");
+            throw new MongoInternalException($"Unsupported compressor: {compressor.Name}.");
         }
 
         private ICompressor FindCompressor(IEnumerable<string> compression)
@@ -268,7 +268,7 @@ namespace MongoDB.Driver.Core.Connections
                     return compressor;
             }
 
-            throw new MongoInternalException($"Unexpected compressor negotiated: {firstCompressorName}");
+            throw new MongoInternalException($"Unexpected compressor negotiated: {firstCompressorName}.");
         }
         
         public void Open(CancellationToken cancellationToken)

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnectionFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnectionFactory.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Core.Connections
             _settings = Ensure.IsNotNull(settings, nameof(settings));
             _streamFactory = Ensure.IsNotNull(streamFactory, nameof(streamFactory));
             _eventSubscriber = Ensure.IsNotNull(eventSubscriber, nameof(eventSubscriber));
-            _connectionInitializer = new ConnectionInitializer(settings.ApplicationName);
+            _connectionInitializer = new ConnectionInitializer(settings.ApplicationName, settings.Compressors);
         }
 
         // methods

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnectionFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnectionFactory.cs
@@ -46,8 +46,8 @@ namespace MongoDB.Driver.Core.Connections
         {
             Ensure.IsNotNull(serverId, nameof(serverId));
             Ensure.IsNotNull(endPoint, nameof(endPoint));
-            // TODO: use configured value
-            return new BinaryConnection(serverId, endPoint, _settings, _streamFactory, _connectionInitializer, _eventSubscriber, _settings.Compressors);
+
+            return new BinaryConnection(serverId, endPoint, _settings, _streamFactory, _connectionInitializer, _eventSubscriber);
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnectionFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnectionFactory.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System.Collections.Generic;
 using System.Net;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
@@ -48,7 +47,7 @@ namespace MongoDB.Driver.Core.Connections
             Ensure.IsNotNull(serverId, nameof(serverId));
             Ensure.IsNotNull(endPoint, nameof(endPoint));
             // TODO: use configured value
-            return new BinaryConnection(serverId, endPoint, _settings, _streamFactory, _connectionInitializer, _eventSubscriber, new []{"zlib"});
+            return new BinaryConnection(serverId, endPoint, _settings, _streamFactory, _connectionInitializer, _eventSubscriber, _settings.Compressors);
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnectionFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnectionFactory.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Net;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
@@ -46,7 +47,8 @@ namespace MongoDB.Driver.Core.Connections
         {
             Ensure.IsNotNull(serverId, nameof(serverId));
             Ensure.IsNotNull(endPoint, nameof(endPoint));
-            return new BinaryConnection(serverId, endPoint, _settings, _streamFactory, _connectionInitializer, _eventSubscriber);
+            // TODO: use configured value
+            return new BinaryConnection(serverId, endPoint, _settings, _streamFactory, _connectionInitializer, _eventSubscriber, new []{"zlib"});
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
@@ -32,7 +32,7 @@ namespace MongoDB.Driver.Core.Connections
         private readonly int _maxBatchCount;
         private readonly int _maxDocumentSize;
         private readonly int _maxMessageSize;
-        private readonly IEnumerable<string> _compressors;
+        private readonly IEnumerable<string> _compression;
         private readonly SemanticVersion _serverVersion;
 
         // constructors
@@ -51,7 +51,7 @@ namespace MongoDB.Driver.Core.Connections
             _maxBatchCount = isMasterResult.MaxBatchCount;
             _maxDocumentSize = isMasterResult.MaxDocumentSize;
             _maxMessageSize = isMasterResult.MaxMessageSize;
-            _compressors = isMasterResult.Compressors;
+            _compression = isMasterResult.Compression;
             _serverVersion = buildInfoResult.ServerVersion;
         }
 
@@ -147,9 +147,9 @@ namespace MongoDB.Driver.Core.Connections
         /// <summary>
         /// Gets the compressors.
         /// </summary>
-        public IEnumerable<string> Compressors
+        public IEnumerable<string> Compression
         {
-            get { return _compressors; }
+            get { return _compression; }
         }
 
         // methods

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
@@ -33,6 +33,7 @@ namespace MongoDB.Driver.Core.Connections
         private readonly int _maxDocumentSize;
         private readonly int _maxMessageSize;
         private readonly IEnumerable<string> _compression;
+        private readonly IEnumerable<string> _compressors;
         private readonly SemanticVersion _serverVersion;
 
         // constructors
@@ -142,6 +143,14 @@ namespace MongoDB.Driver.Core.Connections
         public SemanticVersion ServerVersion
         {
             get { return _serverVersion; }
+        }
+
+        /// <summary>
+        /// Gets the compressors.
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get { return _compressors; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Shared;
 
@@ -31,6 +32,7 @@ namespace MongoDB.Driver.Core.Connections
         private readonly int _maxBatchCount;
         private readonly int _maxDocumentSize;
         private readonly int _maxMessageSize;
+        private readonly IEnumerable<string> _compressors;
         private readonly SemanticVersion _serverVersion;
 
         // constructors
@@ -49,6 +51,7 @@ namespace MongoDB.Driver.Core.Connections
             _maxBatchCount = isMasterResult.MaxBatchCount;
             _maxDocumentSize = isMasterResult.MaxDocumentSize;
             _maxMessageSize = isMasterResult.MaxMessageSize;
+            _compressors = isMasterResult.Compressors;
             _serverVersion = buildInfoResult.ServerVersion;
         }
 
@@ -139,6 +142,14 @@ namespace MongoDB.Driver.Core.Connections
         public SemanticVersion ServerVersion
         {
             get { return _serverVersion; }
+        }
+
+        /// <summary>
+        /// Gets the compressors.
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get { return _compressors; }
         }
 
         // methods

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
@@ -33,7 +33,6 @@ namespace MongoDB.Driver.Core.Connections
         private readonly int _maxDocumentSize;
         private readonly int _maxMessageSize;
         private readonly IEnumerable<string> _compression;
-        private readonly IEnumerable<string> _compressors;
         private readonly SemanticVersion _serverVersion;
 
         // constructors
@@ -143,14 +142,6 @@ namespace MongoDB.Driver.Core.Connections
         public SemanticVersion ServerVersion
         {
             get { return _serverVersion; }
-        }
-
-        /// <summary>
-        /// Gets the compressors.
-        /// </summary>
-        public IEnumerable<string> Compressors
-        {
-            get { return _compressors; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
@@ -16,6 +16,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
@@ -30,11 +46,13 @@ namespace MongoDB.Driver.Core.Connections
     /// </summary>
     internal class ConnectionInitializer : IConnectionInitializer
     {
+        private readonly BsonArray _compressors;
         private readonly BsonDocument _clientDocument;
 
-        public ConnectionInitializer(string applicationName)
+        public ConnectionInitializer(string applicationName, IEnumerable<string> compressors)
         {
             _clientDocument = ClientDocumentHelper.CreateClientDocument(applicationName);
+            _compressors = new BsonArray(compressors);
         }
 
         public ConnectionDescription InitializeConnection(IConnection connection, CancellationToken cancellationToken)

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
@@ -143,6 +143,7 @@ namespace MongoDB.Driver.Core.Connections
         {
             var command = IsMasterHelper.CreateCommand();
             IsMasterHelper.AddClientDocumentToCommand(command, _clientDocument);
+            IsMasterHelper.AddCompressorsToCommand(command, _compressors);
             return IsMasterHelper.CustomizeCommand(command, authenticators);
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
@@ -37,6 +37,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Authentication;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.WireProtocol;
 
 namespace MongoDB.Driver.Core.Connections
@@ -46,13 +47,13 @@ namespace MongoDB.Driver.Core.Connections
     /// </summary>
     internal class ConnectionInitializer : IConnectionInitializer
     {
-        private readonly BsonArray _compressors;
+        private readonly IEnumerable<MongoCompressor> _compressors;
         private readonly BsonDocument _clientDocument;
 
-        public ConnectionInitializer(string applicationName, IEnumerable<string> compressors)
+        public ConnectionInitializer(string applicationName, IEnumerable<MongoCompressor> compressors)
         {
             _clientDocument = ClientDocumentHelper.CreateClientDocument(applicationName);
-            _compressors = new BsonArray(compressors);
+            _compressors = compressors;
         }
 
         public ConnectionDescription InitializeConnection(IConnection connection, CancellationToken cancellationToken)
@@ -145,7 +146,7 @@ namespace MongoDB.Driver.Core.Connections
             return IsMasterHelper.CustomizeCommand(command, authenticators);
         }
 
-        private ConnectionDescription UpdateConnectionIdWithServerValue(ConnectionDescription description, BsonDocument getLastErrorResult)
+        private static ConnectionDescription UpdateConnectionIdWithServerValue(ConnectionDescription description, BsonDocument getLastErrorResult)
         {
             BsonValue connectionIdBsonValue;
             if (getLastErrorResult.TryGetValue("connectionId", out connectionIdBsonValue))

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterHelper.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Authentication;
+using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.WireProtocol;
 
 namespace MongoDB.Driver.Core.Connections
@@ -31,12 +32,19 @@ namespace MongoDB.Driver.Core.Connections
         {
             return command.Add("client", clientDocument, clientDocument != null); 
         }
-        
+
+        internal static BsonDocument AddCompressorsToCommand(BsonDocument command, IEnumerable<MongoCompressor> compressors)
+        {
+            var compressorsArray = new BsonArray(compressors.Select(x => x.Name));
+
+            return command.Add("compression", compressorsArray);
+        }
+
         internal static BsonDocument CreateCommand()
         {
             return new BsonDocument { { "isMaster", 1 } };
         }
-        
+
         internal static BsonDocument CustomizeCommand(BsonDocument command, IReadOnlyList<IAuthenticator> authenticators)
         {
             return authenticators.Count == 1 ? authenticators[0].CustomizeInitialIsMasterCommand(command) : command;
@@ -51,7 +59,7 @@ namespace MongoDB.Driver.Core.Connections
                 resultSerializer: BsonDocumentSerializer.Instance,
                 messageEncoderSettings: null);
         }
-        
+
         internal static IsMasterResult GetResult(
             IConnection connection,
             CommandWireProtocol<BsonDocument> isMasterProtocol,
@@ -69,7 +77,7 @@ namespace MongoDB.Driver.Core.Connections
                 throw new MongoAuthenticationException(connection.ConnectionId, "User not found.", ex);
             }
         }
-        
+
         internal static async Task<IsMasterResult> GetResultAsync(
             IConnection connection,
             CommandWireProtocol<BsonDocument> isMasterProtocol,

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -40,6 +40,7 @@ namespace MongoDB.Driver.Core.Connections
         public IsMasterResult(BsonDocument wrapped)
         {
             _wrapped = Ensure.IsNotNull(wrapped, nameof(wrapped));
+            Console.WriteLine(_wrapped);
         }
 
         // properties
@@ -280,6 +281,19 @@ namespace MongoDB.Driver.Core.Connections
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get
+            {
+                var arr = _wrapped.GetValue("compression").AsBsonArray;
+
+                return arr.Select(x => x.AsString);
+            }
+        }
+        
         /// <summary>
         /// Gets the replica set tags.
         /// </summary>

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -291,7 +291,7 @@ namespace MongoDB.Driver.Core.Connections
                 BsonValue value;
                 if (_wrapped.TryGetValue("compression", out value))
                 {
-                    return value.AsBsonArray.Select(x => x.AsString);
+                    return value.AsBsonArray.Select(x => x.AsString).ToList();
                 }
 
                 return Enumerable.Empty<string>();

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -40,7 +40,6 @@ namespace MongoDB.Driver.Core.Connections
         public IsMasterResult(BsonDocument wrapped)
         {
             _wrapped = Ensure.IsNotNull(wrapped, nameof(wrapped));
-            Console.WriteLine(_wrapped);
         }
 
         // properties

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -305,9 +305,13 @@ namespace MongoDB.Driver.Core.Connections
         {
             get
             {
-                var arr = _wrapped.GetValue("compression").AsBsonArray;
+                BsonValue value;
+                if (_wrapped.TryGetValue("compression", out value))
+                {
+                    return value.AsBsonArray.Select(x => x.AsString);
+                }
 
-                return arr.Select(x => x.AsString);
+                return Enumerable.Empty<string>();
             }
         }
         

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -284,7 +284,7 @@ namespace MongoDB.Driver.Core.Connections
         /// <summary>
         /// 
         /// </summary>
-        public IEnumerable<string> Compressors
+        public IEnumerable<string> Compression
         {
             get
             {

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -297,23 +297,6 @@ namespace MongoDB.Driver.Core.Connections
                 return Enumerable.Empty<string>();
             }
         }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public IEnumerable<string> Compressors
-        {
-            get
-            {
-                BsonValue value;
-                if (_wrapped.TryGetValue("compression", out value))
-                {
-                    return value.AsBsonArray.Select(x => x.AsString);
-                }
-
-                return Enumerable.Empty<string>();
-            }
-        }
         
         /// <summary>
         /// Gets the replica set tags.

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -41,6 +41,7 @@ namespace MongoDB.Driver.Core.Connections
         public IsMasterResult(BsonDocument wrapped)
         {
             _wrapped = Ensure.IsNotNull(wrapped, nameof(wrapped));
+            Console.WriteLine(_wrapped);
         }
 
         // properties
@@ -295,6 +296,19 @@ namespace MongoDB.Driver.Core.Connections
                 }
 
                 return Enumerable.Empty<string>();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get
+            {
+                var arr = _wrapped.GetValue("compression").AsBsonArray;
+
+                return arr.Select(x => x.AsString);
             }
         }
         

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Misc;
@@ -287,9 +288,13 @@ namespace MongoDB.Driver.Core.Connections
         {
             get
             {
-                var arr = _wrapped.GetValue("compression").AsBsonArray;
+                BsonValue value;
+                if (_wrapped.TryGetValue("compression", out value))
+                {
+                    return value.AsBsonArray.Select(x => x.AsString);
+                }
 
-                return arr.Select(x => x.AsString);
+                return Enumerable.Empty<string>();
             }
         }
         

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -41,7 +41,6 @@ namespace MongoDB.Driver.Core.Connections
         public IsMasterResult(BsonDocument wrapped)
         {
             _wrapped = Ensure.IsNotNull(wrapped, nameof(wrapped));
-            Console.WriteLine(_wrapped);
         }
 
         // properties

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CompressedMessage.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CompressedMessage.cs
@@ -1,4 +1,19 @@
-﻿using MongoDB.Driver.Core.Compression;
+﻿/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
 
 namespace MongoDB.Driver.Core.WireProtocol.Messages

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CompressedMessage.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CompressedMessage.cs
@@ -7,7 +7,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
 	/// Represents a compressed message.
 	/// </summary>
 	/// <seealso cref="MongoDB.Driver.Core.WireProtocol.Messages.MongoDBMessage" />
-	public sealed class CompressedMessage : MongoDBMessage
+	public class CompressedMessage : MongoDBMessage
 	{
 		private readonly MongoDBMessage _messageToBeCompressed;
 		private readonly ICompressor _compressor;

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CompressedMessage.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CompressedMessage.cs
@@ -1,0 +1,50 @@
+﻿using MongoDB.Driver.Core.Compression;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
+
+namespace MongoDB.Driver.Core.WireProtocol.Messages
+{
+	/// <summary>
+	/// Represents a compressed message.
+	/// </summary>
+	/// <seealso cref="MongoDB.Driver.Core.WireProtocol.Messages.MongoDBMessage" />
+	public sealed class CompressedMessage : MongoDBMessage
+	{
+		private readonly MongoDBMessage _messageToBeCompressed;
+		private readonly ICompressor _compressor;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CompressedMessage"/> class.
+		/// </summary>
+		/// <param name="messageToBeCompressed">The message to be compressed.</param>
+		/// <param name="compressor">The compressor.</param>
+		public CompressedMessage(MongoDBMessage messageToBeCompressed, ICompressor compressor)
+		{
+			_messageToBeCompressed = messageToBeCompressed;
+			_compressor = compressor;
+		}
+
+		/// <summary>
+		/// Gets the type of the message.
+		/// </summary>
+		public override MongoDBMessageType MessageType => MongoDBMessageType.Compressed;
+
+		/// <summary>
+		/// The message that should be compressed.
+		/// </summary>
+		public MongoDBMessage MessageToBeCompressed => _messageToBeCompressed;
+
+		/// <summary>
+		/// The compressor
+		/// </summary>
+		public ICompressor Compressor
+		{
+			get { return _compressor; }
+		}
+
+		/// <inheritdoc/>
+		public override IMessageEncoder GetEncoder(IMessageEncoderFactory encoderFactory)
+		{
+			return encoderFactory.GetCompressedMessageEncoder();
+		}
+	}
+}

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/BinaryMessageEncoderFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/BinaryMessageEncoderFactory.cs
@@ -16,6 +16,7 @@
 using System.IO;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
+using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
@@ -102,6 +103,12 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         public IMessageEncoder GetUpdateMessageEncoder()
         {
             return new UpdateMessageBinaryEncoder(_stream, _encoderSettings);
+        }
+
+        /// <inheritdoc />
+        public IMessageEncoder GetCompressedMessageEncoder()
+        {
+            return new CompressedMessageBinaryEncoder(_stream, _encoderSettings);
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CompressedMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CompressedMessageBinaryEncoder.cs
@@ -1,4 +1,20 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using MongoDB.Bson.IO;
 using MongoDB.Driver.Core.Compression;
@@ -31,7 +47,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
 		/// <returns>A message.</returns>
 		public CompressedMessage ReadMessage()
 		{
-			return null;
+			throw new NotSupportedException();
 		}
 		
 		/// <summary>

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CompressedMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CompressedMessageBinaryEncoder.cs
@@ -1,0 +1,103 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using MongoDB.Bson.IO;
+using MongoDB.Driver.Core.Compression;
+using MongoDB.Driver.Core.Misc;
+
+namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
+{
+	/// <summary>
+	/// Represents a binary encoder for a compressed message.
+	/// </summary>
+	public sealed class CompressedMessageBinaryEncoder : MessageBinaryEncoderBase, IMessageEncoder
+	{
+		private readonly MessageEncoderSettings _encoderSettings;
+		private const int MessageHeaderLength = 16;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CompressedMessageBinaryEncoder" /> class.
+		/// </summary>
+		/// <param name="stream">The stream.</param>
+		/// <param name="encoderSettings">The encoder settings.</param>
+		public CompressedMessageBinaryEncoder(Stream stream, MessageEncoderSettings encoderSettings)
+			: base(stream, encoderSettings)
+		{
+			_encoderSettings = encoderSettings;
+		}
+
+		/// <summary>
+		/// Reads the message.
+		/// </summary>
+		/// <returns>A message.</returns>
+		public CompressedMessage ReadMessage()
+		{
+			return null;
+		}
+		
+		/// <summary>
+		/// Writes the message.
+		/// </summary>
+		/// <param name="message">The message.</param>
+		public void WriteMessage(CompressedMessage message)
+		{
+			Ensure.IsNotNull(message, nameof(message));
+
+			var writer = CreateBinaryWriter();
+			var stream = writer.BsonStream;
+			var messageStartPosition = stream.Position;
+
+			var originalMessageBytes = EncodeOriginalMessage(message.MessageToBeCompressed);
+
+			WriteHeader(stream, originalMessageBytes, message.Compressor.Id);
+			var compressedBytes = message.Compressor.Compress(originalMessageBytes, MessageHeaderLength);
+
+			stream.Write(compressedBytes, 0, compressedBytes.Length);
+			
+			stream.BackpatchSize(messageStartPosition);
+		}
+
+		[SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
+		private static void WriteHeader(BsonStream bsonStream, byte[] originalMessageBytes, CompressorId compressorId)
+		{
+			using (var stream = new MemoryStream(originalMessageBytes))
+			using (var reader = new BinaryReader(stream))
+			{
+				var messageSize = reader.ReadInt32();
+				var messageRequestId = reader.ReadInt32();
+				var responseTo = reader.ReadInt32();
+				var originalOpCode = reader.ReadInt32();
+				
+				bsonStream.WriteInt32(0); // Compressed message size
+				bsonStream.WriteInt32(messageRequestId);
+				bsonStream.WriteInt32(responseTo);
+				bsonStream.WriteInt32((int)Opcode.Compressed);
+				bsonStream.WriteInt32(originalOpCode);
+				bsonStream.WriteInt32(messageSize - MessageHeaderLength);
+				bsonStream.WriteByte((byte)compressorId);
+			}
+		}
+
+		private byte[] EncodeOriginalMessage(MongoDBMessage originalMessage)
+		{
+			using (var stream = new MemoryStream())
+			{
+				var encoderFactory = new BinaryMessageEncoderFactory(stream, _encoderSettings);
+
+				var encoder = originalMessage.GetEncoder(encoderFactory);
+				encoder.WriteMessage(originalMessage);
+				
+				return stream.ToArray();
+			}
+		}
+		
+		MongoDBMessage IMessageEncoder.ReadMessage()
+		{
+			return ReadMessage();
+		}
+		
+		void IMessageEncoder.WriteMessage(MongoDBMessage message)
+		{
+			WriteMessage((CompressedMessage)message);
+		}
+	}
+}

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/Opcode.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/Opcode.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         GetMore = 2005,
         Delete = 2006,
         KillCursors = 2007,
+        Compressed = 2012,
         OpMsg = 2013
     }
 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/IMessageEncoderFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/IMessageEncoderFactory.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using MongoDB.Bson.Serialization;
+using MongoDB.Driver.Core.Compression;
 
 namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders
 {
@@ -90,5 +91,11 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders
         /// </summary>
         /// <returns>An encoder.</returns>
         IMessageEncoder GetUpdateMessageEncoder();
+
+        /// <summary>
+        /// Gets an encoder for a Compressed message.
+        /// </summary>
+        /// <returns>An encoder.</returns>
+        IMessageEncoder GetCompressedMessageEncoder();
     }
 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/JsonEncoders/JsonMessageEncoderFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/JsonEncoders/JsonMessageEncoderFactory.cs
@@ -126,5 +126,11 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.JsonEncoders
         {
             return new UpdateMessageJsonEncoder(_textReader, _textWriter, _encoderSettings);
         }
+
+        /// <inheritdoc />
+        public IMessageEncoder GetCompressedMessageEncoder()
+        {
+            throw new System.NotSupportedException();
+        }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/MongoDBMessageType.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/MongoDBMessageType.cs
@@ -52,6 +52,10 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         /// <summary>
         /// OP_UPDATE
         /// </summary>
-        Update
+        Update,
+        /// <summary>
+        /// OP_COMPRESSED
+        /// </summary>
+        Compressed,
     }
 }

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -39,6 +39,10 @@
     <Reference Include="DnsClient, Version=1.0.7.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
       <HintPath>..\..\packages\DnsClient.1.0.7\lib\net45\DnsClient.dll</HintPath>
     </Reference>
+    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745">
+      <HintPath>..\..\Packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.3.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
@@ -119,6 +123,9 @@
     <Compile Include="Core\Bindings\CoreTransaction.cs" />
     <Compile Include="Core\Bindings\WrappingCoreServerSession.cs" />
     <Compile Include="Core\Bindings\WrappingCoreSession.cs" />
+    <Compile Include="Core\Compression\CompressorId.cs" />
+    <Compile Include="Core\Compression\ICompressor.cs" />
+    <Compile Include="Core\Compression\ZlibCompressor.cs" />
     <Compile Include="Core\Configuration\SdamLoggingSettings.cs" />
     <Compile Include="Core\Connections\ClientDocumentHelper.cs" />
     <Compile Include="Core\Connections\IsMasterHelper.cs" />
@@ -240,6 +247,8 @@
     <Compile Include="Core\WireProtocol\CommandUsingCommandMessageWireProtocol.cs" />
     <Compile Include="Core\WireProtocol\CommandUsingQueryMessageWireProtocol.cs" />
     <Compile Include="Core\WireProtocol\Messages\CommandMessageDisposer.cs" />
+    <Compile Include="Core\WireProtocol\Messages\CompressedMessage.cs" />
+    <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CompressedMessageBinaryEncoder.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\OpMsgFlags.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandMessageBinaryEncoder.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandRequestMessageBinaryEncoder.cs" />

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -39,8 +39,8 @@
     <Reference Include="DnsClient, Version=1.0.7.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
       <HintPath>..\..\packages\DnsClient.1.0.7\lib\net45\DnsClient.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745">
-      <HintPath>..\..\Packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="SharpCompress, Version=0.21.1.0, Culture=neutral, PublicKeyToken=afb0a02973931d96">
+      <HintPath>..\..\Packages\SharpCompress.0.21.1\lib\net45\SharpCompress.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -123,6 +123,7 @@
     <Compile Include="Core\Bindings\CoreTransaction.cs" />
     <Compile Include="Core\Bindings\WrappingCoreServerSession.cs" />
     <Compile Include="Core\Bindings\WrappingCoreSession.cs" />
+    <Compile Include="Core\Compression\MessageCompressionHelper.cs" />
     <Compile Include="Core\Compression\CompressorId.cs" />
     <Compile Include="Core\Compression\ICompressor.cs" />
     <Compile Include="Core\Compression\ZlibCompressor.cs" />

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -126,6 +126,7 @@
     <Compile Include="Core\Compression\CompressorId.cs" />
     <Compile Include="Core\Compression\ICompressor.cs" />
     <Compile Include="Core\Compression\ZlibCompressor.cs" />
+    <Compile Include="Core\Configuration\MongoCompressor.cs" />
     <Compile Include="Core\Configuration\SdamLoggingSettings.cs" />
     <Compile Include="Core\Connections\ClientDocumentHelper.cs" />
     <Compile Include="Core\Connections\IsMasterHelper.cs" />

--- a/src/MongoDB.Driver.Core/packages.config
+++ b/src/MongoDB.Driver.Core/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net45" developmentDependency="true" />
   <package id="Crc32C.NET" version="1.0.5.0" targetFramework="net45" />
   <package id="DnsClient" version="1.0.7" targetFramework="net45" />
-  <package id="DotNetZip" version="1.11.0" targetFramework="net45" />
+  <package id="SharpCompress" version="0.21.1" targetFramework="net45" />
   <package id="System.Buffers" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
 </packages>

--- a/src/MongoDB.Driver.Core/packages.config
+++ b/src/MongoDB.Driver.Core/packages.config
@@ -1,6 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net45" developmentDependency="true" />
+  <package id="Crc32C.NET" version="1.0.5.0" targetFramework="net45" />
   <package id="DnsClient" version="1.0.7" targetFramework="net45" />
   <package id="DotNetZip" version="1.11.0" targetFramework="net45" />
   <package id="System.Buffers" version="4.3.0" targetFramework="net45" />

--- a/src/MongoDB.Driver.Core/packages.config
+++ b/src/MongoDB.Driver.Core/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net45" developmentDependency="true" />
   <package id="DnsClient" version="1.0.7" targetFramework="net45" />
+  <package id="DotNetZip" version="1.11.0" targetFramework="net45" />
   <package id="System.Buffers" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
 </packages>

--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -34,7 +34,7 @@ namespace MongoDB.Driver
         // private fields
         private string _applicationName;
         private Action<ClusterBuilder> _clusterConfigurator;
-        private IEnumerable<string> _compressors;
+        private IEnumerable<MongoCompressor> _compressors;
         private ConnectionMode _connectionMode;
         private TimeSpan _connectTimeout;
         private MongoCredentialStore _credentials;
@@ -77,7 +77,7 @@ namespace MongoDB.Driver
         public MongoServerSettings()
         {
             _applicationName = null;
-            _compressors = Enumerable.Empty<string>();
+            _compressors = Enumerable.Empty<MongoCompressor>();
             _connectionMode = ConnectionMode.Automatic;
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _credentials = new MongoCredentialStore(new MongoCredential[0]);
@@ -587,7 +587,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the compressors.
         /// </summary>
-        public IEnumerable<string> Compressors
+        public IEnumerable<MongoCompressor> Compressors
         {
             get { return _compressors; }
             set

--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -34,6 +34,7 @@ namespace MongoDB.Driver
         // private fields
         private string _applicationName;
         private Action<ClusterBuilder> _clusterConfigurator;
+        private IEnumerable<string> _compressors;
         private ConnectionMode _connectionMode;
         private TimeSpan _connectTimeout;
         private MongoCredentialStore _credentials;
@@ -76,6 +77,7 @@ namespace MongoDB.Driver
         public MongoServerSettings()
         {
             _applicationName = null;
+            _compressors = Enumerable.Empty<string>();
             _connectionMode = ConnectionMode.Automatic;
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _credentials = new MongoCredentialStore(new MongoCredential[0]);
@@ -582,6 +584,19 @@ namespace MongoDB.Driver
             }
         }
 
+        /// <summary>
+        /// Gets or sets the compressors.
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get { return _compressors; }
+            set
+            {
+                if (_isFrozen) { throw new InvalidOperationException("MongoServerSettings is frozen."); }
+                _compressors = value;
+            }
+        }
+
         // public operators
         /// <summary>
         /// Determines whether two <see cref="MongoServerSettings"/> instances are equal.
@@ -620,6 +635,7 @@ namespace MongoDB.Driver
             var serverSettings = new MongoServerSettings();
             serverSettings.ApplicationName = clientSettings.ApplicationName;
             serverSettings.ClusterConfigurator = clientSettings.ClusterConfigurator;
+            serverSettings.Compressors = clientSettings.Compressors;
             serverSettings.ConnectionMode = clientSettings.ConnectionMode;
             serverSettings.ConnectTimeout = clientSettings.ConnectTimeout;
 #pragma warning disable 618
@@ -664,6 +680,7 @@ namespace MongoDB.Driver
 
             var serverSettings = new MongoServerSettings();
             serverSettings.ApplicationName = url.ApplicationName;
+            serverSettings.Compressors = url.Compressors;
             serverSettings.ConnectionMode = url.ConnectionMode;
             serverSettings.ConnectTimeout = url.ConnectTimeout;
             if (credential != null)
@@ -719,6 +736,7 @@ namespace MongoDB.Driver
             var clone = new MongoServerSettings();
             clone._applicationName = _applicationName;
             clone._clusterConfigurator = _clusterConfigurator;
+            clone._compressors = _compressors;
             clone._connectionMode = _connectionMode;
             clone._connectTimeout = _connectTimeout;
             clone._credentials = _credentials;
@@ -777,6 +795,7 @@ namespace MongoDB.Driver
             return
                 _applicationName == rhs._applicationName &&
                 object.ReferenceEquals(_clusterConfigurator, rhs._clusterConfigurator) &&
+                _compressors == rhs._compressors &&
                _connectionMode == rhs._connectionMode &&
                _connectTimeout == rhs._connectTimeout &&
                _credentials == rhs._credentials &&
@@ -853,6 +872,7 @@ namespace MongoDB.Driver
             return new Hasher()
                 .Hash(_applicationName)
                 .Hash(_clusterConfigurator)
+                .Hash(_compressors)
                 .Hash(_connectionMode)
                 .Hash(_connectTimeout)
                 .Hash(_credentials)
@@ -901,6 +921,7 @@ namespace MongoDB.Driver
             {
                 parts.Add(string.Format("ApplicationName={0}", _applicationName));
             }
+            parts.Add(string.Format("Compressors={0}", string.Join(",", _compressors)));
             parts.Add(string.Format("ConnectionMode={0}", _connectionMode));
             parts.Add(string.Format("ConnectTimeout={0}", _connectTimeout));
             parts.Add(string.Format("Credentials={{{0}}}", _credentials));
@@ -951,6 +972,7 @@ namespace MongoDB.Driver
             return new ClusterKey(
                 _applicationName,
                 _clusterConfigurator,
+                _compressors,
                 _connectionMode,
                 _connectTimeout,
                 _credentials.ToList(),

--- a/src/MongoDB.Driver/ClusterKey.cs
+++ b/src/MongoDB.Driver/ClusterKey.cs
@@ -40,7 +40,7 @@ namespace MongoDB.Driver
         // fields
         private readonly string _applicationName;
         private readonly Action<ClusterBuilder> _clusterConfigurator;
-        private readonly IEnumerable<string> _compressors;
+        private readonly IEnumerable<MongoCompressor> _compressors;
         private readonly ConnectionMode _connectionMode;
         private readonly TimeSpan _connectTimeout;
         private readonly IReadOnlyList<MongoCredential> _credentials;
@@ -70,7 +70,7 @@ namespace MongoDB.Driver
         public ClusterKey(
             string applicationName,
             Action<ClusterBuilder> clusterConfigurator,
-            IEnumerable<string> compressors,
+            IEnumerable<MongoCompressor> compressors,
             ConnectionMode connectionMode,
             TimeSpan connectTimeout,
             IReadOnlyList<MongoCredential> credentials,
@@ -126,7 +126,7 @@ namespace MongoDB.Driver
         // properties
         public string ApplicationName { get { return _applicationName; } }
         public Action<ClusterBuilder> ClusterConfigurator { get { return _clusterConfigurator; } }
-        public IEnumerable<string> Compressors { get { return _compressors; } }
+        public IEnumerable<MongoCompressor> Compressors { get { return _compressors; } }
         public ConnectionMode ConnectionMode { get { return _connectionMode; } }
         public TimeSpan ConnectTimeout { get { return _connectTimeout; } }
         public IReadOnlyList<MongoCredential> Credentials { get { return _credentials; } }

--- a/src/MongoDB.Driver/ClusterKey.cs
+++ b/src/MongoDB.Driver/ClusterKey.cs
@@ -40,6 +40,7 @@ namespace MongoDB.Driver
         // fields
         private readonly string _applicationName;
         private readonly Action<ClusterBuilder> _clusterConfigurator;
+        private readonly IEnumerable<string> _compressors;
         private readonly ConnectionMode _connectionMode;
         private readonly TimeSpan _connectTimeout;
         private readonly IReadOnlyList<MongoCredential> _credentials;
@@ -69,6 +70,7 @@ namespace MongoDB.Driver
         public ClusterKey(
             string applicationName,
             Action<ClusterBuilder> clusterConfigurator,
+            IEnumerable<string> compressors,
             ConnectionMode connectionMode,
             TimeSpan connectTimeout,
             IReadOnlyList<MongoCredential> credentials,
@@ -93,6 +95,7 @@ namespace MongoDB.Driver
         {
             _applicationName = applicationName;
             _clusterConfigurator = clusterConfigurator;
+            _compressors = compressors;
             _connectionMode = connectionMode;
             _connectTimeout = connectTimeout;
             _credentials = credentials;
@@ -123,6 +126,7 @@ namespace MongoDB.Driver
         // properties
         public string ApplicationName { get { return _applicationName; } }
         public Action<ClusterBuilder> ClusterConfigurator { get { return _clusterConfigurator; } }
+        public IEnumerable<string> Compressors { get { return _compressors; } }
         public ConnectionMode ConnectionMode { get { return _connectionMode; } }
         public TimeSpan ConnectTimeout { get { return _connectTimeout; } }
         public IReadOnlyList<MongoCredential> Credentials { get { return _credentials; } }
@@ -168,6 +172,7 @@ namespace MongoDB.Driver
                 _hashCode == rhs._hashCode && // fail fast
                 _applicationName == rhs._applicationName &&
                 object.ReferenceEquals(_clusterConfigurator, rhs._clusterConfigurator) &&
+                _compressors == rhs._compressors &&
                 _connectionMode == rhs._connectionMode &&
                 _connectTimeout == rhs._connectTimeout &&
                 _credentials.SequenceEqual(rhs._credentials) &&

--- a/src/MongoDB.Driver/ClusterRegistry.cs
+++ b/src/MongoDB.Driver/ClusterRegistry.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -112,6 +113,7 @@ namespace MongoDB.Driver
             var authenticators = clusterKey.Credentials.Select(c => c.ToAuthenticator());
             return settings.With(
                 authenticators: Optional.Enumerable(authenticators),
+                compressors: Optional.Enumerable(clusterKey.Compressors),
                 maxIdleTime: clusterKey.MaxConnectionIdleTime,
                 maxLifeTime: clusterKey.MaxConnectionLifeTime,
                 applicationName: clusterKey.ApplicationName);

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -67,6 +67,7 @@ namespace MongoDB.Driver
         private bool _isFrozen;
         private int _frozenHashCode;
         private string _frozenStringRepresentation;
+        private IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>
@@ -78,6 +79,7 @@ namespace MongoDB.Driver
             _connectionMode = ConnectionMode.Automatic;
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _credentials = new MongoCredentialStore(new MongoCredential[0]);
+            _compressors = Enumerable.Empty<string>();
             _guidRepresentation = MongoDefaults.GuidRepresentation;
             _heartbeatInterval = ServerSettings.DefaultHeartbeatInterval;
             _heartbeatTimeout = ServerSettings.DefaultHeartbeatTimeout;
@@ -560,6 +562,19 @@ namespace MongoDB.Driver
             }
         }
 
+        /// <summary>
+        /// Gets or sets the compressors.
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get { return _compressors; }
+            set 
+            {
+                if (_isFrozen) { throw new InvalidOperationException("MongoClientSettings is frozen."); }
+                _compressors = value; 
+            }
+        }
+
         // public operators
         /// <summary>
         /// Determines whether two <see cref="MongoClientSettings"/> instances are equal.
@@ -612,9 +627,12 @@ namespace MongoDB.Driver
             }
 
             var credential = url.GetCredential();
+            
+            Console.WriteLine("Test: " + string.Join(",", url.Compressors));
 
             var clientSettings = new MongoClientSettings();
             clientSettings.ApplicationName = url.ApplicationName;
+            clientSettings.Compressors = url.Compressors;
             clientSettings.ConnectionMode = url.ConnectionMode;
             clientSettings.ConnectTimeout = url.ConnectTimeout;
             if (credential != null)
@@ -670,6 +688,7 @@ namespace MongoDB.Driver
             clone._applicationName = _applicationName;
             clone._clusterConfigurator = _clusterConfigurator;
             clone._connectionMode = _connectionMode;
+            clone._compressors = _compressors;
             clone._connectTimeout = _connectTimeout;
             clone._credentials = _credentials;
             clone._guidRepresentation = _guidRepresentation;
@@ -897,6 +916,7 @@ namespace MongoDB.Driver
             return new ClusterKey(
                 _applicationName,
                 _clusterConfigurator,
+                _compressors,
                 _connectionMode,
                 _connectTimeout,
                 _credentials.ToList(),

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -34,6 +34,7 @@ namespace MongoDB.Driver
         // private fields
         private string _applicationName;
         private Action<ClusterBuilder> _clusterConfigurator;
+        private IEnumerable<MongoCompressor> _compressors;
         private ConnectionMode _connectionMode;
         private TimeSpan _connectTimeout;
         private MongoCredentialStore _credentials;
@@ -67,7 +68,6 @@ namespace MongoDB.Driver
         private bool _isFrozen;
         private int _frozenHashCode;
         private string _frozenStringRepresentation;
-        private IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>
@@ -79,7 +79,7 @@ namespace MongoDB.Driver
             _connectionMode = ConnectionMode.Automatic;
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _credentials = new MongoCredentialStore(new MongoCredential[0]);
-            _compressors = Enumerable.Empty<string>();
+            _compressors = Enumerable.Empty<MongoCompressor>();
             _guidRepresentation = MongoDefaults.GuidRepresentation;
             _heartbeatInterval = ServerSettings.DefaultHeartbeatInterval;
             _heartbeatTimeout = ServerSettings.DefaultHeartbeatTimeout;
@@ -565,7 +565,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the compressors.
         /// </summary>
-        public IEnumerable<string> Compressors
+        public IEnumerable<MongoCompressor> Compressors
         {
             get { return _compressors; }
             set 
@@ -866,6 +866,8 @@ namespace MongoDB.Driver
             {
                 sb.AppendFormat("ApplicationName={0};", _applicationName);
             }
+
+            sb.AppendFormat("Compressors={0};", _compressors);
             sb.AppendFormat("ConnectionMode={0};", _connectionMode);
             sb.AppendFormat("ConnectTimeout={0};", _connectTimeout);
             sb.AppendFormat("Credentials={{{0}}};", _credentials);

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -627,8 +627,6 @@ namespace MongoDB.Driver
             }
 
             var credential = url.GetCredential();
-            
-            Console.WriteLine("Test: " + string.Join(",", url.Compressors));
 
             var clientSettings = new MongoClientSettings();
             clientSettings.ApplicationName = url.ApplicationName;

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -627,6 +627,8 @@ namespace MongoDB.Driver
             }
 
             var credential = url.GetCredential();
+            
+            Console.WriteLine("Test: " + string.Join(",", url.Compressors));
 
             var clientSettings = new MongoClientSettings();
             clientSettings.ApplicationName = url.ApplicationName;

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -867,7 +867,7 @@ namespace MongoDB.Driver
                 sb.AppendFormat("ApplicationName={0};", _applicationName);
             }
 
-            sb.AppendFormat("Compressors={0};", _compressors);
+            sb.AppendFormat("Compressors=[{0}];", string.Join(",", _compressors));
             sb.AppendFormat("ConnectionMode={0};", _connectionMode);
             sb.AppendFormat("ConnectTimeout={0};", _connectTimeout);
             sb.AppendFormat("Credentials={{{0}}};", _credentials);

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -743,6 +743,7 @@ namespace MongoDB.Driver
             return
                 _applicationName == rhs._applicationName &&
                 object.ReferenceEquals(_clusterConfigurator, rhs._clusterConfigurator) &&
+                _compressors == rhs._compressors &&
                 _connectionMode == rhs._connectionMode &&
                 _connectTimeout == rhs._connectTimeout &&
                 _credentials == rhs._credentials &&

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -73,7 +73,7 @@ namespace MongoDB.Driver
         private readonly TimeSpan? _wTimeout;
         private readonly string _url;
         private readonly string _originalUrl;
-        private IEnumerable<string> _compressors;
+        private readonly IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -73,6 +73,7 @@ namespace MongoDB.Driver
         private readonly TimeSpan? _wTimeout;
         private readonly string _url;
         private readonly string _originalUrl;
+        private IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>
@@ -90,6 +91,7 @@ namespace MongoDB.Driver
             _authenticationSource = builder.AuthenticationSource;
             _connectionMode = builder.ConnectionMode;
             _connectTimeout = builder.ConnectTimeout;
+            _compressors = builder.Compressors;
             _databaseName = builder.DatabaseName;
             _fsync = builder.FSync;
             _guidRepresentation = builder.GuidRepresentation;
@@ -450,6 +452,14 @@ namespace MongoDB.Driver
         public TimeSpan? WTimeout
         {
             get { return _wTimeout; }
+        }
+
+        /// <summary>
+        /// Gets the compressors that should be requested.
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get { return _compressors; }
         }
 
         // public operators

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -40,6 +40,7 @@ namespace MongoDB.Driver
         private readonly string _authenticationMechanism;
         private readonly IEnumerable<KeyValuePair<string, string>> _authenticationMechanismProperties;
         private readonly string _authenticationSource;
+        private readonly IEnumerable<MongoCompressor> _compressors;
         private readonly ConnectionMode _connectionMode;
         private readonly TimeSpan _connectTimeout;
         private readonly string _databaseName;
@@ -73,7 +74,6 @@ namespace MongoDB.Driver
         private readonly TimeSpan? _wTimeout;
         private readonly string _url;
         private readonly string _originalUrl;
-        private readonly IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>
@@ -457,7 +457,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the compressors that should be requested.
         /// </summary>
-        public IEnumerable<string> Compressors
+        public IEnumerable<MongoCompressor> Compressors
         {
             get { return _compressors; }
         }

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -42,6 +42,7 @@ namespace MongoDB.Driver
         private string _authenticationMechanism;
         private Dictionary<string, string> _authenticationMechanismProperties;
         private string _authenticationSource;
+        private IEnumerable<MongoCompressor> _compressors;
         private ConnectionMode _connectionMode;
         private TimeSpan _connectTimeout;
         private string _databaseName;
@@ -73,7 +74,6 @@ namespace MongoDB.Driver
         private int _waitQueueSize;
         private TimeSpan _waitQueueTimeout;
         private TimeSpan? _wTimeout;
-        private IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>
@@ -85,7 +85,7 @@ namespace MongoDB.Driver
             _authenticationMechanism = MongoDefaults.AuthenticationMechanism;
             _authenticationMechanismProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _authenticationSource = null;
-            _compressors = Enumerable.Empty<string>();
+            _compressors = Enumerable.Empty<MongoCompressor>();
             _connectionMode = ConnectionMode.Automatic;
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _databaseName = null;
@@ -601,7 +601,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the compressors that should be requested.
         /// </summary>
-        public IEnumerable<string> Compressors
+        public IEnumerable<MongoCompressor> Compressors
         {
             get { return _compressors; }
             set { _compressors = value; }
@@ -634,7 +634,7 @@ namespace MongoDB.Driver
             _authenticationMechanism = connectionString.AuthMechanism;
             _authenticationMechanismProperties = connectionString.AuthMechanismProperties.ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
             _authenticationSource = connectionString.AuthSource;
-            _compressors = connectionString.Compressors ?? Enumerable.Empty<string>();
+            _compressors = connectionString.Compressors ?? Enumerable.Empty<MongoCompressor>();
             switch (connectionString.Connect)
             {
                 case ClusterConnectionMode.Direct:

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -116,6 +116,7 @@ namespace MongoDB.Driver
             _waitQueueSize = MongoDefaults.WaitQueueSize;
             _waitQueueTimeout = MongoDefaults.WaitQueueTimeout;
             _wTimeout = null;
+            Compressors = Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -719,6 +720,7 @@ namespace MongoDB.Driver
             }
             _waitQueueTimeout = connectionString.WaitQueueTimeout.GetValueOrDefault(MongoDefaults.WaitQueueTimeout);
             _wTimeout = connectionString.WTimeout;
+            _compressors = connectionString.Compressors;
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -116,7 +116,6 @@ namespace MongoDB.Driver
             _waitQueueSize = MongoDefaults.WaitQueueSize;
             _waitQueueTimeout = MongoDefaults.WaitQueueTimeout;
             _wTimeout = null;
-            Compressors = Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -720,7 +719,6 @@ namespace MongoDB.Driver
             }
             _waitQueueTimeout = connectionString.WaitQueueTimeout.GetValueOrDefault(MongoDefaults.WaitQueueTimeout);
             _wTimeout = connectionString.WTimeout;
-            _compressors = connectionString.Compressors;
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -73,6 +73,7 @@ namespace MongoDB.Driver
         private int _waitQueueSize;
         private TimeSpan _waitQueueTimeout;
         private TimeSpan? _wTimeout;
+        private IEnumerable<string> _compressors;
 
         // constructors
         /// <summary>
@@ -114,6 +115,7 @@ namespace MongoDB.Driver
             _waitQueueSize = MongoDefaults.WaitQueueSize;
             _waitQueueTimeout = MongoDefaults.WaitQueueTimeout;
             _wTimeout = null;
+            Compressors = Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -596,6 +598,15 @@ namespace MongoDB.Driver
             }
         }
 
+        /// <summary>
+        /// Gets or sets the compressors that should be requested.
+        /// </summary>
+        public IEnumerable<string> Compressors
+        {
+            get { return _compressors; }
+            set { _compressors = value; }
+        }
+
         // public methods
         /// <summary>
         /// Returns a WriteConcern value based on this instance's settings and a default enabled value.
@@ -707,6 +718,7 @@ namespace MongoDB.Driver
             }
             _waitQueueTimeout = connectionString.WaitQueueTimeout.GetValueOrDefault(MongoDefaults.WaitQueueTimeout);
             _wTimeout = connectionString.WTimeout;
+            _compressors = connectionString.Compressors;
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -85,6 +85,7 @@ namespace MongoDB.Driver
             _authenticationMechanism = MongoDefaults.AuthenticationMechanism;
             _authenticationMechanismProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _authenticationSource = null;
+            _compressors = Enumerable.Empty<string>();
             _connectionMode = ConnectionMode.Automatic;
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _databaseName = null;
@@ -115,7 +116,6 @@ namespace MongoDB.Driver
             _waitQueueSize = MongoDefaults.WaitQueueSize;
             _waitQueueTimeout = MongoDefaults.WaitQueueTimeout;
             _wTimeout = null;
-            Compressors = Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -634,6 +634,7 @@ namespace MongoDB.Driver
             _authenticationMechanism = connectionString.AuthMechanism;
             _authenticationMechanismProperties = connectionString.AuthMechanismProperties.ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
             _authenticationSource = connectionString.AuthSource;
+            _compressors = connectionString.Compressors ?? Enumerable.Empty<string>();
             switch (connectionString.Connect)
             {
                 case ClusterConnectionMode.Direct:
@@ -718,7 +719,6 @@ namespace MongoDB.Driver
             }
             _waitQueueTimeout = connectionString.WaitQueueTimeout.GetValueOrDefault(MongoDefaults.WaitQueueTimeout);
             _wTimeout = connectionString.WTimeout;
-            _compressors = connectionString.Compressors;
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -813,6 +813,10 @@ namespace MongoDB.Driver
             {
                 query.AppendFormat("sslVerifyCertificate=false;");
             }
+            if (_compressors.Any())
+            {
+                query.AppendFormat("compressors={0};", string.Join(",", _compressors));
+            }
             if (_connectionMode != ConnectionMode.Automatic)
             {
                 query.AppendFormat("connect={0};", MongoUtils.ToCamelCase(_connectionMode.ToString()));

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -815,7 +815,13 @@ namespace MongoDB.Driver
             }
             if (_compressors.Any())
             {
-                query.AppendFormat("compressors={0};", string.Join(",", _compressors));
+                query.AppendFormat("compressors={0};", string.Join(",", _compressors.Select(x => x.Name)));
+
+                var zlibCompressor = _compressors.FirstOrDefault(x => x.Name == "zlib");
+                object zlibcompressionLevel;
+
+                if (zlibCompressor != null && zlibCompressor.Properties.TryGetValue(MongoCompressor.Level, out zlibcompressionLevel))
+                    query.AppendFormat("zlibCompressionLevel={0};", zlibcompressionLevel);
             }
             if (_connectionMode != ConnectionMode.Automatic)
             {

--- a/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Bson.Tests
         [InlineData("-79228162514264337593543950335", "-79228162514264337593543950335")]
         public void Decimal(string valueString, string s)
         {
-            var value = decimal.Parse(valueString);
+            var value = decimal.Parse(valueString, CultureInfo.InvariantCulture);
             var subject = new Decimal128(value);
 
             subject.ToString().Should().Be(s);
@@ -80,7 +80,7 @@ namespace MongoDB.Bson.Tests
         public void ToDecimal_should_return_expected_result(string valueString, string expectedResultString)
         {
             var subject = Decimal128.Parse(valueString);
-            var expectedResult = decimal.Parse(expectedResultString);
+            var expectedResult = decimal.Parse(expectedResultString, CultureInfo.InvariantCulture);
 
             var result = Decimal128.ToDecimal(subject);
 

--- a/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
@@ -219,7 +219,7 @@ namespace MongoDB.Driver
             var uri = Environment.GetEnvironmentVariable("MONGODB_URI") ?? Environment.GetEnvironmentVariable("MONGO_URI");
             if (uri == null)
             {
-                uri = "mongodb://localhost";
+                uri = "mongodb://localhost/?compressors=zlib";
                 if (IsReplicaSet(uri))
                 {
                     uri += "/?connect=replicaSet";

--- a/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
@@ -219,7 +219,7 @@ namespace MongoDB.Driver
             var uri = Environment.GetEnvironmentVariable("MONGODB_URI") ?? Environment.GetEnvironmentVariable("MONGO_URI");
             if (uri == null)
             {
-                uri = "mongodb://localhost/?compressors=zlib";
+                uri = "mongodb://localhost/";
                 if (IsReplicaSet(uri))
                 {
                     uri += "/?connect=replicaSet";

--- a/tests/MongoDB.Driver.Core.Tests/Core/Compression/MessageCompressionHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Compression/MessageCompressionHelperTests.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using MongoDB.Driver.Core.Helpers;
+using MongoDB.Driver.Core.WireProtocol.Messages;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Compression
+{
+	public class MessageCompressionHelperTests
+	{
+		private MessageCompressionHelper _subject;
+		private MessageEncoderSettings _messageEncoderSettings;
+		private ZlibCompressor _compressor;
+
+		public MessageCompressionHelperTests()
+		{
+			_compressor = new ZlibCompressor(-1);
+			var compressorDictionary = new Dictionary<CompressorId, ICompressor>
+			{
+				{CompressorId.zlib, _compressor}
+			};
+
+			_messageEncoderSettings = new MessageEncoderSettings();
+
+			_subject = new MessageCompressionHelper(compressorDictionary, _messageEncoderSettings);
+		}
+
+		[Fact]
+		public void IsCompressedMessage_does_not_advance_stream()
+		{
+			var stream = SetupStreamHeaderWith(Opcode.Compressed);
+
+			stream.Position = stream.Length;
+			using (var writer = new BinaryWriter(stream, Encoding.Default, true))
+			{
+				writer.Write(1);
+				writer.Write(1);
+				writer.Write(1);
+			}
+
+			stream.Position = stream.Length - 16;
+
+			_subject.IsCompressedMessage(stream);
+
+			stream.Position.Should().Be(stream.Length - 16);
+		}
+
+		[Fact]
+		public void IsCompressedMessage_checks_for_compressed_opcode()
+		{
+			var streamWithCompressed = SetupStreamHeaderWith(Opcode.Compressed);
+			var streamWithoutCompressed = SetupStreamHeaderWith(Opcode.OpMsg);
+
+			var compressed = _subject.IsCompressedMessage(streamWithCompressed);
+			var notCompressed = _subject.IsCompressedMessage(streamWithoutCompressed);
+
+			compressed.Should().BeTrue();
+			notCompressed.Should().BeFalse();
+		}
+
+		[Fact]
+		public void UncompressMessage_throws_if_unsupported_compressor()
+		{
+			byte compressorId = 3;
+			var commandMessageBytes = CommandMessageHelper.CreateMessageBytes();
+			var compressedMessageBytes = CreateCompressedMessageBytes(commandMessageBytes, compressorId);
+
+			using (var memoryStream = new MemoryStream(compressedMessageBytes))
+			{
+				Action action = () => _subject.UncompressMessage(memoryStream);
+
+				action.ShouldThrow<MongoClientException>().WithMessage($"Unsupported*{compressorId}");
+			}
+		}
+		
+		[Fact]
+		public void UncompressMessage_returns_uncompressed_message_stream()
+		{
+			var commandMessageBytes = CommandMessageHelper.CreateMessageBytes();
+			var compressedMessageBytes = CreateCompressedMessageBytes(commandMessageBytes);
+
+			Stream uncompressedStream;
+			using (var memoryStream = new MemoryStream(compressedMessageBytes))
+				uncompressedStream = _subject.UncompressMessage(memoryStream);
+
+			using (var reader = new BinaryReader(uncompressedStream))
+			{
+				var messageSize = reader.ReadInt32();
+				var requestId = reader.ReadInt32();
+				var respondTo = reader.ReadInt32();
+				var opcode = reader.ReadInt32();
+
+				messageSize.Should().Be(commandMessageBytes.Length);
+				requestId.Should().Be(0);
+				respondTo.Should().Be(0);
+				opcode.Should().Be((int) Opcode.OpMsg);
+			}
+		}
+
+		[Fact]
+		public void ReadCompressedResponseMessage_returns_uncompressed_message()
+		{
+			var commandMessageBytes = CommandMessageHelper.CreateMessageBytes();
+			var compressedMessageBytes = CreateCompressedMessageBytes(commandMessageBytes);
+
+			var encoderSelector = new CommandResponseMessageEncoderSelector();
+			
+			CommandResponseMessage response;
+			using (var memoryStream = new MemoryStream(compressedMessageBytes))
+				response = (CommandResponseMessage)_subject.ReadCompressedResponseMessage(memoryStream, encoderSelector);
+
+			response.RequestId.Should().Be(0);
+			response.ResponseTo.Should().Be(0);
+			response.MessageType.Should().Be(MongoDBMessageType.Command);
+		}
+		
+		[Fact]
+		public void ReadCompressedResponseMessage_throws_if_unsupported_compressor()
+		{
+			byte compressorId = 3;
+			var commandMessageBytes = CommandMessageHelper.CreateMessageBytes();
+			var compressedMessageBytes = CreateCompressedMessageBytes(commandMessageBytes, compressorId);
+
+			var encoderSelector = new CommandResponseMessageEncoderSelector();
+			
+			using (var memoryStream = new MemoryStream(compressedMessageBytes))
+			{
+				Action action = () => _subject.ReadCompressedResponseMessage(memoryStream, encoderSelector);
+				
+				action.ShouldThrow<MongoClientException>().WithMessage($"Unsupported*{compressorId}");
+			}
+		}
+		
+		private Stream SetupStreamHeaderWith(Opcode opcode)
+		{
+			var stream = new MemoryStream();
+
+			using (var writer = new BinaryWriter(stream, Encoding.Default, true))
+			{
+				writer.Write(1);
+				writer.Write(1);
+				writer.Write(1);
+				writer.Write((int)opcode);
+			}
+
+			stream.Position = 0;
+			
+			return stream;
+		}
+
+		private byte[] CreateCompressedMessageBytes(byte[] commandMessageBytes, byte compressorId = (byte)CompressorId.zlib)
+		{
+			var compressedCommandMessage = _compressor.Compress(commandMessageBytes, 16);
+
+			return CreateCompressedMessageBytes(commandMessageBytes, compressedCommandMessage, compressorId);
+		}
+
+		private static byte[] CreateCompressedMessageBytes(byte[] commandMesage, byte[] compressedCommandMessage, byte compressorId)
+		{
+			using (var memStream = new MemoryStream())
+			using (var writer = new BinaryWriter(memStream))
+			{
+				writer.Write(25 + compressedCommandMessage.Length);
+				writer.Write(0);
+				writer.Write(0);
+				writer.Write((int)Opcode.Compressed);
+				writer.Write((int)Opcode.OpMsg);
+				writer.Write(commandMesage.Length - 16);
+				writer.Write(compressorId);
+				writer.Write(compressedCommandMessage);
+				
+				return memStream.ToArray();
+			}
+		}
+	}
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionSettingsTests.cs
@@ -17,6 +17,7 @@ using System;
 using FluentAssertions;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Authentication;
+using MongoDB.Driver.Core.Compression;
 using Xunit;
 
 namespace MongoDB.Driver.Core.Configuration
@@ -117,7 +118,7 @@ namespace MongoDB.Driver.Core.Configuration
         [Fact]
         public void constructor_with_compressors_should_initialize_instance()
         {
-            var compressors = new[] {"zlib"};
+            var compressors = new[] {new MongoCompressor{Name = "zlib"}};
 
             var subject = new ConnectionSettings(compressors: compressors);
 
@@ -193,8 +194,8 @@ namespace MongoDB.Driver.Core.Configuration
         [Fact]
         public void With_compressors_should_return_expected_result()
         {
-            var oldCompressors = new[] {"zlib"};
-            var newCompressors = new[] {"snappy"};
+            var oldCompressors = new[] {new MongoCompressor{Name = "zlib"}};
+            var newCompressors = new[] {new MongoCompressor{Name = "snappy"}};
             var subject = new ConnectionSettings(compressors: oldCompressors);
 
             var result = subject.With(compressors: newCompressors);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionSettingsTests.cs
@@ -32,6 +32,7 @@ namespace MongoDB.Driver.Core.Configuration
 
             subject.ApplicationName.Should().BeNull();
             subject.Authenticators.Should().BeEmpty();
+            subject.Compressors.Should().BeEmpty();
             subject.MaxIdleTime.Should().Be(TimeSpan.FromMinutes(10));
             subject.MaxLifeTime.Should().Be(TimeSpan.FromMinutes(30));
         }
@@ -53,6 +54,14 @@ namespace MongoDB.Driver.Core.Configuration
             Action action = () => new ConnectionSettings(authenticators: null);
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("authenticators");
+        }
+        
+        [Fact]
+        public void constructor_should_throw_when_compressors_is_null()
+        {
+            Action action = () => new ConnectionSettings(compressors: null);
+
+            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("compressors");
         }
 
         [Theory]
@@ -84,6 +93,7 @@ namespace MongoDB.Driver.Core.Configuration
 
             subject.ApplicationName.Should().Be("app");
             subject.Authenticators.Should().Equal(__defaults.Authenticators);
+            subject.Compressors.Should().Equal(__defaults.Compressors);
             subject.MaxIdleTime.Should().Be(__defaults.MaxIdleTime);
             subject.MaxLifeTime.Should().Be(__defaults.MaxLifeTime);
         }
@@ -99,6 +109,21 @@ namespace MongoDB.Driver.Core.Configuration
 
             subject.ApplicationName.Should().BeNull();
             subject.Authenticators.Should().Equal(authenticators);
+            subject.Compressors.Should().Equal(__defaults.Compressors);
+            subject.MaxIdleTime.Should().Be(__defaults.MaxIdleTime);
+            subject.MaxLifeTime.Should().Be(__defaults.MaxLifeTime);
+        }
+
+        [Fact]
+        public void constructor_with_compressors_should_initialize_instance()
+        {
+            var compressors = new[] {"zlib"};
+
+            var subject = new ConnectionSettings(compressors: compressors);
+
+            subject.ApplicationName.Should().BeNull();
+            subject.Authenticators.Should().Equal(__defaults.Authenticators);
+            subject.Compressors.Should().Equal(compressors);
             subject.MaxIdleTime.Should().Be(__defaults.MaxIdleTime);
             subject.MaxLifeTime.Should().Be(__defaults.MaxLifeTime);
         }
@@ -112,6 +137,7 @@ namespace MongoDB.Driver.Core.Configuration
 
             subject.ApplicationName.Should().BeNull();
             subject.Authenticators.Should().Equal(__defaults.Authenticators);
+            subject.Compressors.Should().Equal(__defaults.Compressors);
             subject.MaxIdleTime.Should().Be(maxIdleTime);
             subject.MaxLifeTime.Should().Be(__defaults.MaxLifeTime);
         }
@@ -125,6 +151,7 @@ namespace MongoDB.Driver.Core.Configuration
 
             subject.ApplicationName.Should().BeNull();
             subject.Authenticators.Should().Equal(__defaults.Authenticators);
+            subject.Compressors.Should().Equal(__defaults.Compressors);
             subject.MaxIdleTime.Should().Be(__defaults.MaxIdleTime);
             subject.MaxLifeTime.Should().Be(maxLifeTime);
         }
@@ -140,6 +167,7 @@ namespace MongoDB.Driver.Core.Configuration
 
             result.ApplicationName.Should().Be(newApplicationName);
             result.Authenticators.Should().Equal(subject.Authenticators);
+            result.Compressors.Should().Equal(subject.Compressors);
             result.MaxIdleTime.Should().Be(subject.MaxIdleTime);
             result.MaxLifeTime.Should().Be(subject.MaxLifeTime);
         }
@@ -157,6 +185,23 @@ namespace MongoDB.Driver.Core.Configuration
 
             result.ApplicationName.Should().Be(subject.ApplicationName);
             result.Authenticators.Should().Equal(newAuthenticators);
+            result.Compressors.Should().Equal(subject.Compressors);
+            result.MaxIdleTime.Should().Be(subject.MaxIdleTime);
+            result.MaxLifeTime.Should().Be(subject.MaxLifeTime);
+        }
+
+        [Fact]
+        public void With_compressors_should_return_expected_result()
+        {
+            var oldCompressors = new[] {"zlib"};
+            var newCompressors = new[] {"snappy"};
+            var subject = new ConnectionSettings(compressors: oldCompressors);
+
+            var result = subject.With(compressors: newCompressors);
+
+            result.ApplicationName.Should().Be(subject.ApplicationName);
+            result.Authenticators.Should().Equal(subject.Authenticators);
+            result.Compressors.Should().Equal(newCompressors);
             result.MaxIdleTime.Should().Be(subject.MaxIdleTime);
             result.MaxLifeTime.Should().Be(subject.MaxLifeTime);
         }
@@ -172,6 +217,7 @@ namespace MongoDB.Driver.Core.Configuration
 
             result.ApplicationName.Should().Be(subject.ApplicationName);
             result.Authenticators.Should().Equal(subject.Authenticators);
+            result.Compressors.Should().Equal(subject.Compressors);
             result.MaxIdleTime.Should().Be(newMaxIdleTime);
             result.MaxLifeTime.Should().Be(subject.MaxLifeTime);
         }
@@ -187,6 +233,7 @@ namespace MongoDB.Driver.Core.Configuration
 
             result.ApplicationName.Should().Be(subject.ApplicationName);
             result.Authenticators.Should().Equal(subject.Authenticators);
+            result.Compressors.Should().Equal(subject.Compressors);
             result.MaxIdleTime.Should().Be(subject.MaxIdleTime);
             result.MaxLifeTime.Should().Be(newMaxLifeTime);
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionSettingsTests.cs
@@ -118,7 +118,7 @@ namespace MongoDB.Driver.Core.Configuration
         [Fact]
         public void constructor_with_compressors_should_initialize_instance()
         {
-            var compressors = new[] {new MongoCompressor{Name = "zlib"}};
+            var compressors = new[] {new MongoCompressor("zlib")};
 
             var subject = new ConnectionSettings(compressors: compressors);
 
@@ -194,8 +194,8 @@ namespace MongoDB.Driver.Core.Configuration
         [Fact]
         public void With_compressors_should_return_expected_result()
         {
-            var oldCompressors = new[] {new MongoCompressor{Name = "zlib"}};
-            var newCompressors = new[] {new MongoCompressor{Name = "snappy"}};
+            var oldCompressors = new[] {new MongoCompressor("zlib")};
+            var newCompressors = new[] {new MongoCompressor("snappy")};
             var subject = new ConnectionSettings(compressors: oldCompressors);
 
             var result = subject.With(compressors: newCompressors);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
@@ -146,6 +146,7 @@ namespace MongoDB.Driver.Core.Configuration
             subject.ApplicationName.Should().BeNull();
             subject.AuthMechanism.Should().BeNull();
             subject.AuthSource.Should().BeNull();
+            subject.Compressors.Should().BeNull();
             subject.Connect.Should().Be(ClusterConnectionMode.Automatic);
             subject.ConnectTimeout.Should().Be(null);
             subject.DatabaseName.Should().BeNull();
@@ -184,6 +185,7 @@ namespace MongoDB.Driver.Core.Configuration
                 "authMechanism=GSSAPI;" +
                 "authMechanismProperties=CANONICALIZE_HOST_NAME:true;" +
                 "authSource=admin;" +
+                "compressors=zlib,snappy;" +
                 "connect=replicaSet;" +
                 "connectTimeout=15ms;" +
                 "fsync=true;" +
@@ -218,6 +220,7 @@ namespace MongoDB.Driver.Core.Configuration
             subject.AuthMechanismProperties.Count.Should().Be(1);
             subject.AuthMechanismProperties["canonicalize_host_name"].Should().Be("true");
             subject.AuthSource.Should().Be("admin");
+            subject.Compressors.Should().Contain("zlib").And.Contain("snappy");
             subject.Connect.Should().Be(ClusterConnectionMode.ReplicaSet);
             subject.ConnectTimeout.Should().Be(TimeSpan.FromMilliseconds(15));
             subject.DatabaseName.Should().Be("test");
@@ -300,6 +303,16 @@ namespace MongoDB.Driver.Core.Configuration
             var subject = new ConnectionString(connectionString);
 
             subject.AuthSource.Should().Be(authSource);
+        }
+
+        [Theory]
+        [InlineData("mongodb://localhost?compressors=zlib", "zlib")]
+        [InlineData("mongodb://localhost?compressors=snappy", "snappy")]
+        public void When_compressors_are_specified(string connectionString, string compressor)
+        {
+            var subject = new ConnectionString(connectionString);
+
+            subject.Compressors.Should().Contain(compressor);
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -22,6 +22,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Specialized;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
@@ -45,6 +46,7 @@ namespace MongoDB.Driver.Core.Connections
         private MessageEncoderSettings _messageEncoderSettings = new MessageEncoderSettings();
         private Mock<IStreamFactory> _mockStreamFactory;
         private BinaryConnection _subject;
+        private ServerId _serverId;
 
         public BinaryConnectionTests()
         {
@@ -52,22 +54,22 @@ namespace MongoDB.Driver.Core.Connections
             _mockStreamFactory = new Mock<IStreamFactory>();
 
             _endPoint = new DnsEndPoint("localhost", 27017);
-            var serverId = new ServerId(new ClusterId(), _endPoint);
+            _serverId = new ServerId(new ClusterId(), _endPoint);
 
             _mockConnectionInitializer = new Mock<IConnectionInitializer>();
             _mockConnectionInitializer.Setup(i => i.InitializeConnection(It.IsAny<IConnection>(), CancellationToken.None))
                 .Returns(() => new ConnectionDescription(
-                    new ConnectionId(serverId),
+                    new ConnectionId(_serverId),
                     new IsMasterResult(new BsonDocument()),
                     new BuildInfoResult(new BsonDocument("version", "2.6.3"))));
             _mockConnectionInitializer.Setup(i => i.InitializeConnectionAsync(It.IsAny<IConnection>(), CancellationToken.None))
                 .Returns(() => Task.FromResult(new ConnectionDescription(
-                    new ConnectionId(serverId),
+                    new ConnectionId(_serverId),
                     new IsMasterResult(new BsonDocument()),
                     new BuildInfoResult(new BsonDocument("version", "2.6.3")))));
 
             _subject = new BinaryConnection(
-                serverId: serverId,
+                serverId: _serverId,
                 endPoint: _endPoint,
                 settings: new ConnectionSettings(),
                 streamFactory: _mockStreamFactory.Object,
@@ -75,6 +77,22 @@ namespace MongoDB.Driver.Core.Connections
                 eventSubscriber: _capturedEvents);
         }
 
+        [Fact]
+        public void Constructor_should_throw_if_unsupported_compressor()
+        {
+            var settings = new ConnectionSettings(compressors: new[] {new MongoCompressor("test")});
+            
+            Action action = () => new BinaryConnection(
+                _serverId,
+                _endPoint,
+                settings,
+                _mockStreamFactory.Object,
+                _mockConnectionInitializer.Object,
+                _capturedEvents);
+
+            action.ShouldThrow<MongoInternalException>().WithMessage("*test.");
+        }
+        
         [Fact]
         public void Dispose_should_raise_the_correct_events()
         {
@@ -104,6 +122,46 @@ namespace MongoDB.Driver.Core.Connections
             }
 
             act.ShouldThrow<ObjectDisposedException>();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void Open_should_throw_if_unexpected_compressor(
+            [Values(false, true)] bool async)
+        {
+            Action action;
+            var compressorName = "unexpected";
+
+            if (async)
+            {
+                _mockConnectionInitializer.Setup(
+                        i => i.InitializeConnectionAsync(It.IsAny<IConnection>(), CancellationToken.None))
+                    .Returns(
+                        () => Task.FromResult(
+                            new ConnectionDescription(
+                                new ConnectionId(_serverId),
+                                new IsMasterResult(
+                                    new BsonDocument("compression", new BsonArray(new[] {compressorName}))),
+                                new BuildInfoResult(new BsonDocument("version", "2.6.3")))));
+
+                action = () => _subject.OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
+            }
+            else
+            {
+                _mockConnectionInitializer.Setup(
+                        i => i.InitializeConnection(It.IsAny<IConnection>(), CancellationToken.None))
+                    .Returns(
+                        () => new ConnectionDescription(
+                            new ConnectionId(_serverId),
+                            new IsMasterResult(new BsonDocument("compression", new BsonArray(new[] {compressorName}))),
+                            new BuildInfoResult(new BsonDocument("version", "2.6.3"))));
+
+                action = () => _subject.Open(CancellationToken.None);
+            }
+
+            action.ShouldThrow<MongoConnectionException>()
+                .WithInnerException<MongoInternalException>()
+                .WithInnerMessage($"Unexpected compressor*{compressorName}.");
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -72,7 +72,8 @@ namespace MongoDB.Driver.Core.Connections
                 settings: new ConnectionSettings(),
                 streamFactory: _mockStreamFactory.Object,
                 connectionInitializer: _mockConnectionInitializer.Object,
-                eventSubscriber: _capturedEvents);
+                eventSubscriber: _capturedEvents,
+                compressors: null);
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -72,8 +72,7 @@ namespace MongoDB.Driver.Core.Connections
                 settings: new ConnectionSettings(),
                 streamFactory: _mockStreamFactory.Object,
                 connectionInitializer: _mockConnectionInitializer.Object,
-                eventSubscriber: _capturedEvents,
-                compressors: null);
+                eventSubscriber: _capturedEvents);
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
@@ -72,7 +72,8 @@ namespace MongoDB.Driver.Core.Connections
                 settings: new ConnectionSettings(),
                 streamFactory: _mockStreamFactory.Object,
                 connectionInitializer: _mockConnectionInitializer.Object,
-                eventSubscriber: _capturedEvents);
+                eventSubscriber: _capturedEvents,
+                compressors: null);
 
             _stream = new BlockingMemoryStream();
             _mockStreamFactory.Setup(f => f.CreateStreamAsync(_endPoint, CancellationToken.None))

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
@@ -72,8 +72,7 @@ namespace MongoDB.Driver.Core.Connections
                 settings: new ConnectionSettings(),
                 streamFactory: _mockStreamFactory.Object,
                 connectionInitializer: _mockConnectionInitializer.Object,
-                eventSubscriber: _capturedEvents,
-                compressors: null);
+                eventSubscriber: _capturedEvents);
 
             _stream = new BlockingMemoryStream();
             _mockStreamFactory.Setup(f => f.CreateStreamAsync(_endPoint, CancellationToken.None))

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionDescriptionTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using FluentAssertions;
 using MongoDB.Bson;
@@ -33,8 +34,10 @@ namespace MongoDB.Driver.Core.Connections
         private static readonly ConnectionId __connectionId = new ConnectionId(
             new ServerId(new ClusterId(), new DnsEndPoint("localhost", 27017)));
 
+        private static readonly IEnumerable<string> __compression = new[] {"zlib"};
+        
         private static readonly IsMasterResult __isMasterResult = new IsMasterResult(BsonDocument.Parse(
-            "{ ok: 1, maxWriteBatchSize: 10, maxBsonObjectSize: 20, maxMessageSizeBytes: 30 }"
+            "{ ok: 1, maxWriteBatchSize: 10, maxBsonObjectSize: 20, maxMessageSizeBytes: 30, compression: ['zlib'] }"
         ));
 
         [Fact]
@@ -81,6 +84,14 @@ namespace MongoDB.Driver.Core.Connections
             subject1.Equals(subject3).Should().BeFalse();
             subject1.Equals(subject4).Should().BeFalse();
             subject1.Equals(subject5).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Compression_should_return_Compression()
+        {
+            var subject = new ConnectionDescription(__connectionId, __isMasterResult, __buildInfoResult);
+
+            subject.Compression.Should().Equal(__compression);
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -43,7 +43,7 @@ namespace MongoDB.Driver.Core.Connections
 
         public ConnectionInitializerTests()
         {
-            _subject = new ConnectionInitializer("test", new string[] {"zlib"});
+            _subject = new ConnectionInitializer("test", new [] {"zlib"});
         }
 
         [Theory]
@@ -72,7 +72,7 @@ namespace MongoDB.Driver.Core.Connections
             bool async)
         {
             var isMasterReply = MessageHelper.BuildReply<RawBsonDocument>(
-                RawBsonDocumentHelper.FromJson("{ ok: 1 }"));
+                RawBsonDocumentHelper.FromJson("{ ok: 1, compression: ['zlib'] }"));
             var buildInfoReply = MessageHelper.BuildReply<RawBsonDocument>(
                 RawBsonDocumentHelper.FromJson("{ ok: 1, version: \"2.6.3\" }"));
             var gleReply = MessageHelper.BuildReply<RawBsonDocument>(
@@ -95,6 +95,7 @@ namespace MongoDB.Driver.Core.Connections
 
             result.ServerVersion.Should().Be(new SemanticVersion(2, 6, 3));
             result.ConnectionId.ServerValue.Should().Be(10);
+            result.Compression.Should().Contain("zlib");
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -43,7 +43,7 @@ namespace MongoDB.Driver.Core.Connections
 
         public ConnectionInitializerTests()
         {
-            _subject = new ConnectionInitializer("test", new [] {new MongoCompressor{Name = "zlib"}});
+            _subject = new ConnectionInitializer("test", new[] {new MongoCompressor("zlib")});
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -39,11 +39,11 @@ namespace MongoDB.Driver.Core.Connections
     public class ConnectionInitializerTests
     {
         private static readonly ServerId __serverId = new ServerId(new ClusterId(), new DnsEndPoint("localhost", 27017));
-        private ConnectionInitializer _subject;
+        private readonly ConnectionInitializer _subject;
 
         public ConnectionInitializerTests()
         {
-            _subject = new ConnectionInitializer("test", new [] {"zlib"});
+            _subject = new ConnectionInitializer("test", new [] {new MongoCompressor{Name = "zlib"}});
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -43,7 +43,7 @@ namespace MongoDB.Driver.Core.Connections
 
         public ConnectionInitializerTests()
         {
-            _subject = new ConnectionInitializer("test");
+            _subject = new ConnectionInitializer("test", new string[] {"zlib"});
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterHelperTests.cs
@@ -19,6 +19,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using Xunit;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core.Configuration;
 
 namespace MongoDB.Driver.Core.Connections
 {
@@ -34,14 +35,14 @@ namespace MongoDB.Driver.Core.Connections
             var command = IsMasterHelper.CreateCommand();
             var result = IsMasterHelper.AddClientDocumentToCommand(command, clientDocument);
 
-            result.Should().Be($"{{ isMaster : 1, client : {clientDocumentString} }}");
+            result.Should().Be($"{{ isMaster : 1, client : {clientDocumentString}}}");
         }
         
         [Fact]
         public void AddClientDocumentToCommand_with_ConnectionInitializer_client_document_should_return_expected_result()
         {
             var command = IsMasterHelper.CreateCommand();
-            var connectionInitializer = new ConnectionInitializer("test");
+            var connectionInitializer = new ConnectionInitializer("test", Enumerable.Empty<MongoCompressor>());
             var subjectClientDocument = (BsonDocument)Reflector.GetFieldValue(connectionInitializer, "_clientDocument");
             var result = IsMasterHelper.AddClientDocumentToCommand(command, subjectClientDocument);
 
@@ -60,6 +61,20 @@ namespace MongoDB.Driver.Core.Connections
             clientDocument["application"]["name"].AsString.Should().Be("test");
             clientDocument["driver"]["name"].AsString.Should().Be("mongo-csharp-driver");
             clientDocument["driver"]["version"].BsonType.Should().Be(BsonType.String);
+        }
+        
+        [Theory]
+        [ParameterAttributeData]
+        public void AddCompressorsToCommand_with_compressors_should_return_expected_result(
+            [Values("zlib", "snappy")] 
+            string compressor)
+        {
+            var command = IsMasterHelper.CreateCommand();
+            var compressors = new[] {new MongoCompressor(compressor)};
+
+            var result = IsMasterHelper.AddCompressorsToCommand(command, compressors);
+
+            result.Should().Be($"{{ isMaster : 1, compression: ['{compressor}'] }}");
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
@@ -15,11 +15,9 @@
 
 using System;
 using System.Net;
-using System.Net.Sockets;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
-using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Servers;
 using Xunit;
@@ -61,6 +59,20 @@ namespace MongoDB.Driver.Core.Connections
             var subject2 = new IsMasterResult(new BsonDocument("x", 2));
 
             subject1.Equals(subject2).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("{ compression : ['zlib'] }", new []{"zlib"})]
+        [InlineData("{ compression : ['zlib', 'snappy'] }", new []{"zlib", "snappy"})]
+        [InlineData("{ compression : [] }", new string[0])]
+        [InlineData("{ }", new string[0])]
+        public void Compression_should_parse_document_correctly(string json, string[] expectedCompression)
+        {
+            var subject = new IsMasterResult(BsonDocument.Parse(json));
+
+            var result = subject.Compression;
+
+            result.Should().Equal(expectedCompression);
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Helpers/CommandMessageHelper.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Helpers/CommandMessageHelper.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/tests/MongoDB.Driver.Core.Tests/Core/Helpers/CommandMessageHelper.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Helpers/CommandMessageHelper.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.WireProtocol.Messages;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
+
+namespace MongoDB.Driver.Core.Helpers
+{
+	internal static class CommandMessageHelper
+	{
+		public static CommandMessage CreateMessage(
+			int requestId = 0,
+			int responseTo = 0,
+			IEnumerable<CommandMessageSection> sections = null,
+			bool moreToCome = false)
+		{
+			sections = sections ?? new[] {CreateType0Section()};
+			return new CommandMessage(requestId, responseTo, sections, moreToCome);
+		}
+
+		public static Type0CommandMessageSection<BsonDocument> CreateType0Section(BsonDocument document = null)
+		{
+			document = document ?? new BsonDocument("t", 0);
+			return new Type0CommandMessageSection<BsonDocument>(document, BsonDocumentSerializer.Instance);
+		}
+
+		private static byte[] CreateType0SectionBytes(Type0CommandMessageSection<BsonDocument> section)
+		{
+			using (var memoryStream = new MemoryStream())
+			using (var writer = new BsonBinaryWriter(memoryStream))
+			{
+				memoryStream.WriteByte(0);
+				var context = BsonSerializationContext.CreateRoot(writer);
+				BsonDocumentSerializer.Instance.Serialize(context, section.Document);
+				return memoryStream.ToArray();
+			}
+		}
+
+		public static Type1CommandMessageSection<BsonDocument> CreateType1Section(
+			string identifier = null,
+			BsonDocument[] documents = null,
+			bool canBeSplit = false)
+		{
+			identifier = identifier ?? "id";
+			documents = documents ?? new BsonDocument[0];
+			var batch = new BatchableSource<BsonDocument>(documents, canBeSplit: canBeSplit);
+			return new Type1CommandMessageSection<BsonDocument>(
+				identifier,
+				batch,
+				BsonDocumentSerializer.Instance,
+				NoOpElementNameValidator.Instance,
+				null,
+				null);
+		}
+
+		private static byte[] CreateType1SectionBytes(Type1CommandMessageSection<BsonDocument> section)
+		{
+			using (var memoryStream = new MemoryStream())
+			using (var stream = new BsonStreamAdapter(memoryStream))
+			using (var writer = new BsonBinaryWriter(stream))
+			{
+				stream.WriteByte(1);
+				var payloadStartPosition = stream.Position;
+				stream.WriteInt32(0); // size
+				stream.WriteCString(section.Identifier);
+				var context = BsonSerializationContext.CreateRoot(writer);
+				var batch = section.Documents;
+				for (var i = 0; i < batch.Count; i++)
+				{
+					var document = batch.Items[batch.Offset + i];
+					BsonDocumentSerializer.Instance.Serialize(context, document);
+				}
+
+				stream.BackpatchSize(payloadStartPosition);
+				return memoryStream.ToArray();
+			}
+		}
+
+		public static byte[] CreateSectionBytes(CommandMessageSection section)
+		{
+			switch (section.PayloadType)
+			{
+				case PayloadType.Type0:
+					return CreateType0SectionBytes((Type0CommandMessageSection<BsonDocument>) section);
+
+				case PayloadType.Type1:
+					return CreateType1SectionBytes((Type1CommandMessageSection<BsonDocument>) section);
+
+				default:
+					throw new ArgumentException($"Invalid payload type: {section.PayloadType}.");
+			}
+		}
+
+		public static List<CommandMessageSection> CreateSections(params int[] sectionTypes)
+		{
+			var sections = new List<CommandMessageSection>();
+			for (var i = 0; i < sectionTypes.Length; i++)
+			{
+				var sectionType = sectionTypes[i];
+
+				CommandMessageSection section;
+				switch (sectionType)
+				{
+					case 0:
+						section = CreateType0Section();
+						break;
+
+					case 1:
+						var identifier = $"id{i}";
+						var documents = Enumerable.Range(0, i + 1).Select(n => new BsonDocument("n", n)).ToArray();
+						section = CreateType1Section(identifier, documents);
+						break;
+
+					default:
+						throw new ArgumentException($"Invalid payload type: {sectionType}.", nameof(sectionTypes));
+				}
+
+				sections.Add(section);
+			}
+
+			return sections;
+		}
+
+		private static int CreateFlags(CommandMessage message)
+		{
+			return message.MoreToCome
+				? (int) OpMsgFlags.MoreToCome
+				: 0;
+		}
+
+		public static byte[] CreateHeaderBytes(int messageLength, int requestId, int responseTo, int flags)
+		{
+			using (var memoryStream = new MemoryStream())
+			using (var stream = new BsonStreamAdapter(memoryStream))
+			{
+				stream.WriteInt32(messageLength);
+				stream.WriteInt32(requestId);
+				stream.WriteInt32(responseTo);
+				stream.WriteInt32((int) Opcode.OpMsg);
+				stream.WriteInt32(flags);
+				return memoryStream.ToArray();
+			}
+		}
+
+		public static byte[] CreateMessageBytes(byte[] header, byte[][] sections)
+		{
+			var messageLength = header.Length + sections.Select(s => s.Length).Sum();
+			var message = new byte[messageLength];
+			header.CopyTo(message, 0);
+			var offset = header.Length;
+			foreach (var section in sections)
+			{
+				section.CopyTo(message, offset);
+				offset += section.Length;
+			}
+
+			return message;
+		}
+
+		public static byte[] CreateMessageBytes(CommandMessage message)
+		{
+			var sections = message.Sections.Select(s => CreateSectionBytes(s)).ToArray();
+			var messageLength = 20 + sections.Select(s => s.Length).Sum();
+			var header = CreateHeaderBytes(messageLength, message.RequestId, message.ResponseTo, CreateFlags(message));
+			return CreateMessageBytes(header, sections);
+		}
+
+		public static byte[] CreateMessageBytes(
+			int requestId = 0,
+			int responseTo = 0,
+			IEnumerable<CommandMessageSection> sections = null,
+			bool moreToCome = false)
+		{
+			var message = CreateMessage(requestId, responseTo, sections, moreToCome);
+			return CreateMessageBytes(message);
+		}
+	}
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Helpers/CompressedMessageHelper.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Helpers/CompressedMessageHelper.cs
@@ -1,0 +1,49 @@
+﻿/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.IO;
+using MongoDB.Driver.Core.Compression;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
+
+namespace MongoDB.Driver.Core.Helpers
+{
+	internal static class CompressedMessageHelper
+	{
+		public static byte[] CreateCompressedMessageBytes(byte[] commandMessageBytes, ICompressor compressor, byte compressorId = (byte)CompressorId.zlib)
+		{
+			var compressedCommandMessage = compressor.Compress(commandMessageBytes, 16);
+
+			return CreateCompressedMessageBytes(commandMessageBytes, compressedCommandMessage, compressorId);
+		}
+
+		public static byte[] CreateCompressedMessageBytes(byte[] commandMesage, byte[] compressedCommandMessage, byte compressorId)
+		{
+			using (var memStream = new MemoryStream())
+			using (var writer = new BinaryWriter(memStream))
+			{
+				writer.Write(25 + compressedCommandMessage.Length);
+				writer.Write(0);
+				writer.Write(0);
+				writer.Write((int)Opcode.Compressed);
+				writer.Write((int)Opcode.OpMsg);
+				writer.Write(commandMesage.Length - 16);
+				writer.Write(compressorId);
+				writer.Write(compressedCommandMessage);
+				
+				return memStream.ToArray();
+			}
+		}
+	}
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/CompressedMessageTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/CompressedMessageTests.cs
@@ -58,7 +58,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
 
 			var result = subject.GetEncoder(encoderFactory);
 
-			result.Should().BeOfType<CompressedMessageBinaryEncoderTests>();
+			result.Should().BeOfType<CompressedMessageBinaryEncoder>();
 		}
 		
 		private CompressedMessage CreateSubject()

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/CompressedMessageTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/CompressedMessageTests.cs
@@ -1,4 +1,19 @@
-﻿using System.IO;
+﻿/* Copyright 2013-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.IO;
 using FluentAssertions;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Helpers;
@@ -43,7 +58,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
 
 			var result = subject.GetEncoder(encoderFactory);
 
-			result.Should().BeOfType<CompressedMessageBinaryEncoder>();
+			result.Should().BeOfType<CompressedMessageBinaryEncoderTests>();
 		}
 		
 		private CompressedMessage CreateSubject()

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/CompressedMessageTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/CompressedMessageTests.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using FluentAssertions;
+using MongoDB.Driver.Core.Compression;
+using MongoDB.Driver.Core.Helpers;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
+using Xunit;
+
+namespace MongoDB.Driver.Core.WireProtocol.Messages
+{
+	public class CompressedMessageTests
+	{
+		[Fact]
+		public void Constructor_should_initialize_instance()
+		{
+			var message = CommandMessageHelper.CreateMessage();
+			var compressor = new ZlibCompressor(-1);
+
+			var result = new CompressedMessage(message, compressor);
+
+			result.Compressor.Should().Be(compressor);
+			result.MessageToBeCompressed.Should().Be(message);
+		}
+
+		[Fact]
+		public void MessageType_should_return_expected_result()
+		{
+			var subject = CreateSubject();
+
+			var result = subject.MessageType;
+
+			result.Should().Be(MongoDBMessageType.Compressed);
+		}
+
+		[Fact]
+		public void GetEncoder_should_return_a_CompressedMessageEncoder()
+		{
+			var subject = CreateSubject();
+
+			var stream = new MemoryStream();
+			var encoderSettings = new MessageEncoderSettings();
+			var encoderFactory = new BinaryMessageEncoderFactory(stream, encoderSettings);
+
+			var result = subject.GetEncoder(encoderFactory);
+
+			result.Should().BeOfType<CompressedMessageBinaryEncoder>();
+		}
+		
+		private CompressedMessage CreateSubject()
+		{
+			var message = CommandMessageHelper.CreateMessage();
+			var compressor = new ZlibCompressor(-1);
+
+			return new CompressedMessage(message, compressor);
+		}
+	}
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CommandMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CommandMessageBinaryEncoderTests.cs
@@ -14,16 +14,13 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
-using MongoDB.Bson.IO;
-using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
-using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Helpers;
 using Xunit;
 
 namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
@@ -45,7 +42,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [Fact]
         public void ReadMessage_should_throw_when_message_length_is_negative()
         {
-            var bytes = CreateMessageBytes();
+            var bytes = CommandMessageHelper.CreateMessageBytes();
             var messageLength = -1;
             BitConverter.GetBytes(messageLength).CopyTo(bytes, 0);
             var subject = CreateSubject(bytes);
@@ -59,7 +56,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [Fact]
         public void ReadMessage_should_throw_when_message_did_not_end_at_end_position()
         {
-            var bytes = CreateMessageBytes();
+            var bytes = CommandMessageHelper.CreateMessageBytes();
             bytes[0]--;
             var subject = CreateSubject(bytes);
 
@@ -72,7 +69,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [Fact]
         public void ReadMessage_should_throw_when_end_of_file_is_reached()
         {
-            var bytes = CreateMessageBytes();
+            var bytes = CommandMessageHelper.CreateMessageBytes();
             bytes[0]++;
             var subject = CreateSubject(bytes);
 
@@ -86,7 +83,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         public void ReadMessage_should_read_requestId(
             [Values(1, 2)] int requestId)
         {
-            var bytes = CreateMessageBytes(requestId: requestId);
+            var bytes = CommandMessageHelper.CreateMessageBytes(requestId: requestId);
             var subject = CreateSubject(bytes);
 
             var result = subject.ReadMessage();
@@ -99,7 +96,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         public void ReadMessage_should_read_responseTo(
             [Values(1, 2)] int responseTo)
         {
-            var bytes = CreateMessageBytes(responseTo: responseTo);
+            var bytes = CommandMessageHelper.CreateMessageBytes(responseTo: responseTo);
             var subject = CreateSubject(bytes);
 
             var result = subject.ReadMessage();
@@ -110,7 +107,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [Fact]
         public void ReadMessage_should_throw_when_opcode_is_invalid()
         {
-            var bytes = CreateMessageBytes();
+            var bytes = CommandMessageHelper.CreateMessageBytes();
             bytes[12]++;
             var subject = CreateSubject(bytes);
 
@@ -125,7 +122,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         public void ReadMessage_should_read_moreToCome(
             [Values(false, true)] bool moreToCome)
         {
-            var bytes = CreateMessageBytes(moreToCome: moreToCome);
+            var bytes = CommandMessageHelper.CreateMessageBytes(moreToCome: moreToCome);
             var subject = CreateSubject(bytes);
 
             var result = subject.ReadMessage();
@@ -138,7 +135,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         public void ReadMessage_should_throw_when_flags_is_invalid(
            [Values(-1, 1, 4)] int flags)
         {
-            var bytes = CreateMessageBytes();
+            var bytes = CommandMessageHelper.CreateMessageBytes();
             BitConverter.GetBytes(flags).CopyTo(bytes, 16);
             var subject = CreateSubject(bytes);
             var expectedMessage = flags == 1 ? "Command message CheckSumPresent flag not supported." : "Command message has invalid flags";
@@ -158,8 +155,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [InlineData(new[] { 1, 1, 0 })]
         public void ReadMessage_should_read_sections(int[] sectionTypes)
         {
-            var sections = CreateSections(sectionTypes);
-            var bytes = CreateMessageBytes(sections: sections);
+            var sections = CommandMessageHelper.CreateSections(sectionTypes);
+            var bytes = CommandMessageHelper.CreateMessageBytes(sections: sections);
             var subject = CreateSubject(bytes);
 
             var result = subject.ReadMessage();
@@ -174,11 +171,11 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [InlineData(new[] { 1, 1, 1 })]
         public void ReadMessage_should_throw_when_no_type_0_section_is_present(int[] sectionTypes)
         {
-            var sections = CreateSections(sectionTypes);
-            var sectionBytes = sections.Select(s => CreateSectionBytes(s)).ToArray();
+            var sections = CommandMessageHelper.CreateSections(sectionTypes);
+            var sectionBytes = sections.Select(s => CommandMessageHelper.CreateSectionBytes(s)).ToArray();
             var messageLength = 20 + sectionBytes.Select(s => s.Length).Sum();
-            var header = CreateHeaderBytes(messageLength, 0, 0, 0);
-            var bytes = CreateMessageBytes(header, sectionBytes);
+            var header = CommandMessageHelper.CreateHeaderBytes(messageLength, 0, 0, 0);
+            var bytes = CommandMessageHelper.CreateMessageBytes(header, sectionBytes);
             var subject = CreateSubject(bytes);
 
             var exception = Record.Exception(() => subject.ReadMessage());
@@ -194,11 +191,11 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [InlineData(new[] { 1, 0, 0 })]
         public void ReadMessage_should_throw_when_more_than_one_type_0_section_is_present(int[] sectionTypes)
         {
-            var sections = CreateSections(sectionTypes);
-            var sectionBytes = sections.Select(s => CreateSectionBytes(s)).ToArray();
+            var sections = CommandMessageHelper.CreateSections(sectionTypes);
+            var sectionBytes = sections.Select(s => CommandMessageHelper.CreateSectionBytes(s)).ToArray();
             var messageLength = 20 + sectionBytes.Select(s => s.Length).Sum();
-            var header = CreateHeaderBytes(messageLength, 0, 0, 0);
-            var bytes = CreateMessageBytes(header, sectionBytes);
+            var header = CommandMessageHelper.CreateHeaderBytes(messageLength, 0, 0, 0);
+            var bytes = CommandMessageHelper.CreateMessageBytes(header, sectionBytes);
             var subject = CreateSubject(bytes);
 
             var exception = Record.Exception(() => subject.ReadMessage());
@@ -210,8 +207,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [Fact]
         public void ReadMessage_should_throw_when_payload_type_is_invalid()
         {
-            var message = CreateMessage();
-            var bytes = CreateMessageBytes(message);
+            var message = CommandMessageHelper.CreateMessage();
+            var bytes = CommandMessageHelper.CreateMessageBytes(message);
             bytes[20] = 0xff;
             var subject = CreateSubject(bytes);
 
@@ -224,9 +221,9 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [Fact]
         public void ReadMessage_should_throw_when_type_1_payload_size_is_negative()
         {
-            var sections = CreateSections(sectionTypes: new[] { 1, 0 });
-            var message = CreateMessage(sections: sections);
-            var bytes = CreateMessageBytes(message);
+            var sections = CommandMessageHelper.CreateSections(sectionTypes: new[] { 1, 0 });
+            var message = CommandMessageHelper.CreateMessage(sections: sections);
+            var bytes = CommandMessageHelper.CreateMessageBytes(message);
             var negativePayloadSize = -1;
             BitConverter.GetBytes(negativePayloadSize).CopyTo(bytes, 21);
             var subject = CreateSubject(bytes);
@@ -240,9 +237,9 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [Fact]
         public void ReadMessage_should_throw_when_type_1_payload_does_not_end_at_expected_end_position()
         {
-            var sections = CreateSections(sectionTypes: new[] { 1, 0 });
-            var message = CreateMessage(sections: sections);
-            var bytes = CreateMessageBytes(message);
+            var sections = CommandMessageHelper.CreateSections(sectionTypes: new[] { 1, 0 });
+            var message = CommandMessageHelper.CreateMessage(sections: sections);
+            var bytes = CommandMessageHelper.CreateMessageBytes(message);
             bytes[21]--;
             var subject = CreateSubject(bytes);
 
@@ -258,11 +255,11 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [InlineData(new[] { 1, 0 })]
         public void WriteMessage_should_write_messageLength(int[] sectionTypes)
         {
-            var sections = CreateSections(sectionTypes);
-            var message = CreateMessage(sections: sections);
+            var sections = CommandMessageHelper.CreateSections(sectionTypes);
+            var message = CommandMessageHelper.CreateMessage(sections: sections);
             var stream = new MemoryStream();
             var subject = CreateSubject(stream);
-            var bytes = CreateMessageBytes(message);
+            var bytes = CommandMessageHelper.CreateMessageBytes(message);
             var expectedMessageLength = bytes.Length;
 
             subject.WriteMessage(message);
@@ -278,7 +275,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         public void WriteMessage_should_write_requestId(
             [Values(1, 2)] int requestId)
         {
-            var message = CreateMessage(requestId: requestId);
+            var message = CommandMessageHelper.CreateMessage(requestId: requestId);
             var stream = new MemoryStream();
             var subject = CreateSubject(stream);
 
@@ -294,7 +291,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         public void WriteMessage_should_write_responseTo(
             [Values(1, 2)] int responseTo)
         {
-            var message = CreateMessage(responseTo: responseTo);
+            var message = CommandMessageHelper.CreateMessage(responseTo: responseTo);
             var stream = new MemoryStream();
             var subject = CreateSubject(stream);
 
@@ -308,7 +305,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [Fact]
         public void WriteMessage_should_write_expected_opcode()
         {
-            var message = CreateMessage();
+            var message = CommandMessageHelper.CreateMessage();
             var stream = new MemoryStream();
             var subject = CreateSubject(stream);
 
@@ -324,7 +321,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         public void WriteMessage_should_write_flags(
             [Values(false, true)] bool moreToCome)
         {
-            var message = CreateMessage(moreToCome: moreToCome);
+            var message = CommandMessageHelper.CreateMessage(moreToCome: moreToCome);
             var stream = new MemoryStream();
             var subject = CreateSubject(stream);
 
@@ -341,11 +338,11 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         [InlineData(new[] { 1, 0 })]
         public void WriteMessage_should_write_sections(int[] sectionTypes)
         {
-            var sections = CreateSections(sectionTypes);
-            var message = CreateMessage(sections: sections);
+            var sections = CommandMessageHelper.CreateSections(sectionTypes);
+            var message = CommandMessageHelper.CreateMessage(sections: sections);
             var stream = new MemoryStream();
             var subject = CreateSubject(stream);
-            var expectedMessageBytes = CreateMessageBytes(message);
+            var expectedMessageBytes = CommandMessageHelper.CreateMessageBytes(message);
 
             subject.WriteMessage(message);
             var result = stream.ToArray();
@@ -361,7 +358,7 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             var command = BsonDocument.Parse("{ command : \"x\", writeConcern : { w : 0 } }");
             var section = new Type0CommandMessageSection<BsonDocument>(command, BsonDocumentSerializer.Instance);
             var sections = new CommandMessageSection[] { section };
-            var message = CreateMessage(sections: sections, moreToCome: true);
+            var message = CommandMessageHelper.CreateMessage(sections: sections, moreToCome: true);
             message.PostWriteAction = encoder =>
             {
                 encoder.ChangeWriteConcernFromW0ToW1();
@@ -390,10 +387,10 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
                 new BsonDocument("x", 1),
                 new BsonDocument("x", 2)
             };
-            var type0Section = CreateType0Section();
-            var type1Section = CreateType1Section("id", documents, canBeSplit: true);
-            var message = CreateMessage(sections: new CommandMessageSection[] { type0Section, type1Section });
-            var messageBytes = CreateMessageBytes(message);
+            var type0Section = CommandMessageHelper.CreateType0Section();
+            var type1Section = CommandMessageHelper.CreateType1Section("id", documents, canBeSplit: true);
+            var message = CommandMessageHelper.CreateMessage(sections: new CommandMessageSection[] { type0Section, type1Section });
+            var messageBytes = CommandMessageHelper.CreateMessageBytes(message);
             var maxMessageSize = messageBytes.Length - 1;
             var encoderSettings = new MessageEncoderSettings();
             encoderSettings.Add(MessageEncoderSettingsName.MaxMessageSize, maxMessageSize);
@@ -412,109 +409,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         }
 
         // private methods
-        private int CreateFlags(CommandMessage message)
-        {
-            return message.MoreToCome ? (int)OpMsgFlags.MoreToCome : 0;
-        }
 
-        private byte[] CreateHeaderBytes(int messageLength, int requestId, int responseTo, int flags)
-        {
-            using (var memoryStream = new MemoryStream())
-            using (var stream = new BsonStreamAdapter(memoryStream))
-            {
-                stream.WriteInt32(messageLength);
-                stream.WriteInt32(requestId);
-                stream.WriteInt32(responseTo);
-                stream.WriteInt32((int)Opcode.OpMsg);
-                stream.WriteInt32(flags);
-                return memoryStream.ToArray();
-            }
-        }
 
-        private CommandMessage CreateMessage(
-            int requestId = 0,
-            int responseTo = 0,
-            IEnumerable<CommandMessageSection> sections = null,
-            bool moreToCome = false)
-        {
-            sections = sections ?? new[] { CreateType0Section() };
-            return new CommandMessage(requestId, responseTo, sections, moreToCome);
-        }
-
-        private byte[] CreateMessageBytes(byte[] header, byte[][] sections)
-        {
-            var messageLength = header.Length + sections.Select(s => s.Length).Sum();
-            var message = new byte[messageLength];
-            header.CopyTo(message, 0);
-            var offset = header.Length;
-            foreach (var section in sections)
-            {
-                section.CopyTo(message, offset);
-                offset += section.Length;
-            }
-            return message;
-        }
-
-        private byte[] CreateMessageBytes(CommandMessage message)
-        {
-            var sections = message.Sections.Select(s => CreateSectionBytes(s)).ToArray();
-            var messageLength = 20 + sections.Select(s => s.Length).Sum();
-            var header = CreateHeaderBytes(messageLength, message.RequestId, message.ResponseTo, CreateFlags(message));
-            return CreateMessageBytes(header, sections);
-        }
-
-        private byte[] CreateMessageBytes(
-            int requestId = 0,
-            int responseTo = 0,
-            IEnumerable<CommandMessageSection> sections = null,
-            bool moreToCome = false)
-        {
-            var message = CreateMessage(requestId, responseTo, sections, moreToCome);
-            return CreateMessageBytes(message);
-        }
-
-        private byte[] CreateSectionBytes(CommandMessageSection section)
-        {
-            switch (section.PayloadType)
-            {
-                case PayloadType.Type0:
-                    return CreateType0SectionBytes((Type0CommandMessageSection<BsonDocument>)section);
-
-                case PayloadType.Type1:
-                    return CreateType1SectionBytes((Type1CommandMessageSection<BsonDocument>)section);
-
-                default:
-                    throw new ArgumentException($"Invalid payload type: {section.PayloadType}.");
-            }
-        }
-
-        private List<CommandMessageSection> CreateSections(params int[] sectionTypes)
-        {
-            var sections = new List<CommandMessageSection>();
-            for (var i = 0; i < sectionTypes.Length; i++)
-            {
-                var sectionType = sectionTypes[i];
-
-                CommandMessageSection section;
-                switch (sectionType)
-                {
-                    case 0:
-                        section = CreateType0Section();
-                        break;
-
-                    case 1:
-                        var identifier = $"id{i}";
-                        var documents = Enumerable.Range(0, i + 1).Select(n => new BsonDocument("n", n)).ToArray();
-                        section = CreateType1Section(identifier, documents);
-                        break;
-
-                    default:
-                        throw new ArgumentException($"Invalid payload type: {sectionType}.", nameof(sectionTypes));
-                }
-                sections.Add(section);
-            }
-            return sections;
-        }
 
         private CommandMessageBinaryEncoder CreateSubject(byte[] bytes)
         {
@@ -531,55 +427,5 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             return new CommandMessageBinaryEncoder(stream, encoderSettings);
         }
 
-        private Type0CommandMessageSection<BsonDocument> CreateType0Section(BsonDocument document = null)
-        {
-            document = document ?? new BsonDocument("t", 0);
-            return new Type0CommandMessageSection<BsonDocument>(document, BsonDocumentSerializer.Instance);
-        }
-
-        private byte[] CreateType0SectionBytes(Type0CommandMessageSection<BsonDocument> section)
-        {
-            using (var memoryStream = new MemoryStream())
-            using (var writer = new BsonBinaryWriter(memoryStream))
-            {
-                memoryStream.WriteByte(0);
-                var context = BsonSerializationContext.CreateRoot(writer);
-                BsonDocumentSerializer.Instance.Serialize(context, section.Document);
-                return memoryStream.ToArray();
-            }
-        }
-
-        private Type1CommandMessageSection<BsonDocument> CreateType1Section(
-            string identifier = null,
-            BsonDocument[] documents = null,
-            bool canBeSplit = false)
-        {
-            identifier = identifier ?? "id";
-            documents = documents ?? new BsonDocument[0];
-            var batch = new BatchableSource<BsonDocument>(documents, canBeSplit: canBeSplit);
-            return new Type1CommandMessageSection<BsonDocument>(identifier, batch, BsonDocumentSerializer.Instance, NoOpElementNameValidator.Instance, null, null);
-        }
-
-        private byte[] CreateType1SectionBytes(Type1CommandMessageSection<BsonDocument> section)
-        {
-            using (var memoryStream = new MemoryStream())
-            using (var stream = new BsonStreamAdapter(memoryStream))
-            using (var writer = new BsonBinaryWriter(stream))
-            {
-                stream.WriteByte(1);
-                var payloadStartPosition = stream.Position;
-                stream.WriteInt32(0); // size
-                stream.WriteCString(section.Identifier);
-                var context = BsonSerializationContext.CreateRoot(writer);
-                var batch = section.Documents;
-                for (var i = 0; i < batch.Count; i++)
-                {
-                    var document = batch.Items[batch.Offset + i];
-                    BsonDocumentSerializer.Instance.Serialize(context, document);
-                }
-                stream.BackpatchSize(payloadStartPosition);
-                return memoryStream.ToArray();
-            }
-        }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CompressedMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CompressedMessageBinaryEncoderTests.cs
@@ -13,24 +13,13 @@
 * limitations under the License.
 */
 
-namespace MongoDB.Driver.Core.Compression
+namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
 {
-	/// <summary>
-	/// Represents the compressor id.
-	/// </summary>
-	public enum CompressorId
+	public class CompressedMessageBinaryEncoderTests
 	{
-		/// <summary>
-		/// No compression.
-		/// </summary>
-		noop = 0,
-		///// <summary>
-		///// Compression using snappy algorithm. NOT SUPPORTED YET.
-		///// </summary>
-		//snappy = 1, 
-		/// <summary>
-		/// Compression using zlib algorithm. 
-		/// </summary>
-		zlib = 2
+		public void Constructor_should_initialize_instance()
+		{
+			
+		}
 	}
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CompressedMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/CompressedMessageBinaryEncoderTests.cs
@@ -13,13 +13,205 @@
 * limitations under the License.
 */
 
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core.Compression;
+using MongoDB.Driver.Core.Helpers;
+using Xunit;
+
 namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
 {
 	public class CompressedMessageBinaryEncoderTests
 	{
+		private const int MessageHeaderLength = 16;
+		private ZlibCompressor _compressor;
+
+		public CompressedMessageBinaryEncoderTests()
+		{
+			_compressor = new ZlibCompressor(-1);
+		}
+
+		[Fact]
 		public void Constructor_should_initialize_instance()
 		{
-			
+			var stream = new MemoryStream();
+			var encoderSettings = new MessageEncoderSettings();
+
+			var result = new CompressedMessageBinaryEncoder(stream, encoderSettings);
+
+			result._encoderSettings().Should().BeSameAs(encoderSettings);
+			result._stream().Should().BeSameAs(stream);		
 		}
+
+		[Fact]
+		public void ReadMessage_should_throw_not_supported_exception()
+		{
+			var stream = new MemoryStream();
+			var encoderSettings = new MessageEncoderSettings();
+
+			var subject = new CompressedMessageBinaryEncoder(stream, encoderSettings);
+
+			Action action = () => subject.ReadMessage();
+
+			action.ShouldThrow<NotSupportedException>();
+		}
+
+		[Fact]
+		public void WriteMessage_should_write_messageLength()
+		{
+			var commandMessage = CommandMessageHelper.CreateMessage();
+			var uncompressedCommandMessageBytes = CommandMessageHelper.CreateMessageBytes(commandMessage);
+			var compressedMessageBytes = CompressedMessageHelper.CreateCompressedMessageBytes(uncompressedCommandMessageBytes, _compressor);
+			var compressedMessage = CreateCompressedMessage(commandMessage);
+			var stream = new MemoryStream();
+			var expectedMessageLength = compressedMessageBytes.Length;
+			
+			var subject = CreateSubject(stream);
+			subject.WriteMessage(compressedMessage);
+
+			var result = stream.ToArray();
+
+			result.Should().HaveCount(expectedMessageLength);
+			var messageLength = BitConverter.ToInt32(result, 0);
+			messageLength.Should().Be(expectedMessageLength);
+		}
+
+		[Theory]
+		[ParameterAttributeData]
+		public void WriteMessage_should_write_requestId(
+			[Values(1, 2)] int requestId)
+		{
+			var message = CommandMessageHelper.CreateMessage(requestId: requestId);
+			var compressedMessage = CreateCompressedMessage(message);
+			
+			var stream = new MemoryStream();
+			var subject = CreateSubject(stream);
+
+			subject.WriteMessage(compressedMessage);
+			var result = stream.ToArray();
+
+			var resultRequestId = BitConverter.ToInt32(result, 4);
+			resultRequestId.Should().Be(requestId);
+		}
+
+		[Theory]
+		[ParameterAttributeData]
+		public void WriteMessage_should_write_responseTo(
+			[Values(1, 2)] int responseTo)
+		{
+			var message = CommandMessageHelper.CreateMessage(responseTo: responseTo);
+			var compressedMessage = CreateCompressedMessage(message);
+			
+			var stream = new MemoryStream();
+			var subject = CreateSubject(stream);
+
+			subject.WriteMessage(compressedMessage);
+			var result = stream.ToArray();
+
+			var resultResponseTo = BitConverter.ToInt32(result, 8);
+			resultResponseTo.Should().Be(responseTo);
+		}
+		
+		[Fact]
+		public void WriteMessage_should_write_expected_opcode()
+		{
+			var message = CommandMessageHelper.CreateMessage();
+			var compressedMessage = CreateCompressedMessage(message);
+
+			var stream = new MemoryStream();
+			var subject = CreateSubject(stream);
+
+			subject.WriteMessage(compressedMessage);
+			var result = stream.ToArray();
+
+			var opcode = BitConverter.ToInt32(result, 12);
+			opcode.Should().Be((int)Opcode.Compressed);
+		}		
+		
+		[Fact]
+		public void WriteMessage_should_write_expected_original_opcode()
+		{
+			var message = CommandMessageHelper.CreateMessage();
+			var compressedMessage = CreateCompressedMessage(message);
+
+			var stream = new MemoryStream();
+			var subject = CreateSubject(stream);
+
+			subject.WriteMessage(compressedMessage);
+			var result = stream.ToArray();
+
+			var originalOpcode = BitConverter.ToInt32(result, 16);
+			originalOpcode.Should().Be((int)Opcode.OpMsg);
+		}	
+		
+		[Fact]
+		public void WriteMessage_should_write_expected_uncompressed_size()
+		{
+			var message = CommandMessageHelper.CreateMessage();
+			var uncompressedCommandMessageBytes = CommandMessageHelper.CreateMessageBytes(message);
+			var compressedMessage = CreateCompressedMessage(message);
+
+			var stream = new MemoryStream();
+			var subject = CreateSubject(stream);
+
+			subject.WriteMessage(compressedMessage);
+			var result = stream.ToArray();
+
+			var uncompressedSize = BitConverter.ToInt32(result, 20);
+			uncompressedSize.Should().Be(uncompressedCommandMessageBytes.Length - MessageHeaderLength);
+		}		
+		
+		[Fact]
+		public void WriteMessage_should_write_expected_compressorId()
+		{
+			var message = CommandMessageHelper.CreateMessage();
+			var compressedMessage = CreateCompressedMessage(message);
+
+			var stream = new MemoryStream();
+			var subject = CreateSubject(stream);
+
+			subject.WriteMessage(compressedMessage);
+			var result = stream.ToArray();
+
+			var compressorId = result[24];
+			compressorId.Should().Be((byte)_compressor.Id);
+		}	
+		
+		[Fact]
+		public void WriteMessage_should_write_expected_compressedMessageBytes()
+		{
+			var message = CommandMessageHelper.CreateMessage();
+			var compressedMessage = CreateCompressedMessage(message);
+
+			var stream = new MemoryStream();
+			var subject = CreateSubject(stream);
+
+			subject.WriteMessage(compressedMessage);
+			var result = stream.ToArray().ToList();
+
+			var uncompressedMessageBytes = CommandMessageHelper.CreateMessageBytes(message);
+			var expectedCompressedBytes = _compressor.Compress(uncompressedMessageBytes, MessageHeaderLength);
+			
+			var compressedBytes = result.GetRange(25, result.Count - 25);
+			compressedBytes.Should().HaveSameCount(expectedCompressedBytes);
+			compressedBytes.ShouldBeEquivalentTo(expectedCompressedBytes, o => o.WithStrictOrdering());
+		}
+		
+		private CompressedMessage CreateCompressedMessage(CommandMessage commandMessage)
+		{
+			return new CompressedMessage(commandMessage, _compressor);
+		}
+
+		private static CompressedMessageBinaryEncoder CreateSubject(
+			Stream stream = null,
+			MessageEncoderSettings encoderSettings = null)
+		{
+			stream = stream ?? new MemoryStream();
+			encoderSettings = encoderSettings ?? new MessageEncoderSettings();
+			return new CompressedMessageBinaryEncoder(stream, encoderSettings);
+		}	
 	}
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/JsonEncoders/JsonMessageEncoderFactoryTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/JsonEncoders/JsonMessageEncoderFactoryTests.cs
@@ -203,5 +203,16 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.JsonEncoders
                 encoder.Should().BeOfType<UpdateMessageJsonEncoder>();
             }
         }
+        
+        [Fact]
+        public void GetCompressedMessageEncoder_should_throw_not_supported_exception()
+        {
+            using (var textWriter = new StringWriter())
+            {
+                var encoderFactory = new JsonMessageEncoderFactory(null, textWriter, __messageEncoderSettings);
+                Action action =  () => encoderFactory.GetCompressedMessageEncoder();
+                action.ShouldThrow<NotSupportedException>();
+            }
+        }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Core\Clusters\ClusterClockTests.cs" />
     <Compile Include="Core\Clusters\ElectionIdTests.cs" />
     <Compile Include="Core\Clusters\ReplicaSetConfigTests.cs" />
+    <Compile Include="Core\Compression\MessageCompressionHelperTests.cs" />
     <Compile Include="Core\Configuration\ClusterBuilderTests.cs" />
     <Compile Include="Core\Configuration\ClusterSettingsTests.cs" />
     <Compile Include="Core\Configuration\ConnectionPoolSettingsTests.cs" />
@@ -102,6 +103,7 @@
     <Compile Include="Core\Connections\KeepAliveValuesTests.cs" />
     <Compile Include="Core\Events\EventAggregatorTests.cs" />
     <Compile Include="Core\Events\ReflectionEventSubscriberTests.cs" />
+    <Compile Include="Core\Helpers\CommandMessageHelper.cs" />
     <Compile Include="Core\Events\TraceSourceSdamEventSubscriberTests.cs" />
     <Compile Include="Core\Misc\ReadAheadEnumerableTests.cs" />
     <Compile Include="Core\Misc\SemaphoreSlimRequestTests.cs" />

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Core\Events\EventAggregatorTests.cs" />
     <Compile Include="Core\Events\ReflectionEventSubscriberTests.cs" />
     <Compile Include="Core\Helpers\CommandMessageHelper.cs" />
+    <Compile Include="Core\Helpers\CompressedMessageHelper.cs" />
     <Compile Include="Core\Events\TraceSourceSdamEventSubscriberTests.cs" />
     <Compile Include="Core\Misc\ReadAheadEnumerableTests.cs" />
     <Compile Include="Core\Misc\SemaphoreSlimRequestTests.cs" />
@@ -186,6 +187,7 @@
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandMessageBinaryEncoderTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandRequestMessageBinaryEncoderTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandResponseMessageBinaryEncoderTests.cs" />
+    <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CompressedMessageBinaryEncoderTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\MessageBinaryEncoderBaseTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\JsonEncoders\CommandMessageJsonEncoderTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\JsonEncoders\CommandRequestMessageJsonEncoderTests.cs" />

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Core\WireProtocol\Messages\CommandMessageTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\CommandRequestMessageTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\CommandResponseMessageTests.cs" />
+    <Compile Include="Core\WireProtocol\Messages\CompressedMessageTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandMessageBinaryEncoderTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandRequestMessageBinaryEncoderTests.cs" />
     <Compile Include="Core\WireProtocol\Messages\Encoders\BinaryEncoders\CommandResponseMessageBinaryEncoderTests.cs" />

--- a/tests/MongoDB.Driver.Examples/AggregatePrimer.cs
+++ b/tests/MongoDB.Driver.Examples/AggregatePrimer.cs
@@ -22,9 +22,13 @@ namespace MongoDB.Driver.Examples
 {
     public class AggregatePrimer : PrimerTestFixture
     {
-        [Fact]
-        public async Task GroupDocumentsByAFieldAndCalculateCount()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GroupDocumentsByAFieldAndCalculateCount(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+            
             // @begin: group-documents-by-a-field-and-calculate-count
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");
@@ -48,9 +52,13 @@ namespace MongoDB.Driver.Examples
             // @end: group-documents-by-a-field-and-calculate-count
         }
 
-        [Fact]
-        public async Task FilterAndGroupDocuments()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task FilterAndGroupDocuments(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+            
             // @begin: filter-and-group-documents
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");

--- a/tests/MongoDB.Driver.Examples/IndexesPrimer.cs
+++ b/tests/MongoDB.Driver.Examples/IndexesPrimer.cs
@@ -22,9 +22,12 @@ namespace MongoDB.Driver.Examples
 {
     public class IndexesPrimer : PrimerTestFixture
     {
-        [Fact]
-        public async Task SingleFieldIndex()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SingleFieldIndex(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: single-field-index
@@ -46,9 +49,12 @@ namespace MongoDB.Driver.Examples
             // @end: single-field-index
         }
 
-        [Fact]
-        public async Task CreateCompoundIndex()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task CreateCompoundIndex(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: create-compound-index

--- a/tests/MongoDB.Driver.Examples/InsertPrimer.cs
+++ b/tests/MongoDB.Driver.Examples/InsertPrimer.cs
@@ -22,9 +22,12 @@ namespace MongoDB.Driver.Examples
 {
     public class InsertPrimer : PrimerTestFixture
     {
-        [Fact]
-        public async Task InsertADocument()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task InsertADocument(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: insert-a-document

--- a/tests/MongoDB.Driver.Examples/PrimerTestFixture.cs
+++ b/tests/MongoDB.Driver.Examples/PrimerTestFixture.cs
@@ -54,6 +54,32 @@ namespace MongoDB.Driver.Examples
             __reloadCollection = true;
         }
 
+        protected void WithCompression(bool compressionEnabled)
+        {
+            if (!compressionEnabled)
+            {
+                return;
+            }
+
+            var connectionString = CoreTestConfiguration.ConnectionString.ToString();
+
+            connectionString = AppendCompression(connectionString);
+            
+            __client = new MongoClient(connectionString);
+            __database = __client.GetDatabase("test");
+        }
+
+        private string AppendCompression(string connectionString)
+        {
+            if (connectionString.Contains("?"))
+                return $"{connectionString}&compressors=zlib";
+
+            if (connectionString.EndsWith("/"))
+                return $"{connectionString}?compressors=zlib";
+
+            return $"{connectionString}/?compressors=zlib";
+        }
+
         // helper methods
         private void LoadCollection()
         {

--- a/tests/MongoDB.Driver.Examples/QueryPrimer.cs
+++ b/tests/MongoDB.Driver.Examples/QueryPrimer.cs
@@ -30,6 +30,7 @@ namespace MongoDB.Driver.Examples
         {
             // @begin: query-all
             // @code: start
+            
             var collection = __database.GetCollection<BsonDocument>("restaurants");
             var filter = new BsonDocument();
             var count = 0;

--- a/tests/MongoDB.Driver.Examples/QueryPrimer.cs
+++ b/tests/MongoDB.Driver.Examples/QueryPrimer.cs
@@ -25,9 +25,13 @@ namespace MongoDB.Driver.Examples
 {
     public class QueryPrimer : PrimerTestFixture
     {
-        [Fact]
-        public async Task QueryAll()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task QueryAll(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+            
             // @begin: query-all
             // @code: start
             
@@ -55,9 +59,13 @@ namespace MongoDB.Driver.Examples
             // @end: query-all
         }
 
-        [Fact]
-        public async Task LogicalAnd()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LogicalAnd(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+
             // @begin: logical-and
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");
@@ -73,9 +81,13 @@ namespace MongoDB.Driver.Examples
             // @end: logical-and
         }
 
-        [Fact]
-        public async Task LogicalOr()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LogicalOr(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+
             // @begin: logical-or
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");
@@ -91,9 +103,13 @@ namespace MongoDB.Driver.Examples
             // @end: logical-or
         }
 
-        [Fact]
-        public async Task QueryTopLevelField()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task QueryTopLevelField(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+
             // @begin: query-top-level-field
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");
@@ -108,9 +124,13 @@ namespace MongoDB.Driver.Examples
             // @end: query-top-level-field
         }
 
-        [Fact]
-        public async Task QueryEmbeddedDocument()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task QueryEmbeddedDocument(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+
             // @begin: query-embedded-document
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");
@@ -125,9 +145,13 @@ namespace MongoDB.Driver.Examples
             // @end: query-embedded-document
         }
 
-        [Fact]
-        public async Task QueryFieldInArray()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task QueryFieldInArray(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+
             // @begin: query-field-in-array
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");
@@ -142,9 +166,13 @@ namespace MongoDB.Driver.Examples
             // @end: query-field-in-array
         }
 
-        [Fact]
-        public async Task GreaterThan()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task GreaterThan(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+
             // @begin: greater-than
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");
@@ -159,9 +187,13 @@ namespace MongoDB.Driver.Examples
             // @end: greater-than
         }
 
-        [Fact]
-        public async Task LessThan()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LessThan(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+
             // @begin: less-than
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");
@@ -176,9 +208,13 @@ namespace MongoDB.Driver.Examples
             // @end: less-than
         }
 
-        [Fact]
-        public async Task Sort()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Sort(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
+
             // @begin: sort
             // @code: start
             var collection = __database.GetCollection<BsonDocument>("restaurants");

--- a/tests/MongoDB.Driver.Examples/RemovePrimer.cs
+++ b/tests/MongoDB.Driver.Examples/RemovePrimer.cs
@@ -22,9 +22,12 @@ namespace MongoDB.Driver.Examples
 {
     public class RemovePrimer : PrimerTestFixture
     {
-        [Fact]
-        public async Task RemoveMatchingDocument()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RemoveMatchingDocument(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: remove-matching-documents
@@ -41,9 +44,12 @@ namespace MongoDB.Driver.Examples
             // @end: remove-matching-documents
         }
 
-        [Fact]
-        public async Task RemoveAllDocuments()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RemoveAllDocuments(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: remove-all-documents
@@ -60,9 +66,12 @@ namespace MongoDB.Driver.Examples
             // @end: remove-all-documents
         }
 
-        [Fact]
-        public async Task DropCollection()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DropCollection(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: drop-collection

--- a/tests/MongoDB.Driver.Examples/UpdatePrimer.cs
+++ b/tests/MongoDB.Driver.Examples/UpdatePrimer.cs
@@ -25,10 +25,13 @@ namespace MongoDB.Driver.Examples
 {
     public class UpdatePrimer : PrimerTestFixture
     {
-        [SkippableFact]
-        public async Task UpdateTopLevelFields()
+        [SkippableTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UpdateTopLevelFields(bool compressionEnabled)
         {
             RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: update-top-level-fields
@@ -52,9 +55,12 @@ namespace MongoDB.Driver.Examples
             // @end: update-top-level-fields
         }
 
-        [Fact]
-        public async Task UpdateEmbeddedField()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UpdateEmbeddedField(bool compressionEnabled)
         {
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: update-embedded-field
@@ -76,10 +82,13 @@ namespace MongoDB.Driver.Examples
             // @end: update-embedded-field
         }
 
-        [SkippableFact]
-        public async Task UpdateMultipleDocuments()
+        [SkippableTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UpdateMultipleDocuments(bool compressionEnabled)
         {
             RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            WithCompression(compressionEnabled);
             AltersCollection();
 
             // @begin: update-multiple-documents

--- a/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
@@ -20,6 +20,7 @@ using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Configuration;
 using Xunit;
 
 namespace MongoDB.Driver.Tests
@@ -72,7 +73,7 @@ namespace MongoDB.Driver.Tests
         private ClusterKey CreateSubject(string notEqualFieldName = null)
         {
             var applicationName = "app1";
-            var compressors = Enumerable.Empty<string>();
+            var compressors = Enumerable.Empty<MongoCompressor>();
             var connectionMode = ConnectionMode.Direct;
             var connectTimeout = TimeSpan.FromSeconds(1);
 #pragma warning disable 618
@@ -105,7 +106,7 @@ namespace MongoDB.Driver.Tests
             switch (notEqualFieldName)
             {
                 case "ApplicationName": applicationName = "app2"; break;
-                case "Compressors": compressors = new[] {"zlib"}; break;
+                case "Compressors": compressors = new[] {new MongoCompressor{Name = "zlib"}}; break;
                 case "ConnectionMode": connectionMode = ConnectionMode.ReplicaSet; break;
                 case "ConnectTimeout": connectTimeout = TimeSpan.FromSeconds(99); break;
 #pragma warning disable 618

--- a/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
@@ -106,7 +106,7 @@ namespace MongoDB.Driver.Tests
             switch (notEqualFieldName)
             {
                 case "ApplicationName": applicationName = "app2"; break;
-                case "Compressors": compressors = new[] {new MongoCompressor{Name = "zlib"}}; break;
+                case "Compressors": compressors = new[] {new MongoCompressor("zlib")}; break;
                 case "ConnectionMode": connectionMode = ConnectionMode.ReplicaSet; break;
                 case "ConnectTimeout": connectTimeout = TimeSpan.FromSeconds(99); break;
 #pragma warning disable 618

--- a/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
@@ -38,6 +38,7 @@ namespace MongoDB.Driver.Tests
 
         [Theory]
         [InlineData("ApplicationName", true)]
+        [InlineData("Compressors", true)]
         [InlineData("ConnectionMode", true)]
         [InlineData("ConnectTimeout", true)]
         [InlineData("Credentials", false)]
@@ -71,6 +72,7 @@ namespace MongoDB.Driver.Tests
         private ClusterKey CreateSubject(string notEqualFieldName = null)
         {
             var applicationName = "app1";
+            var compressors = Enumerable.Empty<string>();
             var connectionMode = ConnectionMode.Direct;
             var connectTimeout = TimeSpan.FromSeconds(1);
 #pragma warning disable 618
@@ -103,6 +105,7 @@ namespace MongoDB.Driver.Tests
             switch (notEqualFieldName)
             {
                 case "ApplicationName": applicationName = "app2"; break;
+                case "Compressors": compressors = new[] {"zlib"}; break;
                 case "ConnectionMode": connectionMode = ConnectionMode.ReplicaSet; break;
                 case "ConnectTimeout": connectTimeout = TimeSpan.FromSeconds(99); break;
 #pragma warning disable 618
@@ -131,6 +134,7 @@ namespace MongoDB.Driver.Tests
             var clientSettings = new MongoClientSettings
             {
                 ApplicationName = applicationName,
+                Compressors = compressors,
                 ConnectionMode = connectionMode,
                 ConnectTimeout = connectTimeout,
                 Credential = credential,

--- a/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
@@ -25,6 +25,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
+using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
 using Xunit;
 
@@ -57,7 +58,7 @@ namespace MongoDB.Driver.Tests
             var clientSettings = new MongoClientSettings
             {
                 ApplicationName = "app1",
-                Compressors = new []{"zlib"},
+                Compressors = new []{ new MongoCompressor{Name = "zlib"} },
                 ConnectionMode = ConnectionMode.ReplicaSet,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 Credential = credential,

--- a/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
@@ -57,6 +57,7 @@ namespace MongoDB.Driver.Tests
             var clientSettings = new MongoClientSettings
             {
                 ApplicationName = "app1",
+                Compressors = new []{"zlib"},
                 ConnectionMode = ConnectionMode.ReplicaSet,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 Credential = credential,

--- a/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
@@ -58,7 +58,7 @@ namespace MongoDB.Driver.Tests
             var clientSettings = new MongoClientSettings
             {
                 ApplicationName = "app1",
-                Compressors = new []{ new MongoCompressor{Name = "zlib"} },
+                Compressors = new[] {new MongoCompressor("zlib")},
                 ConnectionMode = ConnectionMode.ReplicaSet,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 Credential = credential,

--- a/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
@@ -130,7 +130,7 @@ namespace MongoDB.Driver.Tests
             var settings = new MongoClientSettings();
             Assert.Equal(null, settings.ApplicationName);
             Assert.Equal(ConnectionMode.Automatic, settings.ConnectionMode);
-            Assert.Equal(Enumerable.Empty<string>(), settings.Compressors);
+            Assert.Equal(Enumerable.Empty<MongoCompressor>(), settings.Compressors);
             Assert.Equal(MongoDefaults.ConnectTimeout, settings.ConnectTimeout);
 #pragma warning disable 618
             Assert.Equal(0, settings.Credentials.Count());
@@ -173,7 +173,7 @@ namespace MongoDB.Driver.Tests
             Assert.False(clone.Equals(settings));
 
             clone = settings.Clone();
-            clone.Compressors = new []{"zlib"};
+            clone.Compressors = new []{ new MongoCompressor{Name = "zlib"}};
             Assert.False(clone.Equals(settings));
 
             clone = settings.Clone();
@@ -399,9 +399,9 @@ namespace MongoDB.Driver.Tests
         public void TestCompressors()
         {
             var settings = new MongoClientSettings();
-            Assert.Equal(Enumerable.Empty<string>(), settings.Compressors);
+            Assert.Equal(Enumerable.Empty<MongoCompressor>(), settings.Compressors);
 
-            var compressors = new []{"zlib"};
+            var compressors = new []{ new MongoCompressor{ Name = "zlib"}};
             settings.Compressors = compressors;
             Assert.Equal(compressors, settings.Compressors);
 
@@ -832,7 +832,7 @@ namespace MongoDB.Driver.Tests
             var subject = new MongoClientSettings
             {
                 ApplicationName = "app",
-                Compressors = new []{"zlib"},
+                Compressors = new []{ new MongoCompressor { Name = "zlib"}},
                 ConnectionMode = ConnectionMode.Direct,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 Credential = credential,

--- a/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
@@ -173,7 +173,7 @@ namespace MongoDB.Driver.Tests
             Assert.False(clone.Equals(settings));
 
             clone = settings.Clone();
-            clone.Compressors = new []{ new MongoCompressor{Name = "zlib"}};
+            clone.Compressors = new[] {new MongoCompressor("zlib")};
             Assert.False(clone.Equals(settings));
 
             clone = settings.Clone();
@@ -401,7 +401,7 @@ namespace MongoDB.Driver.Tests
             var settings = new MongoClientSettings();
             Assert.Equal(Enumerable.Empty<MongoCompressor>(), settings.Compressors);
 
-            var compressors = new []{ new MongoCompressor{ Name = "zlib"}};
+            var compressors = new[] {new MongoCompressor("zlib")};
             settings.Compressors = compressors;
             Assert.Equal(compressors, settings.Compressors);
 
@@ -832,7 +832,7 @@ namespace MongoDB.Driver.Tests
             var subject = new MongoClientSettings
             {
                 ApplicationName = "app",
-                Compressors = new []{ new MongoCompressor { Name = "zlib"}},
+                Compressors = new[] {new MongoCompressor("zlib")},
                 ConnectionMode = ConnectionMode.Direct,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 Credential = credential,

--- a/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
@@ -45,6 +45,7 @@ namespace MongoDB.Driver.Tests
                 AuthenticationMechanism = "GSSAPI",
                 AuthenticationMechanismProperties = authMechanismProperties,
                 AuthenticationSource = "db",
+                Compressors = new []{"zlib"},
                 ConnectionMode = ConnectionMode.ReplicaSet,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 DatabaseName = "database",
@@ -84,6 +85,7 @@ namespace MongoDB.Driver.Tests
                 "ipv6=true",
                 "ssl=true", // UseSsl
                 "sslVerifyCertificate=false", // VerifySslCertificate
+                "compressors=zlib",
                 "connect=replicaSet",
                 "replicaSet=name",
                 "readConcernLevel=majority",
@@ -115,6 +117,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(authMechanismProperties, builder.AuthenticationMechanismProperties);
                 Assert.Equal("db", builder.AuthenticationSource);
                 Assert.Equal(123, builder.ComputedWaitQueueSize);
+                Assert.Equal(new []{"zlib"}, builder.Compressors);
                 Assert.Equal(ConnectionMode.ReplicaSet, builder.ConnectionMode);
                 Assert.Equal(TimeSpan.FromSeconds(1), builder.ConnectTimeout);
                 Assert.Equal("database", builder.DatabaseName);
@@ -240,6 +243,22 @@ namespace MongoDB.Driver.Tests
 
         [Theory]
         [InlineData(null, "mongodb://localhost", new[] { "" })]
+        [InlineData(new []{"zlib"}, "mongodb://localhost/?compressors={0}", new[] { "zlib" })]
+        public void TestCompressors(string[] compressors, string formatString, string[] values)
+        {
+            var built = new MongoUrlBuilder { Server = _localhost };
+            if (compressors != null) { built.Compressors = compressors; }
+
+            var canonicalConnectionString = string.Format(formatString, values[0]);
+            foreach (var builder in EnumerateBuiltAndParsedBuilders(built, formatString, values))
+            {
+                Assert.Equal(compressors ?? new string[0], builder.Compressors);
+                Assert.Equal(canonicalConnectionString, builder.ToString());
+            }
+        }
+        
+        [Theory]
+        [InlineData(null, "mongodb://localhost", new[] { "" })]
         [InlineData(ConnectionMode.Automatic, "mongodb://localhost{0}", new[] { "", "/?connect=automatic", "/?connect=Automatic" })]
         [InlineData(ConnectionMode.Direct, "mongodb://localhost/?connect={0}", new[] { "direct", "Direct" })]
         [InlineData(ConnectionMode.ReplicaSet, "mongodb://localhost/?connect={0}", new[] { "replicaSet", "ReplicaSet" })]
@@ -332,6 +351,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(null, builder.AuthenticationMechanism);
                 Assert.Equal(0, builder.AuthenticationMechanismProperties.Count());
                 Assert.Equal(null, builder.AuthenticationSource);
+                Assert.Equal(Enumerable.Empty<string>(), builder.Compressors);
                 Assert.Equal(MongoDefaults.ComputedWaitQueueSize, builder.ComputedWaitQueueSize);
                 Assert.Equal(ConnectionMode.Automatic, builder.ConnectionMode);
                 Assert.Equal(MongoDefaults.ConnectTimeout, builder.ConnectTimeout);

--- a/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
@@ -39,13 +39,16 @@ namespace MongoDB.Driver.Tests
                 { "SERVICE_NAME", "other" },
                 { "CANONICALIZE_HOST_NAME", "true" }
             };
+            var zlibCompressor = new  MongoCompressor("zlib");
+            zlibCompressor.Properties.Add(MongoCompressor.Level, 4);
+
             var built = new MongoUrlBuilder()
             {
                 ApplicationName = "app",
                 AuthenticationMechanism = "GSSAPI",
                 AuthenticationMechanismProperties = authMechanismProperties,
                 AuthenticationSource = "db",
-                Compressors = new []{ new MongoCompressor { Name = "zlib"}},
+                Compressors = new[] {zlibCompressor},
                 ConnectionMode = ConnectionMode.ReplicaSet,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 DatabaseName = "database",
@@ -86,6 +89,7 @@ namespace MongoDB.Driver.Tests
                 "ssl=true", // UseSsl
                 "sslVerifyCertificate=false", // VerifySslCertificate
                 "compressors=zlib",
+                "zlibCompressionLevel=4",
                 "connect=replicaSet",
                 "replicaSet=name",
                 "readConcernLevel=majority",
@@ -117,7 +121,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(authMechanismProperties, builder.AuthenticationMechanismProperties);
                 Assert.Equal("db", builder.AuthenticationSource);
                 Assert.Equal(123, builder.ComputedWaitQueueSize);
-                Assert.Equal(new []{ new MongoCompressor { Name = "zlib"} }, builder.Compressors);
+                Assert.Contains(builder.Compressors, x => x.Name == "zlib");
                 Assert.Equal(ConnectionMode.ReplicaSet, builder.ConnectionMode);
                 Assert.Equal(TimeSpan.FromSeconds(1), builder.ConnectTimeout);
                 Assert.Equal("database", builder.DatabaseName);
@@ -247,7 +251,7 @@ namespace MongoDB.Driver.Tests
         public void TestCompressors(string[] compressors, string formatString, string[] values)
         {
             var built = new MongoUrlBuilder { Server = _localhost };
-            if (compressors != null) { built.Compressors = compressors.Select(x => new MongoCompressor{Name = x}); }
+            if (compressors != null) { built.Compressors = compressors.Select(x => new MongoCompressor("zlib")); }
 
             var canonicalConnectionString = string.Format(formatString, values[0]);
             foreach (var builder in EnumerateBuiltAndParsedBuilders(built, formatString, values))

--- a/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
@@ -37,13 +37,17 @@ namespace MongoDB.Driver.Tests
                 { "SERVICE_NAME", "other" },
                 { "CANONICALIZE_HOST_NAME", "true" }
             };
+            
+            var zlibCompressor = new  MongoCompressor("zlib");
+            zlibCompressor.Properties.Add(MongoCompressor.Level, 4);
+            
             var built = new MongoUrlBuilder()
             {
                 ApplicationName = "app",
                 AuthenticationMechanism = "GSSAPI",
                 AuthenticationMechanismProperties = authMechanismProperties,
                 AuthenticationSource = "db",
-                Compressors = new []{ new MongoCompressor { Name = "zlib"} },
+                Compressors = new[] {zlibCompressor},
                 ConnectionMode = ConnectionMode.ReplicaSet,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 DatabaseName = "database",
@@ -84,6 +88,7 @@ namespace MongoDB.Driver.Tests
                 "ssl=true", // UseSsl
                 "sslVerifyCertificate=false", // VerifySslCertificate
                 "compressors=zlib",
+                "zlibCompressionLevel=4",
                 "connect=replicaSet",
                 "replicaSet=name",
                 "readConcernLevel=majority",
@@ -115,7 +120,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(authMechanismProperties, url.AuthenticationMechanismProperties);
                 Assert.Equal("db", url.AuthenticationSource);
                 Assert.Equal(123, url.ComputedWaitQueueSize);
-                Assert.Equal(new [] { new MongoCompressor { Name = "zlib"}}, url.Compressors);
+                Assert.Contains(url.Compressors, x => x.Name == "zlib");
                 Assert.Equal(ConnectionMode.ReplicaSet, url.ConnectionMode);
                 Assert.Equal(TimeSpan.FromSeconds(1), url.ConnectTimeout);
                 Assert.Equal("database", url.DatabaseName);

--- a/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
@@ -43,7 +43,7 @@ namespace MongoDB.Driver.Tests
                 AuthenticationMechanism = "GSSAPI",
                 AuthenticationMechanismProperties = authMechanismProperties,
                 AuthenticationSource = "db",
-                Compressors = new []{"zlib"},
+                Compressors = new []{ new MongoCompressor { Name = "zlib"} },
                 ConnectionMode = ConnectionMode.ReplicaSet,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 DatabaseName = "database",
@@ -115,7 +115,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(authMechanismProperties, url.AuthenticationMechanismProperties);
                 Assert.Equal("db", url.AuthenticationSource);
                 Assert.Equal(123, url.ComputedWaitQueueSize);
-                Assert.Equal(new [] {"zlib"}, url.Compressors);
+                Assert.Equal(new [] { new MongoCompressor { Name = "zlib"}}, url.Compressors);
                 Assert.Equal(ConnectionMode.ReplicaSet, url.ConnectionMode);
                 Assert.Equal(TimeSpan.FromSeconds(1), url.ConnectTimeout);
                 Assert.Equal("database", url.DatabaseName);

--- a/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
@@ -43,6 +43,7 @@ namespace MongoDB.Driver.Tests
                 AuthenticationMechanism = "GSSAPI",
                 AuthenticationMechanismProperties = authMechanismProperties,
                 AuthenticationSource = "db",
+                Compressors = new []{"zlib"},
                 ConnectionMode = ConnectionMode.ReplicaSet,
                 ConnectTimeout = TimeSpan.FromSeconds(1),
                 DatabaseName = "database",
@@ -82,6 +83,7 @@ namespace MongoDB.Driver.Tests
                 "ipv6=true",
                 "ssl=true", // UseSsl
                 "sslVerifyCertificate=false", // VerifySslCertificate
+                "compressors=zlib",
                 "connect=replicaSet",
                 "replicaSet=name",
                 "readConcernLevel=majority",
@@ -113,6 +115,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(authMechanismProperties, url.AuthenticationMechanismProperties);
                 Assert.Equal("db", url.AuthenticationSource);
                 Assert.Equal(123, url.ComputedWaitQueueSize);
+                Assert.Equal(new [] {"zlib"}, url.Compressors);
                 Assert.Equal(ConnectionMode.ReplicaSet, url.ConnectionMode);
                 Assert.Equal(TimeSpan.FromSeconds(1), url.ConnectTimeout);
                 Assert.Equal("database", url.DatabaseName);


### PR DESCRIPTION
This is the implementation to https://jira.mongodb.org/browse/CSHARP-1991. I tried to follow the existing code in style as closely as possible and took some inspiration from the mongo-java-driver.

Please provide feedback on the changes. I've successfully tested it both through the unit and integration tests against a local MongoDB instance as well as our proprietary application that uses an Atlas MongoDB cluster.

Unfortunately, .net does not provide an implementation of zlib with suitable headers. Only Deflate. So I had to include a 3rd party package to achieve the compression. Please provide feedback on this as well, as I'm not at all knowledgeable in licensing stuff.

Also please ignore double commits. They are the result from wrongly updating fork.

Thanks!