### PR TITLE
CSHARP-3458: Add ToAsyncEnumerable to IAsyncCursorSource

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Operations/AsyncCursorSourceEnumerableAdapter.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/AsyncCursorSourceEnumerableAdapter.cs
@@ -21,7 +21,11 @@ using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Core.Operations
 {
-    internal class AsyncCursorSourceEnumerableAdapter<TDocument> : IEnumerable<TDocument>
+    internal class AsyncCursorSourceEnumerableAdapter<TDocument> :
+#if NETSTANDARD2_1_OR_GREATER
+        IAsyncEnumerable<TDocument>,
+#endif
+        IEnumerable<TDocument>
     {
         // private fields
         private readonly CancellationToken _cancellationToken;
@@ -40,6 +44,14 @@ namespace MongoDB.Driver.Core.Operations
             var cursor = _source.ToCursor(_cancellationToken);
             return new AsyncCursorEnumerator<TDocument>(cursor, _cancellationToken);
         }
+
+#if NETSTANDARD2_1_OR_GREATER
+        public IAsyncEnumerator<TDocument> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            var cursor = _source.ToCursorAsync(cancellationToken);
+            return new AsyncCursorEnumerator<TDocument>(cursor, cancellationToken);
+        }
+#endif
 
         IEnumerator IEnumerable.GetEnumerator()
         {

--- a/src/MongoDB.Driver.Core/IAsyncCursorSource.cs
+++ b/src/MongoDB.Driver.Core/IAsyncCursorSource.cs
@@ -274,6 +274,19 @@ namespace MongoDB.Driver
             }
         }
 
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Wraps a cursor source in an IAsyncEnumerable. Each time GetAsyncEnumerator is called a new cursor is fetched from the cursor source.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <returns>An IAsyncEnumerable.</returns>
+        public static IAsyncEnumerable<TDocument> ToAsyncEnumerable<TDocument>(this IAsyncCursorSource<TDocument> source)
+        {
+            return new AsyncCursorSourceEnumerableAdapter<TDocument>(source, default(CancellationToken));
+        }
+#endif
+
         /// <summary>
         /// Wraps a cursor source in an IEnumerable. Each time GetEnumerator is called a new cursor is fetched from the cursor source.
         /// </summary>

--- a/tests/MongoDB.Driver.Core.Tests/IAsyncCursorSourceExtensionsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/IAsyncCursorSourceExtensionsTests.cs
@@ -203,6 +203,54 @@ namespace MongoDB.Driver
             action.ShouldThrow<InvalidOperationException>();
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [Theory]
+        [ParameterAttributeData]
+        public async Task ToAsyncEnumerable_result_should_be_enumerable_multiple_times(
+            [Values(1, 2)] int times)
+        {
+            var source = CreateCursorSource(2);
+            var expectedDocuments = new[]
+            {
+                new BsonDocument("_id", 0),
+                new BsonDocument("_id", 1)
+            };
+
+            IAsyncEnumerable<BsonDocument> result = null;
+            for (var i = 0; i < times; i++)
+            {
+                result = source.ToAsyncEnumerable();
+                var list = new List<BsonDocument>();
+                await foreach (var item in result)
+                {
+                    list.Add(item);
+                }
+
+                list.Should().Equal(expectedDocuments);
+            }
+        }
+
+        [Fact]
+        public async Task ToAsyncEnumerable_should_return_expected_result()
+        {
+            var source = CreateCursorSource(2);
+            var expectedDocuments = new[]
+            {
+                new BsonDocument("_id", 0),
+                new BsonDocument("_id", 1)
+            };
+
+            var result = source.ToAsyncEnumerable();
+            var list = new List<BsonDocument>();
+            await foreach (var item in result)
+            {
+                list.Add(item);
+            }
+
+            list.Should().Equal(expectedDocuments);
+        }
+#endif
+
         [Theory]
         [ParameterAttributeData]
         public void ToEnumerable_result_should_be_enumerable_multiple_times(


### PR DESCRIPTION
Slightly different from the issue, I added an API to get an instance of `ToAsyncEnumerable`, instead of directly extending any existing interfaces.

Directly extending `IAsyncCursor` or `IAsyncCursorSource` may cause conflict when users use it with [System.Linq.Async](https://www.nuget.org/packages/System.Linq.Async). See https://github.com/dotnet/efcore/issues/24041 and https://github.com/dotnet/efcore/pull/24145.

This PR only affects when users explicitly invoking `ToAsyncEnumerable`, so it does not cause any conflict.