### PR TITLE
CSHARP-2936: Support [Serializable] when targeting netstandard2.0

### DIFF
--- a/src/MongoDB.Bson/Exceptions/BsonException.cs
+++ b/src/MongoDB.Bson/Exceptions/BsonException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonException : Exception
@@ -66,7 +66,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the BsonException class (this overload used by deserialization).
         /// </summary>

--- a/src/MongoDB.Bson/Exceptions/BsonInternalException.cs
+++ b/src/MongoDB.Bson/Exceptions/BsonInternalException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON internal exception (almost surely the result of a bug).
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonInternalException : BsonException
@@ -56,7 +56,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the BsonInternalException class (this overload used by deserialization).
         /// </summary>

--- a/src/MongoDB.Bson/Exceptions/BsonSerializationException.cs
+++ b/src/MongoDB.Bson/Exceptions/BsonSerializationException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON serialization exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonSerializationException : BsonException
@@ -56,7 +56,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the BsonSerializationException class (this overload used by deserialization).
         /// </summary>

--- a/src/MongoDB.Bson/Exceptions/DuplicateBsonMemberMapAttributeException.cs
+++ b/src/MongoDB.Bson/Exceptions/DuplicateBsonMemberMapAttributeException.cs
@@ -14,13 +14,16 @@
 */
 
 using System;
+#if !NETSTANDARD1_5
+using System.Runtime.Serialization;
+#endif
 
 namespace MongoDB.Bson
 {
     /// <summary>
     /// Indicates that an attribute restricted to one member has been applied to multiple members.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class DuplicateBsonMemberMapAttributeException : BsonException
@@ -45,15 +48,13 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="DuplicateBsonMemberMapAttributeException" /> class.
         /// </summary>
         /// <param name="info">The info.</param>
         /// <param name="context">The context.</param>
-        protected DuplicateBsonMemberMapAttributeException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context)
+        protected DuplicateBsonMemberMapAttributeException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }

--- a/src/MongoDB.Bson/Exceptions/TruncationException.cs
+++ b/src/MongoDB.Bson/Exceptions/TruncationException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a truncation exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class TruncationException : BsonException
@@ -56,7 +56,7 @@ namespace MongoDB.Bson
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the TruncationException class (this overload used by deserialization).
         /// </summary>

--- a/src/MongoDB.Bson/IO/BsonBinaryReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryReaderSettings.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonBinaryReader.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonBinaryReaderSettings : BsonReaderSettings

--- a/src/MongoDB.Bson/IO/BsonBinaryWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriterSettings.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonBinaryWriter.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonBinaryWriterSettings : BsonWriterSettings

--- a/src/MongoDB.Bson/IO/BsonDocumentReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentReaderSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonDocumentReader.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonDocumentReaderSettings : BsonReaderSettings

--- a/src/MongoDB.Bson/IO/BsonDocumentWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentWriterSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonDocumentWriter.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonDocumentWriterSettings : BsonWriterSettings

--- a/src/MongoDB.Bson/IO/BsonReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonReaderSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonReader.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class BsonReaderSettings

--- a/src/MongoDB.Bson/IO/BsonWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/BsonWriterSettings.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a BsonWriter.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class BsonWriterSettings

