### PR TITLE
Removed Unnecessary Task.Yeld CSHARP-3183

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
@@ -189,7 +189,7 @@ namespace MongoDB.Driver.Core.Servers
 
         private async Task MonitorServerAsync()
         {
-            await Task.Yield(); // return control immediately
+            //await Task.Yield(); // return control immediately
 
             var metronome = new Metronome(_serverMonitorSettings.HeartbeatInterval);
             var monitorCancellationToken = _monitorCancellationTokenSource.Token;


### PR DESCRIPTION
This PR is related to https://jira.mongodb.org/browse/CSHARP-3183?filter=-2

Actually when I run tests in project https://github.com/ProximoSrl/NStore XUnit runner creates an high number of threads and the connection deadlock.

I've found debugging the code that a Thread enter in MonitorServerAsync, wait for Task.Yield() but never exit from the wait, because an high number of thread are waiting in line 368 of Cluster.cs

![image](https://user-images.githubusercontent.com/358545/90153356-29d05a80-dd89-11ea-9ab2-3458d82f5e93.png)

That particular wait is waiting for three tasks, a cancellation a timeout and a **task that is completed when the cluster changes description**. When too many thread at the same time enter that wait, probably all thread pool threads are in waiting, and for some reason MonitorServerAsync never exit awaiting from the Task.Yeld and everything is freezed.

![image](https://user-images.githubusercontent.com/358545/90153809-b67b1880-dd89-11ea-91aa-f5ef4a2d77e0.png)

Removing the await Task.Yield() solves the problem. That yield was recently added in commit e0568c0f894e2eaafcb894287f33c0b14aa7624b 


