### PR TITLE
CSHARP-2383: Provide overloads for WriteBytes/ReadBytes methods that …

### DIFF
--- a/src/MongoDB.Bson/IO/BsonBinaryReader.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryReader.cs
@@ -273,8 +273,34 @@ namespace MongoDB.Bson.IO
             State = GetNextState();
             return _bsonStream.ReadBytes(size);
         }
-#pragma warning restore 618
 
+        /// <summary>
+        /// Reads BSON binary data from the reader to the buffer at offset and respecting the size.
+        /// </summary>
+        /// <param name="bytes">Target buffer</param>
+        /// <param name="offset">Target offset</param>
+        /// <returns>Bytes read</returns>
+        public override int ReadBytes(byte[] bytes, int offset) {
+            if (Disposed) { ThrowObjectDisposedException(); }
+            VerifyBsonType("ReadBytes", BsonType.Binary);
+
+            int size = ReadSize();
+            
+            var subType = _bsonStream.ReadBinarySubType();
+            if (subType != BsonBinarySubType.Binary)
+            {
+                var message = string.Format("ReadBytes requires the binary sub type to be Binary, not {0}.", subType);
+                throw new FormatException(message);
+            }
+
+            State = GetNextState();
+            
+            _bsonStream.ReadBytes(bytes, offset, size);
+
+            return size;
+        }
+
+#pragma warning restore 618
         /// <summary>
         /// Reads a BSON DateTime from the reader.
         /// </summary>

--- a/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
@@ -261,27 +261,27 @@ namespace MongoDB.Bson.IO
             State = GetNextState();
         }
 
-		/// <summary>
-		/// Writes BSON binary data to the writer.
-		/// </summary>
-		/// <param name="bytes">The bytes.</param>
-		/// <param name="size"> The count of bytes used in the bytes[] </param>
-		public override void WriteBytes(byte[] bytes, int size)
-		{
-			if (Disposed) { throw new ObjectDisposedException("BsonBinaryWriter"); }
-			if (State != BsonWriterState.Value)
-			{
-				ThrowInvalidState("WriteBytes", BsonWriterState.Value);
-			}
+        /// <summary>
+        /// Writes BSON binary data to the writer.
+        /// </summary>
+        /// <param name="bytes">The bytes.</param>
+        /// <param name="size"> The count of bytes used in the bytes[] </param>
+        public override void WriteBytes(byte[] bytes, int size)
+        {
+            if (Disposed) { throw new ObjectDisposedException("BsonBinaryWriter"); }
+            if (State != BsonWriterState.Value)
+            {
+                ThrowInvalidState("WriteBytes", BsonWriterState.Value);
+            }
 
-			_bsonStream.WriteBsonType(BsonType.Binary);
-			WriteNameHelper();
-			_bsonStream.WriteInt32(size);
-			_bsonStream.WriteBinarySubType(BsonBinarySubType.Binary);
-			_bsonStream.WriteBytes(bytes, 0, bytes.Length);
+            _bsonStream.WriteBsonType(BsonType.Binary);
+            WriteNameHelper();
+            _bsonStream.WriteInt32(size);
+            _bsonStream.WriteBinarySubType(BsonBinarySubType.Binary);
+            _bsonStream.WriteBytes(bytes, 0, size);
 
-			State = GetNextState();
-		}
+            State = GetNextState();
+        }
 
         /// <summary>
         /// Writes a BSON DateTime to the writer.

--- a/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
@@ -261,6 +261,28 @@ namespace MongoDB.Bson.IO
             State = GetNextState();
         }
 
+		/// <summary>
+		/// Writes BSON binary data to the writer.
+		/// </summary>
+		/// <param name="bytes">The bytes.</param>
+		/// <param name="size"> The count of bytes used in the bytes[] </param>
+		public override void WriteBytes(byte[] bytes, int size)
+		{
+			if (Disposed) { throw new ObjectDisposedException("BsonBinaryWriter"); }
+			if (State != BsonWriterState.Value)
+			{
+				ThrowInvalidState("WriteBytes", BsonWriterState.Value);
+			}
+
+			_bsonStream.WriteBsonType(BsonType.Binary);
+			WriteNameHelper();
+			_bsonStream.WriteInt32(size);
+			_bsonStream.WriteBinarySubType(BsonBinarySubType.Binary);
+			_bsonStream.WriteBytes(bytes, 0, bytes.Length);
+
+			State = GetNextState();
+		}
+
         /// <summary>
         /// Writes a BSON DateTime to the writer.
         /// </summary>