--- a/src/MongoDB.Bson/IO/JsonReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/JsonReaderSettings.cs
@@ -13,14 +13,16 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 
 namespace MongoDB.Bson.IO
 {
     /// <summary>
     /// Represents settings for a JsonReader.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class JsonReaderSettings : BsonReaderSettings

--- a/src/MongoDB.Bson/IO/JsonWriterSettings.cs
+++ b/src/MongoDB.Bson/IO/JsonWriterSettings.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson.IO
     /// <summary>
     /// Represents settings for a JsonWriter.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class JsonWriterSettings : BsonWriterSettings

--- a/src/MongoDB.Bson/ObjectModel/BsonArray.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonArray.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON array.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonArray : BsonValue, IComparable<BsonArray>, IEquatable<BsonArray>, IList<BsonValue>

--- a/src/MongoDB.Bson/ObjectModel/BsonBinaryData.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonBinaryData.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents BSON binary data.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonBinaryData : BsonValue, IComparable<BsonBinaryData>, IEquatable<BsonBinaryData>

--- a/src/MongoDB.Bson/ObjectModel/BsonBinarySubType.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonBinarySubType.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the binary data subtype of a BsonBinaryData.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public enum BsonBinarySubType

--- a/src/MongoDB.Bson/ObjectModel/BsonBoolean.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonBoolean.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON boolean value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonBoolean : BsonValue, IComparable<BsonBoolean>, IEquatable<BsonBoolean>

--- a/src/MongoDB.Bson/ObjectModel/BsonDateTime.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDateTime.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON DateTime value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonDateTime : BsonValue, IComparable<BsonDateTime>, IEquatable<BsonDateTime>

--- a/src/MongoDB.Bson/ObjectModel/BsonDecimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDecimal128.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Bson
     /// Represents a BSON Decimal128 value.
     /// </summary>
     /// <seealso cref="MongoDB.Bson.BsonValue" />
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonDecimal128 : BsonValue, IComparable<BsonDecimal128>, IEquatable<BsonDecimal128>

--- a/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
@@ -28,7 +27,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON document.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonDocument : BsonValue, IComparable<BsonDocument>, IConvertibleToBsonDocument, IEnumerable<BsonElement>, IEquatable<BsonDocument>

--- a/src/MongoDB.Bson/ObjectModel/BsonDouble.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDouble.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using System.Globalization;
 using MongoDB.Bson.IO;
 
 namespace MongoDB.Bson
@@ -23,7 +22,7 @@ namespace MongoDB.Bson
     /// Represents a BSON double value.
     /// </summary>
     /// <seealso cref="MongoDB.Bson.BsonValue" />
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonDouble : BsonValue, IComparable<BsonDouble>, IEquatable<BsonDouble>

--- a/src/MongoDB.Bson/ObjectModel/BsonElement.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonElement.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON element.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public struct BsonElement : IComparable<BsonElement>, IEquatable<BsonElement>

--- a/src/MongoDB.Bson/ObjectModel/BsonInt32.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonInt32.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON int value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonInt32 : BsonValue, IComparable<BsonInt32>, IEquatable<BsonInt32>

--- a/src/MongoDB.Bson/ObjectModel/BsonInt64.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonInt64.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON long value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonInt64 : BsonValue, IComparable<BsonInt64>, IEquatable<BsonInt64>

--- a/src/MongoDB.Bson/ObjectModel/BsonJavaScript.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonJavaScript.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON JavaScript value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonJavaScript : BsonValue, IComparable<BsonJavaScript>, IEquatable<BsonJavaScript>

--- a/src/MongoDB.Bson/ObjectModel/BsonJavaScriptWithScope.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonJavaScriptWithScope.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON JavaScript value with a scope.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonJavaScriptWithScope : BsonJavaScript, IComparable<BsonJavaScriptWithScope>, IEquatable<BsonJavaScriptWithScope>

--- a/src/MongoDB.Bson/ObjectModel/BsonMaxKey.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonMaxKey.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the BSON MaxKey value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonMaxKey : BsonValue, IComparable<BsonMaxKey>, IEquatable<BsonMaxKey>

--- a/src/MongoDB.Bson/ObjectModel/BsonMinKey.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonMinKey.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the BSON MinKey value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonMinKey : BsonValue, IComparable<BsonMinKey>, IEquatable<BsonMinKey>

--- a/src/MongoDB.Bson/ObjectModel/BsonNull.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonNull.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the BSON Null value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonNull : BsonValue, IComparable<BsonNull>, IEquatable<BsonNull>

--- a/src/MongoDB.Bson/ObjectModel/BsonObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonObjectId.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON ObjectId value (see also ObjectId).
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonObjectId : BsonValue, IComparable<BsonObjectId>, IEquatable<BsonObjectId>

--- a/src/MongoDB.Bson/ObjectModel/BsonRegularExpression.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonRegularExpression.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON regular expression value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonRegularExpression : BsonValue, IComparable<BsonRegularExpression>, IEquatable<BsonRegularExpression>

--- a/src/MongoDB.Bson/ObjectModel/BsonString.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonString.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON string value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonString : BsonValue, IComparable<BsonString>, IEquatable<BsonString>

--- a/src/MongoDB.Bson/ObjectModel/BsonTimestamp.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonTimestamp.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON timestamp value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonTimestamp : BsonValue, IComparable<BsonTimestamp>, IEquatable<BsonTimestamp>

--- a/src/MongoDB.Bson/ObjectModel/BsonType.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonType.cs
@@ -13,14 +13,16 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 
 namespace MongoDB.Bson
 {
     /// <summary>
     /// Represents the type of a BSON element.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public enum BsonType

--- a/src/MongoDB.Bson/ObjectModel/BsonUndefined.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonUndefined.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents the BSON undefined value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BsonUndefined : BsonValue, IComparable<BsonUndefined>, IEquatable<BsonUndefined>

--- a/src/MongoDB.Bson/ObjectModel/BsonValue.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonValue.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a BSON value (this is an abstract class, see the various subclasses).
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class BsonValue : IComparable<BsonValue>, IConvertible, IEquatable<BsonValue>

--- a/src/MongoDB.Bson/ObjectModel/Decimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/Decimal128.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents a Decimal128 value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public struct Decimal128 : IConvertible, IComparable<Decimal128>, IEquatable<Decimal128>

--- a/src/MongoDB.Bson/ObjectModel/GuidRepresentation.cs
+++ b/src/MongoDB.Bson/ObjectModel/GuidRepresentation.cs
@@ -13,13 +13,16 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
+
 namespace MongoDB.Bson
 {
     /// <summary>
     /// Represents the representation to use when converting a Guid to a BSON binary value.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public enum GuidRepresentation

--- a/src/MongoDB.Bson/ObjectModel/ObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/ObjectId.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Bson
     /// <summary>
     /// Represents an ObjectId (see also BsonObjectId).
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public struct ObjectId : IComparable<ObjectId>, IEquatable<ObjectId>, IConvertible

--- a/src/MongoDB.Driver.Core/Core/Authentication/GssapiException.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/GssapiException.cs
@@ -14,8 +14,7 @@
 */
 
 using System;
-
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -24,7 +23,7 @@ namespace MongoDB.Driver.Core.Authentication
     /// <summary>
     /// Thrown from a GSSAPI-related method.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class GssapiException : Exception
@@ -44,7 +43,7 @@ namespace MongoDB.Driver.Core.Authentication
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="GssapiException" /> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/Core/Authentication/Libgssapi/LibgssapiException.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Libgssapi/LibgssapiException.cs
@@ -13,9 +13,7 @@
 * limitations under the License.
 */
 
-using System.Collections.Generic;
-
-#if NET452
+#if !NETSTANDARD1_5
 using System;
 using System.Runtime.Serialization;
 #endif
@@ -25,7 +23,7 @@ namespace MongoDB.Driver.Core.Authentication.Libgssapi
     /// <summary>
     /// Represents a Libgssapi exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class LibgssapiException : GssapiException
@@ -38,7 +36,7 @@ namespace MongoDB.Driver.Core.Authentication.Libgssapi
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="LibgssapiException" /> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/Core/Authentication/Sspi/Win32Exception.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Sspi/Win32Exception.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-#if NET452
+#if !NETSTANDARD1_5
 using System;
 using System.Runtime.Serialization;
 #endif
@@ -23,7 +23,7 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
     /// <summary>
     /// Thrown from a win32 wrapped operation.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class Win32Exception : GssapiException
@@ -48,7 +48,7 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
             HResult = (int)errorCode;
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="Win32Exception" /> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/Core/Clusters/ClusterId.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/ClusterId.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Driver.Core.Clusters
     /// <summary>
     /// Represents a cluster identifier.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class ClusterId : IEquatable<ClusterId>

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionId.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionId.cs
@@ -14,20 +14,8 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-#if NET452
-using System.Runtime.Serialization;
-#endif
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using MongoDB.Bson.Serialization;
-using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Servers;
-using MongoDB.Driver.Core.WireProtocol.Messages;
 using MongoDB.Shared;
 
 namespace MongoDB.Driver.Core.Connections
@@ -35,7 +23,7 @@ namespace MongoDB.Driver.Core.Connections
     /// <summary>
     /// Represents a connection identifier.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class ConnectionId : IEquatable<ConnectionId>

--- a/src/MongoDB.Driver.Core/Core/Misc/EndPointHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/EndPointHelper.cs
@@ -86,7 +86,7 @@ namespace MongoDB.Driver.Core.Misc
             }
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Gets the object data required to serialize an end point.
         /// </summary>

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkWriteConcernError.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkWriteConcernError.cs
@@ -13,7 +13,9 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using System.Collections.Generic;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
@@ -23,7 +25,7 @@ namespace MongoDB.Driver.Core.Operations
     /// <summary>
     /// Represents the details of a write concern error.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class BulkWriteConcernError

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkWriteOperationError.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkWriteOperationError.cs
@@ -13,12 +13,10 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
+#endif
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Core.Operations
@@ -26,7 +24,7 @@ namespace MongoDB.Driver.Core.Operations
     /// <summary>
     /// Represents the details of a write error for a particular request.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class BulkWriteOperationError
@@ -130,4 +128,3 @@ namespace MongoDB.Driver.Core.Operations
         }
     }
 }
