### PR TITLE
CSHARP-3384: Define error handling behavior of writeErrors and writeConcernError on Mongos

### DIFF
--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/errors/write_errors_ignored.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/errors/write_errors_ignored.json
@@ -1,0 +1,96 @@
+{
+  "description": "writeErrors field is ignored",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Ignore command error with writeErrors field",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 9,
+          "type": "command",
+          "response": {
+            "ok": 1,
+            "writeErrors": [
+              {
+                "errmsg": "NotMasterNoSlaveOk",
+                "code": 13435
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/errors/write_errors_ignored.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/errors/write_errors_ignored.yml
@@ -1,0 +1,41 @@
+description: writeErrors field is ignored
+uri: mongodb://a/?replicaSet=rs
+phases:
+- description: Primary A is discovered
+  responses:
+  - - a:27017
+    - ok: 1
+      ismaster: true
+      hosts:
+      - a:27017
+      setName: rs
+      minWireVersion: 0
+      maxWireVersion: 9
+      topologyVersion: &topologyVersion_1_1
+        processId:
+          "$oid": '000000000000000000000001'
+        counter:
+          "$numberLong": '1'
+  outcome: &outcome
+    servers:
+      a:27017:
+        type: RSPrimary
+        setName: rs
+        topologyVersion: *topologyVersion_1_1
+        pool:
+          generation: 0
+    topologyType: ReplicaSetWithPrimary
+    logicalSessionTimeoutMinutes: null
+    setName: rs
+
+- description: Ignore command error with writeErrors field
+  applicationErrors:
+  - address: a:27017
+    when: afterHandshakeCompletes
+    maxWireVersion: 9
+    type: command
+    response:
+      ok: 1
+      writeErrors:
+      - { errmsg: NotMasterNoSlaveOk, code: 13435 }
+  outcome: *outcome


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-3384
EG: https://evergreen.mongodb.com/version/6063856b3e8e861ac9faf89c
Specification: https://github.com/mongodb/specifications/commit/849adad42df1f7b0a4f56a53bb07a431c859ce26

Note: I reused the same test runner change from https://github.com/mongodb/mongo-csharp-driver/pull/483 PR, which assumes that `ExceptionMapper.MapNotPrimaryOrNodeIsRecovering` is able to return no exception.