### PR TITLE
CSHARP-2504: Reduced memory allocations on hot path (serialization)

### DIFF
--- a/src/MongoDB.Bson/IO/BsonWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonWriter.cs
@@ -273,7 +273,7 @@ namespace MongoDB.Bson.IO
 
             if (!_elementNameValidator.IsValidElementName(name))
             {
-                var message = string.Format("Element name '{0}' is not valid'.", name);
+                var message = string.Format("Element name '{0}' is not valid.", name);
                 throw new BsonSerializationException(message);
             }
             _childElementNameValidatorFactory = () => _elementNameValidator.GetValidatorForChildContent(name);

--- a/src/MongoDB.Bson/IO/BsonWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonWriter.cs
@@ -27,7 +27,7 @@ namespace MongoDB.Bson.IO
     public abstract class BsonWriter : IBsonWriter
     {
         // private fields
-        private Func<IElementNameValidator> _childElementNameValidatorFactory = () => NoOpElementNameValidator.Instance;
+        private Func<BsonWriter, IElementNameValidator> _childElementNameValidatorFactory = b => NoOpElementNameValidator.Instance;
         private bool _disposed = false;
         private IElementNameValidator _elementNameValidator = NoOpElementNameValidator.Instance;
         private Stack<IElementNameValidator> _elementNameValidatorStack = new Stack<IElementNameValidator>();
@@ -131,7 +131,7 @@ namespace MongoDB.Bson.IO
         public void PopElementNameValidator()
         {
             _elementNameValidator = _elementNameValidatorStack.Pop();
-            _childElementNameValidatorFactory = () => _elementNameValidator;
+            _childElementNameValidatorFactory = b => b._elementNameValidator;
         }
 
         /// <inheritdoc />
@@ -153,7 +153,7 @@ namespace MongoDB.Bson.IO
 
             _elementNameValidatorStack.Push(_elementNameValidator);
             _elementNameValidator = validator;
-            _childElementNameValidatorFactory = () => _elementNameValidator;
+            _childElementNameValidatorFactory = b => b._elementNameValidator;
         }
 
         /// <inheritdoc />
@@ -276,7 +276,7 @@ namespace MongoDB.Bson.IO
                 var message = string.Format("Element name '{0}' is not valid.", name);
                 throw new BsonSerializationException(message);
             }
-            _childElementNameValidatorFactory = () => _elementNameValidator.GetValidatorForChildContent(name);
+            _childElementNameValidatorFactory = b => b._elementNameValidator.GetValidatorForChildContent(b._name);
 
             _name = name;
             _state = BsonWriterState.Value;
@@ -381,7 +381,7 @@ namespace MongoDB.Bson.IO
                 throw new BsonSerializationException("Maximum serialization depth exceeded (does the object being serialized have a circular reference?).");
             }
 
-            PushElementNameValidator(_childElementNameValidatorFactory());
+            PushElementNameValidator(_childElementNameValidatorFactory(this));
         }
 
         /// <summary>


### PR DESCRIPTION
This change reduces the memory footprint during the serialization process by eliminating four implicit lambda closure allocations inside `BsonWriter`.

