### PR TITLE
CSHARP-2386: Check server in index insertion tests

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -41,6 +41,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __commandMessage = new Feature("CommandMessage", new SemanticVersion(3, 6, 0));
         private static readonly CommandsThatWriteAcceptWriteConcernFeature __commandsThatWriteAcceptWriteConcern = new CommandsThatWriteAcceptWriteConcernFeature("CommandsThatWriteAcceptWriteConcern", new SemanticVersion(3, 3, 11));
         private static readonly Feature __createIndexesCommand = new Feature("CreateIndexesCommand", new SemanticVersion(3, 0, 0));
+        private static readonly Feature __createIndexesUsingInsertOperations = new Feature("CreateIndexesCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 2));
         private static readonly Feature __currentOpCommand = new Feature("CurrentOpCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __documentValidation = new Feature("DocumentValidation", new SemanticVersion(3, 2, 0));
         private static readonly Feature __eval = new Feature("Eval", new SemanticVersion(0, 0, 0), new SemanticVersion(4, 1, 0, ""));
@@ -157,6 +158,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the create indexes command feature.
         /// </summary>
         public static Feature CreateIndexesCommand => __createIndexesCommand;
+        
+        /// <summary>
+        /// Gets the create indexes using insert operations feature.
+        /// </summary>
+        public static Feature CreateIndexesUsingInsertOperations => __createIndexesUsingInsertOperations;
 
         /// <summary>
         /// Gets the current op command feature.

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateIndexesUsingInsertOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateIndexesUsingInsertOperationTests.cs
@@ -94,7 +94,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)]
             bool async)
         {
-            RequireServer.Check();
+            RequireServer.Check().Supports(Feature.CreateIndexesUsingInsertOperations);
             DropCollection();
             var requests = new[] { new CreateIndexRequest(new BsonDocument("x", 1)) { Background = true } };
             var subject = new CreateIndexesUsingInsertOperation(_collectionNamespace, requests, _messageEncoderSettings);
@@ -112,7 +112,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)]
             bool async)
         {
-            RequireServer.Check();
+            RequireServer.Check().Supports(Feature.CreateIndexesUsingInsertOperations);
             DropCollection();
             var requests = new[] { new CreateIndexRequest(new BsonDocument("x", 1)) };
             var subject = new CreateIndexesUsingInsertOperation(_collectionNamespace, requests, _messageEncoderSettings);
@@ -129,7 +129,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)]
             bool async)
         {
-            RequireServer.Check();
+            RequireServer.Check().Supports(Feature.CreateIndexesUsingInsertOperations);
             DropCollection();
             var requests = new[]
             {
@@ -150,7 +150,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)]
             bool async)
         {
-            RequireServer.Check();
+            RequireServer.Check().Supports(Feature.CreateIndexesUsingInsertOperations);
             DropCollection();
             var requests = new[] { new CreateIndexRequest(new BsonDocument("x", 1)) { Sparse = true } };
             var subject = new CreateIndexesUsingInsertOperation(_collectionNamespace, requests, _messageEncoderSettings);
@@ -168,7 +168,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)]
             bool async)
         {
-            RequireServer.Check();
+            RequireServer.Check().Supports(Feature.CreateIndexesUsingInsertOperations);
             DropCollection();
             var expireAfter = TimeSpan.FromSeconds(1.5);
             var requests = new[] { new CreateIndexRequest(new BsonDocument("x", 1)) { ExpireAfter = expireAfter } };
@@ -187,7 +187,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)]
             bool async)
         {
-            RequireServer.Check();
+            RequireServer.Check().Supports(Feature.CreateIndexesUsingInsertOperations);
             DropCollection();
             var requests = new[] { new CreateIndexRequest(new BsonDocument("x", 1)) { Unique = true } };
             var subject = new CreateIndexesUsingInsertOperation(_collectionNamespace, requests, _messageEncoderSettings);


### PR DESCRIPTION
https://evergreen.mongodb.com/version/5b9ac3d32a60ed2d10b0c2f2

Update tests in CreateIndexesUsingInsertOperationTests to check to ensure that the server supports creating indexes using the insert operations.

Currently causing Evergreen to go red when testing against latest.