### PR TITLE
CSHARP-2379 Make evergreen compile use diagnostic output for cake compile

### DIFF
--- a/evergreen/compile.sh
+++ b/evergreen/compile.sh
@@ -10,4 +10,4 @@ set -o errexit  # Exit the script with error if any of the commands fail
 echo "Compiling .NET driver"
 
 for var in TMP TEMP NUGET_PACKAGES NUGET_HTTP_CACHE_PATH APPDATA; do setx $var z:\\data\\tmp; export $var=z:\\data\\tmp; done
-powershell.exe .\\build.ps1 -target Build
+powershell.exe .\\build.ps1 -target Build -Verbosity Diagnostic


### PR DESCRIPTION
In order to debug the issue in [CSHARP-2371](https://jira.mongodb.org/browse/CSHARP-2379), I needed to increase the verbosity of Cake to Diagnostic. This should be the default since it will aid in debugging similar problems in the future, and does not have a significant impact on the verbosity of the build.