-

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkWriteOperationResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkWriteOperationResult.cs
@@ -15,16 +15,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using MongoDB.Bson;
 
 namespace MongoDB.Driver.Core.Operations
 {
     /// <summary>
     /// Represents the result of a bulk write operation.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class BulkWriteOperationResult
@@ -133,8 +130,8 @@ namespace MongoDB.Driver.Core.Operations
         /// <summary>
         /// Represents the result of an acknowledged bulk write operation.
         /// </summary>
-#if NET452
-    [Serializable]
+#if !NETSTANDARD1_5
+        [Serializable]
 #endif
         public class Acknowledged : BulkWriteOperationResult
         {
@@ -227,8 +224,8 @@ namespace MongoDB.Driver.Core.Operations
         /// <summary>
         /// Represents the result of an unacknowledged BulkWrite operation.
         /// </summary>
-#if NET452
-    [Serializable]
+#if !NETSTANDARD1_5
+        [Serializable]
 #endif
         public class Unacknowledged : BulkWriteOperationResult
         {

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkWriteOperationUpsert.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkWriteOperationUpsert.cs
@@ -13,21 +13,18 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
+#endif
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Core.Misc;
-using MongoDB.Shared;
 
 namespace MongoDB.Driver.Core.Operations
 {
     /// <summary>
     /// Represents the information about one Upsert.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BulkWriteOperationUpsert
@@ -76,4 +73,3 @@ namespace MongoDB.Driver.Core.Operations
         }
     }
 }
-

--- a/src/MongoDB.Driver.Core/Core/Operations/MongoBulkWriteOperationException.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/MongoBulkWriteOperationException.cs
@@ -13,11 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using System.Text;
@@ -28,7 +28,7 @@ namespace MongoDB.Driver.Core.Operations
     /// <summary>
     /// Represents a bulk write operation exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoBulkWriteOperationException : MongoServerException
@@ -69,7 +69,7 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoBulkWriteOperationException" /> class.
         /// </summary>
@@ -136,7 +136,7 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/MongoDB.Driver.Core/Core/Operations/WriteRequest.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/WriteRequest.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Driver.Core.Operations
     /// <summary>
     /// Represents a request to write something to the database.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class WriteRequest

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerId.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerId.cs
@@ -14,9 +14,11 @@
 */
 
 using System;
+#if !NETSTANDARD1_5
 using System.Collections.Generic;
+#endif
 using System.Net;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Driver.Core.Clusters;
@@ -28,7 +30,7 @@ namespace MongoDB.Driver.Core.Servers
     /// <summary>
     /// Represents a server identifier.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
     public sealed class ServerId : IEquatable<ServerId>, ISerializable
 #else
@@ -56,7 +58,7 @@ namespace MongoDB.Driver.Core.Servers
                 .GetHashCode();
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         private ServerId(SerializationInfo info, StreamingContext context)
         {
             _clusterId = (ClusterId)info.GetValue("_clusterId", typeof(ClusterId));
@@ -123,7 +125,7 @@ namespace MongoDB.Driver.Core.Servers
         }
 
         // explicit interface implementations
-#if NET452
+#if !NETSTANDARD1_5
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("_clusterId", _clusterId);

--- a/src/MongoDB.Driver.Core/MongoAuthenticationException.cs
+++ b/src/MongoDB.Driver.Core/MongoAuthenticationException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Driver.Core.Connections;
@@ -24,7 +24,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB authentication exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoAuthenticationException : MongoConnectionException
@@ -51,7 +51,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoAuthenticationException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoClientException.cs
+++ b/src/MongoDB.Driver.Core/MongoClientException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB client exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoClientException : MongoException
@@ -48,7 +48,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoClientException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoCommandException.cs
+++ b/src/MongoDB.Driver.Core/MongoCommandException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Bson;
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB command exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoCommandException : MongoServerException
@@ -76,7 +76,7 @@ namespace MongoDB.Driver
             AddErrorLabelsFromCommandResult(this, result);
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoCommandException"/> class.
         /// </summary>
@@ -147,7 +147,7 @@ namespace MongoDB.Driver
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/MongoDB.Driver.Core/MongoConfigurationException.cs
+++ b/src/MongoDB.Driver.Core/MongoConfigurationException.cs
@@ -14,20 +14,16 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MongoDB.Driver
 {
     /// <summary>
     /// Represents a MongoDB configuration exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoConfigurationException : MongoClientException
@@ -52,7 +48,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoConfigurationException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoConnectionClosedException.cs
+++ b/src/MongoDB.Driver.Core/MongoConnectionClosedException.cs
@@ -13,8 +13,8 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Driver.Core.Connections;
@@ -24,7 +24,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB connection failed exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoConnectionClosedException : MongoConnectionException
@@ -39,7 +39,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoConnectionClosedException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoConnectionException.cs
+++ b/src/MongoDB.Driver.Core/MongoConnectionException.cs
@@ -15,7 +15,7 @@
 
 using System;
 using System.Net.Sockets;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Driver.Core.Connections;
@@ -26,7 +26,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB connection exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoConnectionException : MongoException
@@ -57,7 +57,7 @@ namespace MongoDB.Driver
             _connectionId = Ensure.IsNotNull(connectionId, nameof(connectionId));
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoConnectionException"/> class.
         /// </summary>
@@ -129,7 +129,7 @@ namespace MongoDB.Driver
         public virtual bool IsNetworkException => true; // true in subclasses, only if they can be considered as a network error
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/MongoDB.Driver.Core/MongoCursorNotFoundException.cs
+++ b/src/MongoDB.Driver.Core/MongoCursorNotFoundException.cs
@@ -13,8 +13,8 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Bson;
@@ -26,7 +26,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB cursor not found exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoCursorNotFoundException : MongoQueryException
@@ -59,7 +59,7 @@ namespace MongoDB.Driver
             _cursorId = cursorId;
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoCursorNotFoundException"/> class.
         /// </summary>
@@ -85,7 +85,7 @@ namespace MongoDB.Driver
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/MongoDB.Driver.Core/MongoDuplicateKeyException.cs
+++ b/src/MongoDB.Driver.Core/MongoDuplicateKeyException.cs
@@ -13,8 +13,8 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Driver.Core.Connections;
@@ -24,7 +24,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB duplicate key exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoDuplicateKeyException : MongoWriteConcernException
@@ -40,7 +40,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoDuplicateKeyException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoException.cs
+++ b/src/MongoDB.Driver.Core/MongoException.cs
@@ -15,17 +15,17 @@
 
 using System;
 using System.Collections.Generic;
-using MongoDB.Driver.Core.Misc;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
+using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
 {
     /// <summary>
     /// Represents a MongoDB exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoException : Exception
@@ -53,7 +53,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoException"/> class.
         /// </summary>
@@ -110,7 +110,7 @@ namespace MongoDB.Driver
             _errorLabels.Remove(errorLabel);
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/MongoDB.Driver.Core/MongoExecutionTimeoutException.cs
+++ b/src/MongoDB.Driver.Core/MongoExecutionTimeoutException.cs
@@ -14,10 +14,10 @@
 */
 
 using System;
-using MongoDB.Bson;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Connections;
 
 namespace MongoDB.Driver
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB execution timeout exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoExecutionTimeoutException : MongoServerException
@@ -79,7 +79,7 @@ namespace MongoDB.Driver
             AddErrorLabelsFromCommandResult(this, result);
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoExecutionTimeoutException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoExecutionTimeoutException.cs
+++ b/src/MongoDB.Driver.Core/MongoExecutionTimeoutException.cs
@@ -88,6 +88,7 @@ namespace MongoDB.Driver
         public MongoExecutionTimeoutException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            _result = (BsonDocument)info.GetValue("_result", typeof(BsonDocument));
         }
 #endif
 
@@ -110,5 +111,14 @@ namespace MongoDB.Driver
         /// The name of the error code.
         /// </value>
         public string CodeName => _result?.GetValue("codeName", null)?.AsString;
+
+#if !NETSTANDARD1_5
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("_result", _result);
+        }
+#endif
     }
 }

