### PR TITLE
CSHARP-3703: Fix NullReferenceException when Id property has no getter.

### DIFF
--- a/src/MongoDB.Bson/Serialization/Conventions/NamedIdMemberConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/NamedIdMemberConvention.cs
@@ -112,7 +112,9 @@ namespace MongoDB.Bson.Serialization.Conventions
             if (member is PropertyInfo)
             {
                 var getMethodInfo = ((PropertyInfo)member).GetMethod;
-                if (getMethodInfo.IsVirtual && getMethodInfo.GetBaseDefinition().DeclaringType != classMap.ClassType)
+                if (getMethodInfo == null ||
+                    getMethodInfo.IsVirtual &&
+                    getMethodInfo.GetBaseDefinition().DeclaringType != classMap.ClassType)
                 {
                     return false;
                 }

--- a/tests/MongoDB.Bson.Tests/Serialization/Conventions/IdMemberConventionsTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Conventions/IdMemberConventionsTests.cs
@@ -44,6 +44,14 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             public ObjectId _id { get; set; }
         }
 
+        private class TestClassNoIdGetter
+        {
+            public Object Id
+            {
+                set { }
+            }
+        }
+
         [Fact]
         public void TestNamedIdMemberConventionWithTestClassA()
         {
@@ -81,6 +89,15 @@ namespace MongoDB.Bson.Tests.Serialization.Conventions
             convention.Apply(classMap);
             Assert.NotNull(classMap.IdMemberMap);
             Assert.Equal("_id", classMap.IdMemberMap.MemberName);
+        }
+
+        [Fact]
+        public void TestNamedIdMemberConventionWillNotReturnIdWithoutGetter()
+        {
+            var convention = new NamedIdMemberConvention("Id", "id", "_id");
+            var classMap = new BsonClassMap<TestClassNoIdGetter>();
+            convention.Apply(classMap);
+            Assert.Null(classMap.IdMemberMap);
         }
     }
 }


### PR DESCRIPTION
While having an `Id` property without a getter is an uncommon design choice, we actually throw a `NullReferenceException` in `NamedIdMemberConvention` rather than simply not returning the getter-less `Id` member. This prevents the use of other attributes or conventions to identify another property as the `_id`. For example the following classes will throw when attempting to serialize them:

```
[BsonNoId]
class Class1 {
    public int Id { set {} }
}

class Class2 {
    [BsonIgnore]
    public int Id { set {} }
}

class Class2 {
    [BsonIgnore]
    public int Id { set {} }

    [BsonId]
    public int AnotherId { get; set; }
}
```

The added null check in `NamedIdMemberConvention` allows all of the above classes to be mapped.