### PR TITLE
CSHARP-2950: Check BinaryConnection WrapExceptions for exceptions wrapped when targetting netstandard2.0

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -741,7 +741,7 @@ namespace MongoDB.Driver.Core.Connections
         private Exception WrapException(Exception ex, string action)
         {
             if (
-#if NET452
+#if !NETSTANDARD1_5
                 ex is ThreadAbortException ||
                 ex is StackOverflowException ||
 #endif


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-2950
EG: https://evergreen.mongodb.com/version/6086d7e53e8e864ec7ec05f2