### PR TITLE
Add BsonArray.Add(string, BsonValue) overload

### DIFF
--- a/src/MongoDB.Bson/ObjectModel/BsonArray.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonArray.cs
@@ -278,6 +278,25 @@ namespace MongoDB.Bson
             return this;
         }
 
+        // public methods
+        /// <summary>
+        /// Creates and adds an element to the array.
+        /// </summary>
+        /// <param name="name">The name of the element to add to the array.</param>
+        /// <param name="value">The value of the element to add to the array.</param>
+        /// <returns>The array (so method calls can be chained).</returns>
+        public virtual BsonArray Add(string name, BsonValue value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+
+            Add(new BsonDocument(name, value));
+
+            return this;
+        }
+
         /// <summary>
         /// Adds multiple elements to the array.
         /// </summary>

--- a/tests/MongoDB.Bson.Tests/ObjectModel/BsonArrayTests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/BsonArrayTests.cs
@@ -33,6 +33,18 @@ namespace MongoDB.Bson.Tests
         }
 
         [Fact]
+        public void TestAddElement()
+        {
+            var array = new BsonArray();
+            var value = BsonValue.Create(1);
+            array.Add("x", value);
+            Assert.Equal(1, array.Count);
+            Assert.IsType<BsonDocument>(array[0]);
+            Assert.True(array[0].AsBsonDocument.Contains("x"));
+            Assert.Equal(1, array[0].AsBsonDocument.GetValue("x"));
+        }
+
+        [Fact]
         public void TestAddNull()
         {
             var array = new BsonArray();


### PR DESCRIPTION
For simpler BsonArray initialization by taking advantage of C# collection initializer.
So we can simplify BsonArray initializing from this :
```
new BsonArray
{
    new BsonDocument("a", 1),
    new BsonDocument("b", 2),
};
```
To this :
```
new BsonArray
{
    { "a", 1 },
    { "b", 2 },
};
```