### PR TITLE
CSHARP-2066 Serialization of positional operator now culture-insensitive

### DIFF
--- a/src/MongoDB.Driver/Linq/ArrayIndexFormatter.cs
+++ b/src/MongoDB.Driver/Linq/ArrayIndexFormatter.cs
@@ -1,0 +1,24 @@
+﻿namespace MongoDB.Driver.Linq
+{
+	/// <summary>
+	/// In order to support the positional operator, the number -1 should be treated specially when used as an array index.
+	/// </summary>
+	public class ArrayIndexFormatter
+	{
+		/// <summary>
+		/// Formats any object to its string representation, unless <paramref name="index"/> is of type <c>int</c>, in which case a dollar sign ($) is returned.
+		/// </summary>
+		/// <param name="index"></param>
+		/// <returns></returns>
+		public static string FormatArrayIndex(object index)
+		{
+			// We've treated -1 as meaning $ operator. We can't break this now,
+			// so, specifically when we are flattening fields names, this is 
+			// how we'll continue to treat -1.
+
+			return index is int && (int)index == -1
+				? "$"
+				: index.ToString();
+		}
+	}
+}

--- a/src/MongoDB.Driver/Linq/FieldExpressionFlattener.cs
+++ b/src/MongoDB.Driver/Linq/FieldExpressionFlattener.cs
@@ -43,15 +43,14 @@ namespace MongoDB.Driver.Linq
                     throw new NotSupportedException($"Only a constant index is supported in the expression {node}.");
                 }
 
-                var index = constantIndex.Value.ToString();
-                if (index == "-1")
-                {
-                    // We've treated -1 as meaning $ operator. We can't break this now,
-                    // so, specifically when we are flattening fields names, this is 
-                    // how we'll continue to treat -1.
-                    index = "$";
-                }
+                // We've treated -1 as meaning $ operator. We can't break this now,
+                // so, specifically when we are flattening fields names, this is 
+                // how we'll continue to treat -1.
 
+                var index = constantIndex.Value is int intIndex && intIndex == -1
+                    ? "$"
+                    : constantIndex.Value.ToString();
+                    
                 return new FieldExpression(
                     field.AppendFieldName(index),
                     node.Serializer);

--- a/src/MongoDB.Driver/Linq/FieldExpressionFlattener.cs
+++ b/src/MongoDB.Driver/Linq/FieldExpressionFlattener.cs
@@ -20,16 +20,12 @@ using MongoDB.Driver.Linq.Expressions;
 
 namespace MongoDB.Driver.Linq
 {
-    internal class FieldExpressionFlattener : ExtensionExpressionVisitor
+	internal class FieldExpressionFlattener : ExtensionExpressionVisitor
     {
         public static Expression FlattenFields(Expression node)
         {
             var visitor = new FieldExpressionFlattener();
             return visitor.Visit(node);
-        }
-
-        public FieldExpressionFlattener()
-        {
         }
 
         protected internal override Expression VisitArrayIndex(ArrayIndexExpression node)
@@ -43,16 +39,10 @@ namespace MongoDB.Driver.Linq
                     throw new NotSupportedException($"Only a constant index is supported in the expression {node}.");
                 }
 
-                // We've treated -1 as meaning $ operator. We can't break this now,
-                // so, specifically when we are flattening fields names, this is 
-                // how we'll continue to treat -1.
-
-                var index = constantIndex.Value is int intIndex && intIndex == -1
-                    ? "$"
-                    : constantIndex.Value.ToString();
-                    
+                var formattedIndex = ArrayIndexFormatter.FormatArrayIndex(constantIndex.Value);
+                
                 return new FieldExpression(
-                    field.AppendFieldName(index),
+                    field.AppendFieldName(formattedIndex),
                     node.Serializer);
             }
 

--- a/tests/MongoDB.Driver.Tests/ExpressionFlattening/ArrayIndexFormatterTests.cs
+++ b/tests/MongoDB.Driver.Tests/ExpressionFlattening/ArrayIndexFormatterTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using FluentAssertions;
+using MongoDB.Driver.Linq;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.ExpressionFlattening
+{
+	public class ArrayIndexFormatterTests
+	{
+		[Fact]
+		public void MinusOneShouldResultInDollarSign()
+		{
+			ArrayIndexFormatter.FormatArrayIndex(-1).Should().Be("$");
+		}
+
+		[Fact]
+		public void ZeroOrGreaterShouldBeFormattedToStringRepresentationOfNumber()
+		{
+			ArrayIndexFormatter.FormatArrayIndex(0).Should().Be("0");
+			ArrayIndexFormatter.FormatArrayIndex(1).Should().Be("1");
+			ArrayIndexFormatter.FormatArrayIndex(99).Should().Be("99");
+		}
+
+		[Fact]
+		public void ShouldBeCultureInsensitive()
+		{
+			var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
+
+			Thread.CurrentThread.CurrentCulture = swedishCulture;
+			Thread.CurrentThread.CurrentUICulture = swedishCulture;
+
+			ArrayIndexFormatter.FormatArrayIndex(-1).Should().Be("$");
+		}
+	}
+}

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="DropIndexOptionsTest.cs" />
     <Compile Include="CreateViewOptionsTests.cs" />
     <Compile Include="EstimatedDocumentCountOptionsTests.cs" />
+    <Compile Include="ExpressionFlattening\ArrayIndexFormatterTests.cs" />
     <Compile Include="FieldDefinitionTests.cs" />
     <Compile Include="FilterDefinitionBuilderEnumComparedToEnumWithStringRepresentationTests.cs" />
     <Compile Include="FilterDefinitionBuilderEnumComparedToNullableEnumTests.cs" />


### PR DESCRIPTION
Please see my comment in the Jira ticket. I wasn't able to edit the description, so I put all the info in a comment:

https://jira.mongodb.org/browse/CSHARP-2066