### PR TITLE
CSHARP-3462: Unobserved task exception on connection failure raises its head again

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -371,7 +371,6 @@ namespace MongoDB.Driver.Core.Connections
                         catch (Exception ex)
                         {
                             _dropbox.AddException(ex);
-                            throw;
                         }
 
                         if (messageTask.IsCompleted)
@@ -442,7 +441,6 @@ namespace MongoDB.Driver.Core.Connections
                         catch (Exception ex)
                         {
                             _dropbox.AddException(ex);
-                            throw;
                         }
 
                         if (messageTask.IsCompleted)
@@ -786,7 +784,6 @@ namespace MongoDB.Driver.Core.Connections
             {
                 foreach (var taskCompletionSource in _messages.Values)
                 {
-                    taskCompletionSource.Task.IgnoreExceptions();
                     taskCompletionSource.TrySetException(exception); // has no effect on already completed tasks
                 }
             }

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -786,6 +786,7 @@ namespace MongoDB.Driver.Core.Connections
             {
                 foreach (var taskCompletionSource in _messages.Values)
                 {
+                    taskCompletionSource.Task.IgnoreExceptions();
                     taskCompletionSource.TrySetException(exception); // has no effect on already completed tasks
                 }
             }

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -357,7 +357,7 @@ namespace MongoDB.Driver.Core.Connections
                     Task.WaitAny(messageTask, receiveLockRequest.Task);
                     if (messageTask.IsCompleted)
                     {
-                        return _dropbox.RemoveMessage(responseTo);
+                        return _dropbox.RemoveMessage(responseTo); // also propagates exception if any
                     }
 
                     receiveLockRequest.Task.GetAwaiter().GetResult(); // propagate exceptions
@@ -375,7 +375,7 @@ namespace MongoDB.Driver.Core.Connections
 
                         if (messageTask.IsCompleted)
                         {
-                            return _dropbox.RemoveMessage(responseTo);
+                            return _dropbox.RemoveMessage(responseTo); // also propagates exception if any
                         }
 
                         cancellationToken.ThrowIfCancellationRequested();
@@ -427,7 +427,7 @@ namespace MongoDB.Driver.Core.Connections
                     await Task.WhenAny(messageTask, receiveLockRequest.Task).ConfigureAwait(false);
                     if (messageTask.IsCompleted)
                     {
-                        return _dropbox.RemoveMessage(responseTo);
+                        return _dropbox.RemoveMessage(responseTo); // also propagates exception if any
                     }
 
                     receiveLockRequest.Task.GetAwaiter().GetResult(); // propagate exceptions
@@ -445,7 +445,7 @@ namespace MongoDB.Driver.Core.Connections
 
                         if (messageTask.IsCompleted)
                         {
-                            return _dropbox.RemoveMessage(responseTo);
+                            return _dropbox.RemoveMessage(responseTo); // also propagates exception if any
                         }
 
                         cancellationToken.ThrowIfCancellationRequested();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -470,6 +470,68 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
+        public void ReceiveMessage_should_not_produce_unobserved_task_exceptions_on_fail(
+            [Values(false, true)] bool async)
+        {
+            var unobservedTaskExceptionRaised = false;
+            var mockStream = new Mock<Stream>();
+            EventHandler<UnobservedTaskExceptionEventArgs> eventHandler = (s, args) =>
+            {
+                if (args.Exception.InnerException is MongoConnectionException)
+                {
+                    unobservedTaskExceptionRaised = true;
+                }
+            };
+
+            try
+            {
+                TaskScheduler.UnobservedTaskException += eventHandler;
+                var encoderSelector = new ReplyMessageEncoderSelector<BsonDocument>(BsonDocumentSerializer.Instance);
+
+                _mockStreamFactory
+                    .Setup(f => f.CreateStream(_endPoint, CancellationToken.None))
+                    .Returns(mockStream.Object);
+
+                if (async)
+                {
+                    mockStream
+                        .Setup(s => s.ReadAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                        .Throws(new SocketException());
+                }
+                else
+                {
+                    mockStream
+                        .Setup(s => s.Read(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>()))
+                        .Throws(new SocketException());
+                }
+
+                _subject.Open(CancellationToken.None);
+
+                Exception exception;
+                if (async)
+                {
+                    exception = Record.Exception(() => _subject.ReceiveMessageAsync(1, encoderSelector, _messageEncoderSettings, CancellationToken.None).GetAwaiter().GetResult());
+                }
+                else
+                {
+                    exception = Record.Exception(() => _subject.ReceiveMessage(1, encoderSelector, _messageEncoderSettings, CancellationToken.None));
+                }
+                exception.Should().BeOfType<MongoConnectionException>();
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                unobservedTaskExceptionRaised.Should().BeFalse();
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= eventHandler;
+                mockStream.Object?.Dispose();
+            }
+        }
+
+        [Theory]
+        [ParameterAttributeData]
         public void ReceiveMessage_should_throw_network_exception_to_all_awaiters(
             [Values(false, true)]
             bool async1,

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -477,10 +477,8 @@ namespace MongoDB.Driver.Core.Connections
             var mockStream = new Mock<Stream>();
             EventHandler<UnobservedTaskExceptionEventArgs> eventHandler = (s, args) =>
             {
-                if (args.Exception.InnerException is MongoConnectionException)
-                {
-                    unobservedTaskExceptionRaised = true;
-                }
+                unobservedTaskExceptionRaised = true;
+                args.SetObserved();
             };
 
             try
@@ -518,8 +516,8 @@ namespace MongoDB.Driver.Core.Connections
                 }
                 exception.Should().BeOfType<MongoConnectionException>();
 
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
+                GC.Collect(); // Collects the unobserved tasks
+                GC.WaitForPendingFinalizers(); // Assures finilizers are executed
 
                 unobservedTaskExceptionRaised.Should().BeFalse();
             }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-3462
EG: https://evergreen.mongodb.com/version/608081e657e85a60d6a8b5f8

Note: This is leftover from [CSHARP-3102: Memory leak related to heartbeat when connecting to Atlas clusters](https://github.com/mongodb/mongo-csharp-driver/commit/a2303983c22639a114727ec3696cb667e7817b8b).
And the sync path (`BinaryConnection.ReceiveMessage`) did not produce an unhandled exception (or it is not raised in the event for some reason), but I included both paths in the unit test.