### PR TITLE
Fix the issue "x => x.ToLower().Equals("firstname".ToLower())"

### DIFF
--- a/src/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
@@ -188,6 +188,7 @@ namespace MongoDB.Driver.Linq.Translators
                     {
                         case "Contains":
                         case "StartsWith":
+                        case "Equals":
                         case "EndsWith":
                             return true;
                         default:
@@ -806,7 +807,7 @@ namespace MongoDB.Driver.Linq.Translators
                 case "Contains": return TranslateContains(methodCallExpression);
                 case "ContainsKey": return TranslateContainsKey(methodCallExpression);
                 case "EndsWith": return TranslateStringQuery(methodCallExpression);
-                case "Equals": return TranslateEquals(methodCallExpression);
+                case "Equals": return TranslateStringQuery(methodCallExpression);
                 case "HasFlag": return TranslateHasFlag(methodCallExpression);
                 case "In": return TranslateIn(methodCallExpression);
                 case "IsMatch": return TranslateIsMatch(methodCallExpression);


### PR DESCRIPTION
Hello,

**AS-IS :**
When i'm trying to execute the following LINQ request `x => x.ToLower().Equals("firstname")`, the following exception is thrown: `toLower is not supported`, i'm using the version '2.11.6'.
I need this feature to perform "case insensitive" search.

**TO-BE:**
I made some modifications in the pull request to support this feature.