### PR TITLE
CSHARP-2949: Check uses of new HMACSHA1 when targetting netstandard2.0

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/ScramSha1Authenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/ScramSha1Authenticator.cs
@@ -87,10 +87,10 @@ namespace MongoDB.Driver.Core.Authentication
 
         private static byte[] Hmac1(UTF8Encoding encoding, byte[] data, string key)
         {
-#if NET452
-            using (var hmac = new HMACSHA1(data, useManagedSha1: true))
-#else
+#if NETSTANDARD1_5
             using (var hmac = new HMACSHA1(data))
+#else
+            using (var hmac = new HMACSHA1(data, useManagedSha1: true))
 #endif
             {
                 return hmac.ComputeHash(encoding.GetBytes(key));


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-2949
EG: https://evergreen.mongodb.com/version/608873a5c9ec4430ccbe600c

Note: I am not sure if the occurrence here: [Vendored/Rfc2898DeriveBytes.cs:290](https://github.com/mongodb/mongo-csharp-driver/blob/7579652682b8440440bbe0bb380de275342c4757/src/MongoDB.Driver.Core/Core/Authentication/Vendored/Rfc2898DeriveBytes.cs#L290) should be updated. The current .NET Framework implementation uses `HMAC.Create(string algName)` which is not accessible in netstandard 1.5: [Rfc2898DeriveBytes.cs:102](https://referencesource.microsoft.com/#mscorlib/system/security/cryptography/rfc2898derivebytes.cs,102), .NET 5 uses `new HMACSHA1`: [Rfc2898DeriveBytes.cs:248](https://github.com/dotnet/runtime/blob/9a905533d739564c14306ba3349fd7f7d3ebb834/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs#L248) which we currently use. And the Rfc2898DeriveBytes class itself accepts an algorithm name only starting from netstandard 2.1: [netstandard 2.1 -> Rfc2898DeriveBytes](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.rfc2898derivebytes.-ctor?view=netstandard-2.1#System_Security_Cryptography_Rfc2898DeriveBytes__ctor_System_String_System_Byte___System_Int32_System_Security_Cryptography_HashAlgorithmName_).