--- a/src/MongoDB.Driver.Core/MongoIncompatibleDriverException.cs
+++ b/src/MongoDB.Driver.Core/MongoIncompatibleDriverException.cs
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using System.Linq;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Driver.Core.Clusters;
@@ -27,7 +29,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB incompatible driver exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoIncompatibleDriverException : MongoClientException
@@ -82,7 +84,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoIncompatibleDriverException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoInternalException.cs
+++ b/src/MongoDB.Driver.Core/MongoInternalException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB internal exception (almost surely the result of a bug).
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoInternalException : MongoException
@@ -48,7 +48,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoInternalException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoNodeIsRecoveringException.cs
+++ b/src/MongoDB.Driver.Core/MongoNodeIsRecoveringException.cs
@@ -13,8 +13,8 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Bson;
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB node is recovering exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoNodeIsRecoveringException : MongoCommandException
@@ -60,7 +60,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoNodeIsRecoveringException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoNotPrimaryException.cs
+++ b/src/MongoDB.Driver.Core/MongoNotPrimaryException.cs
@@ -13,8 +13,8 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Bson;
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB not primary exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoNotPrimaryException : MongoCommandException
@@ -42,7 +42,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoNotPrimaryException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoQueryException.cs
+++ b/src/MongoDB.Driver.Core/MongoQueryException.cs
@@ -13,12 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Core.Connections;
 
 namespace MongoDB.Driver
@@ -26,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB query exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoQueryException : MongoServerException
@@ -50,7 +49,7 @@ namespace MongoDB.Driver
             _queryResult = queryResult;
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoQueryException"/> class.
         /// </summary>
@@ -88,7 +87,7 @@ namespace MongoDB.Driver
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/MongoDB.Driver.Core/MongoServerException.cs
+++ b/src/MongoDB.Driver.Core/MongoServerException.cs
@@ -15,7 +15,7 @@
 
 using System;
 using MongoDB.Bson;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Driver.Core.Connections;
@@ -26,7 +26,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB server exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoServerException : MongoException
@@ -83,7 +83,7 @@ namespace MongoDB.Driver
             _connectionId = Ensure.IsNotNull(connectionId, nameof(connectionId));
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoServerException"/> class.
         /// </summary>
@@ -106,7 +106,7 @@ namespace MongoDB.Driver
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/MongoDB.Driver.Core/MongoWaitQueueFullException.cs
+++ b/src/MongoDB.Driver.Core/MongoWaitQueueFullException.cs
@@ -13,12 +13,13 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using System.Net;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
-using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
@@ -26,7 +27,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB connection pool wait queue full exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoWaitQueueFullException : MongoClientException
@@ -58,7 +59,7 @@ namespace MongoDB.Driver
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoWaitQueueFullException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.Core/MongoWriteConcernException.cs
+++ b/src/MongoDB.Driver.Core/MongoWriteConcernException.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-#if NET452
+#if !NETSTANDARD1_5
 using System;
 using System.Runtime.Serialization;
 #endif
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a MongoDB write concern exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoWriteConcernException : MongoCommandException
@@ -63,7 +63,7 @@ namespace MongoDB.Driver
             AddErrorLabelsFromWriteConcernResult(this, _writeConcernResult);
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoWriteConcernException"/> class.
         /// </summary>
