### PR TITLE
CSHARP-3244: Corrected wording to refer to XML docs

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,4 +1,4 @@
 # MongoDB .NET Driver Documentation
 
- 1. landing - the front page of all the java docs
+ 1. landing - the front page of all the XML docs
  2. reference - the reference site for the current version of the docs


### PR DESCRIPTION
Changed java docs to XML docs.