### PR TITLE
CSHARP-3371: Support AWS authentication with temporary credentials in CSFLE.

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -256,6 +256,8 @@ functions:
           export FLE_AZURE_CLIENT_SECRET=${FLE_AZURE_CLIENT_SECRET}
           export FLE_GCP_EMAIL=${FLE_GCP_EMAIL}
           export FLE_GCP_PRIVATE_KEY=${FLE_GCP_PRIVATE_KEY}
+          . ./evergreen/set-virtualenv.sh
+          . ./evergreen/set-temp-fle-aws-creds.sh
           ${PREPARE_SHELL}
           SSL=${SSL} evergreen/add-certs-if-needed.sh
           AUTH=${AUTH} \

--- a/evergreen/set-temp-fle-aws-creds.sh
+++ b/evergreen/set-temp-fle-aws-creds.sh
@@ -1,0 +1,47 @@
+# Obtains temporary AWS credentials for CSFLE testing.
+#
+# Run with a . to add environment variables to the current shell:
+# . ./set-temp-fle-aws-creds.sh
+#
+# Requires the python AWS SDK boto3. This can be installed with: pip install boto3
+# The path to python in a virtual environment may be passed with the PYTHON
+# environment variable.
+#
+# Environment variables used as input:
+#   FLE_AWS_ACCESS_KEY_ID                            Set to access for global FLE_AWS_ACCESS_KEY_ID
+#   FLE_AWS_SECRET_ACCESS_KEY                        Set to access for global FLE_AWS_SECRET_ACCESS_KEY
+#
+# Environment variables produced as output:
+#   FLE_AWS_TEMP_ACCESS_KEY_ID                       Temporary AWS_ACCESS_KEY_ID
+#   FLE_AWS_TEMP_SECRET_ACCESS_KEY                   Temporary AWS_SECRET_ACCESS_KEY
+#   FLE_AWS_TEMP_SESSION_TOKEN                       Temporary AWS_SESSION_TOKEN
+
+set +o xtrace # Disable tracing.
+
+#boto3 expects env variables in a bit different form than we use
+export AWS_ACCESS_KEY_ID=$FLE_AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$FLE_AWS_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION=us-east-1
+
+echo "Triggering temporary CSFLE credentials"
+
+get_creds() {
+    $PYTHON - "$@" << 'EOF'
+import boto3
+client = boto3.client("sts")
+credentials = client.get_session_token()["Credentials"]
+print (credentials["AccessKeyId"] + " " + credentials["SecretAccessKey"] + " " + credentials["SessionToken"])
+EOF
+}
+
+PYTHON=${PYTHON:-python}
+$PYTHON -m pip install boto3
+
+CREDS=$(get_creds)
+
+export FLE_AWS_TEMP_ACCESS_KEY_ID=$(echo $CREDS | awk '{print $1}')
+export FLE_AWS_TEMP_SECRET_ACCESS_KEY=$(echo $CREDS | awk '{print $2}')
+export FLE_AWS_TEMP_SESSION_TOKEN=$(echo $CREDS | awk '{print $3}')
+#enable related tests in the driver
+export FLE_AWS_TEMPORARY_CREDS_ENABLED=true
+echo "CSFLE credentials have been exported"

--- a/evergreen/set-virtualenv.sh
+++ b/evergreen/set-virtualenv.sh
@@ -1,0 +1,33 @@
+# Find the version of python on the system.
+# If the directory "venv" exists, start the virtual environment.
+# Otherwise, install a new virtual environment.
+#
+# Environment variables used as input:
+#   OS                                               The current operating system
+#
+# Environment variables produced as output:
+#   PYTHON                                           The venv python path
+
+echo "Initialize PYTHON"
+
+if [ -e "/cygdrive/c/python/Python36/python" ]; then
+    export SYSTEM_PYTHON="/cygdrive/c/python/Python36/python"
+elif [ -e "/opt/mongodbtoolchain/v3/bin/python3" ]; then
+    export SYSTEM_PYTHON="/opt/mongodbtoolchain/v3/bin/python3"
+elif python3 --version >/dev/null 2>&1; then
+    export SYSTEM_PYTHON=python3
+else
+    export SYSTEM_PYTHON=python
+fi
+
+if [ ! -e venv ]; then
+    $SYSTEM_PYTHON -m venv ./venv
+fi
+
+if [ "Windows_NT" = "$OS" ]; then
+    export PYTHON="$(pwd)/venv/Scripts/python"
+else
+    export PYTHON="$(pwd)/venv/bin/python"
+fi
+
+echo "PYTHON has been initialized"

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/README.rst
@@ -147,8 +147,72 @@ Then for each element in ``tests``:
 
 #. Create a **new** MongoClient using ``clientOptions``.
 
