### PR TITLE
CSHARP-3534: Workarounds for killAllSessions in unified test runner.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -75,6 +75,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly HintForUpdateAndReplaceOperationsFeature __hintForUpdateAndReplaceOperations = new HintForUpdateAndReplaceOperationsFeature("HintForUpdateAndReplaceOperations", new SemanticVersion(4, 2, 0));
         private static readonly Feature __keepConnectionPoolWhenNotMasterConnectionException = new Feature("KeepConnectionPoolWhenNotMasterConnectionException", new SemanticVersion(4, 1, 10));
         private static readonly Feature __keepConnectionPoolWhenReplSetStepDown = new Feature("KeepConnectionPoolWhenReplSetStepDown", new SemanticVersion(4, 1, 10));
+        private static readonly Feature __killAllSessions = new Feature("KillAllSessions", new SemanticVersion(3, 6, 0));
         private static readonly Feature __killCursorsCommand = new Feature("KillCursorsCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __listCollectionsCommand = new Feature("ListCollectionsCommand", new SemanticVersion(3, 0, 0));
         private static readonly Feature __listDatabasesAuthorizedDatabases = new Feature("ListDatabasesAuthorizedDatabases", new SemanticVersion(4, 0, 5));
@@ -363,6 +364,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the keep connection pool when replSetStepDown feature.
         /// </summary>
         public static Feature KeepConnectionPoolWhenReplSetStepDown => __keepConnectionPoolWhenReplSetStepDown;
+
+        /// <summary>
+        /// Get the killAllSessions feature.
+        /// </summary>
+        public static Feature KillAllSessions => __killAllSessions;
 
         /// <summary>
         /// Get the killCursors command feature.

--- a/src/MongoDB.Driver.Core/ServerErrorCode.cs
+++ b/src/MongoDB.Driver.Core/ServerErrorCode.cs
@@ -20,6 +20,7 @@ namespace MongoDB.Driver
         // this is not a complete list, more will be added as needed
         // see: https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml
         CappedPositionLost = 136,
+        CommandNotFound = 59,
         CursorKilled = 237,
         CursorNotFound = 43,
         ElectionInProgress = 216,
@@ -44,6 +45,7 @@ namespace MongoDB.Driver
         StaleConfig = 13388,
         StaleEpoch = 150,
         StaleShardVersion = 63,
+        Unauthorized = 13,
         UnknownReplWriteConcern = 79,
         UnsatisfiableWriteConcern = 100,
         WriteConcernFailed = 64

--- a/tests/AstrolabeWorkloadExecutor/Program.cs
+++ b/tests/AstrolabeWorkloadExecutor/Program.cs
@@ -113,7 +113,6 @@ namespace WorkloadExecutor
                 { "events", new AstrolabeEventFormatter() } // "events" matches to the "storeEventsAsEntities.id" in the driverWorkload document
             };
             using (var runner = new UnifiedTestRunner(
-                allowKillSessions: false,
                 additionalArgs: additionalArgs,
                 eventFormatters: eventFormatters))
             {

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -324,12 +324,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     // SERVER-54216
                     return true;
                 }
-                if (!Feature.KillAllSessions.IsSupported(serverVersion) && ex.Code == (int)ServerErrorCode.CommandNotFound)
-                {
-                    // if the command is executed on a pre-3.6 server
-                    // NOTE: this is not the case for the c# driver, but left it here just to make full sync with the spec
-                    return true;
-                }
+                // the spec also mentions CommandNotFound code, but it's not the case for c#
+                // since we don't call killAllSessions for servers less than 3.6
 
                 return false;
             }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -32,7 +32,6 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 {
     public sealed class UnifiedTestRunner : IDisposable
     {
-        private readonly bool _allowKillSessions;
         private UnifiedEntityMap _entityMap;
         private readonly List<FailPoint> _failPoints = new List<FailPoint>();
         private readonly Dictionary<string, object> _additionalArgs;
@@ -40,11 +39,9 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         private bool _runHasBeenCalled;
 
         public UnifiedTestRunner(
-            bool allowKillSessions = true, // TODO: should be removed after SERVER-54216 
             Dictionary<string, object> additionalArgs = null,
             Dictionary<string, IEventFormatter> eventFormatters = null)
         {
-            _allowKillSessions = allowKillSessions;
             _additionalArgs = additionalArgs; // can be null
             _eventFormatters = eventFormatters; // can be null
         }
@@ -107,10 +104,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 throw new SkipException($"Test skipped because '{skipReason}'.");
             }
 
-            if (_allowKillSessions)
-            {
-                KillOpenTransactions(DriverTestConfiguration.Client);
-            }
+            KillOpenTransactions(DriverTestConfiguration.Client);
 
             _entityMap = new UnifiedEntityMapBuilder(_eventFormatters).Build(entities);
 
@@ -146,10 +140,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             }
             try
             {
-                if (_allowKillSessions)
-                {
-                    KillOpenTransactions(DriverTestConfiguration.Client);
-                }
+                KillOpenTransactions(DriverTestConfiguration.Client);
             }
             catch
             {
@@ -305,21 +296,42 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 
         private void KillOpenTransactions(IMongoClient client)
         {
-            if (CoreTestConfiguration.ServerVersion >= new SemanticVersion(3, 6, 0))
+            var serverVersion = CoreTestConfiguration.ServerVersion;
+            if (Feature.KillAllSessions.IsSupported(serverVersion))
             {
                 var command = new BsonDocument("killAllSessions", new BsonArray());
-                var adminDatabase = client.GetDatabase("admin");
+                var adminDatabase = client.GetDatabase(DatabaseNamespace.Admin.DatabaseName);
 
                 try
                 {
                     adminDatabase.RunCommand<BsonDocument>(command);
                 }
-                catch (MongoCommandException exception) when (
-                    CoreTestConfiguration.ServerVersion < new SemanticVersion(4, 1, 9) &&
-                    exception.Code == (int)ServerErrorCode.Interrupted)
+                catch (MongoCommandException ex) when (ShouldIgnoreError(ex))
                 {
-                    // Ignored because of SERVER-38297
+                    // ignore errors
                 }
+            }
+
+            bool ShouldIgnoreError(MongoCommandException ex)
+            {
+                if (serverVersion < new SemanticVersion(4, 1, 9) && ex.Code == (int)ServerErrorCode.Interrupted)
+                {
+                    // SERVER-38335
+                    return true;
+                }
+                if (ex.Code == (int)ServerErrorCode.Unauthorized)
+                {
+                    // SERVER-54216
+                    return true;
+                }
+                if (!Feature.KillAllSessions.IsSupported(serverVersion) && ex.Code == (int)ServerErrorCode.CommandNotFound)
+                {
+                    // if the command is executed on a pre-3.6 server
+                    // NOTE: this is not the case for the c# driver, but left it here just to make full sync with the spec
+                    return true;
+                }
+
+                return false;
             }
         }
     }


### PR DESCRIPTION
Spec: https://github.com/mongodb/specifications/commit/1b4ce24071065b9c00263939dbb7e9524147c068#diff-f718c246f51e05b3731a7b03b176a0d4b0c381a9261810742d2677823f963f98R2638