@@ -91,7 +91,7 @@ namespace MongoDB.Driver
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/MongoDB.Driver.Core/WriteConcernResult.cs
+++ b/src/MongoDB.Driver.Core/WriteConcernResult.cs
@@ -13,9 +13,10 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
@@ -23,7 +24,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents the results of an operation performed with an acknowledged WriteConcern.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class WriteConcernResult

--- a/src/MongoDB.Driver.GridFS/GridFSChunkException.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSChunkException.cs
@@ -13,8 +13,8 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Bson;
@@ -25,7 +25,7 @@ namespace MongoDB.Driver.GridFS
     /// <summary>
     /// Represents a GridFSChunk exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class GridFSChunkException : GridFSException
@@ -52,7 +52,7 @@ namespace MongoDB.Driver.GridFS
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="GridFSChunkException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.GridFS/GridFSException.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -23,7 +23,7 @@ namespace MongoDB.Driver.GridFS
     /// <summary>
     /// Represents a GridFS exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class GridFSException : MongoException
@@ -48,7 +48,7 @@ namespace MongoDB.Driver.GridFS
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="GridFSException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.GridFS/GridFSFileNotFoundException.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSFileNotFoundException.cs
@@ -13,8 +13,8 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Bson;
@@ -25,7 +25,7 @@ namespace MongoDB.Driver.GridFS
     /// <summary>
     /// Represents a GridFSFileNotFound exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class GridFSFileNotFoundException : GridFSException
@@ -64,7 +64,7 @@ namespace MongoDB.Driver.GridFS
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="GridFSFileNotFoundException"/> class.
         /// </summary>

--- a/src/MongoDB.Driver.GridFS/GridFSMD5Exception.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSMD5Exception.cs
@@ -13,8 +13,8 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-#if NET452
 using System.Runtime.Serialization;
 #endif
 using MongoDB.Bson;
@@ -25,7 +25,7 @@ namespace MongoDB.Driver.GridFS
     /// <summary>
     /// Represents a GridFSMD5 exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class GridFSMD5Exception : GridFSException
@@ -48,7 +48,7 @@ namespace MongoDB.Driver.GridFS
         {
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the <see cref="GridFSMD5Exception"/> class.
         /// </summary>

--- a/src/MongoDB.Driver/BulkWriteError.cs
+++ b/src/MongoDB.Driver/BulkWriteError.cs
@@ -13,12 +13,10 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
+#endif
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Support;
 
 namespace MongoDB.Driver
@@ -26,7 +24,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents the details of a write error for a particular request.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BulkWriteError : WriteError

--- a/src/MongoDB.Driver/BulkWriteResult.cs
+++ b/src/MongoDB.Driver/BulkWriteResult.cs
@@ -15,19 +15,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-#if NET452
-using System.Runtime.Serialization;
-#endif
-using MongoDB.Bson;
 
 namespace MongoDB.Driver
 {
     /// <summary>
     /// Represents the result of a bulk write operation.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class BulkWriteResult
@@ -97,7 +92,7 @@ namespace MongoDB.Driver
     /// Represents the result of a bulk write operation.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class BulkWriteResult<TDocument> : BulkWriteResult
@@ -171,7 +166,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Result from an acknowledged write concern.
         /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
         public class Acknowledged : BulkWriteResult<TDocument>
@@ -265,7 +260,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Result from an unacknowledged write concern.
         /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
         public class Unacknowledged : BulkWriteResult<TDocument>

--- a/src/MongoDB.Driver/BulkWriteUpsert.cs
+++ b/src/MongoDB.Driver/BulkWriteUpsert.cs
@@ -13,12 +13,10 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
+#endif
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Support;
 using MongoDB.Shared;
 
@@ -27,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents the information about one Upsert.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class BulkWriteUpsert
@@ -100,4 +98,3 @@ namespace MongoDB.Driver
         }
     }
 }
-

--- a/src/MongoDB.Driver/ConnectionMode.cs
+++ b/src/MongoDB.Driver/ConnectionMode.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Server connection mode.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     [Obsolete("Use DirectConnection instead.")]

--- a/src/MongoDB.Driver/DeleteManyModel.cs
+++ b/src/MongoDB.Driver/DeleteManyModel.cs
@@ -13,7 +13,9 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
@@ -23,7 +25,7 @@ namespace MongoDB.Driver
     /// Model for deleting many documents.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class DeleteManyModel<TDocument> : WriteModel<TDocument>

--- a/src/MongoDB.Driver/DeleteOneModel.cs
+++ b/src/MongoDB.Driver/DeleteOneModel.cs
@@ -13,7 +13,9 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
@@ -23,7 +25,7 @@ namespace MongoDB.Driver
     /// Model for deleting a single document.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class DeleteOneModel<TDocument> : WriteModel<TDocument>

--- a/src/MongoDB.Driver/Encryption/MongoEncryptionException.cs
+++ b/src/MongoDB.Driver/Encryption/MongoEncryptionException.cs
@@ -13,18 +13,17 @@
 * limitations under the License.
 */
 
-#if NET452
+using System;
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
-
-using System;
 
 namespace MongoDB.Driver.Encryption
 {
     /// <summary>
     /// Represents an encryption exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoEncryptionException : MongoClientException
@@ -37,5 +36,17 @@ namespace MongoDB.Driver.Encryption
             : base($"Encryption related exception: {innerException.Message}.", innerException)
         {
         }
+
+#if !NETSTANDARD1_5
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoEncryptionException"/> class (this overload used by deserialization).
+        /// </summary>
+        /// <param name="info">The SerializationInfo.</param>
+        /// <param name="context">The StreamingContext.</param>
+        protected MongoEncryptionException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
     }
 }

--- a/src/MongoDB.Driver/InsertOneModel.cs
+++ b/src/MongoDB.Driver/InsertOneModel.cs
@@ -13,12 +13,9 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MongoDB.Driver.Core.Operations;
+#endif
 
 namespace MongoDB.Driver
 {
@@ -26,7 +23,7 @@ namespace MongoDB.Driver
     /// Model for inserting a single document.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class InsertOneModel<TDocument> : WriteModel<TDocument>

--- a/src/MongoDB.Driver/MongoBulkWriteException.cs
+++ b/src/MongoDB.Driver/MongoBulkWriteException.cs
@@ -13,10 +13,12 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using System.Collections.Generic;
 using System.Linq;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using System.Text;
@@ -28,7 +30,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a bulk write exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class MongoBulkWriteException : MongoServerException
@@ -60,7 +62,7 @@ namespace MongoDB.Driver
             }
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the MongoQueryException class (this overload supports deserialization).
         /// </summary>