-   #. If ``autoEncryptOpts`` includes ``aws``, ``azure``, and/or ``gcp`` as a KMS provider, pass in credentials from the environment.
-   #. If ``autoEncryptOpts`` does not include ``keyVaultNamespace``, default it to ``keyvault.datakeys``.
+   #. If ``autoEncryptOpts`` includes ``aws``, ``awsTemporary``, ``awsTemporaryNoSessionToken``,
+      ``azure``, and/or ``gcp`` as a KMS provider, pass in credentials from the environment.
+
+      - ``awsTemporary``, and ``awsTemporaryNoSessionToken`` require temporary
+        AWS credentials. These can be retrieved using the csfle `set-temp-creds.sh
+        <https://github.com/mongodb-labs/drivers-evergreen-tools/tree/master/.evergreen/csfle>`_
+        script.
+
+      - ``aws``, ``awsTemporary``, and ``awsTemporaryNoSessionToken`` are
+        mutually exclusive.
+
+        ``aws`` should be substituted with:
+
+        .. code:: javascript
+
+           "aws": {
+                "accessKeyId": <set from environment>,
+                "secretAccessKey": <set from environment>
+           }
+
+        ``awsTemporary`` should be substituted with:
+
+        .. code:: javascript
+
+           "aws": {
+                "accessKeyId": <set from environment>,
+                "secretAccessKey": <set from environment>
+                "sessionToken": <set from environment>
+           }
+
+        ``awsTemporaryNoSessionToken`` should be substituted with:
+
+        .. code:: javascript
+
+           "aws": {
+               "accessKeyId": <set from environment>,
+               "secretAccessKey": <set from environment>
+           }
+
+        ``gcp`` should be substituted with:
+
+        .. code:: javascript
+
+           "gcp": {
+               "email": <set from environment>,
+               "privateKey": <set from environment>,
+           }
+
+        ``azure`` should be substituted with:
+
+        .. code:: javascript
+
+           "azure": {
+               "tenantId": <set from environment>,
+               "clientId": <set from environment>,
+               "clientSecret": <set from environment>,
+           }
+
+        ``local`` should be substituted with:
+
+        .. code:: javascript
+
+           "local": { "key": <base64 decoding of LOCAL_MASTERKEY> }
+
+   #. If ``autoEncryptOpts`` does not include ``keyVaultNamespace``, default it
+      to ``keyvault.datakeys``.
 
 #. For each element in ``operations``:
 

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/awsTemporary.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/awsTemporary.json
@@ -1,0 +1,225 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "json_schema": {
+    "properties": {
+      "encrypted_w_altname": {
+        "encrypt": {
+          "keyId": "/altname",
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      },
+      "random": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string_equivalent": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      }
+    },
+    "bsonType": "object"
+  },
+  "key_vault_data": [
+    {
+      "status": 1,
+      "_id": {
+        "$binary": {
+          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+          "subType": "04"
+        }
+      },
+      "masterKey": {
+        "provider": "aws",
+        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        "region": "us-east-1"
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyAltNames": [
+        "altname",
+        "another_altname"
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Insert a document with auto encryption using the AWS provider with temporary credentials",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "awsTemporary": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault"
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 1,
+                  "encrypted_string": {
+                    "$binary": {
+                      "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                      "subType": "06"
+                    }
+                  }
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "encrypted_string": {
+                "$binary": {
+                  "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                  "subType": "06"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Insert with invalid temporary credentials",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "awsTemporaryNoSessionToken": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          },
+          "result": {
+            "errorContains": "security token"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/awsTemporary.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/tests/awsTemporary.yml
@@ -1,0 +1,57 @@
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+data: []
+json_schema: {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+key_vault_data: [{'status': 1, '_id': {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}, 'masterKey': {'provider': 'aws', 'key': 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0', 'region': 'us-east-1'}, 'updateDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyMaterial': {'$binary': {'base64': 'AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO', 'subType': '00'}}, 'creationDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyAltNames': ['altname', 'another_altname']}]
+
+tests:
+  - description: "Insert a document with auto encryption using the AWS provider with temporary credentials"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          awsTemporary: {}
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1, encrypted_string: "string0" }
+    expectations:
+    # Auto encryption will request the collection info.
+    - command_started_event:
+        command:
+          listCollections: 1
+          filter:
+            name: *collection_name
+        command_name: listCollections
+    # Then key is fetched from the key vault.
+    - command_started_event:
+        command:
+          find: datakeys
+          filter: { $or: [ { _id: { $in: [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] } }, { keyAltNames: { $in: [] } } ] }
+          $db: keyvault
+        command_name: find
+    - command_started_event:
+        command:
+          insert: *collection_name
+          documents:
+            - &doc0_encrypted { _id: 1, encrypted_string: {'$binary': {'base64': 'AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==', 'subType': '06'}} }
+          ordered: true
+        command_name: insert
+    outcome:
+      collection:
+        # Outcome is checked using a separate MongoClient without auto encryption.
+        data:
+          - *doc0_encrypted
+  - description: "Insert with invalid temporary credentials"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          awsTemporaryNoSessionToken: {}
+    operations:
+      - name: insertOne
+        arguments:
+          document: *doc0
+        result:
+          errorContains: "security token"


### PR DESCRIPTION
EG:  https://evergreen.mongodb.com/version/60267f001e2d17709ece1633