### PR TITLE
CSHARP-2592: Adding netstandard2.0 support to libraries

### DIFF
--- a/src/MongoDB.Bson/Exceptions/BsonException.cs
+++ b/src/MongoDB.Bson/Exceptions/BsonException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if NET452 || NETSTANDARD2_0
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON exception.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonException : Exception
@@ -66,7 +66,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <summary>
         /// Initializes a new instance of the BsonException class (this overload used by deserialization).
         /// </summary>

--- a/src/MongoDB.Bson/Exceptions/BsonInternalException.cs
+++ b/src/MongoDB.Bson/Exceptions/BsonInternalException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if NET452 || NETSTANDARD2_0
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON internal exception (almost surely the result of a bug).
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonInternalException : BsonException
@@ -56,7 +56,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <summary>
         /// Initializes a new instance of the BsonInternalException class (this overload used by deserialization).
         /// </summary>

--- a/src/MongoDB.Bson/Exceptions/BsonSerializationException.cs
+++ b/src/MongoDB.Bson/Exceptions/BsonSerializationException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if NET452 || NETSTANDARD2_0
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON serialization exception.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonSerializationException : BsonException
@@ -56,7 +56,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <summary>
         /// Initializes a new instance of the BsonSerializationException class (this overload used by deserialization).
         /// </summary>

--- a/src/MongoDB.Bson/Exceptions/DuplicateBsonMemberMapAttributeException.cs
+++ b/src/MongoDB.Bson/Exceptions/DuplicateBsonMemberMapAttributeException.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Indicates that an attribute restricted to one member has been applied to multiple members.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class DuplicateBsonMemberMapAttributeException : BsonException
@@ -45,7 +45,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <summary>
         /// Initializes a new instance of the <see cref="DuplicateBsonMemberMapAttributeException" /> class.
         /// </summary>

--- a/src/MongoDB.Bson/Exceptions/TruncationException.cs
+++ b/src/MongoDB.Bson/Exceptions/TruncationException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if NET452 || NETSTANDARD2_0
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a truncation exception.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class TruncationException : BsonException
@@ -56,7 +56,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <summary>
         /// Initializes a new instance of the TruncationException class (this overload used by deserialization).
         /// </summary>

--- a/src/MongoDB.Bson/IO/BsonBinaryReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryReaderSettings.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonBinaryReader.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonBinaryReaderSettings : BsonReaderSettings

--- a/src/MongoDB.Bson/IO/BsonBinaryWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriterSettings.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonBinaryWriter.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonBinaryWriterSettings : BsonWriterSettings

--- a/src/MongoDB.Bson/IO/BsonDocumentReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentReaderSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonDocumentReader.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonDocumentReaderSettings : BsonReaderSettings

--- a/src/MongoDB.Bson/IO/BsonDocumentWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentWriterSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonDocumentWriter.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonDocumentWriterSettings : BsonWriterSettings

--- a/src/MongoDB.Bson/IO/BsonReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonReaderSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonReader.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public abstract class BsonReaderSettings

