### PR TITLE
bugfix: possible nosql injection

### DIFF
--- a/src/MongoDB.Driver.Legacy/Builders/QueryBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/QueryBuilder.cs
@@ -216,7 +216,7 @@ namespace MongoDB.Driver.Builders
                 throw new ArgumentNullException("value");
             }
 
-            return Query.Create(name, value);
+            return Query.Create(name, new BsonDocument("$eq", value));
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/FilterDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/FilterDefinitionBuilder.cs
@@ -423,7 +423,7 @@ namespace MongoDB.Driver
         /// <returns>An equality filter.</returns>
         public FilterDefinition<TDocument> Eq<TField>(FieldDefinition<TDocument, TField> field, TField value)
         {
-            return new SimpleFilterDefinition<TDocument, TField>(field, value, allowScalarValueForArrayField: true);
+            return new OperatorFilterDefinition<TDocument, TField>("$eq", field, value, allowScalarValueForArrayField: true);
         }
 
         /// <summary>


### PR DESCRIPTION
You can make any comparsion by an equal operator if you compare to BsonDocument for example:
```C#
IMongoCollection<BsonDocument> collection;
var value = new BsonDocument { { "$gt", 3 } };
var query = collection.Find(x => x["field"] == value);

//it will execute:
//find({ "field" : { "$gt" : 3 } })
```

I think it can cause security vulnerability for unaware developer, who trust, that equal operator always will test for equality:

```C#
public List<BsonDocument> GetObjectByUser(IMongoCollection<BsonDocument> collection, BsonValue data)
{
	return collection.Find(x => x["userId"] == data["userId"]).ToList();
}
public void Attack(IMongoCollection<BsonDocument> collection)
{
	var data = GetObjectByUser(collection, new BsonDocument { { "userId", new BsonDocument { { "$ne", ObjectId.Empty } } } });
}
```