### PR TITLE
Correct default chunk size typo

### DIFF
--- a/Docs/reference/content/reference/gridfs/gettingstarted.md
+++ b/Docs/reference/content/reference/gridfs/gettingstarted.md
@@ -45,6 +45,6 @@ var bucket = new GridFSBucket(database, new GridFSBucketOptions
 
 The [`BucketName`]({{< apiref "P_MongoDB_Driver_GridFS_GridFSBucketOptions_BucketName" >}}) value is the root part of the files and chunks collection names, so in this example the two collections would be named "videos.files" and "videos.chunks" instead of "fs.files" and "fs.chunks".
 
-The [`ChunkSizeBytes`]({{< apiref "P_MongoDB_Driver_GridFS_GridFSBucketOptions_ChunkSizeBytes" >}}) value defines the size of each chunk, and in this example we are overriding the default value of 261120 (255MB).
+The [`ChunkSizeBytes`]({{< apiref "P_MongoDB_Driver_GridFS_GridFSBucketOptions_ChunkSizeBytes" >}}) value defines the size of each chunk, and in this example we are overriding the default value of 261120 (255kB).
 
 The [`WriteConcern`]({{< apiref "P_MongoDB_Driver_GridFS_GridFSBucketOptions_WriteConcern" >}}) is used when uploading files to GridFS, and the [`ReadPreference`]({{< apiref "P_MongoDB_Driver_GridFS_GridFSBucketOptions_ReadPreference" >}}) is used when downloading files from GridFS.


### PR DESCRIPTION
This corrects a small typo about default chunk size in gridfs