### PR TITLE
Update DnsClient.NET to 1.4.0 to resolve Kubernetes DNS failures

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -124,7 +124,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.3.1" />
+    <PackageReference Include="DnsClient" Version="1.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.2.0" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -128,7 +128,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.2.0" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -55,7 +55,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Pulling in fix for DnsClient.NET issue #79. See CSHARP-3430 for details. 

Note that DnsClient.NET 1.4.0 depends on System.Buffers 4.5.1 forcing us to upgrade that as well.