--- a/src/MongoDB.Bson/IO/BsonDocumentReader.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentReader.cs
@@ -179,6 +179,32 @@ namespace MongoDB.Bson.IO
 
             return binaryData.Bytes;
         }
+
+        /// <summary>
+        /// Reads BSON binary data from the reader to the buffer at offset and respecting the size.
+        /// </summary>
+        /// <param name="bytes">Target buffer</param>
+        /// <param name="offset">Target offset</param>
+        /// <returns>Bytes read</returns>
+        public override int ReadBytes(byte[] bytes, int offset)
+        {
+            if (Disposed) { ThrowObjectDisposedException(); }
+            VerifyBsonType("ReadBytes", BsonType.Binary);
+
+            State = GetNextState();
+            var binaryData = _currentValue.AsBsonBinaryData;
+
+            var subType = binaryData.SubType;
+            if (subType != BsonBinarySubType.Binary && subType != BsonBinarySubType.OldBinary)
+            {
+                var message = string.Format("ReadBytes requires the binary sub type to be Binary, not {0}.", subType);
+                throw new FormatException(message);
+            }
+
+            binaryData.Bytes.CopyTo(bytes, offset);
+
+            return binaryData.Bytes.Length;
+        }
 #pragma warning restore 618
 
         /// <summary>

--- a/src/MongoDB.Bson/IO/BsonDocumentReader.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentReader.cs
@@ -186,7 +186,7 @@ namespace MongoDB.Bson.IO
         /// <param name="bytes">Target buffer</param>
         /// <param name="offset">Target offset</param>
         /// <returns>Bytes read</returns>
-        public override int ReadBytes(byte[] bytes, int offset)
+        public override int ReadBytes(byte[] bytes, int offset = 0)
         {
             if (Disposed) { ThrowObjectDisposedException(); }
             VerifyBsonType("ReadBytes", BsonType.Binary);

--- a/src/MongoDB.Bson/IO/BsonDocumentWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentWriter.cs
@@ -133,6 +133,21 @@ namespace MongoDB.Bson.IO
             State = GetNextState();
         }
 
+		/// <summary>
+		/// Writes BSON binary data to the writer.
+		/// </summary>
+		/// <param name="bytes">The bytes.</param>
+		/// <param name="size"> The count of bytes used in the bytes[] </param>
+		public override void WriteBytes(byte[] bytes, int size) {
+			if (bytes.Length != size) {
+				// TODO: Better use a buffer manager here or Provide size in BsonBinaryData
+				var copy = new byte[size];
+				Buffer.BlockCopy(bytes, 0, copy, 0, size);
+				WriteBytes(copy);
+			} else 
+				WriteBytes(bytes);
+		}
+
         /// <summary>
         /// Writes a BSON DateTime to the writer.
         /// </summary>

--- a/src/MongoDB.Bson/IO/BsonReader.cs
+++ b/src/MongoDB.Bson/IO/BsonReader.cs
@@ -173,7 +173,7 @@ namespace MongoDB.Bson.IO
         /// <param name="bytes">Target buffer</param>
         /// <param name="offset">Target offset</param>
         /// <returns>Bytes read</returns>
-        public abstract int ReadBytes(byte[] bytes, int offset);
+        public abstract int ReadBytes(byte[] bytes, int offset = 0);
 
         /// <summary>
         /// Reads a BSON DateTime from the reader.

--- a/src/MongoDB.Bson/IO/BsonReader.cs
+++ b/src/MongoDB.Bson/IO/BsonReader.cs
@@ -168,6 +168,14 @@ namespace MongoDB.Bson.IO
         public abstract byte[] ReadBytes();
 
         /// <summary>
