### PR TITLE
CSHARP-3427: Can't make use of compression when application path contain space.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/NativeLibraryLoader/RelativeLibraryLocatorBase.cs
+++ b/src/MongoDB.Driver.Core/Core/NativeLibraryLoader/RelativeLibraryLocatorBase.cs
@@ -26,24 +26,25 @@ namespace MongoDB.Driver.Core.NativeLibraryLoader
         public virtual bool IsX32ModeSupported => false;
 
         // public methods
+        public virtual string GetBaseAssemblyUri() => typeof(RelativeLibraryLocatorBase).GetTypeInfo().Assembly.CodeBase;
+
         public string GetLibraryAbsolutePath(OperatingSystemPlatform currentPlatform)
         {
             var relativePath = GetLibraryRelativePath(currentPlatform);
             return GetAbsolutePath(relativePath);
         }
 
-        public virtual Assembly GetLibraryBaseAssembly()
+        public virtual string GetLibraryBaseAssemblyPath()
         {
-            return typeof(RelativeLibraryLocatorBase).GetTypeInfo().Assembly;
+            var baseAssemblyPathUri = GetBaseAssemblyUri();
+            var uri = new Uri(baseAssemblyPathUri);
+            return Uri.UnescapeDataString(uri.AbsolutePath);
         }
 
         public virtual string GetLibraryBasePath()
         {
-            var assembly = GetLibraryBaseAssembly();
-            var codeBase = assembly.CodeBase;
-            var uri = new Uri(codeBase);
-            var absolutePath = uri.AbsolutePath;
-            return Path.GetDirectoryName(absolutePath);
+            var absoluteAssemblyPath = GetLibraryBaseAssemblyPath();
+            return Path.GetDirectoryName(absoluteAssemblyPath);
         }
 
         public abstract string GetLibraryRelativePath(OperatingSystemPlatform currentPlatform);

--- a/tests/MongoDB.Driver.Core.Tests/Core/NativeLibraryLoader/NativeLibraryLoaderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/NativeLibraryLoader/NativeLibraryLoaderTests.cs
@@ -32,9 +32,10 @@ namespace MongoDB.Driver.Core.Tests.Core.NativeLibraryLoader
         [InlineData("&mongo$csharp@driver%", "&mongo$csharp@driver%")]
         public void GetLibraryBasePath_should_get_correct_paths(string rootTestFolder, string expectedRootTestFolder)
         {
-            string testAssemblyCodeBaseUri = null; // use a default one for null
+            string testAssemblyCodeBaseUri = null; // use assembly-based CodeBase for null
             if (rootTestFolder != null)
             {
+                // mock assembly-based CodeBase path
                 var assemblyPath = Path.Combine(
                     RequirePlatform.GetCurrentOperatingSystem() == SupportedOperatingSystem.Windows ? "C:/" : @"\\data",
                     rootTestFolder,

--- a/tests/MongoDB.Driver.Core.Tests/Core/NativeLibraryLoader/NativeLibraryLoaderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/NativeLibraryLoader/NativeLibraryLoaderTests.cs
@@ -1,0 +1,96 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.IO;
+using FluentAssertions;
+using MongoDB.Driver.Core.NativeLibraryLoader;
+using MongoDB.Driver.TestHelpers;
+using MongoDB.Shared;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Tests.Core.NativeLibraryLoader
+{
+    public class NativeLibraryLoaderTests
+    {
+        [Theory]
+        [InlineData(null, "mongo-csharp-driver")] // the default assembly-based logic
+        [InlineData("mongo-csharp-driver", "mongo-csharp-driver")]
+        [InlineData("mongo csharp driver", "mongo csharp driver")]
+        [InlineData("&mongo$csharp@driver%", "&mongo$csharp@driver%")]
+        public void GetLibraryBasePath_should_get_correct_paths(string rootTestFolder, string expectedRootTestFolder)
+        {
+            string testAssemblyCodeBaseUri = null; // use a default one for null
+            if (rootTestFolder != null)
+            {
+                var assemblyPath = Path.Combine(
+                    RequirePlatform.GetCurrentOperatingSystem() == SupportedOperatingSystem.Windows ? "C:/" : @"\\data",
+                    rootTestFolder,
+                    GetCommonTestAssemblyFolderEnding(),
+                    "MongoDB.Driver.Core.dll");
+                testAssemblyCodeBaseUri = new Uri(assemblyPath).ToString();
+            }
+
+            var subject = new TestRelativeLibraryLocator(testAssemblyCodeBaseUri);
+
+            var result = subject.GetLibraryBasePath();
+
+            var expectedResult = Path.Combine(expectedRootTestFolder, GetCommonTestAssemblyFolderEnding());
+            result.Should().EndWith(expectedResult);
+        }
+
+        // private methods
+        private string GetCommonTestAssemblyFolderEnding() =>
+            Path.Combine(
+                "tests",
+                "MongoDB.Driver.Core.Tests",
+                "bin",
+                GetConfigurationName(),
+                GetTargetFrameworkMonikerName());
+
+        private string GetConfigurationName() =>
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
+
+        private string GetTargetFrameworkMonikerName() =>
+#if NETCOREAPP1_1
+            "netcoreapp1.1";
+#elif NETCOREAPP2_1
+            "netcoreapp2.1";
+#elif NETCOREAPP3_0
+            "netcoreapp3.0";
+#elif NET452
+            "net452";
+#endif
+
+        // nested types
+        private class TestRelativeLibraryLocator : RelativeLibraryLocatorBase
+        {
+            private readonly string _testAssemblyUri;
+
+            public TestRelativeLibraryLocator(string testAssemblyUri)
+            {
+                _testAssemblyUri = testAssemblyUri; // can be null
+            }
+
+            public override string GetBaseAssemblyUri() => _testAssemblyUri ??  base.GetBaseAssemblyUri();
+
+            public override string GetLibraryRelativePath(OperatingSystemPlatform currentPlatform) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/609d8e0e61837d3a55f5a870