### PR TITLE
CSHARP-2371 Pin Cake.Git to 0.18.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #addin "nuget:?package=Cake.FileHelpers"
-#addin "nuget:?package=Cake.Git"
+#addin "nuget:?package=Cake.Git&version=0.18.0"
 #addin "nuget:?package=Cake.Incubator&version=2.0.0"
 #tool "nuget:?package=GitVersion.CommandLine"
 #tool "nuget:?package=xunit.runner.console"


### PR DESCRIPTION
In https://github.com/cake-contrib/Cake_Git/commit/ce283fd073a5360e10505666f2f9956aa2880b7e, Cake.Git updated to .NET Standard 2.0 which is causing the build to fail.