### PR TITLE
CSHARP-3422: Change estimatedDocumentCount() to use the $collStats Agg Stage Instead of Count Command.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -56,6 +56,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __currentOpCommand = new Feature("CurrentOpCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __documentValidation = new Feature("DocumentValidation", new SemanticVersion(3, 2, 0));
         private static readonly Feature __directConnectionSetting = new Feature("DirectConnectionSetting", new SemanticVersion(4, 4, 0));
+        private static readonly Feature __estimatedDocumentCountByCollStats = new Feature("EstimatedDocumentCountByCollStats", new SemanticVersion(4, 9, 0, ""));
         private static readonly Feature __eval = new Feature("Eval", new SemanticVersion(0, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __explainCommand = new Feature("ExplainCommand", new SemanticVersion(3, 0, 0));
         private static readonly Feature __failPoints = new Feature("FailPoints", new SemanticVersion(2, 4, 0));
@@ -266,6 +267,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the directConnection setting feature.
         /// </summary>
         public static Feature DirectConnectionSetting => __directConnectionSetting;
+
+        /// <summary>
+        /// Gets the estimatedDocumentCountByCollStats feature.
+        /// </summary>
+        public static Feature EstimatedDocumentCountByCollStats => __estimatedDocumentCountByCollStats;
 
         /// <summary>
         /// Gets the eval feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/SemanticVersion.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/SemanticVersion.cs
@@ -366,6 +366,15 @@ namespace MongoDB.Driver.Core.Misc
             return !(b < a);
         }
 
+        // internal methods
+        internal int CompareToAsReleased(SemanticVersion other)
+        {
+            var aReleased = new SemanticVersion(_major, _minor, _patch);
+            var bReleased = new SemanticVersion(other._major, other._minor, other._patch);
+            return aReleased.CompareTo(bReleased);
+        }
+
+        // private methods
         private ServerVersion AsServerVersion()
         {
             return new ServerVersion(_major, _minor, _patch, _preRelease);

--- a/src/MongoDB.Driver.Core/Core/Misc/SemanticVersion.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/SemanticVersion.cs
@@ -366,14 +366,6 @@ namespace MongoDB.Driver.Core.Misc
             return !(b < a);
         }
 
-        // internal methods
-        internal int CompareToAsReleased(SemanticVersion other)
-        {
-            var aReleased = new SemanticVersion(_major, _minor, _patch);
-            var bReleased = new SemanticVersion(other._major, other._minor, other._patch);
-            return aReleased.CompareTo(bReleased);
-        }
-
         // private methods
         private ServerVersion AsServerVersion()
         {

--- a/src/MongoDB.Driver.Core/Core/Operations/EstimatedDocumentCountOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/EstimatedDocumentCountOperation.cs
@@ -107,9 +107,9 @@ namespace MongoDB.Driver.Core.Operations
                         // In the event this aggregation is run against a non-existent namespace, a NamespaceNotFound(26) error will be returned during execution.
                         return 0;
                     }
-                    var result = cursor.ToList(cancellationToken);
+                    var results = cursor.ToList(cancellationToken);
 
-                    return ExtractCountFromAggregationResult(result);
+                    return ExtractCountFromAggregationResults(results);
                 }
                 else
                 {
@@ -140,9 +140,9 @@ namespace MongoDB.Driver.Core.Operations
                         // In the event this aggregation is run against a non-existent namespace, a NamespaceNotFound(26) error will be returned during execution.
                         return 0;
                     }
-                    var result = await cursor.ToListAsync(cancellationToken).ConfigureAwait(false);
+                    var results = await cursor.ToListAsync(cancellationToken).ConfigureAwait(false);
 
-                    return ExtractCountFromAggregationResult(result);
+                    return ExtractCountFromAggregationResults(results);
                 }
                 else
                 {
@@ -192,12 +192,12 @@ namespace MongoDB.Driver.Core.Operations
             return countOperation;
         }
 