More info on the topic can be found in the JIRA ticket [CSHARP-2504](https://jira.mongodb.org/browse/CSHARP-2504) and also here: https://blogs.msdn.microsoft.com/pfxteam/2012/02/03/know-thine-implicit-allocations/

Code **before**:
`_childElementNameValidatorFactory = () => _elementNameValidator.GetValidatorForChildContent(name);`

IL **before**:
```
    IL_00a1: ldarg.0      // this
    IL_00a2: ldloc.0      // 'CS$<>8__locals0'
    IL_00a3: ldftn        instance class MongoDB.Bson.IO.IElementNameValidator MongoDB.Bson.IO.BsonWriter/'<>c__DisplayClass44_0'::'<WriteName>b__0'()
    IL_00a9: newobj       instance void class [mscorlib]System.Func`1<class MongoDB.Bson.IO.IElementNameValidator>::.ctor(object, native int)
    IL_00ae: stfld        class [mscorlib]System.Func`1<class MongoDB.Bson.IO.IElementNameValidator> MongoDB.Bson.IO.BsonWriter::_childElementNameValidatorFactory
```
and the corresponding closure type:
```
  .class nested private sealed auto ansi beforefieldinit 
    '<>c__DisplayClass44_0'
      extends [mscorlib]System.Object
  {
    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() 
      = (01 00 00 00 )

    .field public class MongoDB.Bson.IO.BsonWriter '<>4__this'

    .field public string name

    .method public hidebysig specialname rtspecialname instance void 
      .ctor() cil managed 
    {
      .maxstack 8

      IL_0000: ldarg.0      // this
      IL_0001: call         instance void [mscorlib]System.Object::.ctor()
      IL_0006: ret          

    } // end of method '<>c__DisplayClass44_0'::.ctor

    .method assembly hidebysig instance class MongoDB.Bson.IO.IElementNameValidator 
      '<WriteName>b__0'() cil managed 
    {
      .maxstack 8

      // [279 55 - 279 110]
      IL_0000: ldarg.0      // this
      IL_0001: ldfld        class MongoDB.Bson.IO.BsonWriter MongoDB.Bson.IO.BsonWriter/'<>c__DisplayClass44_0'::'<>4__this'
      IL_0006: ldfld        class MongoDB.Bson.IO.IElementNameValidator MongoDB.Bson.IO.BsonWriter::_elementNameValidator
      IL_000b: ldarg.0      // this
      IL_000c: ldfld        string MongoDB.Bson.IO.BsonWriter/'<>c__DisplayClass44_0'::name
      IL_0011: callvirt     instance class MongoDB.Bson.IO.IElementNameValidator MongoDB.Bson.IO.IElementNameValidator::GetValidatorForChildContent(string)
      IL_0016: ret          

    } // end of method '<>c__DisplayClass44_0'::'<WriteName>b__0'
  } // end of class '<>c__DisplayClass44_0'

```

Code **after**:
`_childElementNameValidatorFactory = b => b._elementNameValidator.GetValidatorForChildContent(b._name);`

IL **after**:
```
    IL_0079: ldarg.0      // this
    IL_007a: ldsfld       class [mscorlib]System.Func`2<class MongoDB.Bson.IO.BsonWriter, class MongoDB.Bson.IO.IElementNameValidator> MongoDB.Bson.IO.BsonWriter/'<>c'::'<>9__44_0'
    IL_007f: dup          
    IL_0080: brtrue.s     IL_0099 // re-use of cached instance after initial allocation
    IL_0082: pop          
    IL_0083: ldsfld       class MongoDB.Bson.IO.BsonWriter/'<>c' MongoDB.Bson.IO.BsonWriter/'<>c'::'<>9'
    IL_0088: ldftn        instance class MongoDB.Bson.IO.IElementNameValidator MongoDB.Bson.IO.BsonWriter/'<>c'::'<WriteName>b__44_0'(class MongoDB.Bson.IO.BsonWriter)
    IL_008e: newobj       instance void class [mscorlib]System.Func`2<class MongoDB.Bson.IO.BsonWriter, class MongoDB.Bson.IO.IElementNameValidator>::.ctor(object, native int)
    IL_0093: dup          
    IL_0094: stsfld       class [mscorlib]System.Func`2<class MongoDB.Bson.IO.BsonWriter, class MongoDB.Bson.IO.IElementNameValidator> MongoDB.Bson.IO.BsonWriter/'<>c'::'<>9__44_0'
    IL_0099: stfld        class [mscorlib]System.Func`2<class MongoDB.Bson.IO.BsonWriter, class MongoDB.Bson.IO.IElementNameValidator> MongoDB.Bson.IO.BsonWriter::_childElementNameValidatorFactory
```
and the corresponding static cache field:
```
    .field public static class [mscorlib]System.Func`2<class MongoDB.Bson.IO.BsonWriter, class MongoDB.Bson.IO.IElementNameValidator> '<>9__44_0'
```