### PR TITLE
CSHARP-2579: Allow overriding cached serializers in registry.

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -26,6 +26,7 @@ namespace MongoDB.Bson.Serialization
     {
         // private fields
         private readonly ConcurrentDictionary<Type, IBsonSerializer> _cache;
+        private readonly ConcurrentDictionary<Type, IBsonSerializer> _explicitRegistrations;
         private readonly ConcurrentStack<IBsonSerializationProvider> _serializationProviders;
 
         // constructors
@@ -34,7 +35,8 @@ namespace MongoDB.Bson.Serialization
         /// </summary>
         public BsonSerializerRegistry()
         {
-            _cache = new ConcurrentDictionary<Type,IBsonSerializer>();
+            _cache = new ConcurrentDictionary<Type, IBsonSerializer>();
+            _explicitRegistrations = new ConcurrentDictionary<Type, IBsonSerializer>();
             _serializationProviders = new ConcurrentStack<IBsonSerializationProvider>();
         }
 
@@ -101,11 +103,13 @@ namespace MongoDB.Bson.Serialization
                 throw new ArgumentException(message, "type");
             }
 
-            if (!_cache.TryAdd(type, serializer))
+            if (!_explicitRegistrations.TryAdd(type, serializer))
             {
                 var message = string.Format("There is already a serializer registered for type {0}.", BsonUtils.GetFriendlyTypeName(type));
                 throw new BsonSerializationException(message);
             }
+
+            _cache[type] = serializer;
         }
 
         /// <summary>

--- a/tests/MongoDB.Bson.Tests/Jira/CSharp2579Tests.cs
+++ b/tests/MongoDB.Bson.Tests/Jira/CSharp2579Tests.cs
@@ -1,0 +1,53 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using Xunit;
+
+namespace MongoDB.Bson.Tests.Jira.CSharp2579
+{
+    public class CSharp2579Tests
+    {
+        public struct A { }
+        public class SerializerA: StructSerializerBase<A> { }
+
+        [Fact]
+        public void TestExcplicitSerializerRegistrationOverridesDefault()
+        {
+            var explicitSerializer = new SerializerA();
+            var defaultSerializer = BsonSerializer.SerializerRegistry.GetSerializer<A>();
+
+            BsonSerializer.RegisterSerializer(explicitSerializer);
+
+            Assert.Same(explicitSerializer, BsonSerializer.SerializerRegistry.GetSerializer<A>());
+        }
+
+
+        public struct B { }
+        public class SerializerB: StructSerializerBase<B> { }
+
+        [Fact]
+        public void TestMultipleExcplicitSerializerRegistrationFails()
+        {
+            BsonSerializer.RegisterSerializer(new SerializerB());
+
+            Assert.Throws<BsonSerializationException>(() =>
+            {
+                BsonSerializer.RegisterSerializer(new SerializerB());
+            });
+        }
+    }
+}


### PR DESCRIPTION
This change makes the BsonSerializerRegistry accept registrations of serializers for types that have been cached before. Manual (explicit) registrations will now override the previously created default serializer.

About the implementation: I did not use a HashSet for storing which types have been registered explicitly because of concurrency issues as described here:
https://stackoverflow.com/questions/18922985/concurrent-hashsett-in-net-framework/18923091

This is my first pull request, so I would not mind if my changes are reviewed especially closely.