### PR TITLE
CSHARP-2941: Check uses of TypeCode.DBNull when targeting netstandard2.0

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
@@ -538,7 +538,7 @@ namespace MongoDB.Bson.Serialization
             switch (Type.GetTypeCode(type))
             {
                 case TypeCode.Empty:
-#if NET452
+#if !NETSTANDARD1_5
                 case TypeCode.DBNull:
 #endif
                 case TypeCode.String:


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-2941
EG: https://evergreen.mongodb.com/version/607dbad91e2d175c283b7219