### PR TITLE
CSHARP-3655: Removed deprecated URI option slaveOk=true

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -1034,15 +1034,6 @@ namespace MongoDB.Driver.Core.Configuration
                 case "secondaryacceptablelatencyms":
                     _localThreshold = ParseTimeSpan(name, value);
                     break;
-                case "slaveok":
-                    if (_readPreference != null)
-                    {
-                        throw new MongoConfigurationException("ReadPreference has already been configured.");
-                    }
-                    _readPreference = ParseBoolean(name, value) ?
-                        ReadPreferenceMode.SecondaryPreferred :
-                        ReadPreferenceMode.Primary;
-                    break;
                 case "serverselectiontimeout":
                 case "serverselectiontimeoutms":
                     _serverSelectionTimeout = ParseTimeSpan(name, value);

--- a/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
@@ -1209,21 +1209,6 @@ namespace MongoDB.Driver.Tests
         }
 
         [Theory]
-        [InlineData("mongodb://localhost/?slaveOk=true", ReadPreferenceMode.SecondaryPreferred)]
-        [InlineData("mongodb://localhost/?slaveOk=false", ReadPreferenceMode.Primary)]
-        public void TestSlaveOk(string url, ReadPreferenceMode mode)
-        {
-            var builder = new MongoUrlBuilder(url);
-            Assert.Equal(mode, builder.ReadPreference.ReadPreferenceMode);
-        }
-
-        [Fact]
-        public void TestSlaveOk_AfterReadPreference()
-        {
-            Assert.Throws<MongoConfigurationException>(() => new MongoUrlBuilder("mongodb://localhost/?readPreference=primary&slaveOk=true"));
-        }
-
-        [Theory]
         [InlineData(null, "mongodb://localhost", new[] { "" })]
         [InlineData(500, "mongodb://localhost/?serverSelectionTimeout{0}", new[] { "=500ms", "=0.5", "=0.5s", "=00:00:00.5", "MS=500" })]
         [InlineData(20000, "mongodb://localhost/?serverSelectionTimeout{0}", new[] { "=20s", "=20000ms", "=20", "=00:00:20", "MS=20000" })]


### PR DESCRIPTION
The slaveOk URI option has been deprecated in favour of readPreference=secondaryPreferred since at least MongoDB 2.2. Many drivers (such as pymongo) have already removed it while others never implemented it because it predated the URI options spec.