### PR TITLE
CSHARP-3427 Can't make use of compression when application path contain space

### DIFF
--- a/src/MongoDB.Driver.Core/Core/NativeLibraryLoader/RelativeLibraryLocatorBase.cs
+++ b/src/MongoDB.Driver.Core/Core/NativeLibraryLoader/RelativeLibraryLocatorBase.cs
@@ -40,10 +40,7 @@ namespace MongoDB.Driver.Core.NativeLibraryLoader
         public virtual string GetLibraryBasePath()
         {
             var assembly = GetLibraryBaseAssembly();
-            var codeBase = assembly.CodeBase;
-            var uri = new Uri(codeBase);
-            var absolutePath = uri.AbsolutePath;
-            return Path.GetDirectoryName(absolutePath);
+            return Path.GetDirectoryName(assembly.Location);
         }
 
         public abstract string GetLibraryRelativePath(OperatingSystemPlatform currentPlatform);
@@ -57,7 +54,7 @@ namespace MongoDB.Driver.Core.NativeLibraryLoader
             var absolutePathsToCheck = new[]
             {
                 Path.Combine(libraryBasePath, libraryName),  // look in the current assembly folder
-                Path.Combine(libraryBasePath, @"..\..\", relativePath),
+                Path.Combine(libraryBasePath, "..", "..", relativePath),
                 Path.Combine(libraryBasePath, relativePath)
             };
 


### PR DESCRIPTION
Because of the use or Uri class (don't know why ...), application path containing spaces (e.g. ClickOnce deployed app running on a user account with spaces) produce the following exception when trying to connect to DB with compression enabled:

> System.IO.FileNotFoundException: Could not find library snappy64.dll. Checked C:\Users\User%20Name\source\repos\...\bin\Release\net5.0-windows\snappy64.dll;C:\Users\User%20Name\source\repos\...\bin\Release\net5.0-windows\..\..\runtimes\win\native\snappy64.dll;C:\Users\User%20Name\source\repos\...\bin\Release\net5.0-windows\runtimes\win\native\snappy64.dll.

This pull request fix it. For now I have to disable compression on the connection string (to keep using official nuget packages)