### PR TITLE
CSHARP-3380: Iterate over all connections on connection checkout 

### DIFF
--- a/tests/MongoDB.Bson.TestHelpers/XunitExtensions/ClassValuesAttribute.cs
+++ b/tests/MongoDB.Bson.TestHelpers/XunitExtensions/ClassValuesAttribute.cs
@@ -29,7 +29,7 @@ namespace MongoDB.Bson.TestHelpers.XunitExtensions
 
         public object[] GenerateValues()
         {
-            var generator = (IValueGenerator)Activator.CreateInstance(_classType) as IValueGenerator;
+            var generator = Activator.CreateInstance(_classType) as IValueGenerator;
             if (generator == null)
             {
                 throw new ArgumentException($"The type {_classType} must implement the {nameof(IValueGenerator)} interface.");

--- a/tests/MongoDB.Bson.TestHelpers/XunitExtensions/RandomSeedAttribute.cs
+++ b/tests/MongoDB.Bson.TestHelpers/XunitExtensions/RandomSeedAttribute.cs
@@ -1,0 +1,32 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Diagnostics;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
+
+namespace MongoDB.Bson.TestHelpers
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class RandomSeedAttribute : Attribute, IValueGeneratorAttribute
+    {
+        public object[] GenerateValues() => new object[]
+        {
+            int.MaxValue,
+            int.MaxValue / 2,
+            Environment.TickCount ^ Process.GetCurrentProcess().Id
+        };
+    }
+}

--- a/tests/MongoDB.Bson.Tests/IO/EncodingHelperTests.cs
+++ b/tests/MongoDB.Bson.Tests/IO/EncodingHelperTests.cs
@@ -19,6 +19,7 @@ using System.Text;
 using FluentAssertions;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.TestHelpers;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Bson.Tests.IO
@@ -81,14 +82,15 @@ namespace MongoDB.Bson.Tests.IO
             }
         }
 
-        [Fact]
-        public void GetBytesUsingThreadStaticBuffer_should_return_expected_result_when_multiple_threads_are_used()
+        [Theory]
+        [ParameterAttributeData]
+        public void GetBytesUsingThreadStaticBuffer_should_return_expected_result_when_multiple_threads_are_used([RandomSeed] int seed)
         {
             const int threadsCount = 10;
             const int iterationsCount = 10;
             const int maxSize = 1024;
 
-            var random = new Random();
+            var random = new Random(seed);
             var encoding = Utf8Encodings.Strict;
 
             ThreadingUtilities.ExecuteOnNewThreads(threadsCount, _ =>


### PR DESCRIPTION
CSHARP-3380: Iterate over all connections on connection checkout in ConnectionPool

[EG](https://evergreen.mongodb.com/version/607dc1f2a4cf47318e9e3122) (internal link)