### PR TITLE
CSHARP-3306: Set different appname in sync and async tests variations

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringIntegrationTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringIntegrationTestRunner.cs
@@ -40,12 +40,14 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring
         // public methods
         public void ConfigureFailPoint(IServer server, ICoreSessionHandle session, BsonDocument failCommand)
         {
+            ConfigureFailPointCommand(failCommand);
             var failPoint = FailPoint.Configure(server, session, failCommand);
             AddDisposable(failPoint);
         }
 
         public async Task ConfigureFailPointAsync(IServer server, ICoreSessionHandle session, BsonDocument failCommand)
         {
+            ConfigureFailPointCommand(failCommand);
             var failPoint = await Task.Run(() => FailPoint.Configure(server, session, failCommand)).ConfigureAwait(false);
             AddDisposable(failPoint);
         }


### PR DESCRIPTION
Addressing `MongoClientJsonDrivenTestRunnerBase` based tests runners for now, as related observed test failures so far are in that area.

[EG](https://evergreen.mongodb.com/version/6082f47c9ccd4e32120032fb) (Internal link)