### PR TITLE
NO TICKET: Upgraded DnsClient.NET library to version 1.4.0

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -124,7 +124,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.3.1" />
+    <PackageReference Include="DnsClient" Version="1.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.2.0" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />


### PR DESCRIPTION
Hello,

We are having issues running the Mongodb.net client in our Azure AKS Kubernetes cluster. This issue is fixed in the newest version of DnsClient.NET 1.4.0:

https://github.com/MichaCo/DnsClient.NET/commit/c313562c001875c05c8d9a23b5408781005ac834

I don't have a Jira ticket for this. 
