### PR TITLE
CSHARP-2659 - Adding support for $sample aggregation pipeline stage.

### DIFF
--- a/src/MongoDB.Driver/AggregateFluent.cs
+++ b/src/MongoDB.Driver/AggregateFluent.cs
@@ -235,6 +235,11 @@ namespace MongoDB.Driver
             return WithPipeline(_pipeline.SortByCount(id));
         }
 
+        public override IAggregateFluent<TResult> Sample(int size)
+        {
+            return WithPipeline(_pipeline.Sample(size));
+        }
+
         public override IOrderedAggregateFluent<TResult> ThenBy(SortDefinition<TResult> newSort)
         {
             Ensure.IsNotNull(newSort, nameof(newSort));

--- a/src/MongoDB.Driver/AggregateFluentBase.cs
+++ b/src/MongoDB.Driver/AggregateFluentBase.cs
@@ -204,6 +204,9 @@ namespace MongoDB.Driver
         public abstract IAggregateFluent<TResult> Sort(SortDefinition<TResult> sort);
 
         /// <inheritdoc />
+        public abstract IAggregateFluent<TResult> Sample(int size);
+
+        /// <inheritdoc />
         public virtual IAggregateFluent<AggregateSortByCountResult<TId>> SortByCount<TId>(AggregateExpressionDefinition<TResult, TId> id)
         {
             throw new NotImplementedException();

--- a/src/MongoDB.Driver/IAggregateFluent.cs
+++ b/src/MongoDB.Driver/IAggregateFluent.cs
@@ -386,6 +386,13 @@ namespace MongoDB.Driver
         /// <param name="options">The options.</param>
         /// <returns>The fluent aggregate interface.</returns>
         IAggregateFluent<TNewResult> Unwind<TNewResult>(FieldDefinition<TResult> field, AggregateUnwindOptions<TNewResult> options = null);
+
+        /// <summary>
+        /// Appends a sample stage to the pipeline.
+        /// </summary>
+        /// <param name="size">The sample size.</param>
+        /// <returns>The fluent aggregate interface.</returns>
+        IAggregateFluent<TResult> Sample(int size);
     }
 
     /// <summary>

--- a/src/MongoDB.Driver/PipelineDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineDefinitionBuilder.cs
@@ -1044,6 +1044,25 @@ namespace MongoDB.Driver
             return pipeline.AppendStage(PipelineStageDefinitionBuilder.Sort(sort));
         }
 
+
+        /// <summary>
+        /// Appends a $sample stage to the pipeline.
+        /// </summary>
+        /// <typeparam name="TInput">The type of the input documents.</typeparam>
+        /// <typeparam name="TOutput">The type of the output documents.</typeparam>
+        /// <param name="pipeline">The pipeline.</param>
+        /// <param name="size">The sample size.</param>
+        /// <returns>
+        /// A new pipeline with an additional stage.
+        /// </returns>
+        public static PipelineDefinition<TInput, TOutput> Sample<TInput, TOutput>(
+            this PipelineDefinition<TInput, TOutput> pipeline,
+            int size)
+        {
+            Ensure.IsNotNull(pipeline, nameof(pipeline));
+            return pipeline.AppendStage(PipelineStageDefinitionBuilder.Sample<TOutput>(size));
+        }
+
         /// <summary>
         /// Appends a $sortByCount stage to the pipeline.
         /// </summary>

--- a/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
@@ -1250,6 +1250,19 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Creates a $sample stage.
+        /// </summary>
+        /// <typeparam name="TInput">The type of the input documents.</typeparam>
+        /// <param name="size">The size.</param>
+        /// <returns>The stage.</returns>
+        public static PipelineStageDefinition<TInput, TInput> Sample<TInput>(
+            int size)
+        {
+            Ensure.IsGreaterThanOrEqualToZero(size, nameof(size));
+            return new BsonDocumentPipelineStageDefinition<TInput, TInput>(new BsonDocument("$sample", new BsonDocument("size", size)));
+        }
+
+        /// <summary>
         /// Creates a $sortByCount stage.
         /// </summary>
         /// <typeparam name="TInput">The type of the input documents.</typeparam>

--- a/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
@@ -115,6 +115,18 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void Sample_should_add_expected_stage()
+        {
+            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
+
+            var result = pipeline.Sample(15);
+
+            var stages = RenderStages(result, BsonDocumentSerializer.Instance);
+            stages.Count.Should().Be(1);
+            stages[0].Should().Be("{ $sample: { size: 15 } }");
+        }
+
+        [Fact]
         public void UnionWith_should_add_expected_stage()
         {
             var pipeline = new EmptyPipelineDefinition<BsonDocument>();


### PR DESCRIPTION
While answering this [Stack Overflow Question](https://stackoverflow.com/questions/63346252/mongodb-how-to-return-random-elements-without-linq-mongodb-c) I came across that $sample was not supported in the fluent aggregation syntax and also noticed it's been raised on [Jira (CSHARP-2659)](https://jira.mongodb.org/browse/CSHARP-2659) too.

So decided to have a stab at implementing it.

