### PR TITLE
CSHARP-2456: Use explicit function instead of anonymous

### DIFF
--- a/src/MongoDB.Bson/IO/JsonWriter.cs
+++ b/src/MongoDB.Bson/IO/JsonWriter.cs
@@ -826,7 +826,7 @@ namespace MongoDB.Bson.IO
               }
            }
 
-        return false;
+            return false;
         }
 
         private bool NeedsEscaping(char c)

--- a/src/MongoDB.Bson/IO/JsonWriter.cs
+++ b/src/MongoDB.Bson/IO/JsonWriter.cs
@@ -705,7 +705,7 @@ namespace MongoDB.Bson.IO
         // private methods
         private string EscapedString(string value)
         {
-            if (value.All(c => !NeedsEscaping(c)))
+            if (!NeedsEscaping(value))
             {
                 return value;
             }
@@ -814,6 +814,19 @@ namespace MongoDB.Bson.IO
                 var guid = GuidConverter.FromBytes(bytes, guidRepresentation);
                 return string.Format("{0}(\"{1}\")", uuidConstructorName, guid.ToString());
             }
+        }
+
+        private bool NeedsEscaping(string text)
+        {
+           foreach (var letter in text)
+           {
+              if (NeedsEscaping(letter))
+              {
+                  return true;
+              }
+           }
+
+        return false;
         }
 
         private bool NeedsEscaping(char c)


### PR DESCRIPTION
Anonymous function has to capture 'this' as well as parameter since it calls object instance method.

Each invocation ended allocating 32 bytes, sample print:

```
0000028151aca4c0 (MongoDB.Bson.IO.BsonWriter+<>c__DisplayClass44_0)
    <>4__this:0000028151ac8fd0 (MongoDB.Bson.IO.JsonWriter)
    name:000002824ee886b0 (System.String) Length=11, String="_odata_type"
```
Function is called super-often, memory snapshots indicate ~1M instances are leaving in the heap.