### PR TITLE
CSHARP-2822: StartTransaction throws for Standalone and Unknown servers

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs
+++ b/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs
@@ -458,7 +458,13 @@ namespace MongoDB.Driver.Core.Bindings
 
             foreach (var connectedDataBearingServer in connectedDataBearingServers)
             {
-                if (connectedDataBearingServer.Type == ServerType.ShardRouter)
+                var serverType = connectedDataBearingServer.Type;
+
+                if(serverType == ServerType.Standalone || serverType == ServerType.Unknown)
+                {
+                    throw new NotSupportedException("Transactions are supported only in sharded cluster of replica set deployments.");
+                }
+                else if (serverType == ServerType.ShardRouter)
                 {
                     Feature.ShardedTransactions.ThrowIfNotSupported(connectedDataBearingServer.Version);
                 }


### PR DESCRIPTION
This introduces additional checks to make sure `StartTransaction` throws when connecting to Standalone or Unknow servers.