### PR TITLE
CSHARP-2595: Fix initialization on .NET Core 3.0 preview 4.

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -38,10 +38,7 @@ namespace MongoDB.Bson.Serialization
         private readonly static Queue<Type> __knownTypesQueue = new Queue<Type>();
 
         private static readonly MethodInfo __getUninitializedObjectMethodInfo =
-            typeof(string)
-            .GetTypeInfo()
-            .Assembly
-            .GetType("System.Runtime.Serialization.FormatterServices")
+            GetFormatterServicesType()
             .GetTypeInfo()
             ?.GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
 
@@ -1306,7 +1303,21 @@ namespace MongoDB.Bson.Serialization
             var message = string.Format("Class map for {0} has been not been frozen yet.", _classType.FullName);
             throw new InvalidOperationException(message);
         }
-    }
+
+        private static Type GetFormatterServicesType()
+        {
+#if NET452
+            return typeof(string)
+                .GetTypeInfo()
+                .Assembly
+                .GetType("System.Runtime.Serialization.FormatterServices");
+#else
+            return 
+                Assembly.Load(new AssemblyName("System.Runtime.Serialization.Formatters"))
+                .GetType("System.Runtime.Serialization.FormatterServices");
+#endif
+        }
+	}
 
     /// <summary>
     /// Represents a mapping between a class and a BSON document.


### PR DESCRIPTION
I have faced with problem after upgrade to .NET Core 3.0 preview 4 in my project, this line starts throwing an exception: https://github.com/mongodb/mongo-csharp-driver/blob/660658d4253f06506c1d60aae7ef68745ab609b2/src/MongoDB.Bson/Serialization/BsonClassMap.cs#L40

This change cover .NET Framework and .NET Core ways to get System.Runtime.Serialization.FormatterServices type instance.

I'm don't sure how to write a proper test for that case but test it manually on .NET Framework 4.5.2, .NET Core 2.1, 2.2 and 3.0.

This PR is related to already created jira task with a proposal, which was implemented - https://jira.mongodb.org/browse/CSHARP-2595.