### PR TITLE
CSHARP-3516: Use hello command when API Version is declared.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/DefaultAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/DefaultAuthenticator.cs
@@ -87,7 +87,7 @@ namespace MongoDB.Driver.Core.Authentication
             if (!description.IsMasterResult.HasSaslSupportedMechs
                 && Feature.ScramSha256Authentication.IsSupported(description.ServerVersion))
             {
-                var command = CustomizeInitialIsMasterCommand(HelloHelper.CreateCommand());
+                var command = CustomizeInitialIsMasterCommand(HelloHelper.CreateCommand(_serverApi));
                 var helloProtocol = HelloHelper.CreateProtocol(command, _serverApi);
                 var helloResult = HelloHelper.GetResult(connection, helloProtocol, cancellationToken);
                 var mergedHelloResult = new IsMasterResult(description.IsMasterResult.Wrapped.Merge(helloResult.Wrapped));
@@ -113,7 +113,7 @@ namespace MongoDB.Driver.Core.Authentication
             if (!description.IsMasterResult.HasSaslSupportedMechs
                 && Feature.ScramSha256Authentication.IsSupported(description.ServerVersion))
             {
-                var command = CustomizeInitialIsMasterCommand(HelloHelper.CreateCommand());
+                var command = CustomizeInitialIsMasterCommand(HelloHelper.CreateCommand(_serverApi));
                 var helloProtocol = HelloHelper.CreateProtocol(command, _serverApi);
                 var helloResult = await HelloHelper.GetResultAsync(connection, helloProtocol, cancellationToken).ConfigureAwait(false);
                 var mergedHelloResult = new IsMasterResult(description.IsMasterResult.Wrapped.Merge(helloResult.Wrapped));

--- a/src/MongoDB.Driver.Core/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/CommandEventHelper.cs
@@ -1111,7 +1111,7 @@ namespace MongoDB.Driver.Core.Connections
                     return true;
 
                 case "hello":
-                case string when commandName.Equals(OppressiveLanguageConstants.LegacyHelloCommandName, StringComparison.OrdinalIgnoreCase):
+                case OppressiveLanguageConstants.LegacyHelloCommandNameLowerCase:
                     return command.Names.Any(n => n.ToLowerInvariant() == "speculativeauthenticate");
 
                 default:

--- a/src/MongoDB.Driver.Core/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/CommandEventHelper.cs
@@ -1096,27 +1096,26 @@ namespace MongoDB.Driver.Core.Connections
         private static bool ShouldRedactCommand(BsonDocument command)
         {
             var commandName = command.GetElement(0).Name;
-            var lowerCaseCommandName = commandName.ToLowerInvariant();
-            if (lowerCaseCommandName is "authenticate"
-                                     or "saslstart"
-                                     or "saslcontinue"
-                                     or "getnonce"
-                                     or "createuser"
-                                     or "updateuser"
-                                     or "copydbgetnonce"
-                                     or "copydbsaslstart"
-                                     or "copydb")
+            switch (commandName.ToLowerInvariant())
             {
-                return true;
-            }
-            else if (lowerCaseCommandName == HelloCommand.Modern.ToLowerInvariant()
-                     || lowerCaseCommandName == HelloCommand.Legacy.ToLowerInvariant())
-            {
-                return command.Names.Any(n => n.ToLowerInvariant() == "speculativeauthenticate");
-            }
-            else
-            {
-                return false;
+                // string constants MUST all be lowercase for the case-insensitive comparison to work
+                case "authenticate":
+                case "saslstart":
+                case "saslcontinue":
+                case "getnonce":
+                case "createuser":
+                case "updateuser":
+                case "copydbgetnonce":
+                case "copydbsaslstart":
+                case "copydb":
+                    return true;
+
+                case "hello":
+                case string when commandName.Equals(OppressiveLanguageConstants.LegacyHelloCommandName, StringComparison.OrdinalIgnoreCase):
+                    return command.Names.Any(n => n.ToLowerInvariant() == "speculativeauthenticate");
+
+                default:
+                    return false;
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
@@ -160,7 +160,7 @@ namespace MongoDB.Driver.Core.Connections
 
         private BsonDocument CreateInitialHelloCommand(IReadOnlyList<IAuthenticator> authenticators)
         {
-            var command = HelloHelper.CreateCommand();
+            var command = HelloHelper.CreateCommand(_serverApi);
             HelloHelper.AddClientDocumentToCommand(command, _clientDocument);
             HelloHelper.AddCompressorsToCommand(command, _compressors);
             return HelloHelper.CustomizeCommand(command, authenticators);

--- a/src/MongoDB.Driver.Core/Core/Connections/HelloHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/HelloHelper.cs
@@ -50,10 +50,10 @@ namespace MongoDB.Driver.Core.Connections
                 (topologyVersion != null && maxAwaitTime.HasValue),
                 $"Both {nameof(topologyVersion)} and {nameof(maxAwaitTime)} must be filled or null.");
 
-            var helloCommand = serverApi != null ? HelloCommand.Modern : HelloCommand.Legacy;
+            var helloCommandName = serverApi != null ? "hello" : OppressiveLanguageConstants.LegacyHelloCommandName;
             return new BsonDocument
             {
-                { helloCommand, 1 },
+                { helloCommandName, 1 },
                 { "topologyVersion", () => topologyVersion.ToBsonDocument(), topologyVersion != null },
                 { "maxAwaitTimeMS", () => (long)maxAwaitTime.Value.TotalMilliseconds, maxAwaitTime.HasValue }
             };

--- a/src/MongoDB.Driver.Core/Core/Connections/HelloHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/HelloHelper.cs
@@ -43,16 +43,17 @@ namespace MongoDB.Driver.Core.Connections
             return command.Add("compression", compressorsArray);
         }
 
-        internal static BsonDocument CreateCommand(TopologyVersion topologyVersion = null, TimeSpan? maxAwaitTime = null)
+        internal static BsonDocument CreateCommand(ServerApi serverApi, TopologyVersion topologyVersion = null, TimeSpan? maxAwaitTime = null)
         {
             Ensure.That(
                 (topologyVersion == null && !maxAwaitTime.HasValue) ||
                 (topologyVersion != null && maxAwaitTime.HasValue),
                 $"Both {nameof(topologyVersion)} and {nameof(maxAwaitTime)} must be filled or null.");
 
+            var helloCommand = serverApi != null ? HelloCommand.Modern : HelloCommand.Legacy;
             return new BsonDocument
             {
-                { "isMaster", 1 },
+                { helloCommand, 1 },
                 { "topologyVersion", () => topologyVersion.ToBsonDocument(), topologyVersion != null },
                 { "maxAwaitTimeMS", () => (long)maxAwaitTime.Value.TotalMilliseconds, maxAwaitTime.HasValue }
             };

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -293,7 +293,8 @@ namespace MongoDB.Driver.Core.Connections
 
                 if (_wrapped.Contains("setName"))
                 {
-                    if (_wrapped.GetValue("ismaster", false).ToBoolean())
+                    if (_wrapped.GetValue("isWritablePrimary", false).ToBoolean()
+                        || _wrapped.GetValue(HelloCommand.LegacyResponseIsWritablePrimary, false).ToBoolean())
                     {
                         return ServerType.ReplicaSetPrimary;
                     }

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -293,8 +293,8 @@ namespace MongoDB.Driver.Core.Connections
 
                 if (_wrapped.Contains("setName"))
                 {
-                    if (_wrapped.GetValue("isWritablePrimary", false).ToBoolean()
-                        || _wrapped.GetValue(HelloCommand.LegacyResponseIsWritablePrimary, false).ToBoolean())
+                    if (_wrapped.GetValue("isWritablePrimary", false).ToBoolean() ||
+                        _wrapped.GetValue(OppressiveLanguageConstants.LegacyHelloResponseIsWritablePrimaryFieldName, false).ToBoolean())
                     {
                         return ServerType.ReplicaSetPrimary;
                     }

--- a/src/MongoDB.Driver.Core/Core/Misc/HelloCommand.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HelloCommand.cs
@@ -1,0 +1,8 @@
+namespace MongoDB.Driver.Core.Misc
+{
+    internal static class HelloCommand
+    {
+        public static string Modern => "hello";
+        public static string Legacy => "isMaster";
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Misc/HelloCommand.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HelloCommand.cs
@@ -19,5 +19,7 @@ namespace MongoDB.Driver.Core.Misc
     {
         public static string Modern => "hello";
         public static string Legacy => "isMaster";
+
+        public static string LegacyResponseIsWritablePrimary => "ismaster";
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/HelloCommand.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HelloCommand.cs
@@ -1,3 +1,18 @@
+/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 namespace MongoDB.Driver.Core.Misc
 {
     internal static class HelloCommand

--- a/src/MongoDB.Driver.Core/Core/Misc/OppressiveLanguageConstants.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/OppressiveLanguageConstants.cs
@@ -19,8 +19,8 @@ namespace MongoDB.Driver.Core.Misc
     {
         public const string LegacyHelloCommandName = "isMaster";
         public const string LegacyHelloCommandNameLowerCase = "ismaster";
-        // Note: The isMaster command response contains a boolean field ismaster (all lowercase)
-        //       to indicate whether the current node is the primary.
+        // The isMaster command response contains a boolean field ismaster (all lowercase)
+        // to indicate whether the current node is the primary.
         public const string LegacyHelloResponseIsWritablePrimaryFieldName = "ismaster";
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/OppressiveLanguageConstants.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/OppressiveLanguageConstants.cs
@@ -15,11 +15,9 @@
 
 namespace MongoDB.Driver.Core.Misc
 {
-    internal static class HelloCommand
+    internal static class OppressiveLanguageConstants
     {
-        public static string Modern => "hello";
-        public static string Legacy => "isMaster";
-
-        public static string LegacyResponseIsWritablePrimary => "ismaster";
+        public const string LegacyHelloCommandName = "isMaster";
+        public const string LegacyHelloResponseIsWritablePrimaryFieldName = "ismaster";
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/OppressiveLanguageConstants.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/OppressiveLanguageConstants.cs
@@ -18,6 +18,9 @@ namespace MongoDB.Driver.Core.Misc
     internal static class OppressiveLanguageConstants
     {
         public const string LegacyHelloCommandName = "isMaster";
+        public const string LegacyHelloCommandNameLowerCase = "ismaster";
+        // Note: The isMaster command response contains a boolean field ismaster (all lowercase)
+        //       to indicate whether the current node is the primary.
         public const string LegacyHelloResponseIsWritablePrimaryFieldName = "ismaster";
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Servers/RoundTripTimeMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/RoundTripTimeMonitor.cs
@@ -97,7 +97,7 @@ namespace MongoDB.Driver.Core.Servers
                     }
                     else
                     {
-                        var helloCommand = HelloHelper.CreateCommand();
+                        var helloCommand = HelloHelper.CreateCommand(_serverApi);
                         var helloProtocol = HelloHelper.CreateProtocol(helloCommand, _serverApi);
 
                         var stopwatch = Stopwatch.StartNew();

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
@@ -178,11 +178,11 @@ namespace MongoDB.Driver.Core.Servers
 
                 var veryLargeHeartbeatInterval = TimeSpan.FromDays(1); // the server doesn't support Infinite value, so we set just a big enough value
                 var maxAwaitTime = _serverMonitorSettings.HeartbeatInterval == Timeout.InfiniteTimeSpan ? veryLargeHeartbeatInterval : _serverMonitorSettings.HeartbeatInterval;
-                helloCommand = HelloHelper.CreateCommand(connection.Description.IsMasterResult.TopologyVersion, maxAwaitTime);
+                helloCommand = HelloHelper.CreateCommand(_serverApi, connection.Description.IsMasterResult.TopologyVersion, maxAwaitTime);
             }
             else
             {
-                helloCommand = HelloHelper.CreateCommand();
+                helloCommand = HelloHelper.CreateCommand(_serverApi);
             }
 
             return HelloHelper.CreateProtocol(helloCommand, _serverApi, commandResponseHandling);

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -147,7 +147,7 @@ namespace MongoDB.Driver.Core.WireProtocol
             }
             catch (Exception exception)
             {
-                AddErrorLabelIfRequired(exception, connection.Description.ServerVersion);
+                AddErrorLabelIfRequired(exception, connection.Description?.ServerVersion);
 
                 TransactionHelper.UnpinServerIfNeededOnCommandException(_session, exception);
                 throw;
@@ -201,7 +201,7 @@ namespace MongoDB.Driver.Core.WireProtocol
             }
             catch (Exception exception)
             {
-                AddErrorLabelIfRequired(exception, connection.Description.ServerVersion);
+                AddErrorLabelIfRequired(exception, connection.Description?.ServerVersion);
 
                 TransactionHelper.UnpinServerIfNeededOnCommandException(_session, exception);
                 throw;
@@ -324,7 +324,7 @@ namespace MongoDB.Driver.Core.WireProtocol
 
             AddIfNotAlreadyAdded("$db", _databaseNamespace.DatabaseName);
 
-            if (connectionDescription.IsMasterResult.ServerType != ServerType.Standalone
+            if (connectionDescription?.IsMasterResult.ServerType != ServerType.Standalone
                 && _readPreference != null
                 && _readPreference != ReadPreference.Primary)
             {

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandWireProtocol.cs
@@ -188,7 +188,14 @@ namespace MongoDB.Driver.Core.WireProtocol
             {
                 _cachedConnectionId = connection.ConnectionId;
                 var serverVersion = connection.Description?.ServerVersion;
-                if (serverVersion != null && Feature.CommandMessage.IsSupported(serverVersion))
+                // If server API versioning has been requested, then we SHOULD send the initial hello command
+                // using OP_MSG. Since this is the first message and buildInfo hasn't been sent yet,
+                // connection.Description will be null and we can't rely on the semver check to determine if
+                // the serer supports OP_MSG.
+                // As well since server API versioning is supported on MongoDB 5.0+, we also know that
+                // OP_MSG will be supported regardless and can skip the semver checks for other messages.
+                if (_serverApi != null ||
+                     (serverVersion != null && Feature.CommandMessage.IsSupported(serverVersion)))
                 {
                     return _cachedWireProtocol = CreateCommandUsingCommandMessageWireProtocol();
                 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandWireProtocol.cs
@@ -191,11 +191,11 @@ namespace MongoDB.Driver.Core.WireProtocol
                 // If server API versioning has been requested, then we SHOULD send the initial hello command
                 // using OP_MSG. Since this is the first message and buildInfo hasn't been sent yet,
                 // connection.Description will be null and we can't rely on the semver check to determine if
-                // the serer supports OP_MSG.
+                // the server supports OP_MSG.
                 // As well since server API versioning is supported on MongoDB 5.0+, we also know that
                 // OP_MSG will be supported regardless and can skip the semver checks for other messages.
                 if (_serverApi != null ||
-                     (serverVersion != null && Feature.CommandMessage.IsSupported(serverVersion)))
+                    (serverVersion != null && Feature.CommandMessage.IsSupported(serverVersion)))
                 {
                     return _cachedWireProtocol = CreateCommandUsingCommandMessageWireProtocol();
                 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CommandMessage.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CommandMessage.cs
@@ -31,8 +31,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         // static
         private static readonly HashSet<string> __messagesNotToBeCompressed = new HashSet<string>
         {
-            HelloCommand.Modern,
-            HelloCommand.Legacy,
+            "hello",
+            OppressiveLanguageConstants.LegacyHelloCommandName,
             "saslStart",
             "saslContinue",
             "getnonce",

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CommandMessage.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/CommandMessage.cs
@@ -31,7 +31,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages
         // static
         private static readonly HashSet<string> __messagesNotToBeCompressed = new HashSet<string>
         {
-            "isMaster",
+            HelloCommand.Modern,
+            HelloCommand.Legacy,
             "saslStart",
             "saslContinue",
             "getnonce",

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoAWSAuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoAWSAuthenticatorTests.cs
@@ -216,7 +216,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication
 
         [Theory]
         [ParameterAttributeData]
-        public void Authenticate_should_send_serverApi_with_query_wire_protocol(
+        public void Authenticate_should_send_serverApi_with_command_wire_protocol_if_serverApi_is_provided(
             [Values(false, true)] bool useServerApi,
             [Values(false, true)] bool async)
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoDBCRAuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoDBCRAuthenticatorTests.cs
@@ -172,7 +172,7 @@ namespace MongoDB.Driver.Core.Authentication
 
         [Theory]
         [ParameterAttributeData]
-        public void Authenticate_should_send_serverApi_with_query_wire_protocol(
+        public void Authenticate_should_send_serverApi_with_wire_protocol(
             [Values(false, true)] bool useServerApi,
             [Values(false, true)] bool async)
         {
@@ -183,10 +183,19 @@ namespace MongoDB.Driver.Core.Authentication
 #pragma warning restore 618
 
             var connection = new MockConnection(__serverId);
-            var getNonceReply = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson("{nonce: \"2375531c32080ae8\", ok: 1}"));
-            var authenticateReply = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson("{ok: 1}"));
-            connection.EnqueueReplyMessage(getNonceReply);
-            connection.EnqueueReplyMessage(authenticateReply);
+            var getNonceReply = RawBsonDocumentHelper.FromJson("{nonce: \"2375531c32080ae8\", ok: 1}");
+            var authenticateReply = RawBsonDocumentHelper.FromJson("{ok: 1}");
+            if (useServerApi)
+            {
+                connection.EnqueueCommandResponseMessage(MessageHelper.BuildCommandResponse(getNonceReply));
+                connection.EnqueueCommandResponseMessage(MessageHelper.BuildCommandResponse(authenticateReply));
+            }
+            else
+            {
+                connection.EnqueueReplyMessage(MessageHelper.BuildReply(getNonceReply));
+                connection.EnqueueReplyMessage(MessageHelper.BuildReply(authenticateReply));
+            }
+
             connection.Description = __descriptionQueryWireProtocol;
 
             var expectedRequestId = RequestMessage.CurrentGlobalRequestId + 1;
@@ -210,9 +219,16 @@ namespace MongoDB.Driver.Core.Authentication
             actualRequestId0.Should().BeInRange(expectedRequestId, expectedRequestId + 10);
             actualRequestId1.Should().BeInRange(actualRequestId0 + 1, actualRequestId0 + 11);
 
-            var expectedServerApiString = useServerApi ? ", apiVersion : \"1\", apiStrict : true, apiDeprecationErrors : true" : "";
-            sentMessages[0].Should().Be($"{{ opcode : \"query\", requestId : {actualRequestId0}, database : \"source\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ getnonce : 1{expectedServerApiString} }} }}");
-            sentMessages[1].Should().Be($"{{ opcode : \"query\", requestId : {actualRequestId1}, database : \"source\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ authenticate : 1, user : \"user\", nonce : \"2375531c32080ae8\", key : \"21742f26431831d5cfca035a08c5bdf6\"{expectedServerApiString} }} }}");
+            if (useServerApi)
+            {
+                sentMessages[0].Should().Be($"{{opcode : \"opmsg\", requestId : {actualRequestId0}, responseTo : 0, sections : [{{ \"payloadType\" : 0, \"document\" : {{ \"getnonce\" : 1, \"$db\" : \"source\", \"apiVersion\" : \"1\", \"apiStrict\" : true, \"apiDeprecationErrors\" : true }} }}]}}");
+                sentMessages[1].Should().Be($"{{opcode : \"opmsg\", requestId : {actualRequestId1}, responseTo : 0, sections : [{{ \"payloadType\" : 0, \"document\" : {{ \"authenticate\" : 1, \"user\" : \"user\", \"nonce\" : \"2375531c32080ae8\", \"key\" : \"21742f26431831d5cfca035a08c5bdf6\", \"$db\" : \"source\", \"apiVersion\" : \"1\", \"apiStrict\" : true, \"apiDeprecationErrors\" : true }} }}]}}");
+            }
+            else
+            {
+                sentMessages[0].Should().Be($"{{ opcode : \"query\", requestId : {actualRequestId0}, database : \"source\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ getnonce : 1 }} }}");
+                sentMessages[1].Should().Be($"{{ opcode : \"query\", requestId : {actualRequestId1}, database : \"source\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ authenticate : 1, user : \"user\", nonce : \"2375531c32080ae8\", key : \"21742f26431831d5cfca035a08c5bdf6\" }} }}");
+            }
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoDBCRAuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoDBCRAuthenticatorTests.cs
@@ -172,7 +172,7 @@ namespace MongoDB.Driver.Core.Authentication
 
         [Theory]
         [ParameterAttributeData]
-        public void Authenticate_should_send_serverApi_with_wire_protocol(
+        public void Authenticate_should_send_serverApi_with_command_wire_protocol_if_serverApi_is_provided(
             [Values(false, true)] bool useServerApi,
             [Values(false, true)] bool async)
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoDBX509AuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoDBX509AuthenticatorTests.cs
@@ -91,7 +91,7 @@ namespace MongoDB.Driver.Core.Authentication
 
         [Theory]
         [ParameterAttributeData]
-        public void Authenticate_should_send_serverApi_with_wire_protocol(
+        public void Authenticate_should_send_serverApi_with_command_wire_protocol_if_serverApi_is_provided(
             [Values(false, true)] bool useServerApi,
             [Values(false, true)] bool async)
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/PlainAuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/PlainAuthenticatorTests.cs
@@ -153,7 +153,7 @@ namespace MongoDB.Driver.Core.Authentication
 
         [Theory]
         [ParameterAttributeData]
-        public void Authenticate_should_send_serverApi_with_wire_protocol(
+        public void Authenticate_should_send_serverApi_with_command_wire_protocol_if_serverApi_is_provided(
             [Values(false, true)] bool useServerApi,
             [Values(false, true)] bool async)
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha1AuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha1AuthenticatorTests.cs
@@ -93,7 +93,7 @@ namespace MongoDB.Driver.Core.Authentication
 
         [Theory]
         [ParameterAttributeData]
-        public void Authenticate_should_send_serverApi_with_wire_protocol(
+        public void Authenticate_should_send_serverApi_with_command_wire_protocol_if_serverApi_is_provided(
             [Values(false, true)] bool useServerApi,
             [Values(false, true)] bool async)
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha256AuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha256AuthenticatorTests.cs
@@ -162,7 +162,7 @@ namespace MongoDB.Driver.Core.Authentication
 
         [Theory]
         [ParameterAttributeData]
-        public void Authenticate_should_send_serverApi_with_query_wire_protocol(
+        public void Authenticate_should_send_serverApi_with_command_wire_protocol_if_serverApi_is_provided(
             [Values(false, true)] bool useServerApi,
             [Values(false, true)] bool async)
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using FluentAssertions;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core.Clusters;

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -36,26 +36,21 @@ namespace MongoDB.Driver.Core.Connections
     public class ConnectionInitializerTests
     {
         private static readonly ServerId __serverId = new ServerId(new ClusterId(), new DnsEndPoint("localhost", 27017));
-        private readonly ConnectionInitializer _subject;
-
-        public ConnectionInitializerTests()
-        {
-            _subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
-        }
 
         [Theory]
         [ParameterAttributeData]
-        public void CreateInitialLegacyHello_should_return_legacy_hello_with_speculativeAuthenticate(
+        public void CreateInitialHelloCommand_without_server_api_should_return_legacy_hello_with_speculativeAuthenticate(
             [Values("default", "SCRAM-SHA-256", "SCRAM-SHA-1")] string authenticatorType,
             [Values(false, true)] bool async)
         {
             var credentials = new UsernamePasswordCredential(
                 source: "Pathfinder", username: "Barclay", password: "Barclay-Alpha-1-7-Gamma");
             var authenticator = CreateAuthenticator(authenticatorType, credentials);
-            var connectionSettings = new ConnectionSettings(new[] { new AuthenticatorFactory(() => authenticator) });
 
-            var helloDocument = _subject.CreateInitialHelloCommand(new[] { authenticator });
+            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
+            var helloDocument = subject.CreateInitialHelloCommand(new[] { authenticator });
 
+            helloDocument.Should().Contain("isMaster");
             helloDocument.Should().Contain("speculativeAuthenticate");
             var speculativeAuthenticateDocument = helloDocument["speculativeAuthenticate"].AsBsonDocument;
             speculativeAuthenticateDocument.Should().Contain("mechanism");
@@ -63,6 +58,58 @@ namespace MongoDB.Driver.Core.Connections
                 authenticatorType == "default" ? "SCRAM-SHA-256" : authenticatorType);
             speculativeAuthenticateDocument["mechanism"].Should().Be(expectedMechanism);
             speculativeAuthenticateDocument["db"].Should().Be(new BsonString(credentials.Source));
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void CreateInitialHelloCommand_with_server_api_should_return_hello_with_speculativeAuthenticate(
+            [Values("default", "SCRAM-SHA-256", "SCRAM-SHA-1")] string authenticatorType,
+            [Values(false, true)] bool async)
+        {
+            var credentials = new UsernamePasswordCredential(
+                source: "Pathfinder", username: "Barclay", password: "Barclay-Alpha-1-7-Gamma");
+            var authenticator = CreateAuthenticator(authenticatorType, credentials);
+
+            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: new ServerApi(ServerApiVersion.V1));
+            var helloDocument = subject.CreateInitialHelloCommand(new[] { authenticator });
+
+            helloDocument.Should().Contain("hello");
+            helloDocument.Should().Contain("speculativeAuthenticate");
+            var speculativeAuthenticateDocument = helloDocument["speculativeAuthenticate"].AsBsonDocument;
+            speculativeAuthenticateDocument.Should().Contain("mechanism");
+            var expectedMechanism = new BsonString(
+                authenticatorType == "default" ? "SCRAM-SHA-256" : authenticatorType);
+            speculativeAuthenticateDocument["mechanism"].Should().Be(expectedMechanism);
+            speculativeAuthenticateDocument["db"].Should().Be(new BsonString(credentials.Source));
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void InitializeConnection_should_acquire_connectionId_from_hello_response([Values(false, true)] bool async)
+        {
+            var helloReply = MessageHelper.BuildReply(
+                RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }"));
+            var buildInfoReply = MessageHelper.BuildReply(
+                RawBsonDocumentHelper.FromJson("{ ok : 1, version : \"4.9.0\" }"));
+
+            var connection = new MockConnection(__serverId);
+            connection.EnqueueReplyMessage(helloReply);
+            connection.EnqueueReplyMessage(buildInfoReply);
+
+            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: new ServerApi(ServerApiVersion.V1));
+            ConnectionDescription result;
+            if (async)
+            {
+                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
+            }
+            else
+            {
+                result = subject.InitializeConnection(connection, CancellationToken.None);
+            }
+
+            var sentMessages = connection.GetSentMessages();
+            sentMessages.Should().HaveCount(2);
+            result.ConnectionId.ServerValue.Should().Be(1);
         }
 
         [Theory]
@@ -78,14 +125,15 @@ namespace MongoDB.Driver.Core.Connections
             connection.EnqueueReplyMessage(legacyHelloReply);
             connection.EnqueueReplyMessage(buildInfoReply);
 
+            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
             ConnectionDescription result;
             if (async)
             {
-                result = _subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
+                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
             }
             else
             {
-                result = _subject.InitializeConnection(connection, CancellationToken.None);
+                result = subject.InitializeConnection(connection, CancellationToken.None);
             }
 
             var sentMessages = connection.GetSentMessages();
@@ -111,16 +159,17 @@ namespace MongoDB.Driver.Core.Connections
             connection.EnqueueReplyMessage(legacyHelloReply);
             connection.EnqueueReplyMessage(buildInfoReply);
 
+            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
             // We expect authentication to fail since we have not enqueued the expected authentication replies
             try
             {
                 if (async)
                 {
-                    _subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
+                    subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
                 }
                 else
                 {
-                    _subject.InitializeConnection(connection, CancellationToken.None);
+                    subject.InitializeConnection(connection, CancellationToken.None);
                 }
             }
             catch (InvalidOperationException ex)
@@ -146,14 +195,15 @@ namespace MongoDB.Driver.Core.Connections
             [Values(false, true)]
             bool async)
         {
+            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
             Action act;
             if (async)
             {
-                act = () => _subject.InitializeConnectionAsync(null, CancellationToken.None).GetAwaiter().GetResult();
+                act = () => subject.InitializeConnectionAsync(null, CancellationToken.None).GetAwaiter().GetResult();
             }
             else
             {
-                act = () => _subject.InitializeConnection(null, CancellationToken.None);
+                act = () => subject.InitializeConnection(null, CancellationToken.None);
             }
 
             act.ShouldThrow<ArgumentNullException>();
@@ -161,17 +211,17 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
-        public void InitializeConnection_should_send_serverApi_in_legacy_hello_and_buildInfo(
+        public void InitializeConnection_should_send_serverApi_in_hello_and_buildInfo(
             [Values(false, true)] bool useServerApi,
             [Values(false, true)] bool async)
         {
             var serverApi = useServerApi ? new ServerApi(ServerApiVersion.V1, true, true) : null;
 
-            var legacyHelloReply = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }"));
+            var helloReply = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }"));
             var buildInfoReply = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson("{ ok : 1, version : \"4.2.0\" }"));
 
             var connection = new MockConnection(__serverId);
-            connection.EnqueueReplyMessage(legacyHelloReply);
+            connection.EnqueueReplyMessage(helloReply);
             connection.EnqueueReplyMessage(buildInfoReply);
 
             var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi);
@@ -195,8 +245,10 @@ namespace MongoDB.Driver.Core.Connections
 
             var actualRequestId1 = sentMessages[1]["requestId"].AsInt32;
 
+            var helloCommand = useServerApi ? HelloCommand.Modern : HelloCommand.Legacy;
+
             sentMessages[0]["opcode"].AsString.Should().Be("query");
-            sentMessages[0]["query"]["isMaster"].AsInt32.Should().Be(1);
+            sentMessages[0]["query"][helloCommand].AsInt32.Should().Be(1);
             if (useServerApi)
             {
                 sentMessages[0]["query"]["apiVersion"].AsString.Should().Be("1");
@@ -231,14 +283,15 @@ namespace MongoDB.Driver.Core.Connections
             connection.EnqueueReplyMessage(buildInfoReply);
             connection.EnqueueReplyMessage(gleReply);
 
+            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
             ConnectionDescription result;
             if (async)
             {
-                result = _subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
+                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
             }
             else
             {
-                result = _subject.InitializeConnection(connection, CancellationToken.None);
+                result = subject.InitializeConnection(connection, CancellationToken.None);
             }
 
             result.ServerVersion.Should().Be(new SemanticVersion(2, 6, 3));

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -242,7 +242,7 @@ namespace MongoDB.Driver.Core.Connections
 
             sentMessages[0]["opcode"].AsString.Should().Be("opmsg");
             var helloRequestDocument = sentMessages[0]["sections"][0]["document"];
-            helloRequestDocument[HelloCommand.Modern].AsInt32.Should().Be(1);
+            helloRequestDocument["hello"].AsInt32.Should().Be(1);
             helloRequestDocument["apiVersion"].AsString.Should().Be("1");
             helloRequestDocument["apiStrict"].AsBoolean.Should().Be(true);
             helloRequestDocument["apiDeprecationErrors"].AsBoolean.Should().Be(true);
@@ -282,7 +282,7 @@ namespace MongoDB.Driver.Core.Connections
             var actualRequestId1 = sentMessages[1]["requestId"].AsInt32;
 
             sentMessages[0]["opcode"].AsString.Should().Be("query");
-            sentMessages[0]["query"][HelloCommand.Legacy].AsInt32.Should().Be(1);
+            sentMessages[0]["query"][OppressiveLanguageConstants.LegacyHelloCommandName].AsInt32.Should().Be(1);
             sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiVersion", out _).Should().BeFalse();
             sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiStrict", out _).Should().BeFalse();
             sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiDeprecationErrors", out _).Should().BeFalse();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using FluentAssertions;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core.Clusters;
@@ -87,14 +88,12 @@ namespace MongoDB.Driver.Core.Connections
         [ParameterAttributeData]
         public void InitializeConnection_should_acquire_connectionId_from_hello_response([Values(false, true)] bool async)
         {
-            var helloReply = MessageHelper.BuildReply(
-                RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }"));
-            var buildInfoReply = MessageHelper.BuildReply(
-                RawBsonDocumentHelper.FromJson("{ ok : 1, version : \"4.9.0\" }"));
+            var helloReply = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }"));
+            var buildInfoReply = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson("{ ok : 1, version : \"4.9.0\" }"));
 
             var connection = new MockConnection(__serverId);
-            connection.EnqueueReplyMessage(helloReply);
-            connection.EnqueueReplyMessage(buildInfoReply);
+            connection.EnqueueCommandResponseMessage(helloReply);
+            connection.EnqueueCommandResponseMessage(buildInfoReply);
 
             var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: new ServerApi(ServerApiVersion.V1));
             ConnectionDescription result;
@@ -211,18 +210,15 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
-        public void InitializeConnection_should_send_serverApi_in_hello_and_buildInfo(
-            [Values(false, true)] bool useServerApi,
-            [Values(false, true)] bool async)
+        public void InitializeConnection_with_serverApi_should_send_hello_and_buildInfo([Values(false, true)] bool async)
         {
-            var serverApi = useServerApi ? new ServerApi(ServerApiVersion.V1, true, true) : null;
-
-            var helloReply = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }"));
-            var buildInfoReply = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson("{ ok : 1, version : \"4.2.0\" }"));
+            var serverApi = new ServerApi(ServerApiVersion.V1, true, true);
 
             var connection = new MockConnection(__serverId);
-            connection.EnqueueReplyMessage(helloReply);
-            connection.EnqueueReplyMessage(buildInfoReply);
+            var helloReply = RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }");
+            connection.EnqueueCommandResponseMessage(MessageHelper.BuildCommandResponse(helloReply));
+            var buildInfoReply = RawBsonDocumentHelper.FromJson("{ ok : 1, version : \"4.2.0\" }");
+            connection.EnqueueCommandResponseMessage(MessageHelper.BuildCommandResponse(buildInfoReply));
 
             var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi);
 
@@ -245,24 +241,53 @@ namespace MongoDB.Driver.Core.Connections
 
             var actualRequestId1 = sentMessages[1]["requestId"].AsInt32;
 
-            var helloCommand = useServerApi ? HelloCommand.Modern : HelloCommand.Legacy;
+            sentMessages[0]["opcode"].AsString.Should().Be("opmsg");
+            var helloRequestDocument = sentMessages[0]["sections"][0]["document"];
+            helloRequestDocument[HelloCommand.Modern].AsInt32.Should().Be(1);
+            helloRequestDocument["apiVersion"].AsString.Should().Be("1");
+            helloRequestDocument["apiStrict"].AsBoolean.Should().Be(true);
+            helloRequestDocument["apiDeprecationErrors"].AsBoolean.Should().Be(true);
 
-            sentMessages[0]["opcode"].AsString.Should().Be("query");
-            sentMessages[0]["query"][helloCommand].AsInt32.Should().Be(1);
-            if (useServerApi)
+            sentMessages[1].Should().Be($"{{ \"opcode\" : \"opmsg\", \"requestId\" : {actualRequestId1}, \"responseTo\" : 0, \"sections\" : [ {{ \"payloadType\" : 0, \"document\" : {{ \"buildInfo\" : 1, \"$db\" : \"admin\", \"$readPreference\" : {{ \"mode\" : \"primaryPreferred\" }}, \"apiVersion\" : \"1\", \"apiStrict\" : false, \"apiDeprecationErrors\" : true }} }}] }}");
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void InitializeConnection_without_serverApi_should_send_legacy_hello_and_buildInfo([Values(false, true)] bool async)
+        {
+            var connection = new MockConnection(__serverId);
+            var helloReply = RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }");
+            connection.EnqueueReplyMessage(MessageHelper.BuildReply(helloReply));
+            var buildInfoReply = RawBsonDocumentHelper.FromJson("{ ok : 1, version : \"4.2.0\" }");
+            connection.EnqueueReplyMessage(MessageHelper.BuildReply(buildInfoReply));
+
+            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, null);
+
+            ConnectionDescription result;
+            if (async)
             {
-                sentMessages[0]["query"]["apiVersion"].AsString.Should().Be("1");
-                sentMessages[0]["query"]["apiStrict"].AsBoolean.Should().Be(true);
-                sentMessages[0]["query"]["apiDeprecationErrors"].AsBoolean.Should().Be(true);
+                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
             }
             else
             {
-                sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiVersion", out _).Should().BeFalse();
-                sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiStrict", out _).Should().BeFalse();
-                sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiDeprecationErrors", out _).Should().BeFalse();
+                result = subject.InitializeConnection(connection, CancellationToken.None);
             }
-            var expectedServerApiBuildInfoString = useServerApi ? ", apiVersion : \"1\", apiStrict : false, apiDeprecationErrors : true" : "";
-            sentMessages[1].Should().Be($"{{ opcode : \"query\", requestId : {actualRequestId1}, database : \"admin\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ buildInfo : 1{expectedServerApiBuildInfoString} }}}}");
+
+            result.ConnectionId.ServerValue.Should().Be(1);
+
+            SpinWait.SpinUntil(() => connection.GetSentMessages().Count >= 2, TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+            var sentMessages = MessageHelper.TranslateMessagesToBsonDocuments(connection.GetSentMessages());
+            sentMessages.Count.Should().Be(2);
+
+            var actualRequestId1 = sentMessages[1]["requestId"].AsInt32;
+
+            sentMessages[0]["opcode"].AsString.Should().Be("query");
+            sentMessages[0]["query"][HelloCommand.Legacy].AsInt32.Should().Be(1);
+            sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiVersion", out _).Should().BeFalse();
+            sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiStrict", out _).Should().BeFalse();
+            sentMessages[0]["query"].AsBsonDocument.TryGetElement("apiDeprecationErrors", out _).Should().BeFalse();
+            sentMessages[1].Should().Be($"{{ opcode : \"query\", requestId : {actualRequestId1}, database : \"admin\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ buildInfo : 1 }}}}");
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloHelperTests.cs
@@ -24,8 +24,22 @@ using MongoDB.Driver.Core.Configuration;
 
 namespace MongoDB.Driver.Core.Connections
 {
-    public class IsMasterHelperTests
+    public class HelloHelperTests
     {
+        [Fact]
+        public void CreateCommand_with_ServerApi_should_return_hello_command()
+        {
+            var command = HelloHelper.CreateCommand(new ServerApi(ServerApiVersion.V1));
+            command.Should().Be($"{{ hello : 1 }}");
+        }
+
+        [Fact]
+        public void CreateCommand_without_ServerApi_should_return_legacy_hello_command()
+        {
+            var command = HelloHelper.CreateCommand(null);
+            command.Should().Be($"{{ isMaster : 1 }}");
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void AddClientDocumentToCommand_with_custom_document_should_return_expected_result(
@@ -33,7 +47,7 @@ namespace MongoDB.Driver.Core.Connections
             string clientDocumentString)
         {
             var clientDocument = BsonDocument.Parse(clientDocumentString);
-            var command = HelloHelper.CreateCommand();
+            var command = HelloHelper.CreateCommand(null);
             var result = HelloHelper.AddClientDocumentToCommand(command, clientDocument);
 
             result.Should().Be($"{{ isMaster : 1, client : {clientDocumentString} }}");
@@ -42,7 +56,7 @@ namespace MongoDB.Driver.Core.Connections
         [Fact]
         public void AddClientDocumentToCommand_with_ConnectionInitializer_client_document_should_return_expected_result()
         {
-            var command = HelloHelper.CreateCommand();
+            var command = HelloHelper.CreateCommand(null);
             var connectionInitializer = new ConnectionInitializer("test", new CompressorConfiguration[0], serverApi: null);
             var subjectClientDocument = (BsonDocument)Reflector.GetFieldValue(connectionInitializer, "_clientDocument");
             var result = HelloHelper.AddClientDocumentToCommand(command, subjectClientDocument);
@@ -75,7 +89,7 @@ namespace MongoDB.Driver.Core.Connections
                 new [] { CompressorType.ZStandard, CompressorType.Snappy })]
             CompressorType[] compressorsParameters)
         {
-            var command = HelloHelper.CreateCommand();
+            var command = HelloHelper.CreateCommand(null);
             var compressors =
                 compressorsParameters
                     .Select(c => new CompressorConfiguration(c))

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
@@ -207,6 +207,7 @@ namespace MongoDB.Driver.Core.Connections
         [Theory]
         [InlineData("{ ok: 1, isreplicaset: true, setName: \"awesome\", ismaster: true }", ServerType.ReplicaSetGhost)]
         [InlineData("{ ok: 1, setName: \"awesome\", ismaster: true }", ServerType.ReplicaSetPrimary)]
+        [InlineData("{ ok: 1, setName: \"awesome\", isWritablePrimary: true }", ServerType.ReplicaSetPrimary)]
         [InlineData("{ ok: 1, setName: \"awesome\", ismaster: true, secondary: true }", ServerType.ReplicaSetPrimary)]
         [InlineData("{ ok: 1, setName: \"awesome\", secondary: true }", ServerType.ReplicaSetSecondary)]
         [InlineData("{ ok: 1, setName: \"awesome\", secondary: true, passive: true }", ServerType.ReplicaSetSecondary)]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/RoundTripTimeMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/RoundTripTimeMonitorTests.cs
@@ -153,10 +153,6 @@ namespace MongoDB.Driver.Core.Tests.Core.Servers
         public void RunAsync_should_use_serverApi()
         {
             var serverApi = new ServerApi(ServerApiVersion.V1);
-            var eventCapturer = new EventCapturer();
-            var streamFactory = new TcpStreamFactory();
-            var mockEventSubscriber = new Mock<IEventSubscriber>().Object;
-
             var connection = new MockConnection(__serverId);
 
             var mockConnectionFactory = new Mock<IConnectionFactory>();
@@ -180,7 +176,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Servers
             sentMessages.Count.Should().Be(1);
 
             var requestId = sentMessages[0]["requestId"].AsInt32;
-            sentMessages[0].Should().Be($"{{ opcode : \"query\", requestId : {requestId}, database : \"admin\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ hello : 1, apiVersion : \"1\" }} }}");
+            sentMessages[0].Should().Be($"{{ \"opcode\" : \"opmsg\", \"requestId\" : {requestId}, \"responseTo\" : 0, \"sections\" : [{{ \"payloadType\" : 0, \"document\" : {{ \"hello\" : 1, \"$db\" : \"admin\", \"$readPreference\" : {{ \"mode\" : \"primaryPreferred\" }}, \"apiVersion\" : \"1\" }} }}] }}");
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/RoundTripTimeMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/RoundTripTimeMonitorTests.cs
@@ -180,7 +180,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Servers
             sentMessages.Count.Should().Be(1);
 
             var requestId = sentMessages[0]["requestId"].AsInt32;
-            sentMessages[0].Should().Be($"{{ opcode : \"query\", requestId : {requestId}, database : \"admin\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ isMaster : 1, apiVersion : \"1\" }} }}");
+            sentMessages[0].Should().Be($"{{ opcode : \"query\", requestId : {requestId}, database : \"admin\", collection : \"$cmd\", batchSize : -1, slaveOk : true, query : {{ hello : 1, apiVersion : \"1\" }} }}");
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -341,7 +341,7 @@ namespace MongoDB.Driver.Core.Servers
             sentMessages.Count.Should().Be(1);
 
             var requestId = sentMessages[0]["requestId"].AsInt32;
-            sentMessages[0].Should().Be($"{{ opcode : \"opmsg\", requestId : {requestId}, responseTo : 0, exhaustAllowed : true, sections : [ {{ payloadType : 0, document : {{ isMaster : 1, topologyVersion : {{ processId : ObjectId(\"000000000000000000000000\"), counter : NumberLong(0) }}, maxAwaitTimeMS : NumberLong(86400000), $db : \"admin\", apiVersion : \"1\" }} }} ] }}");
+            sentMessages[0].Should().Be($"{{ opcode : \"opmsg\", requestId : {requestId}, responseTo : 0, exhaustAllowed : true, sections : [ {{ payloadType : 0, document : {{ hello : 1, topologyVersion : {{ processId : ObjectId(\"000000000000000000000000\"), counter : NumberLong(0) }}, maxAwaitTimeMS : NumberLong(86400000), $db : \"admin\", apiVersion : \"1\" }} }} ] }}");
         }
 
         // private methods


### PR DESCRIPTION
This implements using `hello` instead of `isMaster` when server API version is declared for both the initial handshake and monitoring.

NOTE: This PR does not add support for `helloOk:true` and using `hello` for monitoring on supporting servers, which will be implemented separately in CSHARP-3659.