### PR TITLE
CSHARP-2945: Check uses of Marshal when targetting netstandard2.0

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/Sspi/SecurityBufferDescriptor.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Sspi/SecurityBufferDescriptor.cs
@@ -64,34 +64,18 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
             NumBuffers = buffers.Length;
 
             //Allocate memory for SecBuffer Array....
-#if NET452
-            BufferPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(SecurityBuffer)) * NumBuffers);
-#else
             BufferPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SecurityBuffer>() * NumBuffers);
-#endif
 
             for (int i = 0; i < buffers.Length; i++)
             {
                 var currentBuffer = buffers[i];
-#if NET452
-                var currentOffset = i * Marshal.SizeOf(typeof(SecurityBuffer));
-#else
                 var currentOffset = i * Marshal.SizeOf<SecurityBuffer>();
-#endif
                 Marshal.WriteInt32(BufferPtr, currentOffset, currentBuffer.Count);
 
-#if NET452
-                var length = currentOffset + Marshal.SizeOf(typeof(int));
-#else
                 var length = currentOffset + Marshal.SizeOf<int>();
-#endif
                 Marshal.WriteInt32(BufferPtr, length, (int)currentBuffer.BufferType);
 
-#if NET452
-                length = currentOffset + Marshal.SizeOf(typeof(int)) + Marshal.SizeOf(typeof(int));
-#else
                 length = currentOffset + Marshal.SizeOf<int>() + Marshal.SizeOf<int>();
-#endif
                 Marshal.WriteIntPtr(BufferPtr, length, currentBuffer.Token);
             }
         }
@@ -103,11 +87,7 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
             {
                 if (NumBuffers == 1)
                 {
-#if NET452
-                    var buffer = (SecurityBuffer)Marshal.PtrToStructure(BufferPtr, typeof(SecurityBuffer));
-#else
                     var buffer = Marshal.PtrToStructure<SecurityBuffer>(BufferPtr);
-#endif
                     buffer.Free();
                 }
                 else
@@ -116,13 +96,8 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
                     // The 1st buffer is going to be empty. We can skip it.
                     for (int i = 1; i < NumBuffers; i++)
                     {
-#if NET452
-                        var currentOffset = i * Marshal.SizeOf(typeof(SecurityBuffer));
-                        var totalLength = currentOffset + Marshal.SizeOf(typeof(int)) + Marshal.SizeOf(typeof(int));
-#else
                         var currentOffset = i * Marshal.SizeOf<SecurityBuffer>();
                         var totalLength = currentOffset + Marshal.SizeOf<int>() + Marshal.SizeOf<int>();
-#endif
                         var buffer = Marshal.ReadIntPtr(BufferPtr, totalLength);
                         Marshal.FreeHGlobal(buffer);
                     }
@@ -149,11 +124,7 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
 
             if (NumBuffers == 1)
             {
-#if NET452
-                var buffer = (SecurityBuffer)Marshal.PtrToStructure(BufferPtr, typeof(SecurityBuffer));
-#else
                 var buffer = Marshal.PtrToStructure<SecurityBuffer>(BufferPtr);
-#endif
 
                 if (buffer.Count > 0)
                 {
@@ -167,11 +138,7 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
 
                 for (int i = 0; i < NumBuffers; i++)
                 {
-#if NET452
-                    var currentOffset = i * Marshal.SizeOf(typeof(SecurityBuffer));
-#else
                     var currentOffset = i * Marshal.SizeOf<SecurityBuffer>();
-#endif
                     bytesToAllocate += Marshal.ReadInt32(BufferPtr, currentOffset);
                 }
 
@@ -179,24 +146,16 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
 
                 for (int i = 0, bufferIndex = 0; i < NumBuffers; i++)
                 {
-#if NET452
-                    var currentOffset = i * Marshal.SizeOf(typeof(SecurityBuffer));
-#else
                     var currentOffset = i * Marshal.SizeOf<SecurityBuffer>();
-#endif
                     var bytesToCopy = Marshal.ReadInt32(BufferPtr, currentOffset);
-#if NET452
-                    var length = currentOffset + Marshal.SizeOf(typeof(int)) + Marshal.SizeOf(typeof(int));
-#else
                     var length = currentOffset + Marshal.SizeOf<int>() + Marshal.SizeOf<int>();
-#endif
                     IntPtr SecBufferpvBuffer = Marshal.ReadIntPtr(BufferPtr, length);
                     Marshal.Copy(SecBufferpvBuffer, bytes, bufferIndex, bytesToCopy);
                     bufferIndex += bytesToCopy;
                 }
             }
 
-            return (bytes);
+            return bytes;
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Authentication/Sspi/SspiSecurityContext.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Sspi/SspiSecurityContext.cs
@@ -360,18 +360,10 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
                 }
 
                 var current = new IntPtr(array.ToInt64());
-#if NET452
-                var size = Marshal.SizeOf(typeof(SecurityPackageInfo));
-#else
                 var size = Marshal.SizeOf<SecurityPackageInfo>();
-#endif
                 for (int i = 0; i < count; i++)
                 {
-#if NET452
-                    var package = (SecurityPackageInfo)Marshal.PtrToStructure(current, typeof(SecurityPackageInfo));
-#else
                     var package = Marshal.PtrToStructure<SecurityPackageInfo>(current);
-#endif
                     if (package.Name != null && package.Name.Equals(SspiPackage.Kerberos.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
                         return (int)package.MaxTokenSize;


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-2945
EG: https://evergreen.mongodb.com/version/6089b241c9ec443023b2395c

Note: [Marshal.SizeOf\<T\>()](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.sizeof?view=netframework-4.5.2#System_Runtime_InteropServices_Marshal_SizeOf__1) and [Marshal.PtrToStructure\<T\>()](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.ptrtostructure?view=netframework-4.5.2#System_Runtime_InteropServices_Marshal_PtrToStructure__1_System_IntPtr_) are available for .NET 4.5.2.
The reason why these directives were still present is likely because they were not updated when target changed from .NET 4.5 to .NET 4.5.2 along with introducing multitargeting (and these overloads are not available for .NET 4.5).