### PR TITLE
CSHARP-1467 CSHARP-1771 Add support for IQueryable features used by OData (namely IIF expression)

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
@@ -470,7 +470,7 @@ namespace MongoDB.Bson.Serialization
             {
                 throw new ArgumentNullException("serializer");
             }
-            if (serializer.ValueType != _memberType)
+            if (serializer.ValueType != _memberType && serializer.ValueType.DeclaringType != _memberType)
             {
                 var message = string.Format("Value type of serializer is {0} and does not match member type {1}.", serializer.ValueType.FullName, _memberType.FullName);
                 throw new ArgumentException(message, "serializer");

--- a/src/MongoDB.Driver/FilterDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/FilterDefinitionBuilder.cs
@@ -84,6 +84,16 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Creates a cond filter.
+        /// </summary>
+        /// <param name="cond"></param>
+        /// <returns>A cond filter.</returns>
+        public FilterDefinition<TDocument> Expr(BsonValue cond)
+        {
+            return new ExprFilterDefinition<TDocument>(cond);
+        }
+
+        /// <summary>
         /// Creates an equality filter for an array field.
         /// </summary>
         /// <typeparam name="TItem">The type of the item.</typeparam>
@@ -1586,6 +1596,19 @@ namespace MongoDB.Driver
             document.Clear();
             document.Add("$and", clauses);
         }
+    }
+
+    internal sealed class ExprFilterDefinition<TDocument> : FilterDefinition<TDocument>
+    {
+        private readonly BsonValue _aggregatePipeLine;
+
+        public ExprFilterDefinition(BsonValue aggregatePipeLine)
+        {
+            _aggregatePipeLine = Ensure.IsNotNull(aggregatePipeLine, nameof(aggregatePipeLine));
+        }
+
+        public override BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
+            => new BsonDocument("$expr", _aggregatePipeLine);
     }
 
     internal sealed class ArrayOperatorFilterDefinition<TDocument, TItem> : FilterDefinition<TDocument>

--- a/src/MongoDB.Driver/Linq/Expressions/SelectExpression.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/SelectExpression.cs
@@ -28,7 +28,7 @@ namespace MongoDB.Driver.Linq.Expressions
         public SelectExpression(Expression source, string itemName, Expression selector)
         {
             _source = Ensure.IsNotNull(source, nameof(source));
-            _itemName = Ensure.IsNotNull(itemName, nameof(itemName));
+            _itemName = itemName;
             _selector = Ensure.IsNotNull(selector, nameof(selector));
         }
 


### PR DESCRIPTION
I'm trying to connect OData provider to MongoDB using this driver. And I faced several problems with it. For example, OData nullability handling forces it to generate queries like `foo == null ? null : foo.bar` that cannot be handled by current driver. The other problem is `Expression.Parameter` allows to make parameter anonymous, while mongo driver expects it to always have a name, thus it fails to generate a query that otherwise is fine to execute. There are also several smaller fixes.

Although I did it to make my OData query work they are general improvements that allow to use IQueryable interface better.

I'm forced into using fork until this gets somehow adopted in upstream so I hope this will eventually go into master.

Related to https://jira.mongodb.org/browse/CSHARP-1771 , https://jira.mongodb.org/browse/CSHARP-1467