### PR TITLE
CSHARP-3630: Enable aggregations to project the aggregated document

### DIFF
--- a/src/MongoDB.Driver/Linq/Processors/AccumulatorBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/AccumulatorBinder.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Linq.Expressions;
+using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Linq.Expressions;
 using MongoDB.Driver.Linq.Expressions.ResultOperators;
@@ -228,6 +229,12 @@ namespace MongoDB.Driver.Linq.Processors
             if (select != null)
             {
                 return select.Selector;
+            }
+
+            var document = node as DocumentExpression;
+            if (document != null)
+            {
+                return new DocumentExpression(document.Serializer);
             }
 
             throw new NotSupportedException();

--- a/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
@@ -117,6 +117,8 @@ namespace MongoDB.Driver.Linq.Translators
                                 return TranslateArrayIndex((ArrayIndexExpression)node);
                             case ExtensionExpressionType.Concat:
                                 return TranslateConcat((ConcatExpression)node);
+                            case ExtensionExpressionType.Document:
+                                return TranslateDocument((DocumentExpression)node);
                             case ExtensionExpressionType.Except:
                                 return TranslateExcept((ExceptExpression)node);
                             case ExtensionExpressionType.FieldAsDocument:
@@ -254,6 +256,11 @@ namespace MongoDB.Driver.Linq.Translators
         private BsonValue TranslateDocumentWrappedField(FieldAsDocumentExpression expression)
         {
             return new BsonDocument(expression.FieldName, TranslateValue(expression.Expression));
+        }
+
+        private BsonValue TranslateDocument(DocumentExpression expression)
+        {
+            return BsonValue.Create("$$CURRENT");
         }
 
         private BsonValue TranslateExcept(ExceptExpression node)

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/AggregateGroupTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/AggregateGroupTranslatorTests.cs
@@ -368,6 +368,38 @@ namespace MongoDB.Driver.Tests.Linq.Translators
         }
 
         [Fact]
+        public void Should_translate_first_with_selected_root()
+        {
+            var result = Group(x => x.A, g => new { Result = g.Select(x => x).First() });
+
+            result.Projection.Should().Be("{ _id: \"$A\", Result: { \"$first\": \"$$CURRENT\" } }");
+        }
+
+        [Fact]
+        public void Should_translate_first_with_embedded_root()
+        {
+            var result = Group(x => x.A, g => new { Result = g.First() });
+
+            result.Projection.Should().Be("{ _id: \"$A\", Result: { \"$first\": \"$$CURRENT\" } }");
+        }
+
+        [Fact]
+        public void Should_translate_last_with_selected_root()
+        {
+            var result = Group(x => x.A, g => new { Result = g.Select(x => x).Last() });
+
+            result.Projection.Should().Be("{ _id: \"$A\", Result: { \"$last\": \"$$CURRENT\" } }");
+        }
+
+        [Fact]
+        public void Should_translate_last_with_embedded_root()
+        {
+            var result = Group(x => x.A, g => new { Result = g.Last() });
+
+            result.Projection.Should().Be("{ _id: \"$A\", Result: { \"$last\": \"$$CURRENT\" } }");
+        }
+
+        [Fact]
         public void Should_translate_complex_selector()
         {
             var result = Group(x => x.A, g => new


### PR DESCRIPTION
MongoDB allows aggregations to project at the document level using the "$$CURRENT" directive but the driver does not allow it now.
The following example works on MongoDB but not using the driver:

`db.MyCollection.aggregate([{
	$group: {
		_id: "$myColumn",
		lastDocument: { $last: "$$CURRENT" }
	}
}])`