### PR TITLE
CSHARP-3448: Update FLE documentation to mention that we currently don't support arm architecture.

### DIFF
--- a/Docs/reference/content/reference/driver/crud/client_side_encryption.md
+++ b/Docs/reference/content/reference/driver/crud/client_side_encryption.md
@@ -21,6 +21,10 @@ field level encryption supports workloads where applications must guarantee that
 unauthorized parties, including server administrators, cannot read the encrypted
 data.
 
+{{% note class="important" %}} 
+Client-side field level encryption in the .NET/C# driver is currently only supported on x64-compatible CPUs.
+{{% /note %}}
+
 ## mongocryptd configuration
 
 Client-side field level encryption requires the `mongocryptd` daemon / process


### PR DESCRIPTION
Only docs changes.
I restored changes from CSHARP-3300: https://github.com/mongodb/mongo-csharp-driver/pull/450/files#diff-525914cfce0449efb9693ca2513ce901aa04b611f50f800f2e42748fb922ecdfL24 with changed wording.