### PR TITLE
CSHARP-2353 CSHARP-2354 Fix some bugs related to duplicate element names

### DIFF
--- a/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
@@ -72,6 +72,37 @@ namespace MongoDB.Bson
         }
 
         /// <summary>
+        /// Initializes a new instance of the BsonDocument by coping elements from another BsonDocument.
+        /// </summary>
+        /// <param name="document">The document whose elements will be copied</param>
+        public BsonDocument(BsonDocument document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException("document");
+            }
+
+            _allowDuplicateNames = document.AllowDuplicateNames;
+            AddRange(document);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BsonDocument by coping elements from a LazyBsonDocument.
+        /// </summary>
+        /// <param name="document">The document whose elements will be copied</param>
+        public BsonDocument(LazyBsonDocument document) : this((BsonDocument)document)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BsonDocument by coping elements from a RawBsonDocument.
+        /// </summary>
+        /// <param name="document">The document whose elements will be copied</param>
+        public BsonDocument(RawBsonDocument document) : this((BsonDocument)document)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the BsonDocument class and adds new elements from a dictionary of key/value pairs.
         /// </summary>
         /// <param name="dictionary">A dictionary to initialize the document from.</param>
@@ -821,7 +852,7 @@ namespace MongoDB.Bson
         /// <returns>A deep clone of the document.</returns>
         public override BsonValue DeepClone()
         {
-            BsonDocument clone = new BsonDocument();
+            BsonDocument clone = new BsonDocument() { AllowDuplicateNames = AllowDuplicateNames };
             foreach (BsonElement element in _elements)
             {
                 clone.Add(element.DeepClone());

--- a/src/MongoDB.Bson/ObjectModel/LazyBsonDocument.cs
+++ b/src/MongoDB.Bson/ObjectModel/LazyBsonDocument.cs
@@ -50,6 +50,7 @@ namespace MongoDB.Bson
                 throw new ArgumentNullException("slice");
             }
 
+            AllowDuplicateNames = true; // raw BSON always supports duplicate names
             _slice = slice;
         }
 

--- a/src/MongoDB.Bson/ObjectModel/RawBsonDocument.cs
+++ b/src/MongoDB.Bson/ObjectModel/RawBsonDocument.cs
@@ -51,6 +51,7 @@ namespace MongoDB.Bson
                 throw new ArgumentNullException("slice");
             }
 
+            AllowDuplicateNames = true; // raw BSON always supports duplicate names
             _slice = slice;
         }
 


### PR DESCRIPTION
MongoDB.Bson/ObjectModel/BsonDocument.cs:
* Made DeepClone work with documents that have duplicate element names
* Added constructors that take documents and work if they have duplicate names

MongoDB.Bson/ObjectModel/LazyBsonDocument.cs:
MongoDB.Bson/ObjectModel/RawBsonDocument.cs:
* Set AllowDuplicateNames to true since raw BSON always might have duplicate names