### PR TITLE
CSHARP-2366 GSSAPI Scram Authentication starts scram conversation wrong

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
@@ -196,7 +196,7 @@ namespace MongoDB.Driver.Core.Authentication
                 get { return MechanismName; }
             }
 
-            public ISaslStep Initialize(IConnection connection, ConnectionDescription description)
+            public ISaslStep Initialize(IConnection connection, SaslConversation conversation, ConnectionDescription description)
             {
                 Ensure.IsNotNull(connection, nameof(connection));
                 Ensure.IsNotNull(description, nameof(description));
@@ -229,17 +229,19 @@ namespace MongoDB.Driver.Core.Authentication
                     }
                 }
 
-                return new FirstStep(_serviceName, hostName, _realm, _username, _password);
+                return new FirstStep(_serviceName, hostName, _realm, _username, _password, conversation);
             }
         }
 
         private class FirstStep : ISaslStep
         {
             private readonly string _authorizationId;
+            private byte[] _bytesToSendToServer;
+            private readonly Sspi.SecurityContext _context;
             private readonly SecureString _password;
             private readonly string _servicePrincipalName;
 
-            public FirstStep(string serviceName, string hostName, string realm, string username, SecureString password)
+            public FirstStep(string serviceName, string hostName, string realm, string username, SecureString password, SaslConversation conversation)
             {
                 _authorizationId = username;
                 _password = password;
@@ -248,20 +250,7 @@ namespace MongoDB.Driver.Core.Authentication
                 {
                     _servicePrincipalName += "@" + realm;
                 }
-            }
 
-            public byte[] BytesToSendToServer
-            {
-                get { return new byte[0]; }
-            }
-
-            public bool IsComplete
-            {
-                get { return false; }
-            }
-
-            public ISaslStep Transition(SaslConversation conversation, byte[] bytesReceivedFromServer)
-            {
                 SecurityCredential securityCredential;
                 try
                 {
@@ -273,11 +262,9 @@ namespace MongoDB.Driver.Core.Authentication
                     throw new MongoAuthenticationException(conversation.ConnectionId, "Unable to acquire security credential.", ex);
                 }
 
-                byte[] bytesToSendToServer;
-                Sspi.SecurityContext context;
                 try
                 {
-                    context = Sspi.SecurityContext.Initialize(securityCredential, _servicePrincipalName, bytesReceivedFromServer, out bytesToSendToServer);
+                    _context = Sspi.SecurityContext.Initialize(securityCredential, _servicePrincipalName, null, out _bytesToSendToServer);
                 }
                 catch (Win32Exception ex)
                 {
@@ -290,13 +277,33 @@ namespace MongoDB.Driver.Core.Authentication
                         throw new MongoAuthenticationException(conversation.ConnectionId, "Unable to initialize security context.", ex);
                     }
                 }
+            }
 
-                if (!context.IsInitialized)
+            public byte[] BytesToSendToServer => _bytesToSendToServer;
+
+            public bool IsComplete
+            {
+                get { return false; }
+            }
+
+            public ISaslStep Transition(SaslConversation conversation, byte[] bytesReceivedFromServer)
+            {
+                byte[] bytesToSendToServer;
+                try
                 {
-                    return new InitializeStep(_servicePrincipalName, _authorizationId, context, bytesToSendToServer);
+                    _context.Initialize(_servicePrincipalName, bytesReceivedFromServer, out bytesToSendToServer);
+                }
+                catch (Win32Exception ex)
+                {
+                    throw new MongoAuthenticationException(conversation.ConnectionId, "Unable to initialize security context", ex);
                 }
 
-                return new NegotiateStep(_authorizationId, context, bytesToSendToServer);
+                if (!_context.IsInitialized)
+                {
+                    return new InitializeStep(_servicePrincipalName, _authorizationId, _context, bytesToSendToServer);
+                }
+
+                return new NegotiateStep(_authorizationId, _context, bytesToSendToServer);
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Authentication/PlainAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/PlainAuthenticator.cs
@@ -77,7 +77,7 @@ namespace MongoDB.Driver.Core.Authentication
             }
 
             // methods
-            public ISaslStep Initialize(IConnection connection, ConnectionDescription description)
+            public ISaslStep Initialize(IConnection connection, SaslConversation conversation, ConnectionDescription description)
             {
                 Ensure.IsNotNull(connection, nameof(connection));
                 Ensure.IsNotNull(description, nameof(description));

--- a/src/MongoDB.Driver.Core/Core/Authentication/SaslAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/SaslAuthenticator.cs
@@ -67,7 +67,7 @@ namespace MongoDB.Driver.Core.Authentication
 
             using (var conversation = new SaslConversation(description.ConnectionId))
             {
-                var currentStep = _mechanism.Initialize(connection, description);
+                var currentStep = _mechanism.Initialize( connection, conversation, description);
 
                 var command = CreateStartCommand(currentStep);
                 while (true)
@@ -102,7 +102,7 @@ namespace MongoDB.Driver.Core.Authentication
 
             using (var conversation = new SaslConversation(description.ConnectionId))
             {
-                var currentStep = _mechanism.Initialize(connection, description);
+                var currentStep = _mechanism.Initialize(connection, conversation, description);
 
                 var command = CreateStartCommand(currentStep);
                 while (true)
@@ -281,9 +281,10 @@ namespace MongoDB.Driver.Core.Authentication
             /// Initializes the mechanism.
             /// </summary>
             /// <param name="connection">The connection.</param>
+            /// <param name="conversation">The SASL conversation.</param>
             /// <param name="description">The connection description.</param>
             /// <returns>The initial SASL step.</returns>
-            ISaslStep Initialize(IConnection connection, ConnectionDescription description);
+            ISaslStep Initialize(IConnection connection, SaslConversation conversation, ConnectionDescription description);
         }
 
         /// <summary>

--- a/src/MongoDB.Driver.Core/Core/Authentication/ScramShaAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/ScramShaAuthenticator.cs
@@ -131,7 +131,7 @@ namespace MongoDB.Driver.Core.Authentication
 
             public string Name => _name;
 
-            public ISaslStep Initialize(IConnection connection, ConnectionDescription description)
+            public ISaslStep Initialize(IConnection connection, SaslConversation conversation, ConnectionDescription description)
             {
                 Ensure.IsNotNull(connection, nameof(connection));
                 Ensure.IsNotNull(description, nameof(description));


### PR DESCRIPTION
This PR changes it so that the initial GSSAPI scram conversation starts with a non-empty client payload.

In 3.6 and before, MongoDB would return 
```
{ "conversationId" : 1, "done" : false, "payload" : new BinData(0, ""), "ok" : 1.0 }
```
for an empty `saslStart` payload.

In 4.0, MongoDB passes the empty client payload per [SASL spec](https://tools.ietf.org/html/rfc4752#section-3.2) to Kerberos which starts [negotiation](https://github.com/krb5/krb5/blob/09c9b7d6f64767429e90ad11a529e6ffa9538043/src/lib/gssapi/spnego/spnego_mech.c#L1269-L1275).

The C# driver should not pass an empty payload unless it wants to start SPNEGO.

If the C# driver does start calling `saslStart` with a non-empty payload, this is compatible with all versions of MongoDB.