### PR TITLE
CSHARP-2683: Lower GC pressure by reducing allocation during deserialization

### DIFF
--- a/src/MongoDB.Bson/IO/TrieNameDecoder.cs
+++ b/src/MongoDB.Bson/IO/TrieNameDecoder.cs
@@ -13,10 +13,6 @@
 * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace MongoDB.Bson.IO
@@ -89,6 +85,9 @@ namespace MongoDB.Bson.IO
 
                 stream.Position = oldPosition;
             }
+
+            _found = false;
+            _value = default;
 
             return stream.ReadCString(encoding);
         }

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -192,9 +192,9 @@ namespace MongoDB.Bson.Serialization
 
             bsonReader.ReadStartDocument();
             var elementTrie = _classMap.ElementTrie;
+            var trieDecoder = new TrieNameDecoder<int>(elementTrie);
             while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
             {
-                var trieDecoder = new TrieNameDecoder<int>(elementTrie);
                 var elementName = bsonReader.ReadName(trieDecoder);
 
                 if (trieDecoder.Found)

--- a/src/MongoDB.Bson/Serialization/Serializers/SerializerHelper.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/SerializerHelper.cs
@@ -82,9 +82,9 @@ namespace MongoDB.Bson.Serialization.Serializers
             var foundMemberFlags = 0L;
 
             reader.ReadStartDocument();
+            var trieDecoder = new TrieNameDecoder<long>(_trie);
             while (reader.ReadBsonType() != 0)
             {
-                var trieDecoder = new TrieNameDecoder<long>(_trie);
                 var elementName = reader.ReadName(trieDecoder);
 
                 long memberFlag;

--- a/tests/MongoDB.Bson.Tests/IO/TrieNameDecoderTests.cs
+++ b/tests/MongoDB.Bson.Tests/IO/TrieNameDecoderTests.cs
@@ -49,7 +49,7 @@ namespace MongoDB.Bson.Tests.IO
             Assert(trie, "known", true, 10);
         }
 
-        // private
+        // private methods
         private void Assert(string name, TrieNameDecoder<int> subject, bool found, int value)
         {
             using (var memoryStream = new MemoryStream())

--- a/tests/MongoDB.Bson.Tests/IO/TrieNameDecoderTests.cs
+++ b/tests/MongoDB.Bson.Tests/IO/TrieNameDecoderTests.cs
@@ -49,7 +49,8 @@ namespace MongoDB.Bson.Tests.IO
             Assert(trie, "known", true, 10);
         }
 
-        private static void Assert(string name, TrieNameDecoder<int> subject, bool found, int value)
+        // private
+        private void Assert(string name, TrieNameDecoder<int> subject, bool found, int value)
         {
             using (var memoryStream = new MemoryStream())
             using (var bsonStream = new BsonStreamAdapter(memoryStream))


### PR DESCRIPTION
This small PR addresses https://jira.mongodb.org/browse/CSHARP-2683. It avoids recreating literally millions of almost identical instances inside a loop which proved to waste endless memory in my profiling session (see JIRA: ~28 million instances created adding up to ~900MB of heap space).