### PR TITLE
CSHARP-2405 Update ImmutableTypeClassMapConvention.cs

### DIFF
--- a/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/ImmutableTypeClassMapConvention.cs
@@ -39,7 +39,7 @@ namespace MongoDB.Bson.Serialization.Conventions
                 return;
             }
 
-            var properties = typeInfo.GetProperties();
+            var properties = typeInfo.GetProperties(BindingFlags.Instance | BindingFlags.Public );
             if (properties.Any(p => p.CanWrite))
             {
                 return; // a type that has any writable properties is not immutable


### PR DESCRIPTION
Upate to fix problem with static members in F# not allowing serialisation
https://jira.mongodb.org/browse/CSHARP-2405

The above limits the GetProperties to just instance public properties - ignoring static properties.