### PR TITLE
CSHARP-2506: Reduce allocations in BsonClassMapSerializer.SerializeClass

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -584,13 +584,6 @@ namespace MongoDB.Bson.Serialization
                 SerializeMember(context, document, idMemberMap);
             }
 
-            //var autoTimeStampMemberMap = _classMap.AutoTimeStampMemberMap;
-            //if (autoTimeStampMemberMap != null)
-            //{
-            //    SerializeNormalMember(context, document, autoTimeStampMemberMap);
-            //    remainingMemberMaps.Remove(autoTimeStampMemberMap);
-            //}
-
             if (ShouldSerializeDiscriminator(args.NominalType))
             {
                 SerializeDiscriminator(context, args.NominalType, document);

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -576,15 +576,12 @@ namespace MongoDB.Bson.Serialization
         {
             var bsonWriter = context.Writer;
 
-            var remainingMemberMaps = _classMap.AllMemberMaps.ToList();
-
             bsonWriter.WriteStartDocument();
 
             var idMemberMap = _classMap.IdMemberMap;
             if (idMemberMap != null && args.SerializeIdFirst)
             {
                 SerializeMember(context, document, idMemberMap);
-                remainingMemberMaps.Remove(idMemberMap);
             }
 
             //var autoTimeStampMemberMap = _classMap.AutoTimeStampMemberMap;
@@ -599,9 +596,12 @@ namespace MongoDB.Bson.Serialization
                 SerializeDiscriminator(context, args.NominalType, document);
             }
 
-            foreach (var memberMap in remainingMemberMaps)
+            foreach (var memberMap in _classMap.AllMemberMaps)
             {
-                SerializeMember(context, document, memberMap);
+                if (memberMap != idMemberMap || !args.SerializeIdFirst)
+                {
+                    SerializeMember(context, document, memberMap);
+                }
             }
 
             bsonWriter.WriteEndDocument();


### PR DESCRIPTION
Small change that removes a memory issue as described here: https://jira.mongodb.org/browse/CSHARP-2506