### PR TITLE
CSHARP-3707: Force EG variant running all tests projects even some of them were failed.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -160,7 +160,8 @@ Task("Test")
             testProject.FullPath,
             settings
         );
-    });
+    })
+    .DeferOnError();
 
 Task("TestNet452").IsDependentOn("Test");
 Task("TestNetStandard15").IsDependentOn("Test");


### PR DESCRIPTION
Patch example: https://evergreen.mongodb.com/task_log_raw/dot_net_driver_tests_zstandard_compression__version~4.4_os~windows_64_topology~standalone_auth~noauth_ssl~nossl_compressor~zstandard_test_net452_patch_ad0ad177e25debcef9e6f1875f24d4f2c733662a_60c387852fbabe2d4ec892fb_21_06_11_15_56_07/0?type=T#L901