### PR TITLE
CSHARP-2423 Fixed Connection Pools lock contention

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
@@ -116,10 +116,13 @@ namespace MongoDB.Driver.Core.Clusters
         {
             get
             {
-                lock (_descriptionLock)
-                {
+                // we do not need lock here, because reading and writing refs is thread safe
+                // and the worst thing we can came up with - outdated description,
+                // but race condition is impossible 
+                //lock (_descriptionLock)
+                //{
                     return _description;
-                }
+                //}
             }
         }
 


### PR DESCRIPTION
Locks changed to lock-free containers in order to get rid of lock contention in "threads heavy" environments. [JIRA issue](https://jira.mongodb.org/browse/CSHARP-2423)
The main problem in existing code that all releases (Dispose) of connections inside pools was made inside lock. It is possible to rewrite existing code and move Dispose outside of the lock, but lock-free containers are far more effective that current solution