### PR TITLE
CSHARP-3321: Sharing a MongoClient for metadata lookup can lead to deadlock in drivers using automatic encryption.

### DIFF
--- a/src/MongoDB.Driver/MongoClient.cs
+++ b/src/MongoDB.Driver/MongoClient.cs
@@ -83,7 +83,7 @@ namespace MongoDB.Driver
             _operationExecutor = new OperationExecutor(this);
             if (settings.AutoEncryptionOptions != null)
             {
-                _libMongoCryptController = new AutoEncryptionLibMongoCryptController(
+                _libMongoCryptController = AutoEncryptionLibMongoCryptController.Create(
                     this,
                     _cluster.CryptClient,
                     settings.AutoEncryptionOptions);

--- a/tests/MongoDB.Driver.TestHelpers/DisposableMongoClient.cs
+++ b/tests/MongoDB.Driver.TestHelpers/DisposableMongoClient.cs
@@ -18,10 +18,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
-using MongoDB.Driver.Core.Operations;
 
 namespace MongoDB.Driver.TestHelpers
 {
+    /// <summary>
+    /// This class is used in tests to close down the MongoClient cluster (and also the cluster for the internal MongoClient if there is one).
+    /// </summary>
     public class DisposableMongoClient : IMongoClient, IDisposable
     {
         private readonly IMongoClient wrapped;
@@ -237,6 +239,15 @@ namespace MongoDB.Driver.TestHelpers
         public void Dispose()
         {
             ClusterRegistry.Instance.UnregisterAndDisposeCluster(wrapped.Cluster);
+
+            if (wrapped is MongoClient mongoClient)
+            {
+                var internalClient = mongoClient.LibMongoCryptController?.InternalClient;
+                if (internalClient != null)
+                {
+                    ClusterRegistry.Instance.UnregisterAndDisposeCluster(internalClient.Cluster);
+                }
+            }
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/README.rst
@@ -293,8 +293,8 @@ For each KMS provider (``aws``, ``azure``, ``gcp``, and ``local``), referred to 
      .. code:: javascript
 
         {
-          "keyVaultEndpoint": "key-vault-kevinalbs.vault.azure.net",
-          "keyName": "test-key"
+          "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+          "keyName": "key-name-csfle"
         }
 
      For "gcp":
@@ -302,10 +302,10 @@ For each KMS provider (``aws``, ``azure``, ``gcp``, and ``local``), referred to 
      .. code:: javascript
 
         {
-          "projectId": "csfle-poc",
+          "projectId": "devprod-drivers",
           "location": "global",
-          "keyRing": "test",
-          "keyName": "quickstart"
+          "keyRing": "key-ring-csfle",
+          "keyName": "key-name-csfle"
         }
 
      For "local", do not set a masterKey document.
@@ -318,7 +318,7 @@ For each KMS provider (``aws``, ``azure``, ``gcp``, and ``local``), referred to 
 
    - Expect the return value to be a BSON binary subtype 6, referred to as ``encrypted``.
    - Use ``client_encrypted`` to insert ``{ _id: "<provider_name>", "value": <encrypted> }`` into ``db.coll``.
-   - Use ``client_encrypted`` to run a find querying with ``_id`` of "<provider_name>" and expect ``value`` to be "hello local".
+   - Use ``client_encrypted`` to run a find querying with ``_id`` of "<provider_name>" and expect ``value`` to be "hello <provider_name>".
 
 #. Call ``client_encryption.encrypt()`` with the value "hello <provider_name>", the algorithm ``AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic``, and the ``key_alt_name`` of ``<provider_name>_altname``.
 
@@ -668,8 +668,8 @@ Test cases
    .. code:: javascript
 
       {
-        "keyVaultEndpoint": "key-vault-kevinalbs.vault.azure.net",
-        "keyName": "test-key"
+         "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+         "keyName": "key-name-csfle"
       }
 
    Expect this to succeed. Use the returned UUID of the key to explicitly encrypt and decrypt the string "test" to validate it works.
@@ -681,10 +681,10 @@ Test cases
    .. code:: javascript
 
       {
-        "projectId": "csfle-poc",
+        "projectId": "devprod-drivers",
         "location": "global",
-        "keyRing": "test",
-        "keyName": "quickstart",
+        "keyRing": "key-ring-csfle",
+        "keyName": "key-name-csfle",
         "endpoint": "cloudkms.googleapis.com:443"
       }
 
@@ -697,10 +697,10 @@ Test cases
    .. code:: javascript
 
       {
-        "projectId": "csfle-poc",
+        "projectId": "devprod-drivers",
         "location": "global",
-        "keyRing": "test",
-        "keyName": "quickstart",
+        "keyRing": "key-ring-csfle",
+        "keyName": "key-name-csfle",
         "endpoint": "example.com:443"
       }
 
@@ -770,3 +770,177 @@ The following tests that setting ``bypassAutoEncryption=true`` really does bypas
 #. Use ``client_encrypted`` to insert the document ``{"unencrypted": "test"}`` into ``db.coll``. Expect this to succeed. 
 
 #. Validate that mongocryptd was not spawned. Create a MongoClient to localhost:27021 (or whatever was passed via ``--port``) with serverSelectionTimeoutMS=1000. Run an ``isMaster`` command and ensure it fails with a server selection timeout.
+
+Deadlock tests
+~~~~~~~~~~~~~~
+
+.. _Connection Monitoring and Pooling: /source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+
+The following tests only apply to drivers that have implemented a connection pool (see the `Connection Monitoring and Pooling`_ specification).
+
+There are multiple parameterized test cases. Before each test case, perform the setup.
+
+Setup
+`````
+
+Create a ``MongoClient`` for setup operations named ``client_test``.
+
+Create a ``MongoClient`` for key vault operations with ``maxPoolSize=1`` named ``client_keyvault``. Capture command started events.
+
+Using ``client_test``, drop the collections ``keyvault.datakeys`` and ``db.coll``.
+
+Insert the document `external/external-key.json <../external/external-key.json>`_ into ``keyvault.datakeys`` with majority write concern.
+
+Create a collection ``db.coll`` configured with a JSON schema `external/external-schema.json <../external/external-schema.json>`_ as the validator, like so:
+
+.. code:: typescript
+
+   {"create": "coll", "validator": {"$jsonSchema": <json_schema>}}
+
+Create a ``ClientEncryption`` object, named ``client_encryption`` configured with:
+- ``keyVaultClient``=``client_test``
+- ``keyVaultNamespace``="keyvault.datakeys"
+- ``kmsProviders``=``{ "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }``
+
+Use ``client_encryption`` to encrypt the value "string0" with ``algorithm``="AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic" and ``keyAltName``="local". Store the result in a variable named ``ciphertext``.
+
+Proceed to run the test case.
+
+Each test case configures a ``MongoClient`` with automatic encryption (named ``client_encrypted``).
+
+Each test must assert the number of unique ``MongoClient``s created. This can be accomplished by capturing ``TopologyOpeningEvent``, or by checking command started events for a client identifier (not possible in all drivers).
+
+Running a test case
+```````````````````
+- Create a ``MongoClient`` named ``client_encrypted`` configured as follows:
+   - Set ``AutoEncryptionOpts``:
+      - ``keyVaultNamespace="keyvault.datakeys"``
+      - ``kmsProviders``=``{ "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }``
+      - Append ``TestCase.AutoEncryptionOpts`` (defined below)
+   - Capture command started events.
+   - Set ``maxPoolSize=TestCase.MaxPoolSize``
+- If the testcase sets ``AutoEncryptionOpts.bypassAutoEncryption=true``:
+   - Use ``client_test`` to insert ``{ "_id": 0, "encrypted": <ciphertext> }`` into ``db.coll``.
+- Otherwise:
+   - Use ``client_encrypted`` to insert ``{ "_id": 0, "encrypted": "string0" }``.
+- Use ``client_encrypted`` to run a ``findOne`` operation on ``db.coll``, with the filter ``{ "_id": 0 }``.
+- Expect the result to be ``{ "_id": 0, "encrypted": "string0" }``.
+- Check captured events against ``TestCase.Expectations``.
+- Check the number of unique ``MongoClient``s created is equal to ``TestCase.ExpectedNumberOfClients``.
+
+Case 1
+``````
+- MaxPoolSize: 1
+- AutoEncryptionOpts:
+   - bypassAutoEncryption=false
+   - keyVaultClient=unset
+- Expectations:
+   - Expect ``client_encrypted`` to have captured four ``CommandStartedEvent``:
+      - a listCollections to "db".
+      - a find on "keyvault".
+      - an insert on "db".
+      - a find on "db"
+- ExpectedNumberOfClients: 2
+
+Case 2
+``````
+- MaxPoolSize: 1
+- AutoEncryptionOpts:
+   - bypassAutoEncryption=false
+   - keyVaultClient=client_keyvault
+- Expectations:
+   - Expect ``client_encrypted`` to have captured three ``CommandStartedEvent``:
+      - a listCollections to "db".
+      - an insert on "db".
+      - a find on "db"
+   - Expect ``client_keyvault`` to have captured one ``CommandStartedEvent``:
+      - a find on "keyvault".
+- ExpectedNumberOfClients: 2
+
+Case 3
+``````
+- MaxPoolSize: 1
+- AutoEncryptionOpts:
+   - bypassAutoEncryption=true
+   - keyVaultClient=unset
+- Expectations:
+   - Expect ``client_encrypted`` to have captured three ``CommandStartedEvent``:
+      - a find on "db"
+      - a find on "keyvault".
+- ExpectedNumberOfClients: 2
+
+Case 4
+``````
+- MaxPoolSize: 1
+- AutoEncryptionOpts:
+   - bypassAutoEncryption=true
+   - keyVaultClient=client_keyvault
+- Expectations:
+   - Expect ``client_encrypted`` to have captured two ``CommandStartedEvent``:
+      - a find on "db"
+   - Expect ``client_keyvault`` to have captured one ``CommandStartedEvent``:
+      - a find on "keyvault".
+- ExpectedNumberOfClients: 1
+
+Case 5
+``````
+Drivers that do not support an unlimited maximum pool size MUST skip this test.
+
+- MaxPoolSize: 0
+- AutoEncryptionOpts:
+   - bypassAutoEncryption=false
+   - keyVaultClient=unset
+- Expectations:
+   - Expect ``client_encrypted`` to have captured five ``CommandStartedEvent``:
+      - a listCollections to "db".
+      - a listCollections to "keyvault".
+      - a find on "keyvault".
+      - an insert on "db".
+      - a find on "db"
+- ExpectedNumberOfClients: 1
+
+Case 6
+``````
+Drivers that do not support an unlimited maximum pool size MUST skip this test.
+
+- MaxPoolSize: 0
+- AutoEncryptionOpts:
+   - bypassAutoEncryption=false
+   - keyVaultClient=client_keyvault
+- Expectations:
+   - Expect ``client_encrypted`` to have captured three ``CommandStartedEvent``:
+      - a listCollections to "db".
+      - an insert on "db".
+      - a find on "db"
+   - Expect ``client_keyvault`` to have captured one ``CommandStartedEvent``:
+      - a find on "keyvault".
+- ExpectedNumberOfClients: 1
+
+Case 7
+``````
+Drivers that do not support an unlimited maximum pool size MUST skip this test.
+
+- MaxPoolSize: 0
+- AutoEncryptionOpts:
+   - bypassAutoEncryption=true
+   - keyVaultClient=unset
+- Expectations:
+   - Expect ``client_encrypted`` to have captured three ``CommandStartedEvent``:
+      - a find on "db"
+      - a find on "keyvault".
+- ExpectedNumberOfClients: 1
+
+Case 8
+``````
+Drivers that do not support an unlimited maximum pool size MUST skip this test.
+
+- MaxPoolSize: 0
+- AutoEncryptionOpts:
+   - bypassAutoEncryption=true
+   - keyVaultClient=client_keyvault
+- Expectations:
+   - Expect ``client_encrypted`` to have captured two ``CommandStartedEvent``:
+      - a find on "db"
+   - Expect ``client_keyvault`` to have captured one ``CommandStartedEvent``:
+      - a find on "keyvault".
+- ExpectedNumberOfClients: 1

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/aggregate.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/aggregate.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -271,18 +259,6 @@
               "cursor": {}
             },
             "command_name": "aggregate"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
           }
         },
         {

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/aggregate.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/aggregate.yml
@@ -30,13 +30,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -83,13 +76,6 @@ tests:
             cursor: {}
           command_name: aggregate
       # Needs to fetch key when decrypting results
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/azureKMS.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/azureKMS.json
@@ -142,18 +142,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/azureKMS.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/azureKMS.yml
@@ -25,13 +25,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/basic.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/basic.json
@@ -147,18 +147,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -279,18 +267,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/basic.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/basic.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -81,13 +74,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/bulk.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/bulk.json
@@ -181,18 +181,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/bulk.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/bulk.yml
@@ -39,13 +39,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/count.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/count.json
@@ -152,18 +152,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/count.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/count.yml
@@ -28,13 +28,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/countDocuments.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/countDocuments.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/countDocuments.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/countDocuments.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/delete.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/delete.json
@@ -154,18 +154,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -272,18 +260,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/delete.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/delete.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -75,13 +68,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/distinct.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/distinct.json
@@ -164,18 +164,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/distinct.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/distinct.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/explain.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/explain.json
@@ -158,18 +158,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/explain.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/explain.yml
@@ -33,13 +33,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/find.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/find.json
@@ -163,18 +163,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -298,18 +286,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/find.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/find.yml
@@ -30,13 +30,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -77,13 +70,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndDelete.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndDelete.json
@@ -151,18 +151,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndDelete.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndDelete.yml
@@ -28,13 +28,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndReplace.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndReplace.json
@@ -150,18 +150,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndReplace.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndReplace.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndUpdate.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndUpdate.json
@@ -152,18 +152,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndUpdate.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/findOneAndUpdate.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/gcpKMS.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/gcpKMS.json
@@ -144,18 +144,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/gcpKMS.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/gcpKMS.yml
@@ -25,13 +25,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/getMore.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/getMore.json
@@ -182,18 +182,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/getMore.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/getMore.yml
@@ -38,13 +38,6 @@ tests:
             find: *collection_name
             batchSize: 2
           command_name: find
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/insert.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/insert.json
@@ -134,18 +134,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -254,18 +242,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/insert.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/insert.yml
@@ -25,13 +25,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -70,13 +63,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/keyAltName.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/keyAltName.json
@@ -134,18 +134,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/keyAltName.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/keyAltName.yml
@@ -25,13 +25,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/localKMS.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/localKMS.json
@@ -117,18 +117,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/localKMS.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/localKMS.yml
@@ -26,13 +26,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/localSchema.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/localSchema.json
@@ -139,18 +139,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/localSchema.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/localSchema.yml
@@ -25,13 +25,6 @@ tests:
           filter: { _id: 1 }
         result: [*doc0]
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/maxWireVersion.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/maxWireVersion.json
@@ -50,6 +50,9 @@
         "autoEncryptOpts": {
           "kmsProviders": {
             "aws": {}
+          },
+          "extraOptions": {
+            "mongocryptdBypassSpawn": true
           }
         }
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/maxWireVersion.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/maxWireVersion.yml
@@ -12,6 +12,8 @@ tests:
       autoEncryptOpts:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
+        extraOptions:
+          mongocryptdBypassSpawn: true # mongocryptd probably won't be on the path
     operations:
       - name: insertOne
         arguments:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/missingKey.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/missingKey.json
@@ -143,18 +143,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "different"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "different",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/missingKey.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/missingKey.yml
@@ -32,13 +32,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "different"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/replaceOne.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/replaceOne.json
@@ -151,18 +151,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/replaceOne.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/replaceOne.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/types.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/types.json
@@ -106,18 +106,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -257,18 +245,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -405,18 +381,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {
@@ -659,18 +623,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -807,18 +759,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {
@@ -1060,18 +1000,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -1217,18 +1145,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -1369,18 +1285,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/types.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/types.yml
@@ -27,13 +27,6 @@ tests:
           filter: { _id: 1 }
         result: *doc0
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -75,13 +68,6 @@ tests:
           filter: { _id: 1 }
         result: *doc1
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -123,13 +109,6 @@ tests:
           filter: { _id: 1 }
         result: *doc2
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -197,13 +176,6 @@ tests:
           filter: { _id: 1 }
         result: *doc6
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -245,13 +217,6 @@ tests:
           filter: { _id: 1 }
         result: *doc7
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -319,13 +284,6 @@ tests:
           filter: { _id: 1 }
         result: *doc10
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -367,13 +325,6 @@ tests:
           filter: { _id: 1 }
         result: *doc11
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -415,13 +366,6 @@ tests:
           filter: { _id: 1 }
         result: *doc13
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/updateMany.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/updateMany.json
@@ -167,18 +167,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/updateMany.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/updateMany.yml
@@ -32,13 +32,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/updateOne.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/updateOne.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/updateOne.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/updateOne.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/60148e575623433e9c236559