### PR TITLE
Convention based String Id as ObjectId handling

### DIFF
--- a/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/StringIdStoredAsObjectIdConvention.cs
@@ -1,0 +1,44 @@
+﻿using MongoDB.Bson.Serialization.IdGenerators;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace MongoDB.Bson.Serialization.Conventions
+{
+    /// <summary>
+    /// A convention that sets representation of a string id class member to ObjectId in BSON with a StringObjectIdGenerator.
+    /// </summary>
+    public class StringIdStoredAsObjectIdConvention : ConventionBase, IMemberMapConvention
+    {
+        /// <summary>
+        /// Applies a post processing modification to the class map.
+        /// </summary>
+        /// <param name="memberMap">The BsonMemberMap map.</param>
+        /// <remarks>This method sets both the serializer and the IdGenerator on the id member field.</remarks>
+        public void Apply(BsonMemberMap memberMap)
+        {
+            var idMemberMap = memberMap.ClassMap?.IdMemberMap;
+
+            if (idMemberMap == null)
+            {
+                return;
+            }
+
+            if (idMemberMap.MemberType != typeof(string))
+            {
+                return;
+            }
+
+            if (idMemberMap.IdGenerator != null)
+            {
+                return;
+            }
+
+            var idSerializer = idMemberMap.GetSerializer();
+
+            if (idSerializer is StringSerializer stringSerializer && stringSerializer.Representation == BsonType.String)
+            {
+                idMemberMap.SetSerializer(new StringSerializer(representation: BsonType.ObjectId));
+                idMemberMap.SetIdGenerator(StringObjectIdGenerator.Instance);
+            }
+        }
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/StringIdStoredAsObjectIdConventionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/StringIdStoredAsObjectIdConventionTests.cs
@@ -1,0 +1,95 @@
+﻿using Xunit;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.IdGenerators;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace MongoDB.Bson.Tests.Serialization.Conventions
+{
+    public class StringIdStoredAsObjectIdConventionTests
+    {
+        BsonMemberMap SampleMap<T>() => new BsonClassMap<T>(cm => cm.AutoMap()).GetMemberMap("Id");
+
+        [Fact]
+        public void Apply_StringId_SetsSerializer()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithStringId>();
+
+            target.Apply(subject);
+
+            Assert.IsType<StringSerializer>(subject.GetSerializer());
+        }
+
+        [Fact]
+        public void Apply_StringId_SetsIdGenerator()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithStringId>();
+
+            target.Apply(subject);
+
+            Assert.IsType<StringObjectIdGenerator>(subject.IdGenerator);
+        }
+
+        [Fact]
+        public void Apply_ExistingIdGenerator_DoesNotApply()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithStringId>();
+            subject.SetIdGenerator(CombGuidGenerator.Instance);
+
+            target.Apply(subject);
+
+            Assert.IsType<CombGuidGenerator>(subject.IdGenerator);
+        }
+
+        [Fact]
+        public void Apply_NotStringSerializer_DoesNotApply()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithStringId>();
+            subject.SetSerializer(new FakeStringSerializer());
+
+            target.Apply(subject);
+
+            Assert.IsType<FakeStringSerializer>(subject.GetSerializer());
+        }
+
+
+        [Fact]
+        public void Apply_IntId_LeavesSerializer()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithIntId>();
+
+            target.Apply(subject);
+
+            Assert.IsNotType<StringSerializer>(subject.GetSerializer());
+        }
+
+        [Fact]
+        public void Apply_IntId_NoIdGenerator()
+        {
+            var target = new StringIdStoredAsObjectIdConvention();
+            var subject = SampleMap<TestClassWithIntId>();
+
+            target.Apply(subject);
+
+            Assert.Null(subject.IdGenerator);
+        }
+
+
+        public class TestClassWithStringId { public string Id; }
+
+        public class TestClassWithIntId { public int Id; }
+
+        class FakeStringSerializer : SealedClassSerializerBase<string>
+        {
+            public BsonType Representation => BsonType.String;
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
There is no current convention allowing for a string id member on a class represented as an ObjectId with an ObjectId generator. You can achive this with attributes, but this requires the class to reference external libraries which is not always desirable. The issue is further described here: https://jira.mongodb.org/browse/CSHARP-2644 

This PR introduces a convention-only based solution. Using this convention there is no need for any attribute decoration or explicit BsonClassMap configuration.