--- a/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
+++ b/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
@@ -164,7 +164,7 @@ namespace MongoDB.Bson.IO
         }
 
         // methods
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <inheritdoc/>
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
@@ -173,7 +173,7 @@ namespace MongoDB.Bson.IO
         }
 #endif
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <inheritdoc/>
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
@@ -182,7 +182,7 @@ namespace MongoDB.Bson.IO
         }
 #endif
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <inheritdoc/>
         public override void Close()
         {
@@ -214,7 +214,7 @@ namespace MongoDB.Bson.IO
             base.Dispose(disposing);
         }
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <inheritdoc/>
         public override int EndRead(IAsyncResult asyncResult)
         {
@@ -223,7 +223,7 @@ namespace MongoDB.Bson.IO
         }
 #endif
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
         /// <inheritdoc/>
         public override void EndWrite(IAsyncResult asyncResult)
         {

--- a/src/MongoDB.Bson/IO/BsonWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonWriterSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonWriter.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public abstract class BsonWriterSettings

--- a/src/MongoDB.Bson/IO/JsonReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/JsonReaderSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a JsonReader.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class JsonReaderSettings : BsonReaderSettings

--- a/src/MongoDB.Bson/IO/JsonWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/JsonWriterSettings.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a JsonWriter.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class JsonWriterSettings : BsonWriterSettings

--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Bson/ObjectModel/BsonArray.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonArray.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON array.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonArray : BsonValue, IComparable<BsonArray>, IEquatable<BsonArray>, IList<BsonValue>

--- a/src/MongoDB.Bson/ObjectModel/BsonBinaryData.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonBinaryData.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents BSON binary data.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonBinaryData : BsonValue, IComparable<BsonBinaryData>, IEquatable<BsonBinaryData>

--- a/src/MongoDB.Bson/ObjectModel/BsonBinarySubType.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonBinarySubType.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the binary data subtype of a BsonBinaryData.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public enum BsonBinarySubType

--- a/src/MongoDB.Bson/ObjectModel/BsonBoolean.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonBoolean.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON boolean value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonBoolean : BsonValue, IComparable<BsonBoolean>, IEquatable<BsonBoolean>

--- a/src/MongoDB.Bson/ObjectModel/BsonDateTime.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDateTime.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON DateTime value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonDateTime : BsonValue, IComparable<BsonDateTime>, IEquatable<BsonDateTime>

--- a/src/MongoDB.Bson/ObjectModel/BsonDecimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDecimal128.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Bson
     /// Represents a BSON Decimal128 value.
     /// </summary>
     /// <seealso cref="MongoDB.Bson.BsonValue" />
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonDecimal128 : BsonValue, IComparable<BsonDecimal128>, IEquatable<BsonDecimal128>

--- a/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
@@ -28,7 +28,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON document.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonDocument : BsonValue, IComparable<BsonDocument>, IConvertibleToBsonDocument, IEnumerable<BsonElement>, IEquatable<BsonDocument>

--- a/src/MongoDB.Bson/ObjectModel/BsonDouble.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDouble.cs
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// Represents a BSON double value.
     /// </summary>
     /// <seealso cref="MongoDB.Bson.BsonValue" />
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonDouble : BsonValue, IComparable<BsonDouble>, IEquatable<BsonDouble>

--- a/src/MongoDB.Bson/ObjectModel/BsonElement.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonElement.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON element.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public struct BsonElement : IComparable<BsonElement>, IEquatable<BsonElement>

--- a/src/MongoDB.Bson/ObjectModel/BsonInt32.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonInt32.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON int value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonInt32 : BsonValue, IComparable<BsonInt32>, IEquatable<BsonInt32>

--- a/src/MongoDB.Bson/ObjectModel/BsonInt64.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonInt64.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON long value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonInt64 : BsonValue, IComparable<BsonInt64>, IEquatable<BsonInt64>

--- a/src/MongoDB.Bson/ObjectModel/BsonJavaScript.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonJavaScript.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON JavaScript value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonJavaScript : BsonValue, IComparable<BsonJavaScript>, IEquatable<BsonJavaScript>

--- a/src/MongoDB.Bson/ObjectModel/BsonJavaScriptWithScope.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonJavaScriptWithScope.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON JavaScript value with a scope.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonJavaScriptWithScope : BsonJavaScript, IComparable<BsonJavaScriptWithScope>, IEquatable<BsonJavaScriptWithScope>

--- a/src/MongoDB.Bson/ObjectModel/BsonMaxKey.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonMaxKey.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the BSON MaxKey value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonMaxKey : BsonValue, IComparable<BsonMaxKey>, IEquatable<BsonMaxKey>

--- a/src/MongoDB.Bson/ObjectModel/BsonMinKey.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonMinKey.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the BSON MinKey value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonMinKey : BsonValue, IComparable<BsonMinKey>, IEquatable<BsonMinKey>

--- a/src/MongoDB.Bson/ObjectModel/BsonNull.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonNull.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the BSON Null value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonNull : BsonValue, IComparable<BsonNull>, IEquatable<BsonNull>

--- a/src/MongoDB.Bson/ObjectModel/BsonObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonObjectId.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON ObjectId value (see also ObjectId).
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonObjectId : BsonValue, IComparable<BsonObjectId>, IEquatable<BsonObjectId>

--- a/src/MongoDB.Bson/ObjectModel/BsonRegularExpression.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonRegularExpression.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON regular expression value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonRegularExpression : BsonValue, IComparable<BsonRegularExpression>, IEquatable<BsonRegularExpression>

--- a/src/MongoDB.Bson/ObjectModel/BsonString.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonString.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON string value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonString : BsonValue, IComparable<BsonString>, IEquatable<BsonString>

--- a/src/MongoDB.Bson/ObjectModel/BsonTimestamp.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonTimestamp.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON timestamp value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonTimestamp : BsonValue, IComparable<BsonTimestamp>, IEquatable<BsonTimestamp>

--- a/src/MongoDB.Bson/ObjectModel/BsonType.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonType.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the type of a BSON element.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public enum BsonType

--- a/src/MongoDB.Bson/ObjectModel/BsonUndefined.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonUndefined.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the BSON undefined value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public class BsonUndefined : BsonValue, IComparable<BsonUndefined>, IEquatable<BsonUndefined>

--- a/src/MongoDB.Bson/ObjectModel/BsonValue.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonValue.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON value (this is an abstract class, see the various subclasses).
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public abstract class BsonValue : IComparable<BsonValue>, IConvertible, IEquatable<BsonValue>

--- a/src/MongoDB.Bson/ObjectModel/Decimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/Decimal128.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a Decimal128 value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public struct Decimal128 : IConvertible, IComparable<Decimal128>, IEquatable<Decimal128>

--- a/src/MongoDB.Bson/ObjectModel/GuidRepresentation.cs
+++ b/src/MongoDB.Bson/ObjectModel/GuidRepresentation.cs
@@ -19,7 +19,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the representation to use when converting a Guid to a BSON binary value.
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public enum GuidRepresentation

--- a/src/MongoDB.Bson/ObjectModel/ObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/ObjectId.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents an ObjectId (see also BsonObjectId).
     /// </summary>
-#if NET452
+#if NET452 || NETSTANDARD2_0
     [Serializable]
 #endif
     public struct ObjectId : IComparable<ObjectId>, IEquatable<ObjectId>, IConvertible

--- a/src/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -419,7 +419,7 @@ namespace MongoDB.Bson.Serialization
         // private static methods
         private static Type GetFormatterServicesType()
         {
-#if NET452
+#if NET452 || NETSTANDARD2_0
             return typeof(FormatterServices);
 #else
             // TODO: once we depend on newer versions of .NET Standard we should be able to do this without reflection

--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -693,7 +693,7 @@ namespace MongoDB.Bson.Serialization
                 if (!__typesWithRegisteredKnownTypes.Contains(nominalType))
                 {
                     // only call LookupClassMap for classes with a BsonKnownTypesAttribute
-#if NET452
+#if NET452 || NETSTANDARD2_0
                     var knownTypesAttribute = nominalType.GetTypeInfo().GetCustomAttributes(typeof(BsonKnownTypesAttribute), false);
 #else
                     var knownTypesAttribute = nominalType.GetTypeInfo().GetCustomAttributes(typeof(BsonKnownTypesAttribute), false).ToArray();

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -155,7 +155,7 @@ namespace MongoDB.Bson.Serialization
 
             Dictionary<string, object> values = null;
             var document = default(TClass);
-#if NET452
+#if NET452 || NETSTANDARD2_0
             ISupportInitialize supportsInitialization = null;
 #endif
             if (_classMap.HasCreatorMaps)
@@ -168,7 +168,7 @@ namespace MongoDB.Bson.Serialization
                 // for mutable classes we deserialize the values directly into the result object
                 document = (TClass)_classMap.CreateInstance();
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
                 supportsInitialization = document as ISupportInitialize;
                 if (supportsInitialization != null)
                 {
@@ -319,7 +319,7 @@ namespace MongoDB.Bson.Serialization
 
             if (document != null)
             {
-#if NET452
+#if NET452 || NETSTANDARD2_0
                 if (supportsInitialization != null)
                 {
                     supportsInitialization.EndInit();
@@ -471,7 +471,7 @@ namespace MongoDB.Bson.Serialization
             var creatorMap = ChooseBestCreator(values);
             var document = creatorMap.CreateInstance(values); // removes values consumed
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
             var supportsInitialization = document as ISupportInitialize;
             if (supportsInitialization != null)
             {
@@ -491,7 +491,7 @@ namespace MongoDB.Bson.Serialization
                 }
             }
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
             if (supportsInitialization != null)
             {
                 supportsInitialization.EndInit();

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
+++ b/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
+++ b/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Bson.TestHelpers/MongoDB.Bson.TestHelpers.csproj
+++ b/tests/MongoDB.Bson.TestHelpers/MongoDB.Bson.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Core.TestHelpers/MongoDB.Driver.Core.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.Core.TestHelpers/MongoDB.Driver.Core.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Legacy.TestHelpers/MongoDB.Driver.Legacy.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.Legacy.TestHelpers/MongoDB.Driver.Legacy.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.TestHelpers/MongoDB.Driver.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.TestHelpers/MongoDB.Driver.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />


### PR DESCRIPTION
This also removes the `System.Reflection.Emit.Lightweight` dependency in favor of expression tree compilation.

I left the test projects alone since they target `netcoreapp2.1`. In order to test against `netstandard1.5` you'd have to add `netcoreapp1.x` target....which is deprecated.