+        /// Reads BSON binary data from the reader to the buffer at offset and respecting the size.
+        /// </summary>
+        /// <param name="bytes">Target buffer</param>
+        /// <param name="offset">Target offset</param>
+        /// <returns>Bytes read</returns>
+        public abstract int ReadBytes(byte[] bytes, int offset);
+
+        /// <summary>
         /// Reads a BSON DateTime from the reader.
         /// </summary>
         /// <returns>The number of milliseconds since the Unix epoch.</returns>

--- a/src/MongoDB.Bson/IO/BsonWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonWriter.cs
@@ -184,6 +184,13 @@ namespace MongoDB.Bson.IO
         /// <param name="bytes">The bytes.</param>
         public abstract void WriteBytes(byte[] bytes);
 
+		/// <summary>
+		/// Writes BSON binary data to the writer.
+		/// </summary>
+		/// <param name="bytes">The bytes.</param>
+		/// <param name="size"> </param>
+		public abstract void WriteBytes(byte[] bytes, int size);
+
         /// <summary>
         /// Writes a BSON DateTime to the writer.
         /// </summary>

--- a/src/MongoDB.Bson/IO/IBsonReader.cs
+++ b/src/MongoDB.Bson/IO/IBsonReader.cs
@@ -84,6 +84,14 @@ namespace MongoDB.Bson.IO
         byte[] ReadBytes();
 
         /// <summary>
+        /// Reads BSON binary data from the reader to the buffer at offset and respecting the size.
+        /// </summary>
+        /// <param name="buffer">Target buffer</param>
+        /// <param name="offset">Target offset</param>
+        /// <returns>Bytes read</returns>
+        int ReadBytes(byte[] buffer, int offset);
+
+        /// <summary>
         /// Reads a BSON DateTime from the reader.
         /// </summary>
         /// <returns>The number of milliseconds since the Unix epoch.</returns>

--- a/src/MongoDB.Bson/IO/IBsonWriter.cs
+++ b/src/MongoDB.Bson/IO/IBsonWriter.cs
@@ -101,6 +101,13 @@ namespace MongoDB.Bson.IO
         /// <param name="bytes">The bytes.</param>
         void WriteBytes(byte[] bytes);
 
+		/// <summary>
+		/// Writes BSON binary data to the writer.
+		/// </summary>
+		/// <param name="bytes">The bytes.</param>
+		/// <param name="size"> </param>
+		void WriteBytes(byte[] bytes, int size);
+
         /// <summary>
         /// Writes a BSON DateTime to the writer.
         /// </summary>

--- a/src/MongoDB.Bson/IO/JsonReader.cs
+++ b/src/MongoDB.Bson/IO/JsonReader.cs
@@ -421,6 +421,33 @@ namespace MongoDB.Bson.IO
             }
 
             return binaryData.Bytes;
+
+        }
+
+        /// <summary>
+        /// Reads BSON binary data from the reader to the buffer at offset and respecting the size.
+        /// </summary>
+        /// <param name="bytes">Target buffer</param>
+        /// <param name="offset">Target offset</param>
+        /// <returns>Bytes read</returns>
+        public override int ReadBytes(byte[] bytes, int offset)
+        {
+
+            if (Disposed) { ThrowObjectDisposedException(); }
+            VerifyBsonType("ReadBinaryData", BsonType.Binary);
+            State = GetNextState();
+            var binaryData = _currentValue.AsBsonBinaryData;
+
+            var subType = binaryData.SubType;
+            if (subType != BsonBinarySubType.Binary && subType != BsonBinarySubType.OldBinary)
+            {
+                var message = string.Format("ReadBytes requires the binary sub type to be Binary, not {0}.", subType);
+                throw new FormatException(message);
+            }
+
+            binaryData.Bytes.CopyTo(bytes, offset);
+
+            return binaryData.Bytes.Length;
 #pragma warning restore
         }
 