@@ -99,7 +101,7 @@ namespace MongoDB.Driver
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Gets the object data.
         /// </summary>
@@ -137,7 +139,7 @@ namespace MongoDB.Driver
     /// Represents a bulk write exception.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class MongoBulkWriteException<TDocument> : MongoBulkWriteException
@@ -168,7 +170,7 @@ namespace MongoDB.Driver
             _unprocessedRequests = unprocessedRequests.ToList();
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the MongoQueryException class (this overload supports deserialization).
         /// </summary>
@@ -203,7 +205,7 @@ namespace MongoDB.Driver
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Gets the object data.
         /// </summary>

--- a/src/MongoDB.Driver/MongoCredential.cs
+++ b/src/MongoDB.Driver/MongoCredential.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Credential to access a MongoDB database.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoCredential : IEquatable<MongoCredential>

--- a/src/MongoDB.Driver/MongoServerAddress.cs
+++ b/src/MongoDB.Driver/MongoServerAddress.cs
@@ -14,8 +14,6 @@
 */
 
 using System;
-using System.Net;
-using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using MongoDB.Bson.IO;
 
@@ -24,7 +22,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// The address of a MongoDB server.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoServerAddress : IEquatable<MongoServerAddress>

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -27,7 +27,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents an immutable URL style connection string. See also MongoUrlBuilder.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoUrl : IEquatable<MongoUrl>

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -31,7 +31,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents URL-style connection strings.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoUrlBuilder

--- a/src/MongoDB.Driver/MongoWriteException.cs
+++ b/src/MongoDB.Driver/MongoWriteException.cs
@@ -14,7 +14,7 @@
 */
 
 using System;
-#if NET452
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 using System.Text;
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents a write exception.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class MongoWriteException : MongoServerException
@@ -70,7 +70,7 @@ namespace MongoDB.Driver
             }
         }
 
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the MongoQueryException class (this overload supports deserialization).
         /// </summary>
@@ -109,7 +109,7 @@ namespace MongoDB.Driver
         }
 
         // methods
-#if NET452
+#if !NETSTANDARD1_5
         /// <summary>
         /// Gets the object data.
         /// </summary>

--- a/src/MongoDB.Driver/ReplaceOneModel.cs
+++ b/src/MongoDB.Driver/ReplaceOneModel.cs
@@ -13,7 +13,9 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
+#endif
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
@@ -23,7 +25,7 @@ namespace MongoDB.Driver
     /// Model for replacing a single document.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class ReplaceOneModel<TDocument> : WriteModel<TDocument>

--- a/src/MongoDB.Driver/UpdateManyModel.cs
+++ b/src/MongoDB.Driver/UpdateManyModel.cs
@@ -13,11 +13,11 @@
 * limitations under the License.
 */
 
