### PR TITLE
CSHARP-3218: Add [Preserve] to MongoDB.Bson for AOT compiled targets

### DIFF
--- a/src/MongoDB.Bson/Properties/AssemblyInfo.cs
+++ b/src/MongoDB.Bson/Properties/AssemblyInfo.cs
@@ -16,8 +16,14 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using MongoDB.Bson.Internals;
 
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
+
+// Prevents the Xamarin static linker from stripping anything from this assembly.
+// Required for most of the serialization classes on AOT compiled targets, such
+// as Xamarin.iOS/Xamarin.Mac.
+[assembly: Preserve(AllMembers = true)]
 
 [assembly: InternalsVisibleTo("MongoDB.Bson.Tests")]

--- a/src/MongoDB.Bson/Properties/PreserveAttribute.cs
+++ b/src/MongoDB.Bson/Properties/PreserveAttribute.cs
@@ -1,0 +1,38 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.ComponentModel;
+
+namespace MongoDB.Bson.Internals
+{
+	/// <summary>
+	/// Prevents the Xamarin managed linker from linking the target.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.All)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public sealed class PreserveAttribute : Attribute
+	{
+		/// <summary>
+		/// When used on a class rather than a property, ensures that all members of this type are preserved.
+		/// </summary>
+		public bool AllMembers { get; set; }
+
+		/// <summary>
+		/// Flags the method as a method to preserve during linking if the container class is pulled in.
+		/// </summary>
+		public bool Conditional { get; set; }
+	}
+}


### PR DESCRIPTION
On AOT compiled targets (such as Xamarin.iOS/Xamarin.Mac), the linker will remove all members that are not statically linked by the application. This obviously becomes an issue when members are invoked via reflection or objects are dynamically instantiated. The MongoDB.Bson assembly deals with de/serialization, so it has quite a lot of that. Ultimately, it would be great if we selectively applied `[Preserve]` only to members that absolutely have to be preserved and allowed the linker to strip parts of the assembly that are not needed. Since that is a massive undertaking, a stopgap measure is to preserve the entire assembly.

More info here: https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/linker.