### PR TITLE
CSHARP-3623: Check uses of Rfc2898DeriveBytes when targeting netstandard2.0

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/ScramSha1Authenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/ScramSha1Authenticator.cs
@@ -21,9 +21,13 @@ using MongoDB.Driver.Core.Authentication.Vendored;
 #endif
 using MongoDB.Driver.Core.Misc;
 
-// use our vendored version of Rfc2898DeriveBytes because .NET Standard 1.5 and .NET Framework 4.5 do not support
-// a version of Rfc2898DeriveBytes that allows us to specify to hash algorithm to be used
+// Use our vendored version of Rfc2898DeriveBytes for .NET Standard 1.5, .NET Standard 2.0 and .NET Framework 4.5.2
+// because these targets do not support a version of Rfc2898DeriveBytes that allows to specify the hash algorithm
+#if NETSTANDARD2_1
+using Rfc2898DeriveBytes = System.Security.Cryptography.Rfc2898DeriveBytes;
+#else
 using Rfc2898DeriveBytes = MongoDB.Driver.Core.Authentication.Vendored.Rfc2898DeriveBytes;
+#endif
 
 namespace MongoDB.Driver.Core.Authentication
 {
@@ -81,8 +85,12 @@ namespace MongoDB.Driver.Core.Authentication
         private static byte[] Hi1(UsernamePasswordCredential credential, byte[] salt, int iterations)
         {
             var passwordDigest = AuthenticationHelper.MongoPasswordDigest(credential.Username, credential.Password);
-            // 20 is the length of output of a sha-1 hmac
-            return new Rfc2898DeriveBytes(passwordDigest, salt, iterations).GetBytes(20);
+
+            using (var rfc2898 = new Rfc2898DeriveBytes(passwordDigest, salt, iterations, HashAlgorithmName.SHA1))
+            {
+                // 20 is the length of output of a sha-1 hmac
+                return rfc2898.GetBytes(20);
+            }
         }
 
         private static byte[] Hmac1(UTF8Encoding encoding, byte[] data, string key)

--- a/src/MongoDB.Driver.Core/Core/Authentication/ScramSha1Authenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/ScramSha1Authenticator.cs
@@ -86,10 +86,10 @@ namespace MongoDB.Driver.Core.Authentication
         {
             var passwordDigest = AuthenticationHelper.MongoPasswordDigest(credential.Username, credential.Password);
 
-            using (var rfc2898 = new Rfc2898DeriveBytes(passwordDigest, salt, iterations, HashAlgorithmName.SHA1))
+            using (var deriveBytes = new Rfc2898DeriveBytes(passwordDigest, salt, iterations, HashAlgorithmName.SHA1))
             {
                 // 20 is the length of output of a sha-1 hmac
-                return rfc2898.GetBytes(20);
+                return deriveBytes.GetBytes(20);
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Authentication/ScramSha256Authenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/ScramSha256Authenticator.cs
@@ -130,10 +130,10 @@ namespace MongoDB.Driver.Core.Authentication
             {
                 Utf8Encodings.Strict.GetBytes(passwordChars, 0, passwordChars.Length, passwordBytes, 0);
 
-                using (var rfc2898 = new Rfc2898DeriveBytes(passwordBytes, salt, iterations, HashAlgorithmName.SHA256))
+                using (var deriveBytes = new Rfc2898DeriveBytes(passwordBytes, salt, iterations, HashAlgorithmName.SHA256))
                 {
                     // 32 is the length of output of a sha-256 hmac
-                    return rfc2898.GetBytes(32);
+                    return deriveBytes.GetBytes(32);
                 }
             }
             finally


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-3623
EG: https://evergreen.mongodb.com/version/608984a732f417577d8f9a3f

Note: the first version of netstandard to allow specifying hash algorithm in `Rfc2898DeriveBytes` is 2.1: [netstandard 2.1 -> Rfc2898DeriveBytes](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.rfc2898derivebytes.-ctor?view=netstandard-2.1#System_Security_Cryptography_Rfc2898DeriveBytes__ctor_System_String_System_Byte___System_Int32_System_Security_Cryptography_HashAlgorithmName_)