### PR TITLE
CSHARP-3635: Require passing Versioned API options to getMore and transaction-continuing commands

### DIFF
--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -376,16 +376,20 @@ namespace MongoDB.Driver.Core.WireProtocol
                     {
                         AddIfNotAlreadyAdded("readConcern", readConcern);
                     }
-                    if (_serverApi != null)
-                    {
-                        AddServerApiElementsIfNecessaryAndNotAlreadyAdded();
-                    }
                 }
                 AddIfNotAlreadyAdded("autocommit", false);
             }
-            else if (_serverApi != null)
+            if (_serverApi != null)
             {
-                AddServerApiElementsIfNecessaryAndNotAlreadyAdded();
+                AddIfNotAlreadyAdded("apiVersion", _serverApi.Version.ToString());
+                if (_serverApi.Strict.HasValue)
+                {
+                    AddIfNotAlreadyAdded("apiStrict", _serverApi.Strict.Value);
+                }
+                if (_serverApi.DeprecationErrors.HasValue)
+                {
+                    AddIfNotAlreadyAdded("apiDeprecationErrors", _serverApi.DeprecationErrors.Value);
+                }
             }
 
             var elementAppendingSerializer = new ElementAppendingSerializer<BsonDocument>(BsonDocumentSerializer.Instance, extraElements, writerSettingsConfigurator);
@@ -409,25 +413,6 @@ namespace MongoDB.Driver.Core.WireProtocol
                 else
                 {
                     return true;
-                }
-            }
-
-            void AddServerApiElementsIfNecessaryAndNotAlreadyAdded()
-            {
-                var commandName = _command.GetElement(0).Name;
-                if (commandName == "getMore")
-                {
-                    return;
-                }
-
-                AddIfNotAlreadyAdded("apiVersion", _serverApi.Version.ToString());
-                if (_serverApi.Strict.HasValue)
-                {
-                    AddIfNotAlreadyAdded("apiStrict", _serverApi.Strict.Value);
-                }
-                if (_serverApi.DeprecationErrors.HasValue)
-                {
-                    AddIfNotAlreadyAdded("apiDeprecationErrors", _serverApi.DeprecationErrors.Value);
                 }
             }
         }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingQueryMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingQueryMessageWireProtocol.cs
@@ -356,7 +356,7 @@ namespace MongoDB.Driver.Core.WireProtocol
                     }
                 }
             }
-            if (!_session.IsInTransaction && _serverApi != null)
+            if (_serverApi != null)
             {
                 extraElements.Add(new BsonElement("apiVersion", _serverApi.Version.ToString()));
                 if (_serverApi.Strict.HasValue)

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1-strict.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1-strict.json
@@ -651,7 +651,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",
@@ -712,14 +712,10 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
+                  "apiStrict": true,
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1-strict.yml
@@ -240,7 +240,7 @@ tests:
                   - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
-  - description: "find command with declared API version appends to the command, but getMore does not"
+  - description: "find and getMore append API version"
     operations:
       - name: find
         object: *collection
@@ -264,9 +264,7 @@ tests:
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                apiVersion: { $$exists: false }
-                apiStrict: { $$exists: false }
-                apiDeprecationErrors: { $$exists: false }
+                <<: *expectedApiVersion
 
   - description: "findOneAndDelete appends declared API version"
     operations:

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1.json
@@ -643,7 +643,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",
@@ -704,15 +704,11 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
+                  "apiDeprecationErrors": true
                 }
               }
             }

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/crud-api-version-1.yml
@@ -234,7 +234,7 @@ tests:
                   - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
-  - description: "find command with declared API version appends to the command, but getMore does not"
+  - description: "find and getMore append API version"
     operations:
       - name: find
         object: *collection
@@ -258,9 +258,7 @@ tests:
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                apiVersion: { $$exists: false }
-                apiStrict: { $$exists: false }
-                apiDeprecationErrors: { $$exists: false }
+                <<: *expectedApiVersion
 
   - description: "findOneAndDelete appends declared API version"
     operations:

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/transaction-handling.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/transaction-handling.json
@@ -53,17 +53,6 @@
         "apiDeprecationErrors": {
           "$$unsetOrMatches": false
         }
