### PR TITLE
CSHARP-2450 (second attempt): Performance: Reduced lock contention in BsonSerializer.LookupActualType

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -41,7 +42,7 @@ namespace MongoDB.Bson.Serialization
         private static HashSet<Type> __discriminatedTypes = new HashSet<Type>();
         private static BsonSerializerRegistry __serializerRegistry;
         private static TypeMappingSerializationProvider __typeMappingSerializationProvider;
-        private static HashSet<Type> __typesWithRegisteredKnownTypes = new HashSet<Type>();
+        private static Hashtable __typesWithRegisteredKnownTypes = new Hashtable(EqualityComparer<Type>.Default);
 
         private static bool __useNullIdChecker = false;
         private static bool __useZeroIdChecker = false;
@@ -679,23 +680,15 @@ namespace MongoDB.Bson.Serialization
         // internal static methods
         internal static void EnsureKnownTypesAreRegistered(Type nominalType)
         {
-            __configLock.EnterReadLock();
-            try
+            if (__typesWithRegisteredKnownTypes.ContainsKey(nominalType))
             {
-                if (__typesWithRegisteredKnownTypes.Contains(nominalType))
-                {
-                    return;
-                }
-            }
-            finally
-            {
-                __configLock.ExitReadLock();
+                return;
             }
 
             __configLock.EnterWriteLock();
             try
             {
-                if (!__typesWithRegisteredKnownTypes.Contains(nominalType))
+                if (!__typesWithRegisteredKnownTypes.ContainsKey(nominalType))
                 {
                     // only call LookupClassMap for classes with a BsonKnownTypesAttribute
 #if NET452
@@ -709,7 +702,7 @@ namespace MongoDB.Bson.Serialization
                         LookupSerializer(nominalType);
                     }
 
-                    __typesWithRegisteredKnownTypes.Add(nominalType);
+                    __typesWithRegisteredKnownTypes[nominalType] = null /* we don't care about the value */;
                 }
             }
             finally

--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -276,7 +276,20 @@ namespace MongoDB.Bson.Serialization
         public static bool IsTypeDiscriminated(Type type)
         {
             var typeInfo = type.GetTypeInfo();
-            return typeInfo.IsInterface || __discriminatedTypes.Contains(type);
+            if (typeInfo.IsInterface)
+            {
+                return true;
+            }
+
+            __configLock.EnterReadLock();
+            try
+            {
+                return __discriminatedTypes.Contains(type);
+            }
+            finally
+            {
+                __configLock.ExitReadLock();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://jira.mongodb.org/browse/CSHARP-2450.

Kindly review my individual check-ins as all 3 check-ins affect the same file and will be confusing in a single comparison.

The most recent check-in contains the most important change: This is where I trade a tiny little bit of increasing complexity (cloning a small HashSet) on the way less likely write-scenario for a substantially better performing read-scenario.