### PR TITLE
CSHARP-2442: Increase StringBuilder capacity

### DIFF
--- a/src/MongoDB.Bson/IO/JsonWriter.cs
+++ b/src/MongoDB.Bson/IO/JsonWriter.cs
@@ -710,7 +710,7 @@ namespace MongoDB.Bson.IO
                 return value;
             }
 
-            var sb = new StringBuilder(value.Length);
+            var sb = new StringBuilder(value.Length + 1);
 
             foreach (char c in value)
             {


### PR DESCRIPTION
This StringBuilder object is being created because the string named "value" needs escaping. It is unknown at this point exactly how many characters need escaping, but AT MINIMUM there is one. This means the new escaped string length will be larger than original string length by at least one character, and the StringBuilder constructor capacity parameter should reflect this logic. Without this change, the StringBuilder object is GUARANTEED to allocate and chain together a new StringBuilder object under the hood as it increases it's capacity to handle the larger escaped string.