### PR TITLE
CSHARP-3303: Fix Monitor_sleep_at_least_minHeartbeatFreqencyMS test on replica sets

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringProseTests.cs
@@ -96,6 +96,7 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring
                 }}");
 
             var settings = DriverTestConfiguration.GetClientSettings();
+            settings.Servers = new[] { settings.Servers.First() };
 
             // set settings.DirectConnection = true after removing obsolete ConnectionMode
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
Select single server in Monitor_sleep_at_least_minHeartbeatFreqencyMS_between_checks test (test fails on connections strings containing multiple servers)

[EG](https://evergreen.mongodb.com/version/6039742061837d59d55e0d7a) (Internal link)