### PR TITLE
ValueType properties should be deserializable from null if supported by their serializer

### DIFF
--- a/src/MongoDB.Bson/IO/JsonReader.cs
+++ b/src/MongoDB.Bson/IO/JsonReader.cs
@@ -199,7 +199,7 @@ namespace MongoDB.Bson.IO
                 // in JSON the top level value can be of any type so fall through
                 State = BsonReaderState.Type;
             }
-            if (State != BsonReaderState.Type)
+            if (State != BsonReaderState.Type && State != BsonReaderState.Value)
             {
                 ThrowInvalidState("ReadBsonType", BsonReaderState.Type);
             }

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/StructCustomSerializerTest.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/StructCustomSerializerTest.cs
@@ -1,0 +1,87 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using System;
+using Xunit;
+
+namespace MongoDB.Bson.Tests
+{
+    public class StructCustomSerializerTest
+    {
+        public StructCustomSerializerTest()
+        {
+            try
+            {
+                BsonSerializer.RegisterSerializer(typeof(HouseNumber), new HouseNumberSerializer());
+            }
+            catch { }
+        }
+        
+        [Fact]
+        public void Deserialize_StructFromNull_DefaultValue()
+        {
+            var stuff = BsonSerializer.Deserialize<HouseNumber>("null");
+            Assert.Equal(default, stuff);
+        }
+
+        [Fact]
+        public void Deserialize_StructAsPropertyFromModel_DefaultValue()
+        {
+            var address = BsonSerializer.Deserialize<Address>(@"{ ""Value"": null }");
+            Assert.Equal(default, address.Number);
+        }
+
+        internal readonly struct HouseNumber
+        {
+            private readonly int val;
+            public HouseNumber(int val) => this.val = val;
+            public override string ToString() => val < 1 ? "" : val.ToString();
+            public object ToJson() => val < 1 ? null : (object)val;
+        }
+
+        internal class Address
+        {
+            public HouseNumber Number { get; set; }
+        }
+
+        internal class HouseNumberSerializer : SerializerBase<HouseNumber>
+        {
+            public override HouseNumber Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+            {
+                var bsonType = context.Reader.GetCurrentBsonType();
+
+                return bsonType == BsonType.Int32
+                    ? new HouseNumber(context.Reader.ReadInt32())
+                    : default;
+            }
+
+            public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, HouseNumber value)
+            {
+                var val = value.ToJson();
+                if(val is int num)
+                {
+                    context.Writer.WriteInt32(num);
+                }
+                else
+                {
+                    context.Writer.WriteNull();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, if a struct/ValueType has its own converter registered it can be deserialized from null. However if the same struct/ValueType is property (or field) of a class, deserialization fails. Given that there is no test failing if I change that behaviour, I assume that it is a bug. Nevertheless, given example below, I think it makes sense to support it anyway.

``` C#
public readonly struct HouseNumber
{
    private readonly int val;
    public HouseNumber(int val) => this.val = val;
    public override string ToString() => val < 1 ? "" : val.ToString();
    public object ToJson() => val < 1 ? null : (object)val;
}

internal class Address
{
    public HouseNumber Number { get; set; }
}

public class HouseNumberSerializer : SerializerBase<HouseNumber>
{
    public override HouseNumber Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
    {
        var bsonType = context.Reader.GetCurrentBsonType();

        return bsonType == BsonType.Int32
            ? new HouseNumber(context.Reader.ReadInt32())
            : default;
    }

    public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, HouseNumber value)
    {
        var val = value.ToJson();
        if(val is int num)
        {
            context.Writer.WriteInt32(num);
        }
        else
        {
            context.Writer.WriteNull();
        }
    }
}
```