### PR TITLE
CSHARP-3705: Ignore hello commands during event capture for UnifiedTestRunner.

### DIFF
--- a/tests/MongoDB.Driver.Core.TestHelpers/XunitExtensions/RequireServer.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/XunitExtensions/RequireServer.cs
@@ -222,6 +222,11 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
             {
                 switch (item.Name)
                 {
+                    case "authEnabled":
+                        {
+                            var actualAuthentication = CoreTestConfiguration.ConnectionString.Username != null;
+                            return actualAuthentication == item.Value.AsBoolean;
+                        }
                     case "minServerVersion":
                         {
                             var actualVersion = CoreTestConfiguration.ServerVersion;
@@ -277,6 +282,7 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
         {
             switch (topology)
             {
+                case "load-balanced": throw new SkipException("Topology load-balanced has not been implemented yet.");
                 case "single": return Clusters.ClusterType.Standalone;
                 case "replicaset": return Clusters.ClusterType.ReplicaSet;
                 case "sharded-replicaset":

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/MonitoringTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/MonitoringTestRunner.cs
@@ -84,7 +84,7 @@ namespace MongoDB.Driver.Specifications.sdam_monitoring
 
             var address = response[0].AsString;
             var isMasterDocument = response[1].AsBsonDocument;
-            JsonDrivenHelper.EnsureAllFieldsAreValid(isMasterDocument, "hosts", "ismaster", "maxWireVersion", "minWireVersion", "ok", "primary", "secondary", "setName", "setVersion");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(isMasterDocument, "hosts", "isWritablePrimary", OppressiveLanguageConstants.LegacyHelloResponseIsWritablePrimaryFieldName, "maxWireVersion", "minWireVersion", "ok", "primary", "secondary", "setName", "setVersion");
 
             var endPoint = EndPointHelper.Parse(address);
             var isMasterResult = new IsMasterResult(isMasterDocument);
@@ -361,6 +361,12 @@ namespace MongoDB.Driver.Specifications.sdam_monitoring
             {
                 var name = GetTestCaseName(document, document, 0);
                 yield return new JsonDrivenTestCase(name, document, document);
+            }
+
+            protected override bool ShouldReadJsonDocument(string path)
+            {
+                // load balancer support not yet implemented
+                return base.ShouldReadJsonDocument(path) && !path.EndsWith("load_balancer.json");
             }
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringTestRunner.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using FluentAssertions;
@@ -530,8 +531,11 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
         private class TestCaseFactory : JsonDrivenTestCaseFactory
         {
             // private constants
-            private readonly string[] MonitoringPrefixes = {"MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.",
-                                                            "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.legacy_hello.monitoring."};
+            private readonly string[] MonitoringPrefixes =
+            {
+                "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.",
+                "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.legacy_hello.monitoring."
+            };
 
             protected override string PathPrefix => "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.";
 
@@ -543,9 +547,10 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
             protected override bool ShouldReadJsonDocument(string path)
             {
+                var loadBalancerTestDirectory = $"{Path.PathSeparator}load-balanced{Path.PathSeparator}";
                 return base.ShouldReadJsonDocument(path) &&
                        !MonitoringPrefixes.Any(prefix => path.StartsWith(prefix)) &&
-                       !path.EndsWith("discover_load_balancer.json");  // load balancer support not yet implemented
+                       !path.Contains(loadBalancerTestDirectory);  // load balancer support not yet implemented
             }
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringTestRunner.cs
@@ -121,7 +121,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
                     mongoConnectionException.Generation = generation;
                 }
             }
-            
+
             mockConnection.SetupGet(c => c.Generation).Returns(generation);
             mockConnection
                 .SetupGet(c => c.Generation)
@@ -186,7 +186,8 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
                 "electionId",
                 "hidden",
                 "hosts",
-                "ismaster",
+                "isWritablePrimary",
+                OppressiveLanguageConstants.LegacyHelloResponseIsWritablePrimaryFieldName,
                 "isreplicaset",
                 "logicalSessionTimeoutMinutes",
                 "maxWireVersion",
@@ -529,7 +530,8 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
         private class TestCaseFactory : JsonDrivenTestCaseFactory
         {
             // private constants
-            private const string MonitoringPrefix = "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.";
+            private readonly string[] MonitoringPrefixes = {"MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.",
+                                                            "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.legacy_hello.monitoring."};
 
             protected override string PathPrefix => "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.";
 
@@ -541,7 +543,9 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
             protected override bool ShouldReadJsonDocument(string path)
             {
-                return base.ShouldReadJsonDocument(path) && !path.StartsWith(MonitoringPrefix);
+                return base.ShouldReadJsonDocument(path) &&
+                       !MonitoringPrefixes.Any(prefix => path.StartsWith(prefix)) &&
+                       !path.EndsWith("discover_load_balancer.json");  // load balancer support not yet implemented
             }
         }
     }

--- a/tests/MongoDB.Driver.Legacy.Tests/Jira/CSharp365Tests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/Jira/CSharp365Tests.cs
@@ -51,6 +51,11 @@ namespace MongoDB.Driver.Tests.Jira.CSharp365
                     if (winningPlan.Contains("shards"))
                     {
                         winningPlan = winningPlan["shards"][0]["winningPlan"].AsBsonDocument;
+                        // MongoDB 5.0 changes the explain plan output to nest the shard's winningPlan 1 level deeper
+                        if (winningPlan.Contains("queryPlan"))
+                        {
+                            winningPlan = winningPlan["queryPlan"].AsBsonDocument;
+                        }
                     }
                     var inputStage = winningPlan["inputStage"].AsBsonDocument;
                     var stage = inputStage["stage"].AsString;

--- a/tests/MongoDB.Driver.Legacy.Tests/Linq/WithIndexTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/Linq/WithIndexTests.cs
@@ -134,6 +134,11 @@ namespace MongoDB.Driver.Tests.Linq
                 if (winningPlan.Contains("shards"))
                 {
                     winningPlan = winningPlan["shards"][0]["winningPlan"].AsBsonDocument;
+                    // MongoDB 5.0 changes the explain plan output to nest the shard's winningPlan 1 level deeper
+                    if (winningPlan.Contains("queryPlan"))
+                    {
+                        winningPlan = winningPlan["queryPlan"].AsBsonDocument;
+                    }
                 }
                 var inputStage = winningPlan["inputStage"].AsBsonDocument;
                 var stage = inputStage["stage"].AsString;
@@ -221,6 +226,11 @@ namespace MongoDB.Driver.Tests.Linq
                 if (winningPlan.Contains("shards"))
                 {
                     winningPlan = winningPlan["shards"][0]["winningPlan"].AsBsonDocument;
+                    // MongoDB 5.0 changes the explain plan output to nest the shard's winningPlan 1 level deeper
+                    if (winningPlan.Contains("queryPlan"))
+                    {
+                        winningPlan = winningPlan["queryPlan"].AsBsonDocument;
+                    }
                 }
                 var inputStage = winningPlan["inputStage"].AsBsonDocument;
                 var stage = inputStage["stage"].AsString;

--- a/tests/MongoDB.Driver.Tests/ClusterTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterTests.cs
@@ -40,7 +40,8 @@ namespace MongoDB.Driver.Tests
     {
         private static readonly HashSet<string> __commandsToNotCapture = new HashSet<string>
         {
-            "isMaster",
+            "hello",
+            OppressiveLanguageConstants.LegacyHelloCommandName,
             "buildInfo",
             "getLastError",
             "authenticate",

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenTestFactory.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenTestFactory.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core;
+using Xunit;
 
 namespace MongoDB.Driver.Tests.JsonDrivenTests
 {
@@ -114,6 +115,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
                     switch (name)
                     {
                         case "listDatabaseNames": return new JsonDrivenListDatabaseNamesTest(_client, _objectMap);
+                        case "listDatabaseObjects": throw new SkipException(".NET/C# driver does not implement a ListDatabaseObjects helper.");
                         case "listDatabases": return new JsonDrivenListDatabasesTest(_client, _objectMap);
                         case "watch": return new JsonDrivenClientWatchTest(_client, _objectMap);
                         default: throw new FormatException($"Invalid method name: \"{name}\".");
@@ -138,6 +140,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
                         case "createCollection": return new JsonDrivenCreateCollectionTest(database, _objectMap);
                         case "dropCollection": return new JsonDrivenDropCollectionTest(database, _objectMap);
                         case "listCollectionNames": return new JsonDrivenListCollectionNamesTest(database, _objectMap);
+                        case "listCollectionObjects": throw new SkipException(".NET/C# driver does not implement a ListCollectionObjects helper.");
                         case "listCollections": return new JsonDrivenListCollectionsTest(database, _objectMap);
                         case "runCommand": return new JsonDrivenRunCommandTest(database, _objectMap);
                         case "watch": return new JsonDrivenDatabaseWatchTest(database, _objectMap);
@@ -168,6 +171,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
                         case "insertMany": return new JsonDrivenInsertManyTest(collection, _objectMap);
                         case "insertOne": return new JsonDrivenInsertOneTest(collection, _objectMap);
                         case "listIndexes": return new JsonDrivenListIndexesTest(collection, _objectMap);
+                        case "listIndexNames": throw new SkipException(".NET/C# driver does not implement a ListIndexNames helper.");
                         case "mapReduce": return new JsonDrivenMapReduceTest(collection, _objectMap);
                         case "replaceOne": return new JsonDrivenReplaceOneTest(collection, _objectMap);
                         case "updateMany": return new JsonDrivenUpdateManyTest(collection, _objectMap);

--- a/tests/MongoDB.Driver.Tests/PinnedShardRouterTests.cs
+++ b/tests/MongoDB.Driver.Tests/PinnedShardRouterTests.cs
@@ -34,7 +34,8 @@ namespace MongoDB.Driver.Tests
     {
         private static readonly HashSet<string> __commandsToNotCapture = new HashSet<string>
         {
-            "isMaster",
+            "hello",
+            OppressiveLanguageConstants.LegacyHelloCommandName,
             "buildInfo",
             "getLastError",
             "authenticate",

--- a/tests/MongoDB.Driver.Tests/Specifications/Runner/MongoClientJsonDrivenTestRunnerBase.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/Runner/MongoClientJsonDrivenTestRunnerBase.cs
@@ -49,7 +49,8 @@ namespace MongoDB.Driver.Tests.Specifications.Runner
         private readonly string _skipReasonKey = "skipReason";
         private readonly HashSet<string> _defaultCommandsToNotCapture = new HashSet<string>
         {
-            "isMaster",
+            "hello",
+            OppressiveLanguageConstants.LegacyHelloCommandName,
             "buildInfo",
             "getLastError",
             "authenticate",
@@ -329,12 +330,28 @@ namespace MongoDB.Driver.Tests.Specifications.Runner
                     settings.ConnectTimeout = TimeSpan.FromMilliseconds(option.Value.ToInt32());
                     break;
 
+                case "directConnection":
+                    settings.DirectConnection = option.Value.ToBoolean();
+                    break;
+
                 case "heartbeatFrequencyMS":
                     settings.HeartbeatInterval = TimeSpan.FromMilliseconds(option.Value.ToInt32());
                     break;
 
+                case "maxPoolSize":
+                    settings.MaxConnectionPoolSize = option.Value.ToInt32();
+                    break;
+
+                case "minPoolSize":
+                    settings.MinConnectionPoolSize = option.Value.ToInt32();
+                    break;
+
                 case "serverSelectionTimeoutMS":
                     settings.ServerSelectionTimeout = TimeSpan.FromMilliseconds(option.Value.ToInt32());
+                    break;
+
+                case "socketTimeoutMS":
+                    settings.SocketTimeout = TimeSpan.FromMilliseconds(option.Value.ToInt32());
                     break;
 
                 default:

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/ChangeStreamTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/ChangeStreamTestRunner.cs
@@ -25,6 +25,7 @@ using MongoDB.Driver.Core;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
@@ -91,7 +92,8 @@ namespace MongoDB.Driver.Tests.Specifications.change_streams
                 }
             }
 
-            if (test.Contains("expectations") && actualEvents != null)
+            // expectations == null indicates that expectations should not be asserted.
+            if (test.Contains("expectations") && !test["expectations"].IsBsonNull && actualEvents != null)
             {
                 var expectedEvents = test["expectations"].AsBsonArray.Cast<BsonDocument>().ToList();
                 AssertEvents(actualEvents, expectedEvents);
@@ -174,7 +176,8 @@ namespace MongoDB.Driver.Tests.Specifications.change_streams
         {
             var commandsToNotCapture = new HashSet<string>
             {
-                "isMaster",
+                "hello",
+                OppressiveLanguageConstants.LegacyHelloCommandName,
                 "buildInfo",
                 "getLastError",
                 "authenticate",

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -1497,7 +1497,8 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
         {
             var defaultCommandsToNotCapture = new HashSet<string>
             {
-                "isMaster",
+                "hello",
+                OppressiveLanguageConstants.LegacyHelloCommandName,
                 "buildInfo",
                 "getLastError",
                 "authenticate",

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/CrudTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/CrudTestRunner.cs
@@ -21,6 +21,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core;
 using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.TestHelpers;
@@ -34,7 +35,8 @@ namespace MongoDB.Driver.Tests.Specifications.crud
         private static readonly HashSet<string> __commandsToNotCapture = new HashSet<string>
         {
             "configureFailPoint",
-            "isMaster",
+            "hello",
+            OppressiveLanguageConstants.LegacyHelloCommandName,
             "buildInfo",
             "getLastError",
             "authenticate",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsTestRunner.cs
@@ -24,6 +24,7 @@ using MongoDB.Driver.Core;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
@@ -38,7 +39,8 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
         #region static
         private static readonly HashSet<string> __commandsToNotCapture = new HashSet<string>
         {
-            "isMaster",
+            "hello",
+            OppressiveLanguageConstants.LegacyHelloCommandName,
             "buildInfo",
             "getLastError",
             "authenticate",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/CommandConstructionTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/CommandConstructionTests.cs
@@ -435,7 +435,8 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
         {
             var commandsToNotCapture = new HashSet<string>
             {
-                "isMaster",
+                "hello",
+                OppressiveLanguageConstants.LegacyHelloCommandName,
                 "buildInfo",
                 "getLastError",
                 "authenticate",

--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringIntegrationTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringIntegrationTestRunner.cs
@@ -18,7 +18,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
-using MongoDB.Driver;
 using MongoDB.Driver.Core;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/TransactionTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/TransactionTestRunner.cs
@@ -27,6 +27,7 @@ using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.TestHelpers.JsonDrivenTests;
@@ -43,7 +44,8 @@ namespace MongoDB.Driver.Tests.Specifications.transactions
         private static readonly HashSet<string> __commandsToNotCapture = new HashSet<string>
         {
             "configureFailPoint",
-            "isMaster",
+            "hello",
+            OppressiveLanguageConstants.LegacyHelloCommandName,
             "buildInfo",
             "getLastError",
             "authenticate",

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/TransactionUnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/TransactionUnifiedTestRunner.cs
@@ -27,6 +27,11 @@ namespace MongoDB.Driver.Tests.Specifications.transactions
         [ClassData(typeof(TestCaseFactory))]
         public void Run(JsonDrivenTestCase testCase)
         {
+            if (testCase.Name.Contains("mongos-unpin.json"))
+            {
+                throw new SkipException("Load balancer support not yet implemented.");
+            }
+
             using (var runner = new UnifiedTestRunner())
             {
                 runner.Run(testCase);

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
@@ -501,7 +501,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     "configureFailPoint",
                     "getLastError",
                     "getnonce",
-                    "isMaster",
+                    "hello",
+                    OppressiveLanguageConstants.LegacyHelloCommandName,
                     "saslContinue",
                     "saslStart"
                 };

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -51,6 +51,11 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 
         public void Run(JsonDrivenTestCase testCase)
         {
+            if (testCase.Name.Contains("mongos-unpin.json"))
+            {
+                throw new SkipException("Load balancer support not yet implemented.");
+            }
+
             // Top-level fields
             var schemaVersion = testCase.Shared["schemaVersion"].AsString; // cannot be null
             var testSetRunOnRequirements = testCase.Shared.GetValue("runOnRequirements", null)?.AsBsonArray;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -51,11 +51,6 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 
         public void Run(JsonDrivenTestCase testCase)
         {
-            if (testCase.Name.Contains("mongos-unpin.json"))
-            {
-                throw new SkipException("Load balancer support not yet implemented.");
-            }
-
             // Top-level fields
             var schemaVersion = testCase.Shared["schemaVersion"].AsString; // cannot be null
             var testSetRunOnRequirements = testCase.Shared.GetValue("runOnRequirements", null)?.AsBsonArray;


### PR DESCRIPTION
Running patch on latest to verify the fix:
https://spruce.mongodb.com/version/60c27902d1fe0735af1ee280/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC