### PR TITLE
CSHARP-3037: Correcting types in ArgumentException message.

### DIFF
--- a/src/MongoDB.Driver/PipelineDefinition.cs
+++ b/src/MongoDB.Driver/PipelineDefinition.cs
@@ -352,8 +352,8 @@ namespace MongoDB.Driver
             {
                 var message = string.Format(
                     "The output type to the last stage was expected to be {0}, but was {1}.",
-                    nextInputType,
-                    stages.Last().OutputType);
+                    typeof(TOutput),
+                    nextInputType);
                 throw new ArgumentException(message, "stages");
             }
 


### PR DESCRIPTION
Fixing expectation message whereby the wrong type is contained within the exception making it confusing to the end-user.

Take for example the following test:

```csharp
[Fact]
public void Test1()
{
    PipelineDefinition<BsonDocument, MyType>.Create(new IPipelineStageDefinition[]
    {
        new JsonPipelineStageDefinition<BsonDocument, BsonDocument>(
            @"{ project: { } } "),
    });
}

public class MyType { }
```

This throws the following exception
```

System.ArgumentException : The output type to the last stage was expected to be MongoDB.Bson.BsonDocument, but was MongoDB.Bson.BsonDocument. (Parameter 'stages')
```
instead of
```

System.ArgumentException : The output type to the last stage was expected to be SomeExample.MyType, but was MongoDB.Bson.BsonDocument. (Parameter 'stages')
```