### PR TITLE
CSHARP-2943: Check uses of SecureString when targetting netstandard2.0

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/AuthenticationHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/AuthenticationHelper.cs
@@ -69,10 +69,10 @@ namespace MongoDB.Driver.Core.Authentication
             }
             else
             {
-#if NET452
-                var passwordIntPtr = Marshal.SecureStringToGlobalAllocUnicode(password);
-#else
+#if NETSTANDARD1_5
                 var passwordIntPtr = SecureStringMarshal.SecureStringToGlobalAllocUnicode(password);
+#else
+                var passwordIntPtr = Marshal.SecureStringToGlobalAllocUnicode(password);
 #endif
                 try
                 {

--- a/src/MongoDB.Driver.Core/Core/Authentication/ScramSha256Authenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/ScramSha256Authenticator.cs
@@ -15,7 +15,9 @@
 
 using System;
 using System.Runtime.InteropServices;
+#if NETSTANDARD1_5
 using System.Security;
+#endif
 using System.Security.Cryptography;
 using System.Text;
 using MongoDB.Bson.IO;
@@ -89,10 +91,10 @@ namespace MongoDB.Driver.Core.Authentication
 
         private static byte[] Hi256(UsernamePasswordCredential credential, byte[] salt, int iterations)
         {
-#if NET452
-            var passwordIntPtr = Marshal.SecureStringToGlobalAllocUnicode(credential.SaslPreppedPassword);
-#else
+#if NETSTANDARD1_5
             var passwordIntPtr = SecureStringMarshal.SecureStringToGlobalAllocUnicode(credential.SaslPreppedPassword);
+#else
+            var passwordIntPtr = Marshal.SecureStringToGlobalAllocUnicode(credential.SaslPreppedPassword);
 #endif
             try
             {

--- a/src/MongoDB.Driver.Core/Core/Authentication/Sspi/AuthIdentity.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Sspi/AuthIdentity.cs
@@ -52,10 +52,10 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
 
             if (password != null && password.Length > 0)
             {
-#if NET452
-                Password = Marshal.SecureStringToGlobalAllocUnicode(password);
-#else
+#if NETSTANDARD1_5
                 Password = SecureStringMarshal.SecureStringToGlobalAllocUnicode(password);
+#else
+                Password = Marshal.SecureStringToGlobalAllocUnicode(password);
 #endif
                 PasswordLength = password.Length;
             }

--- a/src/MongoDB.Driver.Core/Core/Misc/DecryptedSecureString.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/DecryptedSecureString.cs
@@ -54,10 +54,10 @@ namespace MongoDB.Driver.Core.Misc
         {
             if (_chars == null)
             {
-#if NET452
-                _charsIntPtr = Marshal.SecureStringToGlobalAllocUnicode(_secureString);
-#else
+#if NETSTANDARD1_5
                 _charsIntPtr = SecureStringMarshal.SecureStringToGlobalAllocUnicode(_secureString);
+#else
+                _charsIntPtr = Marshal.SecureStringToGlobalAllocUnicode(_secureString);
 #endif
                 _chars = new char[_secureString.Length];
                 _charsHandle = GCHandle.Alloc(_chars, GCHandleType.Pinned);

--- a/src/MongoDB.Driver/DecryptedSecureString.cs
+++ b/src/MongoDB.Driver/DecryptedSecureString.cs
@@ -55,10 +55,10 @@ namespace MongoDB.Driver
         {
             if (_chars == null)
             {
-#if NET452
-                _charsIntPtr = Marshal.SecureStringToGlobalAllocUnicode(_secureString);
-#else
+#if NETSTANDARD1_5
                 _charsIntPtr = SecureStringMarshal.SecureStringToGlobalAllocUnicode(_secureString);
+#else
+                _charsIntPtr = Marshal.SecureStringToGlobalAllocUnicode(_secureString);
 #endif
                 _chars = new char[_secureString.Length];
                 _charsHandle = GCHandle.Alloc(_chars, GCHandleType.Pinned);

--- a/src/MongoDB.Shared/SecureStringHelper.cs
+++ b/src/MongoDB.Shared/SecureStringHelper.cs
@@ -34,10 +34,10 @@ namespace MongoDB.Shared
             }
             else
             {
-#if NET452
-                var secureStringIntPtr = Marshal.SecureStringToGlobalAllocUnicode(secureString);
-#else
+#if NETSTANDARD1_5
                 var secureStringIntPtr = SecureStringMarshal.SecureStringToGlobalAllocUnicode(secureString);
+#else
+                var secureStringIntPtr = Marshal.SecureStringToGlobalAllocUnicode(secureString);
 #endif
                 try
                 {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-2943
EG: https://evergreen.mongodb.com/version/608051033627e05a49938919