-using MongoDB.Driver.Core.Misc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
+using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
 {
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// Model for updating many documents.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class UpdateManyModel<TDocument> : WriteModel<TDocument>

--- a/src/MongoDB.Driver/UpdateOneModel.cs
+++ b/src/MongoDB.Driver/UpdateOneModel.cs
@@ -13,11 +13,11 @@
 * limitations under the License.
 */
 
-using MongoDB.Driver.Core.Misc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
+using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
 {
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// Model for updating a single document.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class UpdateOneModel<TDocument> : WriteModel<TDocument>

--- a/src/MongoDB.Driver/WriteConcernError.cs
+++ b/src/MongoDB.Driver/WriteConcernError.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Driver
     /// <summary>
     /// Represents the details of a write concern error.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class WriteConcernError

--- a/src/MongoDB.Driver/WriteError.cs
+++ b/src/MongoDB.Driver/WriteError.cs
@@ -13,20 +13,17 @@
 * limitations under the License.
 */
 
+#if !NETSTANDARD1_5
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
+#endif
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using MongoDB.Driver.Support;
 
 namespace MongoDB.Driver
 {
     /// <summary>
     /// Represents the details of a write error.
     /// </summary>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class WriteError

--- a/src/MongoDB.Driver/WriteModel.cs
+++ b/src/MongoDB.Driver/WriteModel.cs
@@ -14,10 +14,10 @@
 */
 
 using System;
-using MongoDB.Bson;
-using MongoDB.Driver.Core.Operations;
 using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Driver.Core.Operations;
 
 namespace MongoDB.Driver
 {
@@ -25,7 +25,7 @@ namespace MongoDB.Driver
     /// Base class for a write model.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-#if NET452
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public abstract class WriteModel<TDocument>

--- a/tests/MongoDB.Bson.Tests/Exceptions/BsonExceptionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Exceptions/BsonExceptionTests.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if !NETCOREAPP1_1
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
+using Xunit;
+#endif
+
+namespace MongoDB.Bson.Tests.Exceptions
+{
+    public class BsonExceptionTests
+    {
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new BsonException("message", new Exception("inner"));
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (BsonException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message);
+            }
+        }
+#endif
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Exceptions/BsonInternalExceptionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Exceptions/BsonInternalExceptionTests.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if !NETCOREAPP1_1
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
+using Xunit;
+#endif
+
+namespace MongoDB.Bson.Tests.Exceptions
+{
+    public class BsonInternalExceptionTests
+    {
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new BsonInternalException("message", new Exception("inner"));
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (BsonInternalException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message);
+            }
+        }
+#endif
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Exceptions/BsonSerializationExceptionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Exceptions/BsonSerializationExceptionTests.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if !NETCOREAPP1_1
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
+using Xunit;
+#endif
+
+namespace MongoDB.Bson.Tests.Exceptions
+{
+    public class BsonSerializationExceptionTests
+    {
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new BsonSerializationException("message", new Exception("inner"));
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (BsonSerializationException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message);
+            }
+        }
+#endif
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Exceptions/DuplicateBsonMemberMapAttributeExceptionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Exceptions/DuplicateBsonMemberMapAttributeExceptionTests.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if !NETCOREAPP1_1
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
+using Xunit;
+#endif
+
+namespace MongoDB.Bson.Tests.Exceptions
+{
+    public class DuplicateBsonMemberMapAttributeExceptionTests
+    {
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new DuplicateBsonMemberMapAttributeException("message", new Exception("inner"));
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (DuplicateBsonMemberMapAttributeException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message);
+            }
+        }
+#endif
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Exceptions/TruncationExceptionTests.cs
+++ b/tests/MongoDB.Bson.Tests/Exceptions/TruncationExceptionTests.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if !NETCOREAPP1_1
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
+using Xunit;
+#endif
+
+namespace MongoDB.Bson.Tests.Exceptions
+{
+    public class TruncationExceptionTests
+    {
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new TruncationException("message", new Exception("inner"));
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (TruncationException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message);
+            }
+        }
+#endif
+    }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/Libgssapi/LibgssapiExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/Libgssapi/LibgssapiExceptionTests.cs
@@ -1,0 +1,46 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if !NETCOREAPP1_1
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
+using MongoDB.Driver.Core.Authentication.Libgssapi;
+using Xunit;
+#endif
+
+namespace MongoDB.Driver.Core.Tests.Core.Authentication.Libgssapi
+{
+    public class LibgssapiExceptionTests
+    {
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new LibgssapiException("message");
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (LibgssapiException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+            }
+        }
+#endif
+    }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/Sspi/Win32ExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/Sspi/Win32ExceptionTests.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if !NETCOREAPP1_1
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
+using MongoDB.Driver.Core.Authentication.Sspi;
+using Xunit;
+#endif
+
+namespace MongoDB.Driver.Core.Tests.Core.Authentication.Sspi
+{
+    public class Win32ExceptionTests
+    {
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new Win32Exception(1234, "message");
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (Win32Exception)formatter.Deserialize(stream);
+
+                rehydrated.HResult.Should().Be(subject.HResult);
+                rehydrated.Message.Should().Be(subject.Message);
+            }
+        }
+#endif
+    }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/MongoBulkWriteOperationExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/MongoBulkWriteOperationExceptionTests.cs
@@ -14,14 +14,18 @@
 */
 
 using System.Collections.Generic;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
 using MongoDB.Bson;
+#if !NETCOREAPP1_1
 using MongoDB.Bson.TestHelpers.EqualityComparers;
+#endif
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Servers;
@@ -63,7 +67,7 @@ namespace MongoDB.Driver.Core.Operations
             subject.WriteErrors.Should().BeSameAs(_writeErrors);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoAuthenticationExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoAuthenticationExceptionTests.cs
@@ -14,9 +14,11 @@
 */
 
 using System;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -53,7 +55,7 @@ namespace MongoDB.Driver
             subject.Message.Should().BeSameAs(_message);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoClientExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoClientExceptionTests.cs
@@ -14,8 +14,8 @@
 */
 
 using System;
+#if !NETCOREAPP1_1
 using System.IO;
-#if NET452
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -46,7 +46,7 @@ namespace MongoDB.Driver
             subject.InnerException.Should().BeSameAs(_innerException);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoCommandExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoCommandExceptionTests.cs
@@ -13,11 +13,11 @@
 * limitations under the License.
 */
 
-using System;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
-using System.Runtime.Serialization;
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -111,7 +111,7 @@ namespace MongoDB.Driver
             result.Should().Be("error message");
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoConfigurationExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoConfigurationExceptionTests.cs
@@ -14,8 +14,8 @@
 */
 
 using System;
+#if !NETCOREAPP1_1
 using System.IO;
-#if NET452
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -46,7 +46,7 @@ namespace MongoDB.Driver
             subject.InnerException.Should().BeSameAs(_innerException);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoConnectionClosedExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoConnectionClosedExceptionTests.cs
@@ -13,10 +13,11 @@
 * limitations under the License.
 */
 
-using System;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -27,7 +28,7 @@ using Xunit;
 
 namespace MongoDB.Driver
 {
-    public class MongoConnectionFailedExceptionTests
+    public class MongoConnectionClosedExceptionTests
     {
         private readonly ConnectionId _connectionId = new ConnectionId(new ServerId(new ClusterId(1), new DnsEndPoint("localhost", 27017)), 2).WithServerValue(3);
 
@@ -41,7 +42,7 @@ namespace MongoDB.Driver
             subject.Message.Should().BeSameAs("The connection was closed while we were waiting our turn to use it.");
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoConnectionExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoConnectionExceptionTests.cs
@@ -14,9 +14,11 @@
 */
 
 using System;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -53,7 +55,7 @@ namespace MongoDB.Driver
             subject.Message.Should().BeSameAs(_message);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoCursorNotFoundExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoCursorNotFoundExceptionTests.cs
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -48,7 +50,7 @@ namespace MongoDB.Driver
             subject.QueryResult.Should().BeNull();
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoDuplicateKeyExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDuplicateKeyExceptionTests.cs
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -47,7 +49,7 @@ namespace MongoDB.Driver
             subject.WriteConcernResult.Should().Be(_writeConcernResult);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoExceptionTests.cs
@@ -15,9 +15,11 @@
 
 using System;
 using System.Collections.Generic;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Linq;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -142,7 +144,7 @@ namespace MongoDB.Driver
             subject.ErrorLabels.Should().Equal(errorLabels.Where(x => x != removeErrorLabel));
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoExecutionTimeoutExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoExecutionTimeoutExceptionTests.cs
@@ -22,6 +22,9 @@ using System.Net;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
+#if !NETCOREAPP1_1
+using MongoDB.Bson;
+#endif
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Servers;
@@ -59,7 +62,7 @@ namespace MongoDB.Driver
         [Fact]
         public void Serialization_should_work()
         {
-            var subject = new MongoExecutionTimeoutException(_connectionId, _message, _innerException);
+            var subject = new MongoExecutionTimeoutException(_connectionId, _message, _innerException, new BsonDocument("code", 1234));
 
             var formatter = new BinaryFormatter();
             using (var stream = new MemoryStream())
@@ -68,9 +71,10 @@ namespace MongoDB.Driver
                 stream.Position = 0;
                 var rehydrated = (MongoExecutionTimeoutException)formatter.Deserialize(stream);
 
+                rehydrated.Code.Should().Be(subject.Code);
                 rehydrated.ConnectionId.Should().Be(subject.ConnectionId);
+                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message);
                 rehydrated.Message.Should().Be(subject.Message);
-                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message); // Exception does not override Equals
             }
         }
 #endif

--- a/tests/MongoDB.Driver.Core.Tests/MongoExecutionTimeoutExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoExecutionTimeoutExceptionTests.cs
@@ -14,9 +14,11 @@
 */
 
 using System;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -53,7 +55,7 @@ namespace MongoDB.Driver
             subject.Message.Should().BeSameAs(_message);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoIncompatibleDriverExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoIncompatibleDriverExceptionTests.cs
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -55,7 +57,7 @@ namespace MongoDB.Driver
             subject.InnerException.Should().BeNull();
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoInternalExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoInternalExceptionTests.cs
@@ -14,8 +14,10 @@
 */
 
 using System;
+#if !NETCOREAPP1_1
 using System.IO;
-#if NET452
+#endif
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -46,7 +48,7 @@ namespace MongoDB.Driver
             subject.Message.Should().BeSameAs(_message);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoNodeIsRecoveringExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoNodeIsRecoveringExceptionTests.cs
@@ -13,10 +13,11 @@
 * limitations under the License.
 */
 
-using System;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -74,7 +75,7 @@ namespace MongoDB.Driver
             result.Result.Should().BeSameAs(serverResult);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoNotPrimaryExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoNotPrimaryExceptionTests.cs
@@ -13,10 +13,11 @@
 * limitations under the License.
 */
 
-using System;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -46,7 +47,7 @@ namespace MongoDB.Driver
             subject.Result.Should().Be(_serverResult);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoQueryExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoQueryExceptionTests.cs
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -46,7 +48,7 @@ namespace MongoDB.Driver
             subject.QueryResult.Should().Be(_queryResult);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoServerExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoServerExceptionTests.cs
@@ -14,9 +14,11 @@
 */
 
 using System;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -53,7 +55,7 @@ namespace MongoDB.Driver
             subject.Message.Should().BeSameAs(_message);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoWaitQueueFullExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoWaitQueueFullExceptionTests.cs
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -51,7 +53,7 @@ namespace MongoDB.Driver
             subject.Message.Should().Be("The wait queue for server selection is full.");
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.Core.Tests/MongoWriteConcernExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoWriteConcernExceptionTests.cs
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -47,7 +49,7 @@ namespace MongoDB.Driver
             subject.WriteConcernResult.Should().Be(_writeConcernResult);
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSChunkExceptionTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSChunkExceptionTests.cs
@@ -14,12 +14,11 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#if !NETCOREAPP1_1
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
 using FluentAssertions;
-using MongoDB.Bson;
 using Xunit;
 
 namespace MongoDB.Driver.GridFS.Tests
@@ -59,5 +58,23 @@ namespace MongoDB.Driver.GridFS.Tests
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("reason");
         }