-      },
-      {
-        "apiVersion": {
-          "$$exists": false
-        },
-        "apiStrict": {
-          "$$exists": false
-        },
-        "apiDeprecationErrors": {
-          "$$exists": false
-        }
       }
     ]
   },
@@ -97,12 +86,13 @@
   ],
   "tests": [
     {
-      "description": "Only the first command in a transaction declares an API version",
+      "description": "All commands in a transaction declare an API version",
       "runOnRequirements": [
         {
           "topologies": [
             "replicaset",
-            "sharded-replicaset"
+            "sharded-replicaset",
+            "load-balanced"
           ]
         }
       ],
@@ -193,119 +183,6 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "Committing a transaction twice does not append server API options",
-      "runOnRequirements": [
-        {
-          "topologies": [
-            "replicaset",
-            "sharded-replicaset"
-          ]
-        }
-      ],
-      "operations": [
-        {
-          "name": "startTransaction",
-          "object": "session"
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 6,
-              "x": 66
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 6
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 7,
-              "x": 77
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 7
-              }
-            }
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 6,
-                      "x": 66
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "startTransaction": true,
                   "apiVersion": "1",
                   "apiStrict": {
                     "$$unsetOrMatches": false
@@ -319,62 +196,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 7,
-                      "x": 77
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
                   "commitTransaction": 1,
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -384,7 +215,7 @@
       ]
     },
     {
-      "description": "abortTransaction does not include an API version",
+      "description": "abortTransaction includes an API version",
       "runOnRequirements": [
         {
           "topologies": [
@@ -480,14 +311,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -499,14 +328,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/transaction-handling.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/tests/transaction-handling.yml
@@ -31,10 +31,6 @@ _yamlAnchors:
       apiVersion: "1"
       apiStrict: { $$unsetOrMatches: false }
       apiDeprecationErrors: { $$unsetOrMatches: false }
-    - &noApiVersion
-      apiVersion: { $$exists: false }
-      apiStrict: { $$exists: false }
-      apiDeprecationErrors: { $$exists: false }
 
 
 initialData:
@@ -48,7 +44,7 @@ initialData:
       - { _id: 5, x: 55 }
 
 tests:
-  - description: "Only the first command in a transaction declares an API version"
+  - description: "All commands in a transaction declare an API version"
     runOnRequirements:
       - topologies: [ replicaset, sharded-replicaset ]
     operations:
@@ -83,61 +79,13 @@ tests:
                 insert: *collectionName
                 documents: [ { _id: 7, x: 77 } ]
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
-                commitTransaction: 1
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-  - description: "Committing a transaction twice does not append server API options"
-    runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset ]
-    operations:
-      - name: startTransaction
-        object: *session
-      - name: insertOne
-        object: *collection
-        arguments:
-          session: *session
-          document: { _id: 6, x: 66 }
-        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 6 } } }
-      - name: insertOne
-        object: *collection
-        arguments:
-          session: *session
-          document: { _id: 7, x: 77 }
-        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 7 } } }
-      - name: commitTransaction
-        object: *session
-      - name: commitTransaction
-        object: *session
-    expectEvents:
-      - client: *client
-        events:
-          - commandStartedEvent:
-              command:
-                insert: *collectionName
-                documents: [ { _id: 6, x: 66 } ]
-                lsid: { $$sessionLsid: *session }
-                startTransaction: true
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
-                insert: *collectionName
-                documents: [ { _id: 7, x: 77 } ]
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
                 commitTransaction: 1
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
-                commitTransaction: 1
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-  - description: "abortTransaction does not include an API version"
+                <<: *expectedApiVersion
+  - description: "abortTransaction includes an API version"
     runOnRequirements:
       - topologies: [ replicaset, sharded-replicaset ]
     operations:
@@ -172,9 +120,9 @@ tests:
                 insert: *collectionName
                 documents: [ { _id: 7, x: 77 } ]
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
+                <<: *expectedApiVersion
           - commandStartedEvent:
               command:
                 abortTransaction: 1
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
+                <<: *expectedApiVersion


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/CSHARP-3635
EG: https://evergreen.mongodb.com/version/60abec5d7742ae543a22b94b
Specification changes: https://github.com/mongodb/specifications/commit/5b892c4061026550f9b0754686a1e0f9783ff354#diff-d81feb8a94e1a811734074bde8dff007c7872dde8117e6ccdc06c6eedcce268d