-        private long ExtractCountFromAggregationResult(List<BsonDocument> result) =>
-            result.Count switch
+        private long ExtractCountFromAggregationResults(List<BsonDocument> results) =>
+            results.Count switch
             {
                 0 => 0,
-                1 => result[0]["n"].ToInt64(),
-                _ => throw new MongoClientException($"Expected aggregate command for {nameof(EstimatedDocumentCountOperation)} to return 1 document, but got {result.Count}."),
+                1 => results[0]["n"].ToInt64(),
+                _ => throw new MongoClientException($"Expected aggregate command for {nameof(EstimatedDocumentCountOperation)} to return 1 document, but got {results.Count}."),
             };
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Operations/EstimatedDocumentCountOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/EstimatedDocumentCountOperation.cs
@@ -1,0 +1,203 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Core.Bindings;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
+
+namespace MongoDB.Driver.Core.Operations
+{
+    /// <summary>
+    /// Represents an estimated document count operation.
+    /// </summary>
+    public class EstimatedDocumentCountOperation : IReadOperation<long>
+    {
+        // private fields
+        private readonly CollectionNamespace _collectionNamespace;
+        private TimeSpan? _maxTime;
+        private readonly MessageEncoderSettings _messageEncoderSettings;
+        private ReadConcern _readConcern = ReadConcern.Default;
+        private bool _retryRequested;
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EstimatedDocumentCountOperation"/> class.
+        /// </summary>
+        /// <param name="collectionNamespace">The collection namespace.</param>
+        /// <param name="messageEncoderSettings">The message encoder settings.</param>
+        public EstimatedDocumentCountOperation(CollectionNamespace collectionNamespace, MessageEncoderSettings messageEncoderSettings)
+        {
+            _collectionNamespace = Ensure.IsNotNull(collectionNamespace, nameof(collectionNamespace));
+            _messageEncoderSettings = Ensure.IsNotNull(messageEncoderSettings, nameof(messageEncoderSettings));
+        }
+
+        // public properties
+        /// <summary>
+        /// Gets the collection namespace.
+        /// </summary>
+        public CollectionNamespace CollectionNamespace => _collectionNamespace;
+
+        /// <summary>
+        /// Gets or sets the maximum time the server should spend on this operation.
+        /// </summary>
+        public TimeSpan? MaxTime
+        {
+            get => _maxTime;
+            set => _maxTime = Ensure.IsNullOrInfiniteOrGreaterThanOrEqualToZero(value, nameof(value));
+        }
+
+        /// <summary>
+        /// Gets the message encoder settings.
+        /// </summary>
+        public MessageEncoderSettings MessageEncoderSettings => _messageEncoderSettings;
+
+        /// <summary>
+        /// Gets or sets the read concern.
+        /// </summary>
+        public ReadConcern ReadConcern
+        {
+            get => _readConcern;
+            set => _readConcern = Ensure.IsNotNull(value, nameof(value));
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to retry.
+        /// </summary>
+        public bool RetryRequested
+        {
+            get => _retryRequested;
+            set => _retryRequested = value;
+        }
+
+        /// <inheritdoc/>
+        public long Execute(IReadBinding binding, CancellationToken cancellationToken)
+        {
+            Ensure.IsNotNull(binding, nameof(binding));
+
+            using (var context = RetryableReadContext.Create(binding, _retryRequested, cancellationToken))
+            {
+                if (Feature.EstimatedDocumentCountByCollStats.IsSupported(context.Channel.ConnectionDescription.ServerVersion))
+                {
+                    var operation = CreateAggregationOperation(context.Channel.ConnectionDescription.ServerVersion);
+                    IAsyncCursor<BsonDocument> cursor;
+                    try
+                    {
+                        cursor = operation.Execute(context, cancellationToken);
+                    }
+                    catch (MongoCommandException ex) when (ex.Code == (int)ServerErrorCode.NamespaceNotFound)
+                    {
+                        // In the event this aggregation is run against a non-existent namespace, a NamespaceNotFound(26) error will be returned during execution.
+                        return 0;
+                    }
+                    var result = cursor.ToList(cancellationToken);
+
+                    return ExtractCountFromAggregationResult(result);
+                }
+                else
+                {
+                    var operation = CreateCountOperation();
+
+                    return operation.Execute(context, cancellationToken);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<long> ExecuteAsync(IReadBinding binding, CancellationToken cancellationToken)
+        {
+            Ensure.IsNotNull(binding, nameof(binding));
+
+            using (var context = RetryableReadContext.Create(binding, _retryRequested, cancellationToken))
+            {
+                if (Feature.EstimatedDocumentCountByCollStats.IsSupported(context.Channel.ConnectionDescription.ServerVersion))
+                {
+                    var operation = CreateAggregationOperation(context.Channel.ConnectionDescription.ServerVersion);
+                    IAsyncCursor<BsonDocument> cursor;
+                    try
+                    {
+                        cursor = await operation.ExecuteAsync(context, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (MongoCommandException ex) when (ex.Code == (int)ServerErrorCode.NamespaceNotFound)
+                    {
+                        // In the event this aggregation is run against a non-existent namespace, a NamespaceNotFound(26) error will be returned during execution.
+                        return 0;
+                    }
+                    var result = await cursor.ToListAsync(cancellationToken).ConfigureAwait(false);
+
+                    return ExtractCountFromAggregationResult(result);
+                }
+                else
+                {
+                    var operation = CreateCountOperation();
+
+                    return await operation.ExecuteAsync(context, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        // private methods
+        private IExecutableInRetryableReadContext<IAsyncCursor<BsonDocument>> CreateAggregationOperation(SemanticVersion serverVersion)
+        {
+            Feature.ReadConcern.ThrowIfNotSupported(serverVersion, _readConcern);
+
+            var pipeline = CreateAggregationPipeline();
+            var aggregateOperation = new AggregateOperation<BsonDocument>(_collectionNamespace, pipeline, BsonDocumentSerializer.Instance, _messageEncoderSettings)
+            {
+                MaxTime = _maxTime,
+                ReadConcern = _readConcern,
+                RetryRequested = _retryRequested
+            };
+            return aggregateOperation;
+
+            IEnumerable<BsonDocument> CreateAggregationPipeline() =>
+                new BsonDocument[]
+                {
+                    new BsonDocument("$collStats", new BsonDocument("count", new BsonDocument())),
+                    new BsonDocument(
+                        "$group",
+                        new BsonDocument
+                        {
+                            { "_id", 1 },
+                            { "n", new BsonDocument("$sum", "$count") }
+                        })
+                };
+        }
+
+        private IExecutableInRetryableReadContext<long> CreateCountOperation()
+        {
+            var countOperation = new CountOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                MaxTime = _maxTime,
+                ReadConcern = _readConcern,
+                RetryRequested = _retryRequested
+            };
+            return countOperation;
+        }
+
+        private long ExtractCountFromAggregationResult(List<BsonDocument> result) =>
+            result.Count switch
+            {
+                0 => 0,
+                1 => result[0]["n"].ToInt64(),
+                _ => throw new MongoClientException($"Expected aggregate command for {nameof(EstimatedDocumentCountOperation)} to return 1 document, but got {result.Count}."),
+            };
+    }
+}

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -951,9 +951,9 @@ namespace MongoDB.Driver
             };
         }
 
-        private CountOperation CreateEstimatedDocumentCountOperation(EstimatedDocumentCountOptions options)
+        private EstimatedDocumentCountOperation CreateEstimatedDocumentCountOperation(EstimatedDocumentCountOptions options)
         {
-            return new CountOperation(_collectionNamespace, _messageEncoderSettings)
+            return new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings)
             {
                 MaxTime = options?.MaxTime,
                 RetryRequested = _database.Client.Settings.RetryReads

--- a/tests/MongoDB.Driver.Core.TestHelpers/XunitExtensions/RequireServer.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/XunitExtensions/RequireServer.cs
@@ -226,7 +226,7 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
                         {
                             var actualVersion = CoreTestConfiguration.ServerVersion;
                             var minServerVersion = SemanticVersion.Parse(item.Value.AsString);
-                            if (actualVersion < minServerVersion)
+                            if (actualVersion.CompareToAsReleased(minServerVersion) < 0)
                             {
                                 return false;
                             }

--- a/tests/MongoDB.Driver.Core.TestHelpers/XunitExtensions/RequireServer.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/XunitExtensions/RequireServer.cs
@@ -226,7 +226,7 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
                         {
                             var actualVersion = CoreTestConfiguration.ServerVersion;
                             var minServerVersion = SemanticVersion.Parse(item.Value.AsString);
-                            if (actualVersion.CompareToAsReleased(minServerVersion) < 0)
+                            if (SemanticVersionCompareToAsReleased(actualVersion, minServerVersion) < 0)
                             {
                                 return false;
                             }
@@ -236,7 +236,7 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
                         {
                             var actualVersion = CoreTestConfiguration.ServerVersion;
                             var maxServerVersion = SemanticVersion.Parse(item.Value.AsString);
-                            if (actualVersion > maxServerVersion)
+                            if (SemanticVersionCompareToAsReleased(actualVersion, maxServerVersion) > 0)
                             {
                                 return false;
                             }
@@ -283,6 +283,13 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
                 case "sharded": return Clusters.ClusterType.Sharded;
                 default: throw new ArgumentException($"Invalid topology: \"{topology}\".", nameof(topology));
             }
+        }
+
+        private int SemanticVersionCompareToAsReleased(SemanticVersion a, SemanticVersion b)
+        {
+            var aReleased = new SemanticVersion(a.Major, a.Minor, a.Patch);
+            var bReleased = new SemanticVersion(b.Major, b.Minor, b.Patch);
+            return aReleased.CompareTo(bReleased);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/EstimatedDocumentCountOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/EstimatedDocumentCountOperationTests.cs
@@ -1,0 +1,389 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core.Bindings;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Connections;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.TestHelpers;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Operations
+{
+    public class EstimatedDocumentCountOperationTests : OperationTestBase
+    {
+        [Fact]
+        public void constructor_should_initialize_instance()
+        {
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings);
+
+            subject.CollectionNamespace.Should().BeSameAs(_collectionNamespace);
+            subject.MessageEncoderSettings.Should().BeSameAs(_messageEncoderSettings);
+            subject.MaxTime.Should().NotHaveValue();
+            subject.ReadConcern.IsServerDefault.Should().BeTrue();
+            subject.RetryRequested.Should().BeFalse();
+        }
+
+        [Fact]
+        public void constructor_should_throw_when_collectionNamespace_is_null()
+        {
+            var exception = Record.Exception(() => new EstimatedDocumentCountOperation(null, _messageEncoderSettings));
+
+            var argumentNullException = exception.Should().BeOfType<ArgumentNullException>().Subject;
+            argumentNullException.ParamName.Should().Be("collectionNamespace");
+        }
+
+        [Fact]
+        public void constructor_should_throw_when_messageEncoderSettings_is_null()
+        {
+            var exception = Record.Exception(() => new EstimatedDocumentCountOperation(_collectionNamespace, null));
+
+            var argumentNullException = exception.Should().BeOfType<ArgumentNullException>().Subject;
+            argumentNullException.ParamName.Should().Be("messageEncoderSettings");
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void MaxTime_get_and_set_should_work(
+            [Values(-10000, 0, 1, 10000, 99999)] long maxTimeTicks)
+        {
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings);
+            var value = TimeSpan.FromTicks(maxTimeTicks);
+
+            subject.MaxTime = value;
+            var result = subject.MaxTime;
+
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void MaxTime_set_should_throw_when_value_is_invalid(
+            [Values(-10001, -9999, -1)] long maxTimeTicks)
+        {
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings);
+            var value = TimeSpan.FromTicks(maxTimeTicks);
+
+            var exception = Record.Exception(() => subject.MaxTime = value);
+
+            var e = exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject;
+            e.ParamName.Should().Be("value");
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void ReadConcern_get_and_set_should_work(
+            [Values(null, ReadConcernLevel.Linearizable, ReadConcernLevel.Local)] ReadConcernLevel? level)
+        {
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings);
+            var value = level == null ? ReadConcern.Default : new ReadConcern(level.Value);
+
+            subject.ReadConcern = value;
+            var result = subject.ReadConcern;
+
+            result.Should().BeSameAs(value);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void RetryRequested_get_and_set_should_work([Values(false, true)] bool value)
+        {
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings);
+
+            subject.RetryRequested = value;
+            var result = subject.RetryRequested;
+
+            result.Should().Be(value);
+        }
+
+        [SkippableFact]
+        public void CreateCommand_should_return_expected_result()
+        {
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings);
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription();
+            var session = OperationTestHelper.CreateSession();
+
+            var result = CreateCommand(subject, connectionDescription, session);
+
+            AssertCommandDocument(result);
+        }
+
+        [Theory]
+        [InlineData(-10000, 0)]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(9999, 1)]
+        [InlineData(10000, 1)]
+        [InlineData(10001, 2)]
+        public void CreateCommand_should_return_expected_result_when_MaxTime_is_set(long maxTimeTicks, int expectedMaxTimeMS)
+        {
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                MaxTime = TimeSpan.FromTicks(maxTimeTicks)
+            };
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription();
+            var session = OperationTestHelper.CreateSession();
+
+            var result = CreateCommand(subject, connectionDescription, session);
+
+            AssertCommandDocument(result, expectedMaxTimeMS: expectedMaxTimeMS);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void CreateCommand_should_return_expected_result_when_ReadConcern_is_set(
+            [Values(null, ReadConcernLevel.Linearizable, ReadConcernLevel.Local)] ReadConcernLevel? level)
+        {
+            var readConcern = level == null ? ReadConcern.Default : new ReadConcern(level);
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                ReadConcern = readConcern
+            };
+
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription(Feature.ReadConcern.FirstSupportedVersion);
+            var session = OperationTestHelper.CreateSession();
+
+            var result = CreateCommand(subject, connectionDescription, session);
+
+            AssertCommandDocument(result, readConcern: readConcern.IsServerDefault ? null : readConcern.ToBsonDocument());
+        }
+
+        [Fact]
+        public void CreateCommand_should_throw_when_ReadConcern_is_set_but_not_supported()
+        {
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                ReadConcern = new ReadConcern(ReadConcernLevel.Linearizable)
+            };
+
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription(Feature.ReadConcern.LastNotSupportedVersion);
+            var session = OperationTestHelper.CreateSession();
+
+            var exception = Record.Exception(() => CreateCommand(subject, connectionDescription, session));
+
+            exception.Should().BeOfType<MongoClientException>();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void CreateCommand_should_return_the_expected_result_when_using_causal_consistency(
+            [Values(null, ReadConcernLevel.Linearizable, ReadConcernLevel.Local)] ReadConcernLevel? level)
+        {
+            var readConcern = level == null ? ReadConcern.Default : new ReadConcern(level);
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                ReadConcern = readConcern
+            };
+
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription(Feature.ReadConcern.FirstSupportedVersion, supportsSessions: true);
+            var session = OperationTestHelper.CreateSession(true, new BsonTimestamp(100));
+
+            var result = CreateCommand(subject, connectionDescription, session);
+
+            var expectedReadConcernDocument = readConcern.ToBsonDocument();
+            expectedReadConcernDocument["afterClusterTime"] = new BsonTimestamp(100);
+
+            AssertCommandDocument(result, readConcern: expectedReadConcernDocument);
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_should_return_expected_result([Values(false, true)] bool async)
+        {
+            RequireServer.Check();
+
+            EnsureTestData();
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings);
+
+            var result = ExecuteOperation(subject, async);
+
+            result.Should().Be(2);
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_should_throw_when_maxTime_is_exceeded([Values(false, true)] bool async)
+        {
+            RequireServer.Check().ClusterTypes(ClusterType.Standalone, ClusterType.ReplicaSet);
+
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
+
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            {
+                var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
+
+                exception.Should().BeOfType<MongoExecutionTimeoutException>();
+            }
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_should_return_expected_result_when_MaxTime_is_set(
+            [Values(null, 1000L)] long? milliseconds,
+            [Values(false, true)] bool async)
+        {
+            RequireServer.Check();
+
+            EnsureTestData();
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                MaxTime = milliseconds == null ? (TimeSpan?)null : TimeSpan.FromMilliseconds(milliseconds.Value)
+            };
+
+            var result = ExecuteOperation(subject, async);
+
+            result.Should().Be(2);
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_should_return_expected_result_when_ReadConcern_is_set(
+            [Values(null, ReadConcernLevel.Local)] ReadConcernLevel? level,
+            [Values(false, true)] bool async)
+        {
+            RequireServer.Check().Supports(Feature.ReadConcern);
+
+            EnsureTestData();
+            var readConcern = level == null ? ReadConcern.Default : new ReadConcern(level.Value);
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                ReadConcern = readConcern
+            };
+
+            var result = ExecuteOperation(subject, async);
+
+            result.Should().Be(2);
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_should_throw_when_ReadConcern_is_set_but_not_supported([Values(false, true)] bool async)
+        {
+            RequireServer.Check().DoesNotSupport(Feature.ReadConcern);
+
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                ReadConcern = new ReadConcern(ReadConcernLevel.Local)
+            };
+
+            var exception = Record.Exception(() => ExecuteOperation(subject, async));
+
+            exception.Should().BeOfType<MongoClientException>();
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_should_send_session_id_when_supported([Values(false, true)] bool async)
+        {
+            RequireServer.Check();
+
+            EnsureTestData();
+            var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings);
+
+            if (Feature.EstimatedDocumentCountByCollStats.IsSupported(CoreTestConfiguration.ServerVersion))
+            {
+                VerifySessionIdWasSentWhenSupported(subject, "aggregate", async);
+            }
+            else
+            {
+                VerifySessionIdWasSentWhenSupported(subject, "count", async);
+            }
+        }
+
+        // private methods
+        private void AssertCommandDocument(BsonDocument actualResult, int? expectedMaxTimeMS = null, BsonDocument readConcern = null)
+        {
+            var currentServerVersion = CoreTestConfiguration.ServerVersion;
+            if (Feature.EstimatedDocumentCountByCollStats.IsSupported(currentServerVersion))
+            {
+                var expectedResult = new BsonDocument
+                {
+                    { "aggregate", _collectionNamespace.CollectionName },
+                    {
+                        "pipeline",
+                        BsonArray.Create(
+                            new []
+                            {
+                                BsonDocument.Parse("{ $collStats : { count : { } } }"),
+                                BsonDocument.Parse("{ $group : { _id : 1, n : { $sum : '$count' } } } ")
+                            })
+                    },
+                    { "maxTimeMS", () => expectedMaxTimeMS.Value, expectedMaxTimeMS.HasValue },
+                    { "readConcern", () => readConcern, readConcern != null },
+                    { "cursor", new BsonDocument() }
+                };
+                actualResult.Should().Be(expectedResult);
+            }
+            else
+            {
+                var expectedResult = new BsonDocument
+                {
+                    { "count", _collectionNamespace.CollectionName },
+                    { "maxTimeMS", () => expectedMaxTimeMS.Value, expectedMaxTimeMS.HasValue },
+                    { "readConcern", () => readConcern, readConcern != null }
+                };
+                actualResult.Should().Be(expectedResult);
+                if (actualResult.TryGetValue("maxTimeMS", out var maxTimeMS))
+                {
+                    maxTimeMS.BsonType.Should().Be(BsonType.Int32);
+                }
+            }
+        }
+
+        private BsonDocument CreateCommand(EstimatedDocumentCountOperation subject, ConnectionDescription connectionDescription, ICoreSession session)
+        {
+            var currentServerVersion = CoreTestConfiguration.ServerVersion;
+            if (Feature.EstimatedDocumentCountByCollStats.IsSupported(currentServerVersion))
+            {
+                var aggregationOperation = (AggregateOperation<BsonDocument>)subject.CreateAggregationOperation(currentServerVersion);
+                return aggregationOperation.CreateCommand(connectionDescription, session);
+            }
+            else
+            {
+                var countOperation = (CountOperation)subject.CreateCountOperation();
+                return countOperation.CreateCommand(connectionDescription, session);
+            }
+        }
+
+        private void EnsureTestData()
+        {
+            RunOncePerFixture(() =>
+            {
+                DropCollection();
+                Insert(new BsonDocument { { "_id", 1 }, { "x", "x" } });
+                Insert(new BsonDocument { { "_id", 2 }, { "x", "X" } });
+            });
+        }
+    }
+
+    internal static class EstimatedDocumentCountOperationReflector
+    {
+        public static IExecutableInRetryableReadContext<IAsyncCursor<BsonDocument>> CreateAggregationOperation(this EstimatedDocumentCountOperation operation, SemanticVersion serverVersion)
+        {
+            return (IExecutableInRetryableReadContext<IAsyncCursor<BsonDocument>>)Reflector.Invoke(operation, nameof(CreateAggregationOperation), serverVersion);
+        }
+
+        public static IExecutableInRetryableReadContext<long> CreateCountOperation(this EstimatedDocumentCountOperation operation)
+        {
+            return (IExecutableInRetryableReadContext<long>)Reflector.Invoke(operation, nameof(CreateCountOperation));
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
@@ -1233,7 +1233,7 @@ namespace MongoDB.Driver
 
         [Theory]
         [ParameterAttributeData]
-        public void EstimatedDocumentCount_should_execute_a_CountOperation(
+        public void EstimatedDocumentCount_should_execute_an_EstimatedDocumentCount_operation(
             [Values(false, true)] bool async)
         {
             var subject = CreateSubject<BsonDocument>();
@@ -1255,16 +1255,11 @@ namespace MongoDB.Driver
             var call = _operationExecutor.GetReadCall<long>();
             VerifySessionAndCancellationToken(call, null, cancellationToken);
 
-            var operation = call.Operation.Should().BeOfType<CountOperation>().Subject;
-            operation.Collation.Should().BeNull();
+            var operation = call.Operation.Should().BeOfType<EstimatedDocumentCountOperation>().Subject;
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
-            operation.Filter.Should().BeNull();
-            operation.Hint.Should().BeNull();
-            operation.Limit.Should().NotHaveValue();
             operation.MaxTime.Should().Be(options.MaxTime);
             operation.ReadConcern.Should().Be(ReadConcern.Default);
             operation.RetryRequested.Should().BeTrue();
-            operation.Skip.Should().NotHaveValue();
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/CrudTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/CrudTestRunner.cs
@@ -313,7 +313,12 @@ namespace MongoDB.Driver.Tests.Specifications.crud
         private class TestCaseFactory : JsonDrivenTestCaseFactory
         {
             // protected properties
-            protected override string PathPrefix => "MongoDB.Driver.Tests.Specifications.crud.tests.";
+            protected override string[] PathPrefixes =>
+                new[]
+                {
+                    "MongoDB.Driver.Tests.Specifications.crud.tests.v1",
+                    "MongoDB.Driver.Tests.Specifications.crud.tests.v2"
+                };
 
             // protected methods
             protected override IEnumerable<JsonDrivenTestCase> CreateTestCases(BsonDocument document)

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/CrudUnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/CrudUnifiedTestRunner.cs
@@ -1,0 +1,57 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers.JsonDrivenTests;
+using MongoDB.Driver.Tests.Specifications.unified_test_format;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Specifications.crud
+{
+    public sealed class CrudUnifiedTestRunner
+    {
+        [SkippableTheory]
+        [ClassData(typeof(TestCaseFactory))]
+        public void Run(JsonDrivenTestCase testCase)
+        {
+            using (var runner = new UnifiedTestFormatTestRunner())
+            {
+                runner.Run(testCase);
+            }
+        }
+
+        // nested types
+        public class TestCaseFactory : JsonDrivenTestCaseFactory
+        {
+            // protected properties
+            protected override string PathPrefix => "MongoDB.Driver.Tests.Specifications.crud.tests.unified.";
+
+            // protected methods
+            protected override IEnumerable<JsonDrivenTestCase> CreateTestCases(BsonDocument document)
+            {
+                foreach (var testCase in base.CreateTestCases(document))
+                {
+                    foreach (var async in new[] { false, true })
+                    {
+                        var name = $"{testCase.Name}:async={async}";
+                        var test = testCase.Test.DeepClone().AsBsonDocument.Add("async", async);
+                        yield return new JsonDrivenTestCase(name, testCase.Shared, test);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/README.rst
@@ -19,21 +19,22 @@ version requirements as noted by the ``runOn`` section, if provided.
 Subdirectories for Test Formats
 -------------------------------
 
-This document describes a current test format, which should be used for any new
-CRUD tests. Additionally, it refers to a "legacy" format, which dates back to
-the initial version of the CRUD specification. Until such time that all original
-tests have been ported to the current format, tests in each format will be
-grouped in their own subdirectory:
+This document describes two legacy formats for CRUD tests: legacy-v1, which dates back
+to the first version of the CRUD specification, and legacy-v2, which was an update to
+the initial format. New CRUD tests should be written in the `unified test format <../../../../unified-test-format/unified-test-format.rst>`_
+and placed under ``unified/``. Until such time that all original tests have been ported
+to the unified test format, tests in each format will be grouped in their own subdirectory:
 
-- ``v1/``: Legacy format tests
-- ``v2/``: Current format tests
+- ``v1/``: Legacy-v1 format tests
+- ``v2/``: Legacy-v2 format tests
+- ``unified/``: Tests using the `unified test format <../../../../unified-test-format/unified-test-format.rst>`_
 
 Since some drivers may not have a unified test runner capable of executing tests
-in both formats, segregating tests in this manner will make it easier for
+in all three formats, segregating tests in this manner will make it easier for
 drivers to sync and feed test files to different test runners.
 
-Test Format
-===========
+Legacy-v2 Test Format
+=====================
 
 *Note: this section pertains to test files in the "v2" directory.*
 
@@ -128,17 +129,17 @@ Each YAML file has the following keys:
         present then use the collection under test.
 
       - ``data``: The data that should exist in the collection after the
-        operation has been run.
+        operation has been run, sorted by "_id".
 
-Legacy Test Format for Single Operations
-----------------------------------------
+Legacy-v1 Test Format for Single Operations
+-------------------------------------------
 
 *Note: this section pertains to test files in the "v1" directory.*
 
 The test format above supports both multiple operations and APM expectations,
 and is consistent with the formats used by other specifications. Previously, the
 CRUD spec tests used a simplified format that only allowed for executing a
-single operation. Notable differences from the current format are as follows:
+single operation. Notable differences from the legacy-v2 format are as follows:
 
 - Instead of a ``tests[i].operations`` array, a single operation was defined as
   a document in ``tests[i].operation``. That document consisted of only the
@@ -156,14 +157,25 @@ single operation. Notable differences from the current format are as follows:
   field is not present, it should be assumed that there is no corresponding bound
   on the required server version.
 
-The legacy format should not conflict with the newer, multi-operation format
+The legacy-v1 format should not conflict with the newer, multi-operation format
 used by other specs (e.g. Transactions). It is possible to create a unified test
-runner capable of executing both formats (as some drivers do).
+runner capable of executing both legacy formats (as some drivers do).
+
+Error Assertions for Bulk Write Operations
+==========================================
+
+When asserting errors (e.g. ``errorContains``, ``errorCodeName``) for bulk write
+operations, the test harness should inspect the ``writeConcernError`` and/or
+``writeErrors`` properties of the bulk write exception. This may not be needed for
+``errorContains`` if a driver concatenates all write and write concern error
+messages into the bulk write exception's top-level message.
 
 Test Runner Implementation
 ==========================
 
-This section provides guidance for implementing a test runner.
+This section provides guidance for implementing a test runner for legacy-v1 and
+legacy-v2 tests. See the `unified test format spec <../../../../unified-test-format/unified-test-format.rst>`_ for how to run tests under
+``unified/``.
 
 Before running the tests:
 
@@ -237,6 +249,8 @@ For each test file:
 
   - If the ``outcome`` field is present, assert the contents of the specified
     collection using ``globalMongoClient``.
+    Note the server does not guarantee that documents returned by a find
+    command will be in inserted order. This find MUST sort by ``{_id:1}``.
 
 Evaluating Matches
 ------------------
@@ -293,3 +307,35 @@ specification, such as ``insertedId`` (for InsertOneResult), ``insertedIds``
 (for InsertManyResult), and ``upsertedCount`` (for UpdateResult). Drivers that
 do not implement these fields should ignore them when comparing ``actual`` with
 ``expected``.
+
+Prose Tests
+===========
+
+The following tests have not yet been automated, but MUST still be tested.
+
+"errInfo" is propagated
+-----------------------
+Test that a writeConcernError "errInfo" is propagated to the user in whatever way is idiomatic to the driver (exception, error object, etc.). Using a 4.0+ server, set the following failpoint:
+
+.. code:: javascript
+
+   {
+     "configureFailPoint": "failCommand",
+     "data": {
+       "failCommands": ["insert"],
+       "writeConcernError": {
+         "code": 100,
+         "codeName": "UnsatisfiableWriteConcern",
+         "errmsg": "Not enough data-bearing nodes",
+         "errInfo": {
+           "writeConcern": {
+             "w": 2,
+             "wtimeout": 0,
+             "provenance": "clientSupplied"
+           }
+         }
+       }
+     },
+     "mode": { "times": 1 }
+   }
+Then, perform an insert on the same database. Assert that an error occurs and that the "errInfo" is accessible and matches the one set in the failpoint.

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/estimatedDocumentCount.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/estimatedDocumentCount.json
@@ -1,0 +1,562 @@
+{
+    "description": "estimatedDocumentCount",
+    "schemaVersion": "1.0",
+    "createEntities": [
+        {
+            "client": {
+                "id": "client0",
+                "observeEvents": [
+                    "commandStartedEvent"
+                ],
+                "uriOptions": {
+                    "retryReads": false
+                },
+                "useMultipleMongoses": false
+            }
+        },
+        {
+            "database": {
+                "id": "database0",
+                "client": "client0",
+                "databaseName": "edc-tests"
+            }
+        },
+        {
+            "collection": {
+                "id": "collection0",
+                "database": "database0",
+                "collectionName": "coll0"
+            }
+        },
+        {
+            "collection": {
+                "id": "collection1",
+                "database": "database0",
+                "collectionName": "coll1"
+            }
+        }
+    ],
+    "initialData": [
+        {
+            "collectionName": "coll0",
+            "databaseName": "edc-tests",
+            "documents": [
+                {
+                    "_id": 1,
+                    "x": 11
+                },
+                {
+                    "_id": 2,
+                    "x": 22
+                },
+                {
+                    "_id": 3,
+                    "x": 33
+                }
+            ]
+        }
+    ],
+    "tests": [
+        {
+            "description": "estimatedDocumentCount uses $collStats on 4.9.0 or greater",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectResult": 3
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll0",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount with maxTimeMS on 4.9.0 or greater",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "arguments": {
+                        "maxTimeMS": 6000
+                    },
+                    "expectResult": 3
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll0",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "maxTimeMS": 6000
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount on non-existent collection on 4.9.0 or greater",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection1",
+                    "expectResult": 0
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll1",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount errors correctly on 4.9.0 or greater--command error",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "failPoint",
+                    "object": "testRunner",
+                    "arguments": {
+                        "client": "client0",
+                        "failPoint": {
+                            "configureFailPoint": "failCommand",
+                            "mode": {
+                                "times": 1
+                            },
+                            "data": {
+                                "failCommands": [
+                                    "aggregate"
+                                ],
+                                "errorCode": 8
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectError": {
+                        "errorCode": 8
+                    }
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll0",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount errors correctly on 4.9.0 or greater--socket error",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "failPoint",
+                    "object": "testRunner",
+                    "arguments": {
+                        "client": "client0",
+                        "failPoint": {
+                            "configureFailPoint": "failCommand",
+                            "mode": {
+                                "times": 1
+                            },
+                            "data": {
+                                "failCommands": [
+                                    "aggregate"
+                                ],
+                                "closeConnection": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectError": {
+                        "isError": true
+                    }
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll0",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount uses count on less than 4.9.0",
+            "runOnRequirements": [
+                {
+                    "maxServerVersion": "4.8.99"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectResult": 3
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll0"
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount with maxTimeMS on less than 4.9.0",
+            "runOnRequirements": [
+                {
+                    "maxServerVersion": "4.8.99"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "arguments": {
+                        "maxTimeMS": 6000
+                    },
+                    "expectResult": 3
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll0",
+                                    "maxTimeMS": 6000
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount on non-existent collection on less than 4.9.0",
+            "runOnRequirements": [
+                {
+                    "maxServerVersion": "4.8.99"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection1",
+                    "expectResult": 0
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll1"
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount errors correctly on less than 4.9.0--command error",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.0.0",
+                    "maxServerVersion": "4.8.99",
+                    "topologies": [
+                        "single",
+                        "replicaset"
+                    ]
+                },
+                {
+                    "minServerVersion": "4.2.0",
+                    "maxServerVersion": "4.8.99",
+                    "topologies": [
+                        "sharded"
+                    ]
+                }
+            ],
+            "operations": [
+                {
+                    "name": "failPoint",
+                    "object": "testRunner",
+                    "arguments": {
+                        "client": "client0",
+                        "failPoint": {
+                            "configureFailPoint": "failCommand",
+                            "mode": {
+                                "times": 1
+                            },
+                            "data": {
+                                "failCommands": [
+                                    "count"
+                                ],
+                                "errorCode": 8
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectError": {
+                        "errorCode": 8
+                    }
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll0"
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount errors correctly on less than 4.9.0--socket error",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.0.0",
+                    "maxServerVersion": "4.8.99",
+                    "topologies": [
+                        "single",
+                        "replicaset"
+                    ]
+                },
+                {
+                    "minServerVersion": "4.2.0",
+                    "maxServerVersion": "4.8.99",
+                    "topologies": [
+                        "sharded"
+                    ]
+                }
+            ],
+            "operations": [
+                {
+                    "name": "failPoint",
+                    "object": "testRunner",
+                    "arguments": {
+                        "client": "client0",
+                        "failPoint": {
+                            "configureFailPoint": "failCommand",
+                            "mode": {
+                                "times": 1
+                            },
+                            "data": {
+                                "failCommands": [
+                                    "count"
+                                ],
+                                "closeConnection": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectError": {
+                        "isError": true
+                    }
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll0"
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/estimatedDocumentCount.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/estimatedDocumentCount.yml
@@ -1,0 +1,267 @@
+description: "estimatedDocumentCount"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false # Avoid setting fail points with multiple mongoses
+      uriOptions: { retryReads: false } # Avoid retrying fail points with closeConnection
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name edc-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+  - collection:
+      # Nonexistent collection intentionally omitted from initialData
+      id: &collection1 collection1
+      database: *database0
+      collectionName: &collection1Name coll1
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: "estimatedDocumentCount uses $collStats on 4.9.0 or greater"
+    runOnRequirements:
+      - minServerVersion: "4.9.0"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection0
+        expectResult: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: &pipeline
+                  - $collStats: { count: {} }
+                  - $group: { _id: 1, n: { $sum: $count }}
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount with maxTimeMS on 4.9.0 or greater"
+    runOnRequirements:
+      - minServerVersion: "4.9.0"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection0
+        arguments:
+          maxTimeMS: 6000
+        expectResult: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: &pipeline
+                  - $collStats: { count: {} }
+                  - $group: { _id: 1, n: { $sum: $count }}
+                maxTimeMS: 6000
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount on non-existent collection on 4.9.0 or greater"
+    runOnRequirements:
+      - minServerVersion: "4.9.0"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection1
+        expectResult: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection1Name
+                pipeline: &pipeline
+                  - $collStats: { count: {} }
+                  - $group: { _id: 1, n: { $sum: $count }}
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount errors correctly on 4.9.0 or greater--command error"
+    runOnRequirements:
+      - minServerVersion: "4.9.0"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ aggregate ]
+              errorCode: 8 # UnknownError
+      - name: estimatedDocumentCount
+        object: *collection0
+        expectError:
+          errorCode: 8 # UnknownError
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: &pipeline
+                  - $collStats: { count: {} }
+                  - $group: { _id: 1, n: { $sum: $count }}
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount errors correctly on 4.9.0 or greater--socket error"
+    runOnRequirements:
+      - minServerVersion: "4.9.0"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ aggregate ]
+              closeConnection: true
+      - name: estimatedDocumentCount
+        object: *collection0
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: &pipeline
+                  - $collStats: { count: {} }
+                  - $group: { _id: 1, n: { $sum: $count }}
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount uses count on less than 4.9.0"
+    runOnRequirements:
+      - maxServerVersion: "4.8.99"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection0
+        expectResult: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+              commandName: count
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount with maxTimeMS on less than 4.9.0"
+    runOnRequirements:
+      - maxServerVersion: "4.8.99"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection0
+        arguments:
+          maxTimeMS: 6000
+        expectResult: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+                maxTimeMS: 6000
+              commandName: count
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount on non-existent collection on less than 4.9.0"
+    runOnRequirements:
+      - maxServerVersion: "4.8.99"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection1
+        expectResult: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection1Name
+              commandName: count
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount errors correctly on less than 4.9.0--command error"
+    runOnRequirements:
+      - minServerVersion: "4.0.0"
+        maxServerVersion: "4.8.99"
+        topologies: [ single, replicaset ]
+      - minServerVersion: "4.2.0"
+        maxServerVersion: "4.8.99"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ count ]
+              errorCode: 8 # UnknownError
+      - name: estimatedDocumentCount
+        object: *collection0
+        expectError:
+          errorCode: 8 # UnknownError
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+              commandName: count
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount errors correctly on less than 4.9.0--socket error"
+    runOnRequirements:
+      - minServerVersion: "4.0.0"
+        maxServerVersion: "4.8.99"
+        topologies: [ single, replicaset ]
+      - minServerVersion: "4.2.0"
+        maxServerVersion: "4.8.99"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ count ]
+              closeConnection: true
+      - name: estimatedDocumentCount
+        object: *collection0
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+              commandName: count
+              databaseName: *database0Name

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-4.9.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-4.9.json
@@ -1,0 +1,246 @@
+{
+    "runOn": [
+        {
+            "minServerVersion": "4.9.0"
+        }
+    ],
+    "database_name": "retryable-reads-tests",
+    "collection_name": "coll",
+    "data": [
+        {
+            "_id": 1,
+            "x": 11
+        },
+        {
+            "_id": 2,
+            "x": 22
+        }
+    ],
+    "tests": [
+        {
+            "description": "EstimatedDocumentCount succeeds on first attempt",
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds on second attempt",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "closeConnection": true
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount fails on first attempt",
+            "clientOptions": {
+                "retryReads": false
+            },
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "closeConnection": true
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "error": true
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount fails on second attempt",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 2
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "closeConnection": true
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "error": true
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-4.9.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-4.9.yml
@@ -1,10 +1,5 @@
 runOn:
-    -
-        minServerVersion: "4.0"
-        topology: ["single", "replicaset"]
-    -
-        minServerVersion: "4.1.7"
-        topology: ["sharded"]
+    - minServerVersion: "4.9.0"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -26,7 +21,10 @@ tests:
             - &retryable_command_started_event
                 command_started_event:
                     command:
-                        count: *collection_name
+                        aggregate: *collection_name
+                        pipeline: &pipeline
+                          - $collStats: { count: {} }
+                          - $group: { _id: 1, n: { $sum: $count }}
                     database_name: *database_name
     -
         description: "EstimatedDocumentCount succeeds on second attempt"
@@ -34,7 +32,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
-                failCommands: [count]
+                failCommands: [aggregate]
                 closeConnection: true
         operations: [*retryable_operation_succeeds]
         expectations:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-pre4.9.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-pre4.9.json
@@ -2,6 +2,7 @@
   "runOn": [
     {
       "minServerVersion": "4.0",
+      "maxServerVersion": "4.8.99",
       "topology": [
         "single",
         "replicaset"
@@ -9,6 +10,7 @@
     },
     {
       "minServerVersion": "4.1.7",
+      "maxServerVersion": "4.8.99",
       "topology": [
         "sharded"
       ]

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-pre4.9.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-pre4.9.yml
@@ -1,0 +1,64 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        maxServerVersion: "4.8.99"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        maxServerVersion: "4.8.99"
+        topology: ["sharded"]
+
+database_name: &database_name "retryable-reads-tests"
+collection_name: &collection_name "coll"
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    -
+        description: "EstimatedDocumentCount succeeds on first attempt"
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: estimatedDocumentCount
+                    object: collection
+                result: 2
+        expectations:
+            - &retryable_command_started_event
+                command_started_event:
+                    command:
+                        count: *collection_name
+                    database_name: *database_name
+    -
+        description: "EstimatedDocumentCount succeeds on second attempt"
+        failPoint:  &failCommand_failPoint
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+                failCommands: [count]
+                closeConnection: true
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount fails on first attempt"
+        clientOptions:
+            retryReads: false
+        failPoint: *failCommand_failPoint
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
+        expectations:
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount fails on second attempt"
+        failPoint:
+          <<: *failCommand_failPoint
+          mode: { times: 2 }
+        operations: [*retryable_operation_fails]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-4.9.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-4.9.json
@@ -1,0 +1,911 @@
+{
+    "runOn": [
+        {
+            "minServerVersion": "4.9.0"
+        }
+    ],
+    "database_name": "retryable-reads-tests",
+    "collection_name": "coll",
+    "data": [
+        {
+            "_id": 1,
+            "x": 11
+        },
+        {
+            "_id": 2,
+            "x": 22
+        }
+    ],
+    "tests": [
+        {
+            "description": "EstimatedDocumentCount succeeds after InterruptedAtShutdown",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 11600
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after InterruptedDueToReplStateChange",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 11602
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after NotMaster",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 10107
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 13435
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after NotMasterOrSecondary",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 13436
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after PrimarySteppedDown",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 189
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after ShutdownInProgress",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 91
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after HostNotFound",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 7
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after HostUnreachable",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 6
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after NetworkTimeout",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 89
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after SocketException",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 9001
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount fails after two NotMaster errors",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 2
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 10107
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "error": true
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount fails after NotMaster when retryReads is false",
+            "clientOptions": {
+                "retryReads": false
+            },
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 10107
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "error": true
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-4.9.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-4.9.yml
@@ -1,0 +1,146 @@
+runOn:
+    - minServerVersion: "4.9.0"
+
+database_name: &database_name "retryable-reads-tests"
+collection_name: &collection_name "coll"
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    -
+        description: "EstimatedDocumentCount succeeds after InterruptedAtShutdown"
+        failPoint: &failCommand_failPoint
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data: { failCommands: [aggregate], errorCode: 11600 }
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: estimatedDocumentCount
+                    object: collection
+                result: 2
+        expectations:
+            - &retryable_command_started_event
+                command_started_event:
+                    command:
+                      aggregate: *collection_name
+                      pipeline: &pipeline
+                        - $collStats: { count: {} }
+                        - $group: { _id: 1, n: { $sum: $count }}
+                    database_name: *database_name
+            - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after InterruptedDueToReplStateChange"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 11602 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after NotMaster"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 10107 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 13435 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after NotMasterOrSecondary"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 13436 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after PrimarySteppedDown"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 189 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after ShutdownInProgress"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 91 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after HostNotFound"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 7 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after HostUnreachable"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 6 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after NetworkTimeout"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 89 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount succeeds after SocketException"
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 9001 }
+        operations: [*retryable_operation_succeeds]
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount fails after two NotMaster errors"
+        failPoint:
+            <<: *failCommand_failPoint
+            mode: { times: 2 }
+            data: { failCommands: [aggregate], errorCode: 10107 }
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
+        expectations:
+             - *retryable_command_started_event
+             - *retryable_command_started_event
+    -
+        description: "EstimatedDocumentCount fails after NotMaster when retryReads is false"
+        clientOptions:
+            retryReads: false
+        failPoint:
+            <<: *failCommand_failPoint
+            data: { failCommands: [aggregate], errorCode: 10107 }
+        operations: [*retryable_operation_fails]
+        expectations:
+             - *retryable_command_started_event

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-pre4.9.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-pre4.9.json
@@ -2,6 +2,7 @@
   "runOn": [
     {
       "minServerVersion": "4.0",
+      "maxServerVersion": "4.8.99",
       "topology": [
         "single",
         "replicaset"
@@ -9,6 +10,7 @@
     },
     {
       "minServerVersion": "4.1.7",
+      "maxServerVersion": "4.8.99",
       "topology": [
         "sharded"
       ]

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-pre4.9.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-pre4.9.yml
@@ -1,9 +1,11 @@
 runOn:
     -
         minServerVersion: "4.0"
+        maxServerVersion: "4.8.99"
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
+        maxServerVersion: "4.8.99"
         topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1-strict.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1-strict.json
@@ -301,6 +301,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -353,7 +359,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -396,6 +405,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -596,7 +608,12 @@
     },
     {
       "description": "estimatedDocumentCount appends declared API version",
-      "skipReason": "DRIVERS-1437 count was removed from API version 1",
+      "skipReason": "DRIVERS-1561 collStats is not in API version 1",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9.0"
+        }
+      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -611,7 +628,22 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "count": "test",
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$collStats": {
+                        "count": {}
+                      }
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": "$count"
+                        }
+                      }
+                    }
+                  ],
                   "apiVersion": "1",
                   "apiStrict": true,
                   "apiDeprecationErrors": {
@@ -952,6 +984,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1007,7 +1042,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1057,6 +1095,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1-strict.yml
@@ -116,7 +116,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -128,7 +131,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -140,7 +146,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "countDocuments appends declared API version"
@@ -216,7 +225,9 @@ tests:
                 <<: *expectedApiVersion
 
   - description: "estimatedDocumentCount appends declared API version"
-    skipReason: "DRIVERS-1437 count was removed from API version 1"
+    skipReason: "DRIVERS-1561 collStats is not in API version 1"
+    runOnRequirements:
+      - minServerVersion: "4.9.0" # $collStats is not used in estimatedDocumentCount on < 4.9
     operations:
       - name: estimatedDocumentCount
         object: *collection
@@ -226,7 +237,10 @@ tests:
         events:
           - commandStartedEvent:
               command:
-                count: *collectionName
+                aggregate: *collectionName
+                pipeline: &pipeline
+                  - $collStats: { count: {} }
+                  - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
   - description: "find command with declared API version appends to the command, but getMore does not"
@@ -357,7 +371,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "updateMany appends declared API version"
@@ -374,7 +391,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
 
   - description: "updateOne appends declared API version"
@@ -391,5 +411,8 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1.json
@@ -298,6 +298,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -350,7 +356,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -393,6 +402,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -587,7 +599,12 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount appends declared API version",
+      "description": "estimatedDocumentCount appends declared API version on less than 4.9.0",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.8.99"
+        }
+      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -603,6 +620,55 @@
               "commandStartedEvent": {
                 "command": {
                   "count": "test",
+                  "apiVersion": "1",
+                  "apiStrict": {
+                    "$$unsetOrMatches": false
+                  },
+                  "apiDeprecationErrors": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "estimatedDocumentCount appends declared API version on 4.9.0 or greater",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "arguments": {}
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$collStats": {
+                        "count": {}
+                      }
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": "$count"
+                        }
+                      }
+                    }
+                  ],
                   "apiVersion": "1",
                   "apiStrict": {
                     "$$unsetOrMatches": false
@@ -943,6 +1009,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -998,7 +1067,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1048,6 +1120,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1.yml
@@ -116,7 +116,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -128,7 +131,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -140,7 +146,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "countDocuments appends declared API version"
@@ -209,7 +218,9 @@ tests:
                 key: x
                 <<: *expectedApiVersion
 
-  - description: "estimatedDocumentCount appends declared API version"
+  - description: "estimatedDocumentCount appends declared API version on less than 4.9.0"
+    runOnRequirements:
+      - maxServerVersion: "4.8.99"
     operations:
       - name: estimatedDocumentCount
         object: *collection
@@ -220,6 +231,24 @@ tests:
           - commandStartedEvent:
               command:
                 count: *collectionName
+                <<: *expectedApiVersion
+
+  - description: "estimatedDocumentCount appends declared API version on 4.9.0 or greater"
+    runOnRequirements:
+      - minServerVersion: "4.9.0"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection
+        arguments: {}
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collectionName
+                pipeline: &pipeline
+                  - $collStats: { count: {} }
+                  - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
   - description: "find command with declared API version appends to the command, but getMore does not"
@@ -350,7 +379,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "updateMany appends declared API version"
@@ -367,7 +399,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
 
   - description: "updateOne appends declared API version"
@@ -384,5 +419,8 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion

--- a/tests/MongoDB.Driver.Tests/Specifications/wireversion-featurelist.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/wireversion-featurelist.rst
@@ -1,0 +1,67 @@
+====================================
+Server Wire version and Feature List
+====================================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Server version
+     - Wire version
+     - Feature List
+
+   * - 2.6
+     - 1
+     - | Aggregation cursor
+       | Auth commands
+
+   * - 2.6
+     - 2
+     - | Write commands (insert/update/delete)
+       | Aggregation $out pipeline operator
+
+   * - 3.0
+     - 3
+     - | listCollections
+       | listIndexes
+       | SCRAM-SHA-1
+       | explain command
+
+   * - 3.2
+     - 4
+     - | (find/getMore/killCursors) commands
+       | currentOp command
+       | fsyncUnlock command
+       | findAndModify take write concern
+       | Commands take read concern
+       | Document-level validation
+       | explain command supports distinct and findAndModify
+
+   * - 3.4
+     - 5
+     - | Commands take write concern
+       | Commands take collation
+
+   * - 3.6
+     - 6
+     - | Supports OP_MSG
+       | Collection-level ChangeStream support
+       | Retryable Writes
+       | Causally Consistent Reads
+       | Logical Sessions
+       | update "arrayFilters" option
+
+   * - 4.0
+     - 7
+     - | ReplicaSet transactions
+       | Database and cluster-level change streams and startAtOperationTime option
+
+   * - 4.2
+     - 8
+     - | Sharded transactions
+       | Aggregation $merge pipeline operator
+
+   * - 5.0
+     - 12
+     - | Consistent $collStats count behavior on sharded and non-sharded topologies
+
+For more information see MongoDB Server repo: https://github.com/mongodb/mongo/blob/master/src/mongo/db/wire_version.h

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEstimatedDocumentCountOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEstimatedDocumentCountOperation.cs
@@ -76,20 +76,20 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         {
             var collection = _entityMap.GetCollection(targetCollectionId);
 
-            var estimatedDocumentCountOptions = new EstimatedDocumentCountOptions();
+            var options = new EstimatedDocumentCountOptions();
             foreach (var argument in arguments ?? Enumerable.Empty<BsonElement>())
             {
                 switch (argument.Name)
                 {
                     case "maxTimeMS":
-                        estimatedDocumentCountOptions.MaxTime = TimeSpan.FromMilliseconds(argument.Value.AsInt32);
+                        options.MaxTime = TimeSpan.FromMilliseconds(argument.Value.AsInt32);
                         break;
                     default:
                         throw new FormatException($"Invalid {nameof(UnifiedEstimatedDocumentCountOperation)} argument name: '{argument.Name}'.");
                 }
             }
 
-            return new UnifiedEstimatedDocumentCountOperation(collection, estimatedDocumentCountOptions);
+            return new UnifiedEstimatedDocumentCountOperation(collection, options);
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEstimatedDocumentCountOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEstimatedDocumentCountOperation.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -75,18 +76,20 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         {
             var collection = _entityMap.GetCollection(targetCollectionId);
 
-            EstimatedDocumentCountOptions options = null;
-
-            foreach (var argument in arguments)
+            var estimatedDocumentCountOptions = new EstimatedDocumentCountOptions();
+            foreach (var argument in arguments ?? Enumerable.Empty<BsonElement>())
             {
                 switch (argument.Name)
                 {
+                    case "maxTimeMS":
+                        estimatedDocumentCountOptions.MaxTime = TimeSpan.FromMilliseconds(argument.Value.AsInt32);
+                        break;
                     default:
-                        throw new FormatException($"Invalid EstimatedDocumentCountOperation argument name: '{argument.Name}'.");
+                        throw new FormatException($"Invalid {nameof(UnifiedEstimatedDocumentCountOperation)} argument name: '{argument.Name}'.");
                 }
             }
 
-            return new UnifiedEstimatedDocumentCountOperation(collection, options);
+            return new UnifiedEstimatedDocumentCountOperation(collection, estimatedDocumentCountOptions);
         }
     }
 }


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/603d9a267742ae71684b20ab