### PR TITLE
CSHARP-3567: Replace usages of 'acceptAPIVersion2' with 'acceptApiVersion2'

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/README.rst
@@ -12,7 +12,7 @@ Notes
 This directory contains tests for the Versioned API specification. They are
 implemented in the `Unified Test Format <../../unified-test-format/unified-test-format.rst>`__,
 and require schema version 1.1. Note that to run these tests, the server must be
-started with both ``enableTestCommands`` and ``acceptAPIVersion2`` parameters
+started with both ``enableTestCommands`` and ``acceptApiVersion2`` parameters
 set to true.
 
 Testing with required API version

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/test-commands-deprecation-errors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/test-commands-deprecation-errors.json
@@ -6,7 +6,7 @@
       "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true,
-        "acceptAPIVersion2": true,
+        "acceptApiVersion2": true,
         "requireApiVersion": false
       }
     }

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/test-commands-deprecation-errors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/test-commands-deprecation-errors.yml
@@ -6,7 +6,7 @@ runOnRequirements:
   - minServerVersion: "4.9"
     serverParameters:
       enableTestCommands: true
-      acceptAPIVersion2: true
+      acceptApiVersion2: true
       requireApiVersion: false
 
 createEntities:


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-3567
EG: https://evergreen.mongodb.com/version/6076220a1e2d176bc70a1024