### PR TITLE
[Documentation] Fix for examples of RunCommand in Admin Quick Tour

### DIFF
--- a/Docs/reference/content/getting_started/admin_quick_tour.md
+++ b/Docs/reference/content/getting_started/admin_quick_tour.md
@@ -233,8 +233,8 @@ Not all commands have a specific helper, however you can run any command by usin
 var buildInfoCommand = new BsonDocument("buildinfo", 1);
 ```
 ```csharp
-var result = database.RunCommand(buildInfoCommand);
+var result = database.RunCommand<BsonDocument>(buildInfoCommand);
 ```
 ```csharp
-var result = await database.RunCommandAsync(buildInfoCommand);
+var result = await database.RunCommandAsync<BsonDocument>(buildInfoCommand);
 ```


### PR DESCRIPTION
The examples of RunCommand usage don't work correctly. I added the missing generic BsonDocument parameter.