+
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new GridFSChunkException(123, 2, "missing");
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (GridFSChunkException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+            }
+        }
+#endif
     }
 }

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSExceptionTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSExceptionTests.cs
@@ -14,10 +14,10 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#if !NETCOREAPP1_1
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
 using FluentAssertions;
 using Xunit;
 
@@ -42,5 +42,24 @@ namespace MongoDB.Driver.GridFS.Tests
             result.Message.Should().Be("message");
             result.InnerException.Should().BeSameAs(innerException);
         }
+
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new GridFSException("message", new Exception("inner"));
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (GridFSException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message);
+            }
+        }
+#endif
     }
 }

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSFileNotFoundExceptionTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSFileNotFoundExceptionTests.cs
@@ -14,10 +14,10 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#if !NETCOREAPP1_1
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
 using FluentAssertions;
 using Xunit;
 
@@ -57,5 +57,23 @@ namespace MongoDB.Driver.GridFS.Tests
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("id");
         }
+
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new GridFSFileNotFoundException("filename", 123);
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (GridFSFileNotFoundException)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+            }
+        }
+#endif
     }
 }

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSMD5ExceptionTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSMD5ExceptionTests.cs
@@ -14,10 +14,10 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#if !NETCOREAPP1_1
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
 using FluentAssertions;
 using Xunit;
 
@@ -40,5 +40,23 @@ namespace MongoDB.Driver.GridFS.Tests
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("id");
         }
+
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new GridFSMD5Exception(123);
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (GridFSMD5Exception)formatter.Deserialize(stream);
+
+                rehydrated.Message.Should().Be(subject.Message);
+            }
+        }
+#endif
     }
 }

--- a/tests/MongoDB.Driver.Tests/Encryption/MongoEncryptionExceptionTests.cs
+++ b/tests/MongoDB.Driver.Tests/Encryption/MongoEncryptionExceptionTests.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if !NETCOREAPP1_1
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using FluentAssertions;
+using MongoDB.Driver.Encryption;
+using Xunit;
+#endif
+
+namespace MongoDB.Driver.Tests.Encryption
+{
+    public class MongoEncryptionExceptionTests
+    {
+#if !NETCOREAPP1_1
+        [Fact]
+        public void Serialization_should_work()
+        {
+            var subject = new MongoEncryptionException(new Exception("inner"));
+
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, subject);
+                stream.Position = 0;
+                var rehydrated = (MongoEncryptionException)formatter.Deserialize(stream);
+
+                rehydrated.InnerException.Message.Should().Be(subject.InnerException.Message);
+            }
+        }
+#endif
+    }
+}

--- a/tests/MongoDB.Driver.Tests/MongoBulkWriteExceptionTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoBulkWriteExceptionTests.cs
@@ -15,9 +15,11 @@
 
 
 using System.Collections.Generic;
+#if !NETCOREAPP1_1
 using System.IO;
+#endif
 using System.Net;
-#if NET452
+#if !NETCOREAPP1_1
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 using FluentAssertions;
@@ -143,7 +145,7 @@ namespace MongoDB.Driver.Tests
             ((InsertOneModel<BsonDocument>)mapped.UnprocessedRequests[0]).Document.Should().Be("{a:1}");
         }
 
-#if NET452
+#if !NETCOREAPP1_1
         [Fact]
         public void Serialization_should_work()
         {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-2936
EG: https://evergreen.mongodb.com/version/6074d8d23627e056aee4fc20

Note: there were several `[Serializable]` occurrences in Legacy, but I omitted them.