### PR TITLE
CSHARP-2478: Update dependency "System.Net.Security" to version 4.3.2

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Net.Security" Version="4.0.0" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Security.SecureString" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Ticket [2478](https://jira.mongodb.org/browse/CSHARP-2478) 
Update on dependency `System.Net.Security` to avoid [vulnerability](https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETSECURITY-60072) (and warning from snyk utility)