--- a/src/MongoDB.Bson/IO/JsonToken.cs
+++ b/src/MongoDB.Bson/IO/JsonToken.cs
@@ -13,6 +13,9 @@
 * limitations under the License.
 */
 
+
+
+
 using System;
 
 namespace MongoDB.Bson.IO

--- a/src/MongoDB.Bson/IO/JsonWriter.cs
+++ b/src/MongoDB.Bson/IO/JsonWriter.cs
@@ -175,6 +175,21 @@ namespace MongoDB.Bson.IO
             WriteBinaryData(new BsonBinaryData(bytes, BsonBinarySubType.Binary));
         }
 
+		/// <summary>
+		/// Writes BSON binary data to the writer.
+		/// </summary>
+		/// <param name="bytes">The bytes.</param>
+		/// <param name="size"> The count of bytes used in the bytes[] </param>
+		public override void WriteBytes(byte[] bytes, int size) {
+			if (bytes.Length != size) {
+				// TODO: Better use a buffer manager here or Provide size in BsonBinaryData
+				var copy = new byte[size];
+				Buffer.BlockCopy(bytes, 0, copy, 0, size);
+				WriteBytes(copy);
+			} else 
+				WriteBytes(bytes);
+		}
+
         /// <summary>
         /// Writes a BSON DateTime to the writer.
         /// </summary>

--- a/src/MongoDB.Bson/IO/WrappingBsonWriter.cs
+++ b/src/MongoDB.Bson/IO/WrappingBsonWriter.cs
@@ -168,6 +168,13 @@ namespace MongoDB.Bson.IO
             _wrapped.WriteBytes(bytes);
         }
 
+		/// <inheritdoc />
+		public virtual void WriteBytes(byte[] bytes, int size)
+		{
+			ThrowIfDisposed();
+			_wrapped.WriteBytes(bytes, size);
+		}
+
         /// <inheritdoc />
         public virtual void WriteDateTime(long value)
         {

--- a/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/JoinSerializer.cs
+++ b/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/JoinSerializer.cs
@@ -188,7 +188,7 @@ namespace MongoDB.Driver.Linq.Processors.Pipeline.MethodCallBinders
                 return _parent.ReadBytes();
             }
 
-            public int ReadBytes(byte[] bytes, int offset)
+            public int ReadBytes(byte[] bytes, int offset = 0)
             {
                 return _parent.ReadBytes(bytes, offset);
             }

--- a/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/JoinSerializer.cs
+++ b/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/JoinSerializer.cs
@@ -188,6 +188,11 @@ namespace MongoDB.Driver.Linq.Processors.Pipeline.MethodCallBinders
                 return _parent.ReadBytes();
             }
 
+            public int ReadBytes(byte[] bytes, int offset)
+            {
+                return _parent.ReadBytes(bytes, offset);
+            }
+
             public long ReadDateTime()
             {
                 return _parent.ReadDateTime();

--- a/tests/MongoDB.Bson.Tests/IO/WrappingBsonWriterTests.cs
+++ b/tests/MongoDB.Bson.Tests/IO/WrappingBsonWriterTests.cs
@@ -368,6 +368,20 @@ namespace MongoDB.Bson.Tests.IO
             mockWrapped.Verify(m => m.WriteBytes(value), Times.Once);
         }
 
+
+        [Fact]
+        public void WriteBytesPars_should_call_wrapped()
+        {
+            Mock<IBsonWriter> mockWrapped;
+            var subject = CreateSubject(out mockWrapped);
+            const int size = 0;
+            var value = new byte[0];
+
+            subject.WriteBytes(value, size);
+
+            mockWrapped.Verify(m => m.WriteBytes(value, size), Times.Once);
+        }
+
         [Fact]
         public void WriteBytes_should_throw_when_disposed()
         {


### PR DESCRIPTION
…allow buffer reuse.

I've created overloads for reading and writing buffers that are larger than the data they hold. With this new api one can limit the size of the used buffer with a parameter. Now it is possible the reuse one large enough buffer and reduce fragmentation of memory.

The overloads in JsonWriter will clone buffers that are too large and reduce them to the given size.