### PR TITLE
CSHARP-3676: SRV support for load balancer mode + SDAM.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -334,6 +334,38 @@ Task("TestGssapiNetStandard15").IsDependentOn("TestGssapi");
 Task("TestGssapiNetStandard20").IsDependentOn("TestGssapi");
 Task("TestGssapiNetStandard21").IsDependentOn("TestGssapi");
 
+Task("TestLoadBalanced")
+    .IsDependentOn("Build")
+    .DoesForEach(
+        GetFiles("./**/*.Tests.csproj"),
+        testProject =>
+     {
+        var settings = new DotNetCoreTestSettings
+        {
+            NoBuild = true,
+            NoRestore = true,
+            Configuration = configuration,
+            ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
+            Filter = "Category=\"SupportLoadBalancing\""
+        };
+
+        switch (target.ToLowerInvariant())
+        {
+            case "testloadbalancednetstandard15": settings.Framework = "netcoreapp1.1"; break;
+            case "testloadbalancednetstandard20": settings.Framework = "netcoreapp2.1"; break;
+            case "testloadbalancednetstandard21": settings.Framework = "netcoreapp3.0"; break;
+        }
+
+        DotNetCoreTest(
+            testProject.FullPath,
+            settings
+        );
+     });
+ 
+Task("TestLoadBalancedNetStandard15").IsDependentOn("TestLoadBalanced");
+Task("TestLoadBalancedNetStandard20").IsDependentOn("TestLoadBalanced");
+Task("TestLoadBalancedNetStandard21").IsDependentOn("TestLoadBalanced");
+
 Task("Docs")
     .IsDependentOn("ApiDocs")
     .IsDependentOn("RefDocs");

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -242,6 +242,37 @@ functions:
           DRIVERS_TOOLS="${DRIVERS_TOOLS}" \
           sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
 
+  run-load-balancer:
+    - command: shell.exec
+      params:
+        script: |
+          DRIVERS_TOOLS=${DRIVERS_TOOLS} MONGODB_URI=${MONGODB_URI} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh start
+    - command: expansions.update
+      params:
+        file: lb-expansion.yml
+
+  run-load-balancer-tests:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "mongo-csharp-driver"
+        script: |
+          ${PREPARE_SHELL}
+          SSL=${SSL} OS=${OS} evergreen/add-certs-if-needed.sh
+          AUTH="${AUTH}" SSL="${SSL}" \
+          FRAMEWORK=${FRAMEWORK} \
+          OS=${OS} \
+          SINGLE_MONGOS_LB_URI="${SINGLE_MONGOS_LB_URI}" \
+          MULTI_MONGOS_LB_URI="${MULTI_MONGOS_LB_URI}" \
+          evergreen/run-load-balancer-tests.sh
+
+  stop-load-balancer:
+    - command: shell.exec
+      params:
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen
+          DRIVERS_TOOLS=${DRIVERS_TOOLS} MONGODB_URI=${MONGODB_URI} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh stop
+
   run-tests:
     - command: shell.exec
       type: test
@@ -675,6 +706,33 @@ tasks:
       commands:
         - func: bootstrap-mongo-orchestration
         - func: run-tests
+          vars:
+            FRAMEWORK: netstandard21
+
+    - name: test-load-balancer-netstandard15
+      commands:
+        - func: bootstrap-mongo-orchestration
+        - func: run-load-balancer
+        - func: run-load-balancer-tests
+        - func: stop-load-balancer
+          vars:
+            FRAMEWORK: netstandard15
+
+    - name: test-load-balancer-netstandard20
+      commands:
+        - func: bootstrap-mongo-orchestration
+        - func: run-load-balancer
+        - func: run-load-balancer-tests
+        - func: stop-load-balancer
+          vars:
+            FRAMEWORK: netstandard20
+        
+    - name: test-load-balancer-netstandard21
+      commands:
+        - func: bootstrap-mongo-orchestration
+        - func: run-load-balancer
+        - func: run-load-balancer-tests
+        - func: stop-load-balancer
           vars:
             FRAMEWORK: netstandard21
 
@@ -1326,6 +1384,22 @@ buildvariants:
   display_name: "PLAIN (LDAP) Auth Tests"
   tasks:
     - name: plain-auth-tests
+
+- matrix_name: tests-load-balancer
+  matrix_spec: { version: ["5.0", "latest"], auth: "noauth", ssl: "nossl", topology: "sharded-cluster", os: "ubuntu-1804" }
+  display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
+  tasks:
+    - name: "test-load-balancer-netstandard15"
+    - name: "test-load-balancer-netstandard20"
+    - name: "test-load-balancer-netstandard21"  
+    
+- matrix_name: tests-load-balancer-secure
+  matrix_spec: { version: ["5.0", "latest"], auth: "auth", ssl: "ssl", topology: "sharded-cluster", os: "ubuntu-1804" }
+  display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
+  tasks:
+    - name: "test-load-balancer-netstandard15"
+    - name: "test-load-balancer-netstandard20"
+    - name: "test-load-balancer-netstandard21"
 
 - name: atlas-connectivity-tests
   display_name: "Atlas Connectivity Tests"

--- a/evergreen/run-load-balancer-tests.sh
+++ b/evergreen/run-load-balancer-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -o xtrace  # Write all commands first to stderr
+set -o errexit # Exit the script with error if any of the commands fail
+
+# Supported/used environment variables:
+#   SSL                         Set to enable SSL. Values are "ssl" / "nossl" (default)
+#   OS                          Set to current operating system
+#   FRAMEWORK                   Set to .net framework
+#   SINGLE_MONGOS_LB_URI        Set the URI pointing to a load balancer configured with a single mongos server
+#   MULTI_MONGOS_LB_URI         Set the URI pointing to a load balancer configured with multiple mongos servers
+
+SSL=${SSL:-nossl}
+
+############################################
+#            Main Program                  #
+############################################
+
+if [[ ! "$OS" =~ Ubuntu|ubuntu ]]; then
+  echo "Unsupported OS:${OS}" 1>&2 # write to stderr
+  exit 1
+fi
+
+
+if [ "$SSL" != "nossl" ]; then 
+  SINGLE_MONGOS_LB_URI="${SINGLE_MONGOS_LB_URI}&ssl=true&tlsDisableCertificateRevocationCheck=true"
+  MULTI_MONGOS_LB_URI="${MULTI_MONGOS_LB_URI}&ssl=true&tlsDisableCertificateRevocationCheck=true" 
+fi
+
+echo "Running $AUTH tests (${FRAMEWORK}) over $SSL and connecting to SINGLE_MONGOS_LB_URI: $SINGLE_MONGOS_LB_URI or MULTI_MONGOS_LB_URI: $MULTI_MONGOS_LB_URI" 
+
+export MONGODB_URI=${SINGLE_MONGOS_LB_URI}
+export MONGODB_URI_WITH_MULTIPLE_MONGOSES=${MULTI_MONGOS_LB_URI}
+
+# show test output
+set -x
+
+./build.sh --target TestLoadBalanced${FRAMEWORK}

--- a/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
@@ -87,6 +87,7 @@ namespace MongoDB.Driver.Core.Clusters
         protected Cluster(ClusterSettings settings, IClusterableServerFactory serverFactory, IEventSubscriber eventSubscriber)
         {
             _settings = Ensure.IsNotNull(settings, nameof(settings));
+            Ensure.That(!_settings.LoadBalanced, "LoadBalanced mode is not supported.");
             _serverFactory = Ensure.IsNotNull(serverFactory, nameof(serverFactory));
             Ensure.IsNotNull(eventSubscriber, nameof(eventSubscriber));
             _state = new InterlockedInt32(State.Initial);
@@ -155,7 +156,7 @@ namespace MongoDB.Driver.Core.Clusters
 
         protected IClusterableServer CreateServer(EndPoint endPoint)
         {
-            return _serverFactory.CreateServer(_clusterId, _clusterClock, endPoint);
+            return _serverFactory.CreateServer(_settings.GetInitialClusterType(), _clusterId, _clusterClock, endPoint);
         }
 
         public void Dispose()

--- a/src/MongoDB.Driver.Core/Core/Clusters/ClusterFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/ClusterFactory.cs
@@ -40,6 +40,12 @@ namespace MongoDB.Driver.Core.Clusters
         {
             var settings = _settings;
 
+            bool createLoadBalancedCluster = settings.LoadBalanced;
+            if (createLoadBalancedCluster)
+            {
+                return CreateLoadBalancedCluster(settings);
+            }
+
             bool createSingleServerCluster;
 #pragma warning disable CS0618 // Type or member is obsolete
             if (settings.ConnectionModeSwitch == ConnectionModeSwitch.UseDirectConnection)
@@ -87,6 +93,11 @@ namespace MongoDB.Driver.Core.Clusters
         private SingleServerCluster CreateSingleServerCluster(ClusterSettings settings)
         {
             return new SingleServerCluster(settings, _serverFactory, _eventSubscriber);
+        }
+
+        private LoadBalancedCluster CreateLoadBalancedCluster(ClusterSettings setting)
+        {
+            return new LoadBalancedCluster(setting, _serverFactory, _eventSubscriber);
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Clusters/LoadBalancedCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/LoadBalancedCluster.cs
@@ -1,0 +1,333 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver.Core.Bindings;
+using MongoDB.Driver.Core.Clusters.ServerSelectors;
+using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
+using MongoDB.Libmongocrypt;
+
+namespace MongoDB.Driver.Core.Clusters
+{
+    /// <summary>
+    /// Represents the cluster that uses loadbalancing mode.
+    /// </summary>
+    internal class LoadBalancedCluster : ICluster, IDnsMonitoringCluster
+    {
+        private readonly IClusterClock _clusterClock;
+        private readonly ClusterId _clusterId;
+        private readonly ClusterType _clusterType = ClusterType.LoadBalanced;
+        private CryptClient _cryptClient = null;
+        private ClusterDescription _description;
+        private readonly IDnsMonitorFactory _dnsMonitorFactory;
+        private Thread _dnsMonitorThread;
+        private readonly CancellationTokenSource _dnsMonitorCancellationTokenSource;
+        private readonly IEventSubscriber _eventSubscriber;
+        private IClusterableServer _server;
+        private readonly IClusterableServerFactory _serverFactory;
+        private readonly TaskCompletionSource<bool> _serverReadyTaskCompletionSource;
+        private readonly ICoreServerSessionPool _serverSessionPool;
+        private readonly ClusterSettings _settings;
+        private readonly InterlockedInt32 _state;
+
+        private readonly Action<ClusterClosingEvent> _closingEventHandler;
+        private readonly Action<ClusterClosedEvent> _closedEventHandler;
+        private readonly Action<ClusterOpeningEvent> _openingEventHandler;
+        private readonly Action<ClusterOpenedEvent> _openedEventHandler;
+        private readonly Action<ClusterDescriptionChangedEvent> _descriptionChangedEventHandler;
+
+        public LoadBalancedCluster(
+            ClusterSettings settings,
+            IClusterableServerFactory serverFactory,
+            IEventSubscriber eventSubscriber)
+            : this(
+                  settings,
+                  serverFactory,
+                  eventSubscriber,
+                  dnsMonitorFactory: new DnsMonitorFactory(new EventAggregator())) // should not trigger any events
+        {
+        }
+
+        public LoadBalancedCluster(
+            ClusterSettings settings,
+            IClusterableServerFactory serverFactory,
+            IEventSubscriber eventSubscriber,
+            IDnsMonitorFactory dnsMonitorFactory)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            Ensure.That(settings.ConnectionModeSwitch != ConnectionModeSwitch.UseConnectionMode, $"{nameof(ConnectionModeSwitch.UseConnectionMode)} must not be used for a {nameof(LoadBalancedCluster)}.");
+            if (settings.ConnectionModeSwitch == ConnectionModeSwitch.UseDirectConnection)
+            {
+                Ensure.That(!settings.DirectConnection.GetValueOrDefault(), $"DirectConnection mode is not supported for {nameof(LoadBalancedCluster)}.");
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+            Ensure.That(settings.LoadBalanced, $"Only Load balanced mode is supported for a {nameof(LoadBalancedCluster)}.");
+
+            Ensure.IsEqualTo(settings.EndPoints.Count, 1, nameof(settings.EndPoints.Count));
+            Ensure.IsNull(settings.ReplicaSetName, nameof(settings.ReplicaSetName));
+
+            _clusterClock = new ClusterClock();
+            _clusterId = new ClusterId();
+
+            _dnsMonitorCancellationTokenSource = new CancellationTokenSource();
+            _dnsMonitorFactory = Ensure.IsNotNull(dnsMonitorFactory, nameof(dnsMonitorFactory));
+            _settings = Ensure.IsNotNull(settings, nameof(settings));
+
+            _serverFactory = Ensure.IsNotNull(serverFactory, nameof(serverFactory));
+            _serverReadyTaskCompletionSource = new TaskCompletionSource<bool>();
+
+            _serverSessionPool = new CoreServerSessionPool(this);
+
+            _state = new InterlockedInt32(State.Initial);
+
+            _description = ClusterDescription.CreateInitial(
+                _clusterId,
+#pragma warning disable CS0618 // Type or member is obsolete
+                ClusterConnectionMode.Automatic,
+                ConnectionModeSwitch.UseConnectionMode,
+#pragma warning restore CS0618 // Type or member is obsolete
+                null);
+
+            _eventSubscriber = eventSubscriber;
+            eventSubscriber.TryGetEventHandler(out _closingEventHandler);
+            eventSubscriber.TryGetEventHandler(out _closedEventHandler);
+            eventSubscriber.TryGetEventHandler(out _openingEventHandler);
+            eventSubscriber.TryGetEventHandler(out _openedEventHandler);
+            eventSubscriber.TryGetEventHandler(out _descriptionChangedEventHandler);
+        }
+
+        public ClusterId ClusterId => _clusterId;
+        public CryptClient CryptClient => _cryptClient;
+
+        public ClusterDescription Description => _description;
+
+        public ClusterSettings Settings => _settings;
+
+        public event EventHandler<ClusterDescriptionChangedEventArgs> DescriptionChanged;
+
+        // public methods
+        public ICoreServerSession AcquireServerSession()
+        {
+            ThrowIfDisposed();
+            return _serverSessionPool.AcquireSession();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_state.TryChange(State.Disposed))
+            {
+                if (disposing)
+                {
+                    _dnsMonitorCancellationTokenSource.Cancel();
+                    _dnsMonitorCancellationTokenSource.Dispose();
+
+                    _closingEventHandler?.Invoke(new ClusterClosingEvent(ClusterId));
+                    var stopwatch = Stopwatch.StartNew();
+                    if (_server != null)
+                    {
+                        _server.DescriptionChanged -= ServerDescriptionChangedHandler;
+                        _server.Dispose();
+                    }
+                    _closedEventHandler?.Invoke(new ClusterClosedEvent(ClusterId, stopwatch.Elapsed));
+                }
+            }
+        }
+
+        public void Initialize()
+        {
+            ThrowIfDisposed();
+
+            if (_state.TryChange(State.Initial, State.Open))
+            {
+                var stopwatch = Stopwatch.StartNew();
+                _openingEventHandler?.Invoke(new ClusterOpeningEvent(ClusterId, Settings));
+
+                if (_settings.KmsProviders != null || _settings.SchemaMap != null)
+                {
+                    _cryptClient = CryptClientCreator.CreateCryptClient(_settings.KmsProviders, _settings.SchemaMap);
+                }
+
+                var endPoint = _settings.EndPoints.Single();
+                if (_settings.Scheme != ConnectionStringScheme.MongoDBPlusSrv)
+                {
+                    _server = CreateInitializedServer(endPoint);
+                }
+                else
+                {
+                    // _server will be created after srv resolving
+                    var dnsEndPoint = (DnsEndPoint)endPoint;
+                    var lookupDomainName = dnsEndPoint.Host;
+                    var monitor = _dnsMonitorFactory.CreateDnsMonitor(this, lookupDomainName, _dnsMonitorCancellationTokenSource.Token);
+                    _dnsMonitorThread = monitor.Start();
+                }
+
+                _openedEventHandler?.Invoke(new ClusterOpenedEvent(ClusterId, Settings, stopwatch.Elapsed));
+            }
+        }
+
+        public IServer SelectServer(IServerSelector _, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            var timeoutTask = Task.Delay(_settings.ServerSelectionTimeout, cancellationToken);
+            var index = Task.WaitAny(_serverReadyTaskCompletionSource.Task, timeoutTask);
+            if (index != 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                throw CreateTimeoutException(_description); // _description will contain dnsException
+            }
+
+            return
+                _server ??
+                throw new InvalidOperationException("The server must be created before usage."); // should not be reached
+        }
+
+        public async Task<IServer> SelectServerAsync(IServerSelector _, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            var timeoutTask = Task.Delay(_settings.ServerSelectionTimeout, cancellationToken);
+            var triggeredTask = await Task.WhenAny(_serverReadyTaskCompletionSource.Task, timeoutTask).ConfigureAwait(false);
+            if (triggeredTask == timeoutTask)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                throw CreateTimeoutException(_description); // _description will contain dnsException
+            }
+
+            return
+                _server ??
+                throw new InvalidOperationException("The server must be created before usage."); // should not be reached
+        }
+
+        public ICoreSessionHandle StartSession(CoreSessionOptions options = null)
+        {
+            ThrowIfDisposed();
+
+            options = options ?? new CoreSessionOptions();
+            var serverSession = AcquireServerSession();
+            var session = new CoreSession(this, serverSession, options);
+            return new CoreSessionHandle(session);
+        }
+
+        // private method
+        private IClusterableServer CreateInitializedServer(EndPoint endPoint)
+        {
+            var server = _serverFactory.CreateServer(_clusterType, _clusterId, _clusterClock, endPoint);
+
+            var newClusterDescription = _description
+                .WithType(ClusterType.LoadBalanced)
+                .WithServerDescription(server.Description)
+                .WithDnsMonitorException(null);
+            UpdateClusterDescription(newClusterDescription);
+
+            server.DescriptionChanged += ServerDescriptionChangedHandler;
+            server.Initialize();
+            return server;
+        }
+
+        private Exception CreateTimeoutException(ClusterDescription description)
+        {
+            var ms = (int)Math.Round(_settings.ServerSelectionTimeout.TotalMilliseconds);
+            var message = string.Format(
+                "A timeout occurred after {0}ms selecting a server. Client view of cluster state is {1}.",
+                ms.ToString(),
+                description.ToString());
+            return new TimeoutException(message);
+        }
+
+        private void UpdateClusterDescription(ClusterDescription newClusterDescription)
+        {
+            var oldClusterDescription = Interlocked.CompareExchange(ref _description, newClusterDescription, _description);
+            OnClusterDescriptionChanged(oldClusterDescription, newClusterDescription, true);
+
+            void OnClusterDescriptionChanged(ClusterDescription oldDescription, ClusterDescription newDescription, bool shouldSdamClusterDescriptionChangedEventBePublished)
+            {
+                if (shouldSdamClusterDescriptionChangedEventBePublished && _descriptionChangedEventHandler != null)
+                {
+                    _descriptionChangedEventHandler(new ClusterDescriptionChangedEvent(oldDescription, newDescription));
+                }
+
+                // used only in tests and legacy
+                var handler = DescriptionChanged;
+                if (handler != null)
+                {
+                    var args = new ClusterDescriptionChangedEventArgs(oldDescription, newDescription);
+                    handler(this, args);
+                }
+            }
+        }
+
+        private void ServerDescriptionChangedHandler(object sender, ServerDescriptionChangedEventArgs e)
+        {
+            var newClusterDescription = _description.WithServerDescription(e.NewServerDescription);
+            UpdateClusterDescription(newClusterDescription);
+
+            _serverReadyTaskCompletionSource.TrySetResult(true); // the server is ready
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_state.Value == State.Disposed)
+            {
+                throw new ObjectDisposedException(nameof(LoadBalancedCluster));
+            }
+        }
+
+        void IDnsMonitoringCluster.ProcessDnsException(Exception exception)
+        {
+            var newDescription = _description.WithDnsMonitorException(exception);
+            UpdateClusterDescription(newDescription);
+        }
+
+        void IDnsMonitoringCluster.ProcessDnsResults(List<DnsEndPoint> endPoints)
+        {
+            switch (endPoints.Count)
+            {
+                case < 1:
+                    throw new InvalidOperationException("No srv records were resolved.");
+                case > 1:
+                    throw new InvalidOperationException("Load balanced mode cannot be used with multiple host names.");
+            }
+
+            var resolvedEndpoint = endPoints.Single();
+            _server = CreateInitializedServer(resolvedEndpoint);
+        }
+
+        bool IDnsMonitoringCluster.ShouldDnsMonitorStop() => true;  // we need only one successful attempt
+
+        // nested type
+        private static class State
+        {
+            public const int Initial = 0;
+            public const int Open = 1;
+            public const int Disposed = 2;
+        }
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
@@ -66,23 +66,15 @@ namespace MongoDB.Driver.Core.Clusters
 #pragma warning disable CS0618 // Type or member is obsolete
             if (settings.ConnectionModeSwitch == ConnectionModeSwitch.UseDirectConnection)
             {
-                if (settings.DirectConnection.GetValueOrDefault())
-                {
-                    throw new ArgumentException("DirectConnection is not supported for a MultiServerCluster.");
-                }
+                Ensure.That(!settings.DirectConnection.GetValueOrDefault(), "DirectConnection is not supported for a MultiServerCluster.");
             }
             else
             {
-                if (settings.ConnectionMode == ClusterConnectionMode.Standalone)
-                {
-                    throw new ArgumentException("ClusterConnectionMode.StandAlone is not supported for a MultiServerCluster.");
-                }
-                if (settings.ConnectionMode == ClusterConnectionMode.Direct)
-                {
-                    throw new ArgumentException("ClusterConnectionMode.Direct is not supported for a MultiServerCluster.");
-                }
+                Ensure.That(settings.ConnectionMode != ClusterConnectionMode.Standalone, $"{nameof(ClusterConnectionMode.Standalone)} is not supported for a {nameof(MultiServerCluster)}.");
+                Ensure.That(settings.ConnectionMode != ClusterConnectionMode.Direct, $"{nameof(ClusterConnectionMode.Direct)} is not supported for a {nameof(MultiServerCluster)}.");
             }
 #pragma warning restore CS0618 // Type or member is obsolete
+            Ensure.That(!settings.LoadBalanced, $"Load balanced mode is not supported for a {nameof(MultiServerCluster)}.");
 
             _dnsMonitorFactory = dnsMonitorFactory ?? new DnsMonitorFactory(eventSubscriber);
             _monitorServersCancellationTokenSource = new CancellationTokenSource();

--- a/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
@@ -74,7 +74,6 @@ namespace MongoDB.Driver.Core.Clusters
                 Ensure.That(settings.ConnectionMode != ClusterConnectionMode.Direct, $"{nameof(ClusterConnectionMode.Direct)} is not supported for a {nameof(MultiServerCluster)}.");
             }
 #pragma warning restore CS0618 // Type or member is obsolete
-            Ensure.That(!settings.LoadBalanced, $"Load balanced mode is not supported for a {nameof(MultiServerCluster)}.");
 
             _dnsMonitorFactory = dnsMonitorFactory ?? new DnsMonitorFactory(eventSubscriber);
             _monitorServersCancellationTokenSource = new CancellationTokenSource();

--- a/src/MongoDB.Driver.Core/Core/Clusters/ServerSelectors/ReadPreferenceServerSelector.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/ServerSelectors/ReadPreferenceServerSelector.cs
@@ -90,6 +90,7 @@ namespace MongoDB.Driver.Core.Clusters.ServerSelectors
                 case ClusterType.Sharded: return SelectForShardedCluster(servers);
                 case ClusterType.Standalone: return SelectForStandaloneCluster(servers);
                 case ClusterType.Unknown: return __noServers;
+                case ClusterType.LoadBalanced: return SelectForLoadBalancedCluster(servers);
                 default:
                     var message = string.Format("ReadPreferenceServerSelector is not implemented for cluster of type: {0}.", cluster.Type);
                     throw new NotImplementedException(message);
@@ -182,6 +183,11 @@ namespace MongoDB.Driver.Core.Clusters.ServerSelectors
         private IEnumerable<ServerDescription> SelectForStandaloneCluster(IEnumerable<ServerDescription> servers)
         {
             return servers.Where(n => n.Type == ServerType.Standalone); // standalone servers match any ReadPreference (to facilitate testing)
+        }
+
+        private IEnumerable<ServerDescription> SelectForLoadBalancedCluster(IEnumerable<ServerDescription> servers)
+        {
+            return servers.Where(n => n.Type == ServerType.LoadBalanced);
         }
 
         private List<ServerDescription> SelectPrimary(IEnumerable<ServerDescription> servers)

--- a/src/MongoDB.Driver.Core/Core/Clusters/ServerSelectors/WritableServerSelector.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/ServerSelectors/WritableServerSelector.cs
@@ -55,10 +55,7 @@ namespace MongoDB.Driver.Core.Clusters.ServerSelectors
                 return servers;
             }
 
-            return servers.Where(x =>
-                x.Type == ServerType.ReplicaSetPrimary ||
-                x.Type == ServerType.ShardRouter ||
-                x.Type == ServerType.Standalone);
+            return servers.Where(x => x.Type.IsWritable());
         }
 
         /// <inheritdoc/>

--- a/src/MongoDB.Driver.Core/Core/Clusters/SingleServerCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/SingleServerCluster.cs
@@ -49,6 +49,8 @@ namespace MongoDB.Driver.Core.Clusters
             Ensure.IsEqualTo(settings.EndPoints.Count, 1, "settings.EndPoints.Count");
             _replicaSetName = settings.ReplicaSetName;  // can be null
 
+            Ensure.That(!settings.LoadBalanced, $"Load balanced mode is not supported for a {nameof(SingleServerCluster)}.");
+
             _state = new InterlockedInt32(State.Initial);
 
             eventSubscriber.TryGetEventHandler(out _closingEventHandler);

--- a/src/MongoDB.Driver.Core/Core/Clusters/SingleServerCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/SingleServerCluster.cs
@@ -49,8 +49,6 @@ namespace MongoDB.Driver.Core.Clusters
             Ensure.IsEqualTo(settings.EndPoints.Count, 1, "settings.EndPoints.Count");
             _replicaSetName = settings.ReplicaSetName;  // can be null
 
-            Ensure.That(!settings.LoadBalanced, $"Load balanced mode is not supported for a {nameof(SingleServerCluster)}.");
-
             _state = new InterlockedInt32(State.Initial);
 
             eventSubscriber.TryGetEventHandler(out _closingEventHandler);

--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilderExtensions.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilderExtensions.cs
@@ -214,7 +214,14 @@ namespace MongoDB.Driver.Core.Configuration
             var connectionModeSwitch = connectionString.ConnectionModeSwitch;
             var connectionMode = connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode ? connectionString.Connect : default;
             var directConnection = connectionModeSwitch == ConnectionModeSwitch.UseDirectConnection ? connectionString.DirectConnection : default;
-            builder = builder.ConfigureCluster(s => s.With(connectionMode: connectionMode, connectionModeSwitch: connectionModeSwitch, directConnection: directConnection, scheme: connectionString.Scheme));
+            builder = builder.ConfigureCluster(
+                s =>
+                    s.With(
+                        connectionMode: connectionMode,
+                        connectionModeSwitch: connectionModeSwitch,
+                        directConnection: directConnection,
+                        scheme: connectionString.Scheme,
+                        loadBalanced: connectionString.LoadBalanced));
 #pragma warning restore CS0618 // Type or member is obsolete
             if (connectionString.Hosts.Count > 0)
             {

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionSettings.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver.Core.Configuration
         private readonly string _applicationName;
         private readonly IReadOnlyList<IAuthenticatorFactory> _authenticatorFactories;
         private readonly IReadOnlyList<CompressorConfiguration> _compressors;
+        private readonly bool _loadBalanced;
         private readonly TimeSpan _maxIdleTime;
         private readonly TimeSpan _maxLifeTime;
 
@@ -40,18 +41,21 @@ namespace MongoDB.Driver.Core.Configuration
         /// </summary>
         /// <param name="authenticatorFactories">The authenticator factories.</param>
         /// <param name="compressors">The compressors.</param>
+        /// <param name="loadBalanced">Whether the load balanced mode is enabled.</param>
         /// <param name="maxIdleTime">The maximum idle time.</param>
         /// <param name="maxLifeTime">The maximum life time.</param>
         /// <param name="applicationName">The application name.</param>
         public ConnectionSettings(
             Optional<IEnumerable<IAuthenticatorFactory>> authenticatorFactories = default,
             Optional<IEnumerable<CompressorConfiguration>> compressors = default(Optional<IEnumerable<CompressorConfiguration>>),
+            Optional<bool> loadBalanced = default,
             Optional<TimeSpan> maxIdleTime = default(Optional<TimeSpan>),
             Optional<TimeSpan> maxLifeTime = default(Optional<TimeSpan>),
             Optional<string> applicationName = default(Optional<string>))
         {
             _authenticatorFactories = Ensure.IsNotNull(authenticatorFactories.WithDefault(Enumerable.Empty<IAuthenticatorFactory>()), nameof(authenticatorFactories)).ToList().AsReadOnly();
             _compressors = Ensure.IsNotNull(compressors.WithDefault(Enumerable.Empty<CompressorConfiguration>()), nameof(compressors)).ToList();
+            _loadBalanced = loadBalanced.WithDefault(false);
             _maxIdleTime = Ensure.IsGreaterThanZero(maxIdleTime.WithDefault(TimeSpan.FromMinutes(10)), "maxIdleTime");
             _maxLifeTime = Ensure.IsGreaterThanZero(maxLifeTime.WithDefault(TimeSpan.FromMinutes(30)), "maxLifeTime");
             _applicationName = ApplicationNameHelper.EnsureApplicationNameIsValid(applicationName.WithDefault(null), nameof(applicationName));
@@ -92,6 +96,14 @@ namespace MongoDB.Driver.Core.Configuration
         }
 
         /// <summary>
+        /// Whether the load balanced mode is enabled.
+        /// </summary>
+        public bool LoadBalanced
+        {
+            get { return _loadBalanced; }
+        }
+
+        /// <summary>
         /// Gets the maximum idle time.
         /// </summary>
         /// <value>
@@ -119,6 +131,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// </summary>
         /// <param name="authenticatorFactories">The authenticator factories.</param>
         /// <param name="compressors">The compressors.</param>
+        /// <param name="loadBalanced">Whether the load balanced mode is enabled.</param>
         /// <param name="maxIdleTime">The maximum idle time.</param>
         /// <param name="maxLifeTime">The maximum life time.</param>
         /// <param name="applicationName">The application name.</param>
@@ -126,6 +139,7 @@ namespace MongoDB.Driver.Core.Configuration
         public ConnectionSettings With(
             Optional<IEnumerable<IAuthenticatorFactory>> authenticatorFactories = default,
             Optional<IEnumerable<CompressorConfiguration>> compressors = default(Optional<IEnumerable<CompressorConfiguration>>),
+            Optional<bool> loadBalanced = default,
             Optional<TimeSpan> maxIdleTime = default(Optional<TimeSpan>),
             Optional<TimeSpan> maxLifeTime = default(Optional<TimeSpan>),
             Optional<string> applicationName = default(Optional<string>))
@@ -133,6 +147,7 @@ namespace MongoDB.Driver.Core.Configuration
             return new ConnectionSettings(
                 authenticatorFactories: Optional.Enumerable(authenticatorFactories.WithDefault(_authenticatorFactories)),
                 compressors: Optional.Enumerable(compressors.WithDefault(_compressors)),
+                loadBalanced: loadBalanced.WithDefault(_loadBalanced),
                 maxIdleTime: maxIdleTime.WithDefault(_maxIdleTime),
                 maxLifeTime: maxLifeTime.WithDefault(_maxLifeTime),
                 applicationName: applicationName.WithDefault(_applicationName));

--- a/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
+++ b/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
@@ -17,6 +17,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Events;
@@ -388,6 +389,17 @@ namespace MongoDB.Driver.Core.ConnectionPools
                 ThrowIfDisposed();
                 throw new InvalidOperationException("ConnectionPool must be initialized.");
             }
+        }
+
+        public void Clear(ObjectId serviceId)
+        {
+            ThrowIfNotOpen();
+
+            _clearingEventHandler?.Invoke(new ConnectionPoolClearingEvent(_serverId, _settings));
+
+            // TODO: temporary reverted
+
+            _clearedEventHandler?.Invoke(new ConnectionPoolClearedEvent(_serverId, _settings));
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/ConnectionPools/IConnectionPool.cs
+++ b/src/MongoDB.Driver.Core/Core/ConnectionPools/IConnectionPool.cs
@@ -20,6 +20,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Servers;
 
@@ -66,6 +67,11 @@ namespace MongoDB.Driver.Core.ConnectionPools
         /// Clears the connection pool.
         /// </summary>
         void Clear();
+
+        /// <summary>
+        /// Clears the connection pool.
+        /// </summary>
+        void Clear(ObjectId serviceId);
 
         /// <summary>
         /// Initializes the connection pool.

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -288,7 +288,9 @@ namespace MongoDB.Driver.Core.Connections
                 helper.OpeningConnection();
                 _stream = _streamFactory.CreateStream(_endPoint, cancellationToken);
                 helper.InitializingConnection();
-                _description = _connectionInitializer.InitializeConnection(this, cancellationToken);
+                _description = _connectionInitializer.Handshake(this, cancellationToken);
+                // we always need to have access to description after handshake regardless furher errors
+                _description = _connectionInitializer.ConnectionAuthentication(this, _description, cancellationToken);
                 _sendCompressorType = ChooseSendCompressorTypeIfAny(_description);
 
                 helper.OpenedConnection();
@@ -309,7 +311,9 @@ namespace MongoDB.Driver.Core.Connections
                 helper.OpeningConnection();
                 _stream = await _streamFactory.CreateStreamAsync(_endPoint, cancellationToken).ConfigureAwait(false);
                 helper.InitializingConnection();
-                _description = await _connectionInitializer.InitializeConnectionAsync(this, cancellationToken).ConfigureAwait(false);
+                _description = await _connectionInitializer.HandshakeAsync(this, cancellationToken).ConfigureAwait(false);
+                // we always need to have access to description after handshake regardless furher errors
+                _description = await _connectionInitializer.ConnectionAuthenticationAsync(this, _description, cancellationToken).ConfigureAwait(false);
                 _sendCompressorType = ChooseSendCompressorTypeIfAny(_description);
 
                 helper.OpenedConnection();

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -299,7 +299,6 @@ namespace MongoDB.Driver.Core.Connections
             }
             catch (Exception ex)
             {
-                // if we have successful handshake description, we should propogate it to upper levels
                 _description ??= handshakeDescription;
                 var wrappedException = WrapException(ex, "opening a connection to the server");
                 helper.FailedOpeningConnection(wrappedException);
@@ -326,8 +325,7 @@ namespace MongoDB.Driver.Core.Connections
             }
             catch (Exception ex)
             {
-                // if we have successful handshake description, we should propogate it to upper levels
-                _description = handshakeDescription;
+                _description ??= handshakeDescription;
                 var wrappedException = WrapException(ex, "opening a connection to the server");
                 helper.FailedOpeningConnection(wrappedException);
                 throw wrappedException;

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -291,7 +291,6 @@ namespace MongoDB.Driver.Core.Connections
                 _stream = _streamFactory.CreateStream(_endPoint, cancellationToken);
                 helper.InitializingConnection();
                 handshakeDescription = _connectionInitializer.SendHello(this, cancellationToken);
-                // we always need to have access to description after handshake regardless furher errors
                 _description = _connectionInitializer.Authenticate(this, handshakeDescription, cancellationToken);
                 _sendCompressorType = ChooseSendCompressorTypeIfAny(_description);
 
@@ -317,7 +316,6 @@ namespace MongoDB.Driver.Core.Connections
                 _stream = await _streamFactory.CreateStreamAsync(_endPoint, cancellationToken).ConfigureAwait(false);
                 helper.InitializingConnection();
                 handshakeDescription = await _connectionInitializer.SendHelloAsync(this, cancellationToken).ConfigureAwait(false);
-                // we always need to have access to description after handshake regardless furher errors
                 _description = await _connectionInitializer.AuthenticateAsync(this, handshakeDescription, cancellationToken).ConfigureAwait(false);
                 _sendCompressorType = ChooseSendCompressorTypeIfAny(_description);
 

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionDescription.cs
@@ -15,7 +15,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Shared;
@@ -36,6 +36,7 @@ namespace MongoDB.Driver.Core.Connections
         private readonly int _maxDocumentSize;
         private readonly int _maxMessageSize;
         private readonly SemanticVersion _serverVersion;
+        private readonly ObjectId? _serviceId;
 
         // constructors
         /// <summary>
@@ -54,6 +55,7 @@ namespace MongoDB.Driver.Core.Connections
             _maxBatchCount = isMasterResult.MaxBatchCount;
             _maxDocumentSize = isMasterResult.MaxDocumentSize;
             _maxMessageSize = isMasterResult.MaxMessageSize;
+            _serviceId = isMasterResult.ServiceId;
             _serverVersion = buildInfoResult.ServerVersion;
         }
 
@@ -152,6 +154,17 @@ namespace MongoDB.Driver.Core.Connections
         public SemanticVersion ServerVersion
         {
             get { return _serverVersion; }
+        }
+
+        /// <summary>
+        /// Gets the service identifier.
+        /// </summary>
+        /// <value>
+        /// The service identifier.
+        /// </value>
+        public ObjectId? ServiceId
+        {
+            get { return _serviceId; }
         }
 
         // methods

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
@@ -46,43 +46,7 @@ namespace MongoDB.Driver.Core.Connections
             _serverApi = serverApi;
         }
 
-        public ConnectionDescription Handshake(IConnection connection, CancellationToken cancellationToken)
-        {
-            Ensure.IsNotNull(connection, nameof(connection));
-            var authenticators = GetAuthenticators(connection.Settings);
-            var helloCommand = CreateInitialHelloCommand(authenticators, connection.Settings.LoadBalanced);
-            var helloProtocol = HelloHelper.CreateProtocol(helloCommand, _serverApi);
-            var helloResult = HelloHelper.GetResult(connection, helloProtocol, cancellationToken);
-            if (connection.Settings.LoadBalanced && !helloResult.ServiceId.HasValue)
-            {
-                throw new InvalidOperationException("Driver attempted to initialize in load balancing mode, but the server does not support this mode.");
-            }
-
-            var buildInfoProtocol = CreateBuildInfoProtocol(_serverApi);
-            var buildInfoResult = new BuildInfoResult(buildInfoProtocol.Execute(connection, cancellationToken));
-
-            return new ConnectionDescription(connection.ConnectionId, helloResult, buildInfoResult);
-        }
-
-        public async Task<ConnectionDescription> HandshakeAsync(IConnection connection, CancellationToken cancellationToken)
-        {
-            Ensure.IsNotNull(connection, nameof(connection));
-            var authenticators = GetAuthenticators(connection.Settings);
-            var helloCommand = CreateInitialHelloCommand(authenticators, connection.Settings.LoadBalanced);
-            var helloProtocol = HelloHelper.CreateProtocol(helloCommand, _serverApi);
-            var helloResult = await HelloHelper.GetResultAsync(connection, helloProtocol, cancellationToken).ConfigureAwait(false);
-            if (connection.Settings.LoadBalanced && !helloResult.ServiceId.HasValue)
-            {
-                throw new InvalidOperationException("Driver attempted to initialize in load balancing mode, but the server does not support this mode.");
-            }
-
-            var buildInfoProtocol = CreateBuildInfoProtocol(_serverApi);
-            var buildInfoResult = new BuildInfoResult(await buildInfoProtocol.ExecuteAsync(connection, cancellationToken).ConfigureAwait(false));
-
-            return new ConnectionDescription(connection.ConnectionId, helloResult, buildInfoResult);
-        }
-
-        public ConnectionDescription ConnectionAuthentication(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken)
+        public ConnectionDescription Authenticate(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken)
         {
             Ensure.IsNotNull(connection, nameof(connection));
             Ensure.IsNotNull(description, nameof(description));
@@ -113,7 +77,7 @@ namespace MongoDB.Driver.Core.Connections
             return description;
         }
 
-        public async Task<ConnectionDescription> ConnectionAuthenticationAsync(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken)
+        public async Task<ConnectionDescription> AuthenticateAsync(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken)
         {
             Ensure.IsNotNull(connection, nameof(connection));
             Ensure.IsNotNull(description, nameof(description));
@@ -144,6 +108,42 @@ namespace MongoDB.Driver.Core.Connections
             }
 
             return description;
+        }
+
+        public ConnectionDescription SendHello(IConnection connection, CancellationToken cancellationToken)
+        {
+            Ensure.IsNotNull(connection, nameof(connection));
+            var authenticators = GetAuthenticators(connection.Settings);
+            var helloCommand = CreateInitialHelloCommand(authenticators, connection.Settings.LoadBalanced);
+            var helloProtocol = HelloHelper.CreateProtocol(helloCommand, _serverApi);
+            var helloResult = HelloHelper.GetResult(connection, helloProtocol, cancellationToken);
+            if (connection.Settings.LoadBalanced && !helloResult.ServiceId.HasValue)
+            {
+                throw new InvalidOperationException("Driver attempted to initialize in load balancing mode, but the server does not support this mode.");
+            }
+
+            var buildInfoProtocol = CreateBuildInfoProtocol(_serverApi);
+            var buildInfoResult = new BuildInfoResult(buildInfoProtocol.Execute(connection, cancellationToken));
+
+            return new ConnectionDescription(connection.ConnectionId, helloResult, buildInfoResult);
+        }
+
+        public async Task<ConnectionDescription> SendHelloAsync(IConnection connection, CancellationToken cancellationToken)
+        {
+            Ensure.IsNotNull(connection, nameof(connection));
+            var authenticators = GetAuthenticators(connection.Settings);
+            var helloCommand = CreateInitialHelloCommand(authenticators, connection.Settings.LoadBalanced);
+            var helloProtocol = HelloHelper.CreateProtocol(helloCommand, _serverApi);
+            var helloResult = await HelloHelper.GetResultAsync(connection, helloProtocol, cancellationToken).ConfigureAwait(false);
+            if (connection.Settings.LoadBalanced && !helloResult.ServiceId.HasValue)
+            {
+                throw new InvalidOperationException("Driver attempted to initialize in load balancing mode, but the server does not support this mode.");
+            }
+
+            var buildInfoProtocol = CreateBuildInfoProtocol(_serverApi);
+            var buildInfoResult = new BuildInfoResult(await buildInfoProtocol.ExecuteAsync(connection, cancellationToken).ConfigureAwait(false));
+
+            return new ConnectionDescription(connection.ConnectionId, helloResult, buildInfoResult);
         }
 
         // private methods

--- a/src/MongoDB.Driver.Core/Core/Connections/HelloHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/HelloHelper.cs
@@ -43,7 +43,7 @@ namespace MongoDB.Driver.Core.Connections
             return command.Add("compression", compressorsArray);
         }
 
-        internal static BsonDocument CreateCommand(ServerApi serverApi, TopologyVersion topologyVersion = null, TimeSpan? maxAwaitTime = null)
+        internal static BsonDocument CreateCommand(ServerApi serverApi, TopologyVersion topologyVersion = null, TimeSpan? maxAwaitTime = null, bool loadBalanced = false)
         {
             Ensure.That(
                 (topologyVersion == null && !maxAwaitTime.HasValue) ||
@@ -55,7 +55,8 @@ namespace MongoDB.Driver.Core.Connections
             {
                 { helloCommandName, 1 },
                 { "topologyVersion", () => topologyVersion.ToBsonDocument(), topologyVersion != null },
-                { "maxAwaitTimeMS", () => (long)maxAwaitTime.Value.TotalMilliseconds, maxAwaitTime.HasValue }
+                { "maxAwaitTimeMS", () => (long)maxAwaitTime.Value.TotalMilliseconds, maxAwaitTime.HasValue },
+                { "loadBalanced", true, loadBalanced }
             };
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/IConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IConnectionInitializer.cs
@@ -13,16 +13,17 @@
 * limitations under the License.
 */
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-using MongoDB.Driver.Core.Servers;
 
 namespace MongoDB.Driver.Core.Connections
 {
     internal interface IConnectionInitializer
     {
-        ConnectionDescription InitializeConnection(IConnection connection, CancellationToken cancellationToken);
-        Task<ConnectionDescription> InitializeConnectionAsync(IConnection connection, CancellationToken cancellationToken);
+        ConnectionDescription Handshake(IConnection connection, CancellationToken cancellationToken);
+        ConnectionDescription ConnectionAuthentication(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken);
+
+        Task<ConnectionDescription> HandshakeAsync(IConnection connection, CancellationToken cancellationToken);
+        Task<ConnectionDescription> ConnectionAuthenticationAsync(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken);
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Connections/IConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IConnectionInitializer.cs
@@ -20,10 +20,9 @@ namespace MongoDB.Driver.Core.Connections
 {
     internal interface IConnectionInitializer
     {
-        ConnectionDescription Handshake(IConnection connection, CancellationToken cancellationToken);
-        ConnectionDescription ConnectionAuthentication(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken);
-
-        Task<ConnectionDescription> HandshakeAsync(IConnection connection, CancellationToken cancellationToken);
-        Task<ConnectionDescription> ConnectionAuthenticationAsync(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken);
+        ConnectionDescription Authenticate(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken);
+        Task<ConnectionDescription> AuthenticateAsync(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken);
+        ConnectionDescription SendHello(IConnection connection, CancellationToken cancellationToken);
+        Task<ConnectionDescription> SendHelloAsync(IConnection connection, CancellationToken cancellationToken);
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -338,8 +338,9 @@ namespace MongoDB.Driver.Core.Connections
         {
             get
             {
-                return TopologyVersion?.ProcessId; // TODO: uncomment the below line when the server will support serviceId
-                    //_wrapped.TryGetValue("serviceId", out var serviceIdBsonValue) ? ObjectId.Parse(serviceIdBsonValue.ToString()) : null;
+                return _wrapped.TryGetValue("serviceId", out var serviceIdBsonValue)
+                    ? ObjectId.Parse(serviceIdBsonValue.ToString())
+                    : TopologyVersion?.ProcessId; // TODO: should be just null when the server will support serviceId;
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -338,9 +338,22 @@ namespace MongoDB.Driver.Core.Connections
         {
             get
             {
-                return _wrapped.TryGetValue("serviceId", out var serviceIdBsonValue)
-                    ? ObjectId.Parse(serviceIdBsonValue.ToString())
-                    : TopologyVersion?.ProcessId; // TODO: should be just null when the server will support serviceId;
+                if (_wrapped.TryGetValue("serviceId", out var serviceIdBsonValue))
+                {
+                    return ObjectId.Parse(serviceIdBsonValue.ToString());
+                }
+                else
+                {
+                    if (ServiceIdHelper.IsServiceIdEmulationEnabled)
+                    {
+                        // TODO: temporary solution until server will actually support serviceId
+                        return TopologyVersion?.ProcessId;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -319,7 +319,27 @@ namespace MongoDB.Driver.Core.Connections
                     return ServerType.ShardRouter;
                 }
 
+                if (ServiceId != null)
+                {
+                    return ServerType.LoadBalanced; // TODO: change when Service Id will be supported by server
+                }
+
                 return ServerType.Standalone;
+            }
+        }
+
+        /// <summary>
+        /// Gets the service identifier.
+        /// </summary>
+        /// <value>
+        /// The service identifier.
+        /// </value>
+        public ObjectId? ServiceId
+        {
+            get
+            {
+                return TopologyVersion?.ProcessId; // TODO: uncomment the below line when the server will support serviceId
+                    //_wrapped.TryGetValue("serviceId", out var serviceIdBsonValue) ? ObjectId.Parse(serviceIdBsonValue.ToString()) : null;
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Operations/ReadConcernHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ReadConcernHelper.cs
@@ -35,7 +35,7 @@ namespace MongoDB.Driver.Core.Operations
         // private static methods
         private static BsonDocument ToBsonDocument(ICoreSession session, ConnectionDescription connectionDescription, ReadConcern readConcern)
         {
-            var sessionsAreSupported = connectionDescription.IsMasterResult.LogicalSessionTimeout != null;
+            var sessionsAreSupported = connectionDescription.IsMasterResult.LogicalSessionTimeout != null || connectionDescription.ServiceId.HasValue;
             var shouldSendAfterClusterTime = sessionsAreSupported && session.IsCausallyConsistent && session.OperationTime != null;
             var shouldSendReadConcern = !readConcern.IsServerDefault || shouldSendAfterClusterTime;
 

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableWriteOperationExecutor.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableWriteOperationExecutor.cs
@@ -135,9 +135,10 @@ namespace MongoDB.Driver.Core.Operations
 
         private static bool AreRetryableWritesSupported(ConnectionDescription connectionDescription)
         {
+            var isMasterResult = connectionDescription.IsMasterResult;
             return
-                connectionDescription.IsMasterResult.LogicalSessionTimeout != null &&
-                connectionDescription.IsMasterResult.ServerType != ServerType.Standalone;
+                isMasterResult.ServerType == ServerType.LoadBalanced ||
+                (isMasterResult.LogicalSessionTimeout != null && isMasterResult.ServerType != ServerType.Standalone);
         }
 
         private static bool DoesContextAllowRetries(RetryableWriteContext context)

--- a/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
@@ -175,7 +175,7 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
-        protected override void Initializing()
+        protected override void InitializeSubClass()
         {
             _monitor.DescriptionChanged += OnMonitorDescriptionChanged;
             _monitor.Initialize();

--- a/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
@@ -1,0 +1,281 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using MongoDB.Bson;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.ConnectionPools;
+using MongoDB.Driver.Core.Connections;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Misc;
+
+namespace MongoDB.Driver.Core.Servers
+{
+    internal class DefaultServer : Server
+    {
+        #region static
+        // static fields
+        private static readonly List<Type> __invalidatingExceptions = new List<Type>
+        {
+            typeof(MongoConnectionException),
+            typeof(SocketException),
+            typeof(EndOfStreamException),
+            typeof(IOException),
+        };
+        #endregion
+
+        private readonly ServerDescription _baseDescription;
+        private ServerDescription _currentDescription;
+        private readonly IServerMonitor _monitor;
+
+        public DefaultServer(
+            ClusterId clusterId,
+            IClusterClock clusterClock,
+#pragma warning disable CS0618 // Type or member is obsolete
+            ClusterConnectionMode clusterConnectionMode,
+            ConnectionModeSwitch connectionModeSwitch,
+#pragma warning restore CS0618 // Type or member is obsolete
+            bool? directConnection,
+            ServerSettings settings,
+            EndPoint endPoint,
+            IConnectionPoolFactory connectionPoolFactory,
+            IServerMonitorFactory monitorFactory,
+            IEventSubscriber eventSubscriber,
+            ServerApi serverApi)
+            : base(
+                  clusterId,
+                  clusterClock,
+                  clusterConnectionMode,
+                  connectionModeSwitch,
+                  directConnection,
+                  settings,
+                  endPoint,
+                  connectionPoolFactory,
+                  eventSubscriber,
+                  serverApi)
+        {
+            _monitor = Ensure.IsNotNull(monitorFactory, nameof(monitorFactory)).Create(ServerId, endPoint);
+            _baseDescription = _currentDescription = new ServerDescription(ServerId, endPoint, reasonChanged: "ServerInitialDescription", heartbeatInterval: settings.HeartbeatInterval);
+        }
+
+        // properties
+        public override ServerDescription Description => Interlocked.CompareExchange(ref _currentDescription, value: null, comparand: null);
+
+        // public methods
+        public override void Initializing()
+        {
+            _monitor.DescriptionChanged += OnMonitorDescriptionChanged;
+            _monitor.Initialize();
+        }
+
+        public override void Invalidate(string reasonInvalidated, bool clearConnectionPool, TopologyVersion topologyVersion)
+        {
+            if (clearConnectionPool)
+            {
+                ConnectionPool.Clear();
+            }
+            var newDescription = _baseDescription.With(
+                    $"InvalidatedBecause:{reasonInvalidated}",
+                    lastUpdateTimestamp: DateTime.UtcNow,
+                    topologyVersion: topologyVersion);
+            SetDescription(newDescription);
+            // TODO: make the heartbeat request conditional so we adhere to this part of the spec
+            // > Network error when reading or writing: ... Clients MUST NOT request an immediate check of the server;
+            // > since application sockets are used frequently, a network error likely means the server has just become
+            // > unavailable, so an immediate refresh is likely to get a network error, too.
+            RequestHeartbeat();
+        }
+
+        public override void RequestHeartbeat()
+        {
+            _monitor.RequestHeartbeat();
+        }
+
+        // protected methods
+        protected override void Dispose(bool disposing)
+        {
+            _monitor.Dispose();
+            _monitor.DescriptionChanged -= OnMonitorDescriptionChanged;
+        }
+
+        protected override void HandleBeforeHandshakeCompletesException(Exception ex)
+        {
+            if (ex is MongoAuthenticationException)
+            {
+                ConnectionPool.Clear();
+                return;
+            }
+
+            if (ex is MongoConnectionException mongoConnectionException)
+            {
+                lock (_monitor.Lock)
+                {
+                    if (mongoConnectionException.Generation != null &&
+                        mongoConnectionException.Generation != ConnectionPool.Generation)
+                    {
+                        return; // stale generation number
+                    }
+
+                    if (mongoConnectionException.IsNetworkException &&
+                        !mongoConnectionException.ContainsTimeoutException)
+                    {
+                        _monitor.CancelCurrentCheck();
+                    }
+
+                    if (mongoConnectionException.IsNetworkException || mongoConnectionException.ContainsTimeoutException)
+                    {
+                        Invalidate($"ChannelException during handshake: {ex}.", clearConnectionPool: true, topologyVersion: null);
+                    }
+                }
+            }
+        }
+
+        protected override void HandleAfterHandshakeCompletesException(IConnection connection, Exception ex)
+        {
+            lock (_monitor.Lock)
+            {
+                if (ex is MongoConnectionException mongoConnectionException)
+                {
+                    if (mongoConnectionException.Generation != null &&
+                        mongoConnectionException.Generation != ConnectionPool.Generation)
+                    {
+                        return; // stale generation number
+                    }
+
+                    if (mongoConnectionException.IsNetworkException &&
+                        !mongoConnectionException.ContainsTimeoutException)
+                    {
+                        _monitor.CancelCurrentCheck();
+                    }
+                }
+
+                var description = Description; // use Description property to access _description value safely
+                if (ShouldInvalidateServer(connection, ex, description, out TopologyVersion responseTopologyVersion))
+                {
+                    var shouldClearConnectionPool = ShouldClearConnectionPoolForChannelException(ex, connection.Description.ServerVersion);
+                    Invalidate($"ChannelException:{ex}", shouldClearConnectionPool, responseTopologyVersion);
+                }
+                else
+                {
+                    RequestHeartbeat();
+                }
+            }
+        }
+
+        // private methods
+        private void OnMonitorDescriptionChanged(object sender, ServerDescriptionChangedEventArgs e)
+        {
+            var currentDescription = Interlocked.CompareExchange(ref _currentDescription, value: null, comparand: null);
+
+            var heartbeatException = e.NewServerDescription.HeartbeatException;
+            // The heartbeat commands are hello/isMaster + buildInfo. These commands will throw a MongoCommandException on
+            // {ok: 0}, but a reply (with a potential topologyVersion) will still have been received.
+            // Not receiving a reply to the heartbeat commands implies a network error or a "HeartbeatFailed" type
+            // exception (i.e. ServerDescription.WithHeartbeatException was called), in which case we should immediately
+            // set the description to "Unknown"// (which is what e.NewServerDescription will be in such a case)
+            var heartbeatReplyNotReceived = heartbeatException != null && !(heartbeatException is MongoCommandException);
+
+            // We cannot use FresherThan(e.NewServerDescription.TopologyVersion, currentDescription.TopologyVersion)
+            // because due to how TopologyVersions comparisons are defined, IsStalerThanOrEqualTo(x, y) does not imply
+            // FresherThan(y, x)
+            if (heartbeatReplyNotReceived ||
+                TopologyVersion.IsStalerThanOrEqualTo(currentDescription.TopologyVersion, e.NewServerDescription.TopologyVersion))
+            {
+                SetDescription(e.NewServerDescription);
+            }
+        }
+
+        private void SetDescription(ServerDescription newDescription)
+        {
+            var oldDescription = Interlocked.CompareExchange(ref _currentDescription, value: newDescription, comparand: _currentDescription);
+            OnDescriptionChanged(sender: this, new ServerDescriptionChangedEventArgs(oldDescription, newDescription));
+        }
+
+        private void OnDescriptionChanged(object sender, ServerDescriptionChangedEventArgs e)
+        {
+            if (e.NewServerDescription.HeartbeatException != null)
+            {
+                ConnectionPool.Clear();
+            }
+
+            // propagate event to upper levels
+            TriggerServerDescriptionChanged(this, e);
+        }
+
+        private bool ShouldInvalidateServer(
+            IConnection connection,
+            Exception exception,
+            ServerDescription description,
+            out TopologyVersion invalidatingResponseTopologyVersion)
+        {
+            if (exception is MongoConnectionException mongoConnectionException &&
+                mongoConnectionException.ContainsTimeoutException)
+            {
+                invalidatingResponseTopologyVersion = null;
+                return false;
+            }
+
+            if (__invalidatingExceptions.Contains(exception.GetType()))
+            {
+                invalidatingResponseTopologyVersion = null;
+                return true;
+            }
+
+            var exceptionsToCheck = new[]
+            {
+                exception as MongoCommandException,
+                (exception as MongoWriteConcernException)?.MappedWriteConcernResultException
+            }
+            .OfType<MongoCommandException>();
+            foreach (MongoCommandException commandException in exceptionsToCheck)
+            {
+                if (IsStateChangeException(commandException))
+                {
+                    return !IsStaleStateChangeError(commandException.Result, out invalidatingResponseTopologyVersion);
+                }
+            }
+
+            invalidatingResponseTopologyVersion = null;
+            return false;
+
+            bool IsStaleStateChangeError(BsonDocument response, out TopologyVersion nonStaleResponseTopologyVersion)
+            {
+                if (ConnectionPool.Generation > connection.Generation)
+                {
+                    // stale generation number
+                    nonStaleResponseTopologyVersion = null;
+                    return true;
+                }
+
+                var responseTopologyVersion = TopologyVersion.FromMongoCommandResponse(response);
+                // We use FresherThanOrEqualTo instead of FresherThan because a state change should come with a new
+                // topology version.
+                // We cannot use StalerThan(responseTopologyVersion, description.TopologyVersion) because due to how
+                // TopologyVersions comparisons are defined, FresherThanOrEqualTo(x, y) does not imply StalerThan(y, x)
+                bool isStale = TopologyVersion.IsFresherThanOrEqualTo(description.TopologyVersion, responseTopologyVersion);
+
+                nonStaleResponseTopologyVersion = isStale ? null : responseTopologyVersion;
+                return isStale;
+            }
+        }
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
@@ -81,12 +81,6 @@ namespace MongoDB.Driver.Core.Servers
         public override ServerDescription Description => Interlocked.CompareExchange(ref _currentDescription, value: null, comparand: null);
 
         // public methods
-        public override void Initializing()
-        {
-            _monitor.DescriptionChanged += OnMonitorDescriptionChanged;
-            _monitor.Initialize();
-        }
-
         public override void Invalidate(string reasonInvalidated, bool clearConnectionPool, TopologyVersion topologyVersion)
         {
             if (clearConnectionPool)
@@ -179,6 +173,12 @@ namespace MongoDB.Driver.Core.Servers
                     RequestHeartbeat();
                 }
             }
+        }
+
+        protected override void Initializing()
+        {
+            _monitor.DescriptionChanged += OnMonitorDescriptionChanged;
+            _monitor.Initialize();
         }
 
         // private methods

--- a/src/MongoDB.Driver.Core/Core/Servers/IClusterableServerFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/IClusterableServerFactory.cs
@@ -27,12 +27,13 @@ namespace MongoDB.Driver.Core.Servers
         /// <summary>
         /// Creates the server.
         /// </summary>
+        /// <param name="clusterType">The cluster type.</param>
         /// <param name="clusterId">The cluster identifier.</param>
         /// <param name="clusterClock">The cluster clock.</param>
         /// <param name="endPoint">The end point.</param>
         /// <returns>
         /// A server.
         /// </returns>
-        IClusterableServer CreateServer(ClusterId clusterId, IClusterClock clusterClock, EndPoint endPoint);
+        IClusterableServer CreateServer(ClusterType clusterType, ClusterId clusterId, IClusterClock clusterClock, EndPoint endPoint);
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
@@ -1,0 +1,122 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Net;
+using System.Threading;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.ConnectionPools;
+using MongoDB.Driver.Core.Connections;
+using MongoDB.Driver.Core.Events;
+
+namespace MongoDB.Driver.Core.Servers
+{
+    internal class LoadBalancedServer : Server
+    {
+        private readonly ServerDescription _baseDescription;
+        private ServerDescription _currentDescription;
+        private readonly object _connectionPoolLock = new object();
+
+        public LoadBalancedServer(
+            ClusterId clusterId,
+            IClusterClock clusterClock,
+            ServerSettings serverSettings,
+            EndPoint endPoint,
+            IConnectionPoolFactory connectionPoolFactory,
+            IEventSubscriber eventSubscriber,
+            ServerApi serverApi)
+            : base(
+                  clusterId,
+                  clusterClock,
+#pragma warning disable CS0618 // Type or member is obsolete
+                  ClusterConnectionMode.Automatic,
+                  ConnectionModeSwitch.UseConnectionMode,
+#pragma warning restore CS0618 // Type or member is obsolete
+                  directConnection: null,
+                  serverSettings,
+                  endPoint,
+                  connectionPoolFactory,
+                  eventSubscriber,
+                  serverApi)
+        {
+            _baseDescription = _currentDescription = new ServerDescription(ServerId, endPoint, reasonChanged: "ServerInitialDescription");
+        }
+
+        public override ServerDescription Description => Interlocked.CompareExchange(ref _currentDescription, value: null, comparand: null);
+
+        protected override void Dispose(bool disposing)
+        {
+            // no-opt
+        }
+
+        protected override void HandleBeforeHandshakeCompletesException(Exception ex)
+        {
+            // drivers MUST NOT perform SDAM error handling for any errors that occur before the MongoDB Handshake
+
+            if (ex is MongoAuthenticationException mongoAuthenticationException &&
+                mongoAuthenticationException.ServiceId.HasValue) // this value will be always filled for MongoAuthenticationException, adding this condition just in case
+            {
+                // when requiring the connection pool to be cleared, MUST only clear connections for the serviceId.
+                ConnectionPool.Clear(mongoAuthenticationException.ServiceId.Value);
+            }
+        }
+
+        protected override void HandleAfterHandshakeCompletesException(IConnection connection, Exception ex)
+        {
+            lock (_connectionPoolLock)
+            {
+                if (ex is MongoConnectionException mongoConnectionException &&
+                    mongoConnectionException.Generation.HasValue &&
+                    mongoConnectionException.Generation.Value != ConnectionPool.Generation)
+                {
+                    return; // stale generation number
+                }
+
+                if (ShouldClearConnectionPoolForChannelException(ex, connection.Description.ServerVersion) &&
+                    connection.Description.ServiceId.HasValue) // this value will be always filled in this place, adding this here just in case
+                {
+                    // when requiring the connection pool to be cleared, MUST only clear connections for the serviceId.
+                    ConnectionPool.Clear(connection.Description.ServiceId.Value);
+                }
+            }
+        }
+
+        public override void Initializing()
+        {
+            // generate initial server description
+            var newDescription = _baseDescription
+                .With(
+                    type: ServerType.LoadBalanced,
+                    reasonChanged: "Initialized",
+                    state: ServerState.Connected);
+            var oldDescription = Interlocked.CompareExchange(ref _currentDescription, value: newDescription, comparand: _currentDescription);
+            var eventArgs = new ServerDescriptionChangedEventArgs(oldDescription, newDescription);
+
+            // propagate event to upper levels, this will be called only once
+            TriggerServerDescriptionChanged(this, eventArgs);
+        }
+
+        public override void Invalidate(string reasonInvalidated, bool clearConnectionPool, TopologyVersion topologyVersion)
+        {
+            // no-opt
+        }
+
+        public override void RequestHeartbeat()
+        {
+            // no-opt
+        }
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
@@ -59,7 +59,7 @@ namespace MongoDB.Driver.Core.Servers
 
         protected override void Dispose(bool disposing)
         {
-            // no-opt
+            // no-op
         }
 
         protected override void HandleBeforeHandshakeCompletesException(Exception ex)
@@ -94,7 +94,7 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
-        protected override void Initializing()
+        protected override void InitializeSubClass()
         {
             // generate initial server description
             var newDescription = _baseDescription
@@ -111,12 +111,12 @@ namespace MongoDB.Driver.Core.Servers
 
         public override void Invalidate(string reasonInvalidated, bool clearConnectionPool, TopologyVersion topologyVersion)
         {
-            // no-opt
+            // no-op
         }
 
         public override void RequestHeartbeat()
         {
-            // no-opt
+            // no-op
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
@@ -94,7 +94,7 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
-        public override void Initializing()
+        protected override void Initializing()
         {
             // generate initial server description
             var newDescription = _baseDescription

--- a/src/MongoDB.Driver.Core/Core/Servers/Server.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/Server.cs
@@ -202,8 +202,6 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
-        public abstract void Initializing();
-
         [Obsolete("Use Invalidate with TopologyDescription instead.")]
         public void Invalidate(string reasonInvalidated)
         {
@@ -220,6 +218,8 @@ namespace MongoDB.Driver.Core.Servers
         public abstract void RequestHeartbeat();
 
         // protected methods
+        protected abstract void Initializing();
+
         protected bool IsStateChangeException(Exception ex) => ex is MongoNotPrimaryException || ex is MongoNodeIsRecoveringException;
 
         protected bool IsShutdownException(Exception ex) => ex is MongoNodeIsRecoveringException mongoNodeIsRecoveringException && mongoNodeIsRecoveringException.IsShutdownError;

--- a/src/MongoDB.Driver.Core/Core/Servers/Server.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/Server.cs
@@ -16,9 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -40,21 +38,9 @@ namespace MongoDB.Driver.Core.Servers
     /// <summary>
     /// Represents a server in a MongoDB cluster.
     /// </summary>
-    internal sealed class Server : IClusterableServer
+    internal abstract class Server : IClusterableServer
     {
-        #region static
-        // static fields
-        private static readonly List<Type> __invalidatingExceptions = new List<Type>
-        {
-            typeof(MongoConnectionException),
-            typeof(SocketException),
-            typeof(EndOfStreamException),
-            typeof(IOException),
-        };
-        #endregion
-
         // fields
-        private readonly ServerDescription _baseDescription;
         private readonly IClusterClock _clusterClock;
 #pragma warning disable CS0618 // Type or member is obsolete
         private readonly ClusterConnectionMode _clusterConnectionMode;
@@ -62,9 +48,7 @@ namespace MongoDB.Driver.Core.Servers
 #pragma warning restore CS0618 // Type or member is obsolete
         private readonly IConnectionPool _connectionPool;
         private readonly bool? _directConnection;
-        private ServerDescription _currentDescription;
         private readonly EndPoint _endPoint;
-        private readonly IServerMonitor _monitor;
         private readonly ServerId _serverId;
         private readonly ServerSettings _settings;
         private readonly InterlockedInt32 _state;
@@ -78,9 +62,6 @@ namespace MongoDB.Driver.Core.Servers
         private readonly Action<ServerClosedEvent> _closedEventHandler;
         private readonly Action<ServerDescriptionChangedEvent> _descriptionChangedEventHandler;
 
-        // events
-        public event EventHandler<ServerDescriptionChangedEventArgs> DescriptionChanged;
-
         // constructors
         public Server(
             ClusterId clusterId,
@@ -93,29 +74,22 @@ namespace MongoDB.Driver.Core.Servers
             ServerSettings settings,
             EndPoint endPoint,
             IConnectionPoolFactory connectionPoolFactory,
-            IServerMonitorFactory serverMonitorFactory,
             IEventSubscriber eventSubscriber,
             ServerApi serverApi)
         {
             ClusterConnectionModeHelper.EnsureConnectionModeValuesAreValid(clusterConnectionMode, connectionModeSwitch, directConnection);
 
-            Ensure.IsNotNull(clusterId, nameof(clusterId));
             _clusterClock = Ensure.IsNotNull(clusterClock, nameof(clusterClock));
             _clusterConnectionMode = clusterConnectionMode;
             _connectionModeSwitch = connectionModeSwitch;
             _directConnection = directConnection;
             _settings = Ensure.IsNotNull(settings, nameof(settings));
             _endPoint = Ensure.IsNotNull(endPoint, nameof(endPoint));
-            Ensure.IsNotNull(connectionPoolFactory, nameof(connectionPoolFactory));
-            Ensure.IsNotNull(serverMonitorFactory, nameof(serverMonitorFactory));
             Ensure.IsNotNull(eventSubscriber, nameof(eventSubscriber));
 
             _serverId = new ServerId(clusterId, endPoint);
-            _connectionPool = connectionPoolFactory.CreateConnectionPool(_serverId, endPoint);
+            _connectionPool = Ensure.IsNotNull(connectionPoolFactory, nameof(connectionPoolFactory)).CreateConnectionPool(_serverId, endPoint);
             _state = new InterlockedInt32(State.Initial);
-            _monitor = serverMonitorFactory.Create(_serverId, _endPoint);
-            _baseDescription = new ServerDescription(_serverId, endPoint, reasonChanged: "ServerInitialDescription", heartbeatInterval: settings.HeartbeatInterval);
-            _currentDescription = _baseDescription;
             _serverApi = serverApi;
             _outstandingOperationsCount = 0;
 
@@ -126,20 +100,20 @@ namespace MongoDB.Driver.Core.Servers
             eventSubscriber.TryGetEventHandler(out _descriptionChangedEventHandler);
         }
 
+        // events
+        public event EventHandler<ServerDescriptionChangedEventArgs> DescriptionChanged;
+
         // properties
-        public ServerDescription Description => Interlocked.CompareExchange(ref _currentDescription, value: null, comparand: null);
-
+        public IClusterClock ClusterClock => _clusterClock;
+        public IConnectionPool ConnectionPool => _connectionPool;
+        public abstract ServerDescription Description { get; }
         public EndPoint EndPoint => _endPoint;
-
         public bool IsInitialized => _state.Value != State.Initial;
-
         public ServerId ServerId => _serverId;
-
-        internal IClusterClock ClusterClock => _clusterClock;
 
         int IClusterableServer.OutstandingOperationsCount => Interlocked.CompareExchange(ref _outstandingOperationsCount, 0, 0);
 
-        // methods
+        // public methods
         public void Dispose()
         {
             if (_state.TryChange(State.Disposed))
@@ -150,8 +124,9 @@ namespace MongoDB.Driver.Core.Servers
                 }
 
                 var stopwatch = Stopwatch.StartNew();
-                _monitor.Dispose();
-                _monitor.DescriptionChanged -= OnMonitorDescriptionChanged;
+
+                Dispose(disposing: true);
+
                 _connectionPool.Dispose();
                 stopwatch.Stop();
 
@@ -162,6 +137,11 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
+        protected abstract void Dispose(bool disposing);
+
+        protected abstract void HandleBeforeHandshakeCompletesException(Exception ex);
+        protected abstract void HandleAfterHandshakeCompletesException(IConnection connection, Exception ex);
+
         public IChannelHandle GetChannel(CancellationToken cancellationToken)
         {
             ThrowIfNotOpen();
@@ -169,6 +149,7 @@ namespace MongoDB.Driver.Core.Servers
             try
             {
                 Interlocked.Increment(ref _outstandingOperationsCount);
+
                 var connection = _connectionPool.AcquireConnection(cancellationToken);
                 return new ServerChannel(this, connection);
             }
@@ -211,8 +192,7 @@ namespace MongoDB.Driver.Core.Servers
 
                 var stopwatch = Stopwatch.StartNew();
                 _connectionPool.Initialize();
-                _monitor.DescriptionChanged += OnMonitorDescriptionChanged;
-                _monitor.Initialize();
+                Initializing();
                 stopwatch.Stop();
 
                 if (_openedEventHandler != null)
@@ -222,6 +202,8 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
+        public abstract void Initializing();
+
         [Obsolete("Use Invalidate with TopologyDescription instead.")]
         public void Invalidate(string reasonInvalidated)
         {
@@ -230,23 +212,20 @@ namespace MongoDB.Driver.Core.Servers
 
         public void Invalidate(string reasonInvalidated, TopologyVersion responseTopologyDescription)
         {
-            ThrowIfNotOpen();
             Invalidate(reasonInvalidated, clearConnectionPool: true, responseTopologyDescription);
         }
 
-        public void RequestHeartbeat()
-        {
-            ThrowIfNotOpen();
-            _monitor.RequestHeartbeat();
-        }
+        public abstract void Invalidate(string reasonInvalidated, bool clearConnectionPool, TopologyVersion responseTopologyDescription);
 
-        private void OnDescriptionChanged(object sender, ServerDescriptionChangedEventArgs e)
-        {
-            if (e.NewServerDescription.HeartbeatException != null)
-            {
-                _connectionPool.Clear();
-            }
+        public abstract void RequestHeartbeat();
 
+        // protected methods
+        protected bool IsStateChangeException(Exception ex) => ex is MongoNotPrimaryException || ex is MongoNodeIsRecoveringException;
+
+        protected bool IsShutdownException(Exception ex) => ex is MongoNodeIsRecoveringException mongoNodeIsRecoveringException && mongoNodeIsRecoveringException.IsShutdownError;
+
+        protected void TriggerServerDescriptionChanged(object sender, ServerDescriptionChangedEventArgs e)
+        {
             var shouldServerDescriptionChangedEventBePublished = !e.OldServerDescription.SdamEquals(e.NewServerDescription);
             if (shouldServerDescriptionChangedEventBePublished && _descriptionChangedEventHandler != null)
             {
@@ -261,222 +240,7 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
-        private void OnMonitorDescriptionChanged(object sender, ServerDescriptionChangedEventArgs e)
-        {
-            var currentDescription = Interlocked.CompareExchange(ref _currentDescription, value: null, comparand: null);
-
-            var heartbeatException = e.NewServerDescription.HeartbeatException;
-            // The heartbeat commands are hello/isMaster + buildInfo. These commands will throw a MongoCommandException on
-            // {ok: 0}, but a reply (with a potential topologyVersion) will still have been received.
-            // Not receiving a reply to the heartbeat commands implies a network error or a "HeartbeatFailed" type
-            // exception (i.e. ServerDescription.WithHeartbeatException was called), in which case we should immediately
-            // set the description to "Unknown"// (which is what e.NewServerDescription will be in such a case)
-            var heartbeatReplyNotReceived = heartbeatException != null && !(heartbeatException is MongoCommandException);
-
-            // We cannot use FresherThan(e.NewServerDescription.TopologyVersion, currentDescription.TopologyVersion)
-            // because due to how TopologyVersions comparisons are defined, IsStalerThanOrEqualTo(x, y) does not imply
-            // FresherThan(y, x)
-            if (heartbeatReplyNotReceived ||
-                TopologyVersion.IsStalerThanOrEqualTo(currentDescription.TopologyVersion, e.NewServerDescription.TopologyVersion))
-            {
-                SetDescription(e.NewServerDescription);
-            }
-        }
-
-        private void HandleChannelException(IConnection connection, Exception ex)
-        {
-            if (_state.Value != State.Open)
-            {
-                return;
-            }
-
-            var aggregateException = ex as AggregateException;
-            if (aggregateException != null && aggregateException.InnerExceptions.Count == 1)
-            {
-                ex = aggregateException.InnerException;
-            }
-
-            // For most connection exceptions, we are going to immediately
-            // invalidate the server. However, we aren't going to invalidate
-            // because of OperationCanceledExceptions. We trust that the
-            // implementations of connection don't leave themselves in a state
-            // where they can't be used based on user cancellation.
-            if (ex.GetType() == typeof(OperationCanceledException))
-            {
-                return;
-            }
-
-            lock (_monitor.Lock)
-            {
-                if (ex is MongoConnectionException mongoConnectionException)
-                {
-                    if (mongoConnectionException.Generation != null &&
-                        mongoConnectionException.Generation != _connectionPool.Generation)
-                    {
-                        return; // stale generation number
-                    }
-
-                    if (mongoConnectionException.IsNetworkException &&
-                        !mongoConnectionException.ContainsTimeoutException)
-                    {
-                        _monitor.CancelCurrentCheck();
-                    }
-                }
-
-                var description = Description; // use Description property to access _description value safely
-                if (ShouldInvalidateServer(connection, ex, description, out TopologyVersion responseTopologyVersion))
-                {
-                    var shouldClearConnectionPool = ShouldClearConnectionPoolForChannelException(ex, connection.Description.ServerVersion);
-                    Invalidate($"ChannelException:{ex}", shouldClearConnectionPool, responseTopologyVersion);
-                }
-                else
-                {
-                    RequestHeartbeat();
-                }
-            }
-        }
-
-        private void HandleBeforeHandshakeCompletesException(Exception ex)
-        {
-            if (ex is MongoAuthenticationException)
-            {
-                _connectionPool.Clear();
-                return;
-            }
-
-            if (ex is MongoConnectionException mongoConnectionException)
-            {
-                lock (_monitor.Lock)
-                {
-                    if (mongoConnectionException.Generation != null &&
-                        mongoConnectionException.Generation != _connectionPool.Generation)
-                    {
-                        return; // stale generation number
-                    }
-
-                    if (mongoConnectionException.IsNetworkException &&
-                        !mongoConnectionException.ContainsTimeoutException)
-                    {
-                        _monitor.CancelCurrentCheck();
-                    }
-
-                    if (mongoConnectionException.IsNetworkException || mongoConnectionException.ContainsTimeoutException)
-                    {
-                        Invalidate($"ChannelException during handshake: {ex}.", clearConnectionPool: true, responseTopologyVersion: null);
-                    }
-                }
-            }
-        }
-
-        private void Invalidate(string reasonInvalidated, bool clearConnectionPool, TopologyVersion responseTopologyVersion)
-        {
-            if (clearConnectionPool)
-            {
-                _connectionPool.Clear();
-            }
-            var newDescription = _baseDescription.With(
-                    $"InvalidatedBecause:{reasonInvalidated}",
-                    lastUpdateTimestamp: DateTime.UtcNow,
-                    topologyVersion: responseTopologyVersion);
-            SetDescription(newDescription);
-            // TODO: make the heartbeat request conditional so we adhere to this part of the spec
-            // > Network error when reading or writing: ... Clients MUST NOT request an immediate check of the server;
-            // > since application sockets are used frequently, a network error likely means the server has just become
-            // > unavailable, so an immediate refresh is likely to get a network error, too.
-            RequestHeartbeat();
-        }
-
-        private bool IsNotWritablePrimary(ServerErrorCode? code, string message)
-        {
-            if (code.HasValue)
-            {
-                switch (code.Value)
-                {
-                    case ServerErrorCode.LegacyNotPrimary: // 10058
-                    case ServerErrorCode.NotWritablePrimary: // 10107
-                    case ServerErrorCode.NotPrimaryNoSecondaryOk: // 13435
-                        return true;
-                }
-            }
-            else if (message != null)
-            {
-                if (message.IndexOf("not master", StringComparison.OrdinalIgnoreCase) != -1 &&
-                    message.IndexOf("not master or secondary", StringComparison.OrdinalIgnoreCase) == -1)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private bool IsNotWritablePrimaryErrorException(Exception exception)
-        {
-            return
-                exception is MongoCommandException commandException &&
-                IsNotWritablePrimary((ServerErrorCode)commandException.Code, commandException.ErrorMessage);
-        }
-
-        private bool IsStateChangeError(ServerErrorCode? code, string message)
-        {
-            return IsNotWritablePrimary(code, message) || IsRecovering(code, message);
-        }
-
-        private bool IsShutdownError(ServerErrorCode errorCode)
-        {
-            switch (errorCode)
-            {
-                case ServerErrorCode.InterruptedAtShutdown: // 1160
-                case ServerErrorCode.ShutdownInProgress: // 91
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        private bool IsShutdownErrorException(Exception exception)
-        {
-            return exception is MongoCommandException commandException && IsShutdownError((ServerErrorCode)commandException.Code);
-        }
-
-        private bool IsRecovering(ServerErrorCode? code, string message)
-        {
-            if (code.HasValue)
-            {
-                switch (code.Value)
-                {
-                    case ServerErrorCode.InterruptedAtShutdown: // 11600
-                    case ServerErrorCode.InterruptedDueToReplStateChange: // 11602
-                    case ServerErrorCode.NotPrimaryOrSecondary: // 13436
-                    case ServerErrorCode.PrimarySteppedDown: // 189
-                    case ServerErrorCode.ShutdownInProgress: // 91
-                        return true;
-                }
-            }
-            else if (message != null)
-            {
-                if (message.IndexOf("not master or secondary", StringComparison.OrdinalIgnoreCase) != -1 ||
-                    message.IndexOf("node is recovering", StringComparison.OrdinalIgnoreCase) != -1)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private bool IsRecoveringErrorException(Exception exception)
-        {
-            return exception is MongoNodeIsRecoveringException;
-        }
-
-        private void SetDescription(ServerDescription newDescription)
-        {
-            var oldDescription = Interlocked.CompareExchange(ref _currentDescription, value: newDescription, comparand: _currentDescription);
-            OnDescriptionChanged(sender: this, new ServerDescriptionChangedEventArgs(oldDescription, newDescription));
-        }
-
-        private bool ShouldClearConnectionPoolForChannelException(Exception ex, SemanticVersion serverVersion)
+        protected bool ShouldClearConnectionPoolForChannelException(Exception ex, SemanticVersion serverVersion)
         {
             if (ex is MongoConnectionException mongoCommandException &&
                 mongoCommandException.IsNetworkException &&
@@ -484,87 +248,44 @@ namespace MongoDB.Driver.Core.Servers
             {
                 return true;
             }
-            if (IsNotWritablePrimaryErrorException(ex) || IsRecoveringErrorException(ex))
+            if (IsStateChangeException(ex))
             {
                 return
-                    IsShutdownErrorException(ex) ||
+                    IsShutdownException(ex) ||
                     !Feature.KeepConnectionPoolWhenNotMasterConnectionException.IsSupported(serverVersion); // i.e. serverVersion < 4.1.10
             }
             return false;
         }
 
-        private bool ShouldInvalidateServer(
-            IConnection connection,
-            Exception exception,
-            ServerDescription description,
-            out TopologyVersion invalidatingResponseTopologyVersion)
+        // private methods
+        private void HandleChannelException(IConnection connection, Exception ex)
         {
-            if (exception is MongoConnectionException mongoConnectionException &&
-                mongoConnectionException.ContainsTimeoutException)
+            if (!IsOpened() || ShouldIgnoreException(ex))
             {
-                invalidatingResponseTopologyVersion = null;
-                return false;
+                return;
             }
 
-            if (__invalidatingExceptions.Contains(exception.GetType()))
+            ex = GetEffectiveException(ex);
+
+            HandleAfterHandshakeCompletesException(connection, ex);
+
+            bool ShouldIgnoreException(Exception ex)
             {
-                invalidatingResponseTopologyVersion = null;
-                return true;
+                // For most connection exceptions, we are going to immediately
+                // invalidate the server. However, we aren't going to invalidate
+                // because of OperationCanceledExceptions. We trust that the
+                // implementations of connection don't leave themselves in a state
+                // where they can't be used based on user cancellation.
+                return ex is OperationCanceledException;
             }
 
-            var commandException = exception as MongoCommandException;
-            if (commandException != null)
-            {
-                var code = (ServerErrorCode?)commandException.Result.GetValue("code", null)?.ToInt32();
-                var message = commandException.ErrorMessage;
-
-                if (IsStateChangeError(code, message))
-                {
-                    return !IsStaleStateChangeError(commandException.Result, out invalidatingResponseTopologyVersion);
-                }
-
-                if (commandException.GetType() == typeof(MongoWriteConcernException))
-                {
-                    var writeConcernException = (MongoWriteConcernException)commandException;
-                    var writeConcernResult = writeConcernException.WriteConcernResult;
-                    var response = writeConcernResult.Response;
-                    var writeConcernError = response["writeConcernError"].AsBsonDocument;
-                    if (writeConcernError != null)
-                    {
-                        code = (ServerErrorCode?)writeConcernError.GetValue("code", null)?.ToInt32();
-                        message = writeConcernError.GetValue("errmsg", null)?.AsString;
-
-                        if (IsStateChangeError(code, message))
-                        {
-                            return !IsStaleStateChangeError(commandException.Result, out invalidatingResponseTopologyVersion);
-                        }
-                    }
-                }
-            }
-
-            invalidatingResponseTopologyVersion = null;
-            return false;
-
-            bool IsStaleStateChangeError(BsonDocument response, out TopologyVersion nonStaleResponseTopologyVersion)
-            {
-                if (_connectionPool.Generation > connection.Generation)
-                {
-                    // stale generation number
-                    nonStaleResponseTopologyVersion = null;
-                    return true;
-                }
-
-                var responseTopologyVersion = TopologyVersion.FromMongoCommandResponse(response);
-                // We use FresherThanOrEqualTo instead of FresherThan because a state change should come with a new
-                // topology version.
-                // We cannot use StalerThan(responseTopologyVersion, description.TopologyVersion) because due to how
-                // TopologyVersions comparisons are defined, FresherThanOrEqualTo(x, y) does not imply StalerThan(y, x)
-                bool isStale = TopologyVersion.IsFresherThanOrEqualTo(description.TopologyVersion, responseTopologyVersion);
-
-                nonStaleResponseTopologyVersion = isStale ? null : responseTopologyVersion;
-                return isStale;
-            }
+            Exception GetEffectiveException(Exception ex) =>
+                ex is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1
+                    ? aggregateException.InnerException
+                    : ex;
         }
+
+        private bool IsOpened() => _state.Value == State.Open;
 
         private void ThrowIfDisposed()
         {
@@ -576,7 +297,7 @@ namespace MongoDB.Driver.Core.Servers
 
         private void ThrowIfNotOpen()
         {
-            if (_state.Value != State.Open)
+            if (!IsOpened())
             {
                 ThrowIfDisposed();
                 throw new InvalidOperationException("Server must be initialized.");
@@ -611,6 +332,8 @@ namespace MongoDB.Driver.Core.Servers
             }
 
             // properties
+            public IConnectionHandle Connection => _connection;
+
             public ConnectionDescription ConnectionDescription
             {
                 get { return _connection.Description; }

--- a/src/MongoDB.Driver.Core/Core/Servers/Server.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/Server.cs
@@ -192,7 +192,7 @@ namespace MongoDB.Driver.Core.Servers
 
                 var stopwatch = Stopwatch.StartNew();
                 _connectionPool.Initialize();
-                Initializing();
+                InitializeSubClass();
                 stopwatch.Stop();
 
                 if (_openedEventHandler != null)
@@ -218,7 +218,7 @@ namespace MongoDB.Driver.Core.Servers
         public abstract void RequestHeartbeat();
 
         // protected methods
-        protected abstract void Initializing();
+        protected abstract void InitializeSubClass();
 
         protected bool IsStateChangeException(Exception ex) => ex is MongoNotPrimaryException || ex is MongoNodeIsRecoveringException;
 
@@ -260,7 +260,7 @@ namespace MongoDB.Driver.Core.Servers
         // private methods
         private void HandleChannelException(IConnection connection, Exception ex)
         {
-            if (!IsOpened() || ShouldIgnoreException(ex))
+            if (!IsOpen() || ShouldIgnoreException(ex))
             {
                 return;
             }
@@ -285,7 +285,7 @@ namespace MongoDB.Driver.Core.Servers
                     : ex;
         }
 
-        private bool IsOpened() => _state.Value == State.Open;
+        private bool IsOpen() => _state.Value == State.Open;
 
         private void ThrowIfDisposed()
         {
@@ -297,7 +297,7 @@ namespace MongoDB.Driver.Core.Servers
 
         private void ThrowIfNotOpen()
         {
-            if (!IsOpened())
+            if (!IsOpen())
             {
                 ThrowIfDisposed();
                 throw new InvalidOperationException("Server must be initialized.");

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerDescription.cs
@@ -227,6 +227,7 @@ namespace MongoDB.Driver.Core.Servers
         /// <c>true</c> if this server is compatible with the driver; otherwise, <c>false</c>.
         /// </value>
         public bool IsCompatibleWithDriver =>
+            _type == ServerType.LoadBalanced ||
             _type == ServerType.Unknown ||
             _wireVersionRange == null ||
             _wireVersionRange.Overlaps(Cluster.SupportedWireVersionRange);
@@ -247,6 +248,7 @@ namespace MongoDB.Driver.Core.Servers
                     case ServerType.ReplicaSetPrimary:
                     case ServerType.ReplicaSetSecondary:
                     case ServerType.ShardRouter:
+                    case ServerType.LoadBalanced:
                         return true;
 
                     default:

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerFactory.cs
@@ -63,20 +63,32 @@ namespace MongoDB.Driver.Core.Servers
 
         // methods
         /// <inheritdoc/>
-        public IClusterableServer CreateServer(ClusterId clusterId, IClusterClock clusterClock, EndPoint endPoint)
-        {
-            return new Server(
-                clusterId,
-                clusterClock,
-                _clusterConnectionMode,
-                _connectionModeSwitch,
-                _directConnection,
-                _settings,
-                endPoint,
-                _connectionPoolFactory,
-                _serverMonitorFactory,
-                _eventSubscriber,
-                _serverApi);
-        }
+        public IClusterableServer CreateServer(ClusterType clusterType, ClusterId clusterId, IClusterClock clusterClock, EndPoint endPoint) =>
+            clusterType switch
+            {
+                ClusterType.LoadBalanced =>
+                    new LoadBalancedServer(
+                        clusterId,
+                        clusterClock,
+                        _settings,
+                        endPoint,
+                        _connectionPoolFactory,
+                        _eventSubscriber,
+                        _serverApi),
+
+                _ =>
+                    new DefaultServer(
+                        clusterId,
+                        clusterClock,
+                        _clusterConnectionMode,
+                        _connectionModeSwitch,
+                        _directConnection,
+                        _settings,
+                        endPoint,
+                        _connectionPoolFactory,
+                        _serverMonitorFactory,
+                        _eventSubscriber,
+                        _serverApi),
+            };
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerFactory.cs
@@ -88,7 +88,7 @@ namespace MongoDB.Driver.Core.Servers
                         _connectionPoolFactory,
                         _serverMonitorFactory,
                         _eventSubscriber,
-                        _serverApi),
+                        _serverApi)
             };
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerType.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerType.cs
@@ -14,10 +14,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MongoDB.Driver.Core.Clusters;
 
 namespace MongoDB.Driver.Core.Servers
@@ -71,7 +67,12 @@ namespace MongoDB.Driver.Core.Servers
         /// <summary>
         /// The server is a replica set ghost member.
         /// </summary>
-        ReplicaSetGhost
+        ReplicaSetGhost,
+
+        /// <summary>
+        /// The server is under load balancing.
+        /// </summary>
+        LoadBalanced
     }
 
     /// <summary>
@@ -101,6 +102,7 @@ namespace MongoDB.Driver.Core.Servers
                 case ServerType.ReplicaSetPrimary:
                 case ServerType.ShardRouter:
                 case ServerType.Standalone:
+                case ServerType.LoadBalanced:
                     return true;
 
                 default:
@@ -129,6 +131,8 @@ namespace MongoDB.Driver.Core.Servers
                     return ClusterType.Standalone;
                 case ServerType.Unknown:
                     return ClusterType.Unknown;
+                case ServerType.LoadBalanced:
+                    return ClusterType.LoadBalanced;
                 default:
                     var message = string.Format("Invalid server type: {0}.", serverType);
                     throw new ArgumentException(message, "serverType");

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingQueryMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingQueryMessageWireProtocol.cs
@@ -341,7 +341,9 @@ namespace MongoDB.Driver.Core.WireProtocol
             var extraElements = new List<BsonElement>();
             if (_session.Id != null)
             {
-                var areSessionsSupported = connectionDescription.IsMasterResult.LogicalSessionTimeout.HasValue;
+                var areSessionsSupported =
+                    connectionDescription.IsMasterResult.LogicalSessionTimeout.HasValue ||
+                    connectionDescription.IsMasterResult.ServiceId.HasValue;
                 if (areSessionsSupported)
                 {
                     var lsid = new BsonElement("lsid", _session.Id);

--- a/src/MongoDB.Driver.Core/MongoConnectionException.cs
+++ b/src/MongoDB.Driver.Core/MongoConnectionException.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Net.Sockets;
+using MongoDB.Bson;
 #if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
@@ -34,6 +35,7 @@ namespace MongoDB.Driver
         // fields
         private readonly ConnectionId _connectionId;
         private int? _generation = null;
+        private ObjectId? _serviceId = null;
 
         // constructors
         /// <summary>
@@ -153,6 +155,23 @@ namespace MongoDB.Driver
                 }
 
                 _generation = value;
+            }
+        }
+
+        /// <summary>
+        /// A value for propagating a serviceId to the SDAM logic after handshake completed but before acquiring connection.
+        /// </summary>
+        internal ObjectId? ServiceId
+        {
+            get { return _serviceId; }
+            set
+            {
+                if (_serviceId != null)
+                {
+                    throw new InvalidOperationException("Service Id is already set.");
+                }
+
+                _serviceId = value;
             }
         }
     }

--- a/src/MongoDB.Driver.Core/MongoNodeIsRecoveringException.cs
+++ b/src/MongoDB.Driver.Core/MongoNodeIsRecoveringException.cs
@@ -71,5 +71,24 @@ namespace MongoDB.Driver
         {
         }
 #endif
+
+        /// <summary>
+        /// Gets whether it caused by shutdown or no.
+        /// </summary>
+        public bool IsShutdownError
+        {
+            get
+            {
+                var errorCode = (ServerErrorCode)Code;
+                switch (errorCode)
+                {
+                    case ServerErrorCode.InterruptedAtShutdown: // 1160
+                    case ServerErrorCode.ShutdownInProgress: // 91
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
     }
 }

--- a/src/MongoDB.Driver.Core/MongoWriteConcernException.cs
+++ b/src/MongoDB.Driver.Core/MongoWriteConcernException.cs
@@ -46,7 +46,6 @@ namespace MongoDB.Driver
 
         private static bool TryMapWriteConcernResultToException(ConnectionId connectionId, WriteConcernResult writeConcernResult, out Exception mappedException)
         {
-            mappedException = null;
             var responseDocument = writeConcernResult?.Response;
             if (responseDocument != null && responseDocument.TryGetValue("writeConcernError", out var writeConcernError))
             {
@@ -60,6 +59,7 @@ namespace MongoDB.Driver
                 }
             }
 
+            mappedException = null;
             return false;
         }
         #endregion

--- a/src/MongoDB.Driver.Core/ServiceIdHelper.cs
+++ b/src/MongoDB.Driver.Core/ServiceIdHelper.cs
@@ -1,0 +1,25 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Core
+{
+    internal static class ServiceIdHelper
+    {
+        /// <summary>
+        /// Temporary workaround until server will actually support serviceId.
+        /// </summary>
+        public static bool IsServiceIdEmulationEnabled { get; set; } = false;
+    }
+}

--- a/src/MongoDB.Driver/ClusterRegistry.cs
+++ b/src/MongoDB.Driver/ClusterRegistry.cs
@@ -118,6 +118,7 @@ namespace MongoDB.Driver
             return settings.With(
                 authenticatorFactories: Optional.Enumerable<IAuthenticatorFactory>(authenticatorFactories),
                 compressors: Optional.Enumerable(clusterKey.Compressors),
+                loadBalanced: clusterKey.LoadBalanced,
                 maxIdleTime: clusterKey.MaxConnectionIdleTime,
                 maxLifeTime: clusterKey.MaxConnectionLifeTime,
                 applicationName: clusterKey.ApplicationName);

--- a/src/MongoDB.Driver/MongoClient.cs
+++ b/src/MongoDB.Driver/MongoClient.cs
@@ -467,7 +467,7 @@ namespace MongoDB.Driver
 
         private bool? AreSessionsSupported(ClusterDescription clusterDescription)
         {
-            if (clusterDescription.LogicalSessionTimeout.HasValue)
+            if (clusterDescription.LogicalSessionTimeout.HasValue || clusterDescription.Type == ClusterType.LoadBalanced)
             {
                 return true;
             }

--- a/tests/MongoDB.Bson.TestHelpers/Reflector.cs
+++ b/tests/MongoDB.Bson.TestHelpers/Reflector.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -70,12 +71,11 @@ namespace MongoDB.Bson.TestHelpers
             }
         }
 
-        public static object Invoke<T1, T2>(object obj, string name, T1 arg1, T2 arg2)
+        public static object Invoke<T1, T2>(object obj, string name, T1 arg1, T2 arg2, BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance, bool checkBaseClass = false)
         {
             var parameterTypes = new[] { typeof(T1), typeof(T2) };
-            var methodInfo = obj.GetType().GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
-                .Where(m => m.Name == name && m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes))
-                .Single();
+
+            var methodInfo = GetDeclaredOrInheritedMethod(obj.GetType(), name, flags, parameterTypes, checkBaseClass);
             try
             {
                 return methodInfo.Invoke(obj, new object[] { arg1, arg2 });
@@ -106,6 +106,32 @@ namespace MongoDB.Bson.TestHelpers
                 var result = methodInfo.Invoke(obj, arguments);
                 arg1 = (T1)arguments[0];
                 arg2 = (T2)arguments[1];
+                return result;
+            }
+            catch (TargetInvocationException exception)
+            {
+                throw exception.InnerException;
+            }
+        }
+
+        public static object Invoke<T1, T2, T3, T4>(object obj, string name, T1 arg1, T2 arg2, T3 arg3, out T4 arg4)
+        {
+            arg4 = default;
+            var parameterTypes = new[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4) }.Select(t => t.FullName);
+            var methodInfo = obj
+                .GetType()
+                .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(m =>
+                    m.Name == name &&
+                    m.GetParameters()
+                        .Select(p => p.ParameterType.FullName.TrimEnd('&'))
+                        .SequenceEqual(parameterTypes))
+                .Single();
+            try
+            {
+                var arguments = new object[] { arg1, arg2, arg3, arg4 };
+                var result = methodInfo.Invoke(obj, arguments);
+                arg4 = (T4)arguments[3];
                 return result;
             }
             catch (TargetInvocationException exception)
@@ -228,6 +254,24 @@ namespace MongoDB.Bson.TestHelpers
                 type == null ?
                     null :
                     type.GetField(name, bindingFlags) ?? GetDeclaredOrInheritedField(type.GetTypeInfo().BaseType, name, bindingFlags);
+        }
+
+        private static MethodInfo GetDeclaredOrInheritedMethod(Type type, string name, BindingFlags bindingFlags, Type[] parameterTypes, bool checkBaseClass = false)
+        {
+            if (type == null)
+            {
+               throw new InvalidFilterCriteriaException($"The method name {name} has not been found in {type.Name}.");
+            }
+
+            var methodInfo = GetMethods(type).SingleOrDefault();
+            return methodInfo == null && checkBaseClass
+                ? GetDeclaredOrInheritedMethod(type.GetTypeInfo().BaseType, name, bindingFlags, parameterTypes, checkBaseClass)
+                : methodInfo;
+
+            IEnumerable<MethodInfo> GetMethods(Type type) =>
+                type
+                    .GetMethods(bindingFlags)
+                    .Where(m => m.Name == name && m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes));
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.TestHelpers/ClusterDescriptionParser.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/ClusterDescriptionParser.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Servers;
@@ -36,6 +35,7 @@ namespace MongoDB.Driver.Core.TestHelpers
                 connectionModeSwitch = ConnectionModeSwitch.UseConnectionMode;
                 connectionMode = (ClusterConnectionMode)Enum.Parse(typeof(ClusterConnectionMode), connectionModeBson.AsString);
             }
+
             bool? directConnection = null;
             if (args.TryGetValue("directConnection", out var directConnectionBson))
             {

--- a/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
@@ -20,6 +20,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Core;
 using MongoDB.Driver.Core.Authentication;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
@@ -238,13 +239,25 @@ namespace MongoDB.Driver
                 }
             }
 
-            return new ConnectionString(uri);
+            var connectionString = new ConnectionString(uri);
+            if (connectionString.LoadBalanced)
+            {
+                // TODO: temporary solution until server will actually support serviceId
+                ServiceIdHelper.IsServiceIdEmulationEnabled = true;
+            }
+            return connectionString;
         }
 
         private static ConnectionString GetConnectionStringWithMultipleShardRouters()
         {
             var uri = Environment.GetEnvironmentVariable("MONGODB_URI_WITH_MULTIPLE_MONGOSES") ?? "mongodb://localhost,localhost:27018";
-            return new ConnectionString(uri);
+            var connectionString = new ConnectionString(uri);
+            if (connectionString.LoadBalanced)
+            {
+                // TODO: temporary solution until server will actually support serviceId
+                ServiceIdHelper.IsServiceIdEmulationEnabled = true;
+            }
+            return connectionString;
         }
 
         private static DatabaseNamespace GetDatabaseNamespace()

--- a/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
@@ -383,7 +383,7 @@ namespace MongoDB.Driver
         {
             return
                 clusterDescription.Servers.Any(s => s.State == ServerState.Connected) &&
-                clusterDescription.LogicalSessionTimeout.HasValue;
+                (clusterDescription.LogicalSessionTimeout.HasValue || clusterDescription.Type == ClusterType.LoadBalanced);
         }
 
         private static IReadBindingHandle CreateReadBinding(ICoreSessionHandle session)

--- a/tests/MongoDB.Driver.Core.Tests/Core/Bindings/CoreServerSessionPoolTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Bindings/CoreServerSessionPoolTests.cs
@@ -18,10 +18,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
+using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Clusters.ServerSelectors;
+using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Servers;
+using MongoDB.Libmongocrypt;
 using Moq;
 using Xunit;
 
@@ -215,6 +221,21 @@ namespace MongoDB.Driver.Tests
             result.Should().Be(expectedResult);
         }
 
+        [Fact]
+        public void IsAboutToExpire_should_never_expire_in_load_balancing_mode()
+        {
+            var subject = CreateSubject();
+            var mockedCluster = new TestCluster(ClusterType.LoadBalanced);
+            var mockedServerSessionPool = new CoreServerSessionPool(mockedCluster);
+            var mockSession = new Mock<ICoreServerSession>();
+            var lastUsedAt = DateTime.UtcNow.AddSeconds(1741);
+            mockSession.SetupGet(m => m.LastUsedAt).Returns(lastUsedAt);
+
+            var result = mockedServerSessionPool.IsAboutToExpire(mockSession.Object);
+
+            result.Should().BeFalse();
+        }
+
         // private methods
         private Mock<ICoreServerSession> CreateMockExpiredSession()
         {
@@ -262,6 +283,33 @@ namespace MongoDB.Driver.Tests
             mockCluster.SetupGet(m => m.Description).Returns(clusterDescription);
 
             return new CoreServerSessionPool(mockCluster.Object);
+        }
+
+        private class TestCluster : ICluster
+        {
+            public TestCluster(ClusterType clusterType)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                Description = new ClusterDescription(new ClusterId(), ClusterConnectionMode.Automatic, clusterType, Enumerable.Empty<ServerDescription>());
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            public ClusterId ClusterId => throw new NotImplementedException();
+
+            public ClusterDescription Description { get; }
+
+            public ClusterSettings Settings => throw new NotImplementedException();
+
+            public CryptClient CryptClient => throw new NotImplementedException();
+
+            public event EventHandler<ClusterDescriptionChangedEventArgs> DescriptionChanged;
+
+            public ICoreServerSession AcquireServerSession() => throw new NotImplementedException();
+            public void Dispose() => throw new NotImplementedException();
+            public void Initialize() => DescriptionChanged?.Invoke(this, new ClusterDescriptionChangedEventArgs(Description, Description));
+            public IServer SelectServer(IServerSelector selector, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task<IServer> SelectServerAsync(IServerSelector selector, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public ICoreSessionHandle StartSession(CoreSessionOptions options = null) => throw new NotImplementedException();
         }
     }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Bindings/CoreServerSessionPoolTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Bindings/CoreServerSessionPoolTests.cs
@@ -205,6 +205,21 @@ namespace MongoDB.Driver.Tests
             }
         }
 
+        [Fact]
+        public void IsAboutToExpire_should_never_expire_in_load_balancing_mode()
+        {
+            var subject = CreateSubject();
+            var mockedCluster = new TestCluster(ClusterType.LoadBalanced);
+            var mockedServerSessionPool = new CoreServerSessionPool(mockedCluster);
+            var mockSession = new Mock<ICoreServerSession>();
+            var lastUsedAt = DateTime.UtcNow.AddSeconds(1741);
+            mockSession.SetupGet(m => m.LastUsedAt).Returns(lastUsedAt);
+
+            var result = mockedServerSessionPool.IsAboutToExpire(mockSession.Object);
+
+            result.Should().BeFalse();
+        }
+
         [Theory]
         [InlineData(null, true)]
         [InlineData(1741, true)]
@@ -219,21 +234,6 @@ namespace MongoDB.Driver.Tests
             var result = subject.IsAboutToExpire(mockSession.Object);
 
             result.Should().Be(expectedResult);
-        }
-
-        [Fact]
-        public void IsAboutToExpire_should_never_expire_in_load_balancing_mode()
-        {
-            var subject = CreateSubject();
-            var mockedCluster = new TestCluster(ClusterType.LoadBalanced);
-            var mockedServerSessionPool = new CoreServerSessionPool(mockedCluster);
-            var mockSession = new Mock<ICoreServerSession>();
-            var lastUsedAt = DateTime.UtcNow.AddSeconds(1741);
-            mockSession.SetupGet(m => m.LastUsedAt).Returns(lastUsedAt);
-
-            var result = mockedServerSessionPool.IsAboutToExpire(mockSession.Object);
-
-            result.Should().BeFalse();
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterDescriptionTests.cs
@@ -471,12 +471,14 @@ namespace MongoDB.Driver.Core.Clusters
                         {
                             connectionModeSwitch = ConnectionModeSwitch.UseConnectionMode;
                             connectionMode = ClusterConnectionMode.Standalone;
-                        } break;
+                        }
+                        break;
                     case "DirectConnection":
                         {
                             connectionModeSwitch = ConnectionModeSwitch.UseDirectConnection;
                             directConnection = true;
-                        } break;
+                        }
+                        break;
                     case "DnsMonitorException": dnsMonitorException = new Exception(); break;
                     case "Type": type = ClusterType.Unknown; break;
                     case "Servers": servers = new[] { __serverDescription1 }; break;

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterTests.cs
@@ -45,8 +45,8 @@ namespace MongoDB.Driver.Core.Clusters
         {
             _settings = new ClusterSettings(serverSelectionTimeout: TimeSpan.FromSeconds(2));
             _mockServerFactory = new Mock<IClusterableServerFactory>();
-            _mockServerFactory.Setup(f => f.CreateServer(It.IsAny<ClusterId>(), It.IsAny<IClusterClock>(), It.IsAny<EndPoint>()))
-                .Returns((ClusterId clusterId, IClusterClock clusterClock, EndPoint endPoint) =>
+            _mockServerFactory.Setup(f => f.CreateServer(It.IsAny<ClusterType>(), It.IsAny<ClusterId>(), It.IsAny<IClusterClock>(), It.IsAny<EndPoint>()))
+                .Returns((ClusterType _, ClusterId _, IClusterClock _, EndPoint endPoint) =>
                 {
                     var mockServer = new Mock<IClusterableServer>();
                     mockServer.SetupGet(s => s.EndPoint).Returns(endPoint);
@@ -440,8 +440,8 @@ namespace MongoDB.Driver.Core.Clusters
             [Values(false, true)]
             bool async)
         {
-            _mockServerFactory.Setup(f => f.CreateServer(It.IsAny<ClusterId>(), It.IsAny<IClusterClock>(), It.IsAny<EndPoint>()))
-                .Returns((ClusterId _, IClusterClock clusterClock, EndPoint endPoint) =>
+            _mockServerFactory.Setup(f => f.CreateServer(It.IsAny<ClusterType>(), It.IsAny<ClusterId>(), It.IsAny<IClusterClock>(), It.IsAny<EndPoint>()))
+                .Returns((ClusterType _, ClusterId _, IClusterClock clusterClock, EndPoint endPoint) =>
                 {
                     var mockServer = new Mock<IClusterableServer>();
                     mockServer.SetupGet(s => s.EndPoint).Returns(endPoint);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/LoadBalancedClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/LoadBalancedClusterTests.cs
@@ -1,0 +1,505 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using FluentAssertions;
+using MongoDB.Bson.TestHelpers;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Clusters.ServerSelectors;
+using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Helpers;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
+using Moq;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Tests.Core.Clusters
+{
+    public class LoadBalancedClusterTests
+    {
+        private EventCapturer _capturedEvents;
+        private readonly MockClusterableServerFactory _mockServerFactory;
+        private ClusterSettings _settings;
+        private readonly EndPoint _endPoint = new DnsEndPoint("localhost", 27017);
+
+        public LoadBalancedClusterTests()
+        {
+            _settings = new ClusterSettings().With(loadBalanced: true);
+            _mockServerFactory = new MockClusterableServerFactory();
+            _capturedEvents = new EventCapturer();
+        }
+
+        [Fact]
+        public void Constructor_should_initialize_instance()
+        {
+            var settings = new ClusterSettings(loadBalanced: true);
+            var serverFactory = Mock.Of<IClusterableServerFactory>();
+            var mockEventSubscriber = new Mock<IEventSubscriber>();
+            var dnsMonitorFactory = Mock.Of<IDnsMonitorFactory>();
+
+            var result = new LoadBalancedCluster(settings, serverFactory, mockEventSubscriber.Object, dnsMonitorFactory);
+
+            result._dnsMonitorFactory().Should().BeSameAs(dnsMonitorFactory);
+            result._eventSubscriber().Should().BeSameAs(mockEventSubscriber.Object);
+            result._state().Value.Should().Be(0); // State.Initial
+            AssertTryGetEventHandlerWasCalled<ClusterClosingEvent>(mockEventSubscriber);
+            AssertTryGetEventHandlerWasCalled<ClusterClosedEvent>(mockEventSubscriber);
+            AssertTryGetEventHandlerWasCalled<ClusterOpeningEvent>(mockEventSubscriber);
+            AssertTryGetEventHandlerWasCalled<ClusterOpenedEvent>(mockEventSubscriber);
+            AssertTryGetEventHandlerWasCalled<ClusterDescriptionChangedEvent>(mockEventSubscriber);
+        }
+
+        [Theory]
+        [ParameterAttributeData()]
+        public void Constructor_should_handle_directConnection_correctly([Values(null, false, true)] bool? directConnection)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            _settings = _settings.With(connectionModeSwitch: ConnectionModeSwitch.UseDirectConnection, directConnection: directConnection);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            var exception = Record.Exception(() => new LoadBalancedCluster(_settings, _mockServerFactory, _capturedEvents));
+
+            if (directConnection.GetValueOrDefault())
+            {
+                exception.Should().BeOfType<ArgumentException>();
+            }
+            else
+            {
+                exception.Should().BeNull();
+            }
+        }
+
+        [Theory]
+        [ParameterAttributeData()]
+        public void Constructor_should_handle_loadBalanced_correctly([Values(false, true)] bool loadBalanced)
+        {
+            _settings = _settings.With(loadBalanced: loadBalanced);
+
+            var exception = Record.Exception(() => new LoadBalancedCluster(_settings, _mockServerFactory, _capturedEvents));
+
+            if (!loadBalanced)
+            {
+                exception.Should().BeOfType<ArgumentException>();
+            }
+            else
+            {
+                exception.Should().BeNull();
+            }
+        }
+
+        [Theory]
+#pragma warning disable CS0618 // Type or member is obsolete
+        [InlineData(ConnectionModeSwitch.UseConnectionMode, true)]
+        [InlineData(ConnectionModeSwitch.UseDirectConnection, false)]
+        [InlineData(ConnectionModeSwitch.NotSet, false)]
+        public void Constructor_should_throw_when_ConnectionModeSwitch_is_invalid(ConnectionModeSwitch connectionModeSwitch, bool shouldThrow)
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
+            _settings = _settings.With(connectionModeSwitch: connectionModeSwitch);
+
+            var exception = Record.Exception(() => new LoadBalancedCluster(_settings, _mockServerFactory, _capturedEvents));
+
+            if (shouldThrow)
+            {
+                exception.Should().BeOfType<ArgumentException>();
+            }
+            else
+            {
+                exception.Should().BeNull();
+            }
+        }
+
+        [Fact]
+        public void Constructor_should_throw_when_more_than_one_endpoint_is_specified()
+        {
+            _settings = _settings.With(endPoints: new[] { _endPoint, new DnsEndPoint("localhost", 27018) });
+
+            var exception = Record.Exception(() => new LoadBalancedCluster(_settings, _mockServerFactory, _capturedEvents));
+
+            exception.Should().BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void Constructor_should_throw_when_replicaSetName_is_specified()
+        {
+            _settings = _settings.With(replicaSetName: "rs");
+
+            var exception = Record.Exception(() => new LoadBalancedCluster(_settings, _mockServerFactory, _capturedEvents));
+
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Description_should_contain_expected_server_description()
+        {
+            var subject = CreateSubject();
+            subject.Description.Servers.Should().BeEmpty();
+            subject.Initialize();
+            _capturedEvents.Clear();
+
+            PublishDescription(_endPoint);
+
+            var description = subject.Description;
+            description.Servers.Should().ContainSingle(s => EndPointHelper.Equals(s.EndPoint, _endPoint) && s.State == ServerState.Connected);
+
+            _capturedEvents.Next().Should().BeOfType<ClusterDescriptionChangedEvent>();
+            _capturedEvents.Any().Should().BeFalse();
+        }
+
+        [Fact]
+        public void Dispose_should_dispose_of_the_server()
+        {
+            var subject = CreateSubject();
+            subject._state().Value.Should().Be(0); // initial
+            subject.Initialize();
+            subject._state().Value.Should().Be(1); // opened
+
+            _capturedEvents.Clear();
+
+            subject.Dispose();
+            subject._state().Value.Should().Be(2); // disposed
+
+            var mockServer = Mock.Get(_mockServerFactory.GetServer(_endPoint));
+            mockServer.Verify(s => s.Dispose(), Times.Once);
+
+            _capturedEvents.Next().Should().BeOfType<ClusterClosingEvent>();
+            _capturedEvents.Next().Should().BeOfType<ClusterClosedEvent>();
+            _capturedEvents.Any().Should().BeFalse();
+        }
+
+
+        [Fact]
+        public void Initialize_should_create_and_initialize_the_server()
+        {
+            var subject = CreateSubject();
+            subject._state().Value.Should().Be(0); // initial
+            subject.Initialize();
+            subject._state().Value.Should().Be(1); // opened
+
+            var mockServer = Mock.Get(_mockServerFactory.GetServer(_endPoint));
+            mockServer.Verify(s => s.Initialize(), Times.Once);
+
+            _capturedEvents.Next().Should().BeOfType<ClusterOpeningEvent>();
+            _capturedEvents.Next().Should().BeOfType<ClusterDescriptionChangedEvent>();
+            _capturedEvents.Next().Should().BeOfType<ClusterOpenedEvent>();
+            _capturedEvents.Any().Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(ConnectionStringScheme.MongoDB, false)]
+        [InlineData(ConnectionStringScheme.MongoDBPlusSrv, true)]
+        public void Initialize_should_not_start_dns_monitor_thread_when_scheme_is_MongoDB(ConnectionStringScheme connectionStringScheme, bool shouldStartDnsResolving)
+        {
+            var settings = _settings.With(scheme: connectionStringScheme, endPoints: new[] { new DnsEndPoint("a.b.com", 53) });
+            using (var subject = CreateSubject(settings))
+            {
+                subject.Initialize();
+                if (connectionStringScheme == ConnectionStringScheme.MongoDBPlusSrv)
+                {
+                    PublishDnsResults(subject, _endPoint);
+                }
+
+                if (shouldStartDnsResolving)
+                {
+                    subject._dnsMonitorThread().Should().NotBeNull();
+                }
+                else
+                {
+                    subject._dnsMonitorThread().Should().BeNull();
+                }
+            }
+
+            _capturedEvents.Next().Should().BeOfType<ClusterOpeningEvent>();
+            if (connectionStringScheme == ConnectionStringScheme.MongoDB)
+            {
+                _capturedEvents.Next().Should().BeOfType<ClusterDescriptionChangedEvent>();
+                _capturedEvents.Next().Should().BeOfType<ClusterOpenedEvent>();
+            }
+            else
+            {
+                // the events are in reverse order because async mode for srv resolving
+                _capturedEvents.Next().Should().BeOfType<ClusterOpenedEvent>();
+                _capturedEvents.Next().Should().BeOfType<ClusterDescriptionChangedEvent>();
+            }
+            _capturedEvents.Next().Should().BeOfType<ClusterClosingEvent>();
+            _capturedEvents.Next().Should().BeOfType<ClusterClosedEvent>();
+            _capturedEvents.Any().Should().BeFalse();
+        }
+
+        [Fact]
+        public void Initialize_should_throw_when_disposed()
+        {
+            var subject = CreateSubject();
+            subject.Dispose();
+
+            var exception = Record.Exception(() => subject.Initialize());
+
+            exception.Should().BeOfType<ObjectDisposedException>();
+        }
+
+        [Fact]
+        public void ProcessDnsResults_should_call_Initialize_on_added_servers()
+        {
+            var settings = _settings.With(scheme: ConnectionStringScheme.MongoDBPlusSrv, endPoints: new[] { new DnsEndPoint("a.b.com", 53) });
+            var mockDnsMonitorFactory = CreateMockDnsMonitorFactory();
+            using (var subject = CreateSubject(settings: settings, dnsMonitorFactory: mockDnsMonitorFactory.Object))
+            {
+                subject.Initialize();
+                var endPoints = new[] { _endPoint }.ToArray();
+
+                PublishDnsResults(subject, endPoints);
+
+                var server = subject._server();
+                var mockServer = Mock.Get(server);
+                mockServer.Verify(m => m.Initialize(), Times.Once);
+            }
+        }
+
+        [Fact]
+        public void ProcessDnsResults_should_clear_dns_monitor_exception()
+        {
+            var settings = _settings.With(scheme: ConnectionStringScheme.MongoDBPlusSrv, endPoints: new[] { new DnsEndPoint("a.b.com", 53) });
+            var mockDnsMonitorFactory = CreateMockDnsMonitorFactory();
+            using (var subject = CreateSubject(settings: settings, dnsMonitorFactory: mockDnsMonitorFactory.Object))
+            {
+                subject.Initialize();
+                var exception = new Exception("Dns exception");
+                PublishDnsException(subject, exception);
+                subject.Description.DnsMonitorException.Should().BeSameAs(exception);
+
+                PublishDnsResults(subject, _endPoint);
+
+                subject.Description.DnsMonitorException.Should().BeNull();
+            }
+        }
+
+        [Theory]
+        [InlineData(0, "No srv records were resolved.")]
+        [InlineData(2, "Load balanced mode cannot be used with multiple host names.")]
+        [InlineData(3, "Load balanced mode cannot be used with multiple host names.")]
+        public void ProcessDnsResults_should_throw_when_srv_records_number_is_unexpected(int numberOfRecords, string expectedErrorMessage)
+        {
+            var settings = _settings.With(scheme: ConnectionStringScheme.MongoDBPlusSrv, endPoints: new[] { new DnsEndPoint("a.b.com", 53) });
+            var mockDnsMonitorFactory = CreateMockDnsMonitorFactory();
+            using (var subject = CreateSubject(settings: settings, dnsMonitorFactory: mockDnsMonitorFactory.Object))
+            {
+                subject.Initialize();
+                var endPoints = Enumerable.Repeat(_endPoint, numberOfRecords).ToArray();
+                var originalDescription = subject.Description;
+
+                var exception = Record.Exception(() => PublishDnsResults(subject, endPoints));
+
+                exception
+                    .Should().BeOfType<InvalidOperationException>().Subject
+                    .Message.Should().Be(expectedErrorMessage);
+            }
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void SelectServer_should_return_expected_server(
+            [Values(ConnectionStringScheme.MongoDB, ConnectionStringScheme.MongoDBPlusSrv)] ConnectionStringScheme connectionStringScheme,
+            [Values(false, true)] bool async)
+        {
+            var settings = _settings.With(scheme: connectionStringScheme);
+            var mockDnsMonitorFactory = CreateMockDnsMonitorFactory();
+            using (var subject = CreateSubject(settings: settings, dnsMonitorFactory: mockDnsMonitorFactory.Object))
+            {
+                subject.Initialize();
+
+                if (connectionStringScheme == ConnectionStringScheme.MongoDBPlusSrv)
+                {
+                    PublishDnsResults(subject, _endPoint);
+                }
+
+                PublishDescription(_endPoint); 
+
+                IServer result;
+                if (async)
+                {
+                    result = subject.SelectServerAsync(Mock.Of<IServerSelector>(), CancellationToken.None).GetAwaiter().GetResult();
+                }
+                else
+                {
+                    result = subject.SelectServer(Mock.Of<IServerSelector>(), CancellationToken.None);
+                }
+
+                result.EndPoint.Should().Be(_endPoint);
+            }
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void SelectServer_should_throw_server_selection_timeout_if_server_has_not_been_created_in_time(
+            [Values(ConnectionStringScheme.MongoDB, ConnectionStringScheme.MongoDBPlusSrv)] ConnectionStringScheme connectionStringScheme,
+            [Values(false, true)] bool async)
+        {
+            var serverSelectionTimeout = TimeSpan.FromMilliseconds(500);
+            var settings = _settings.With(scheme: connectionStringScheme, serverSelectionTimeout: serverSelectionTimeout);
+            var mockDnsMonitorFactory = CreateMockDnsMonitorFactory();
+            using (var subject = CreateSubject(settings: settings, dnsMonitorFactory: mockDnsMonitorFactory.Object))
+            {
+                subject.Initialize();
+
+                var dnsException = new Exception("Dns exception");
+                if (connectionStringScheme == ConnectionStringScheme.MongoDBPlusSrv)
+                {
+                    // it has affect only on srv mode
+                    PublishDnsException(subject, dnsException);
+                }
+
+                Exception exception;
+                if (async)
+                {
+                    exception = Record.Exception(() => subject.SelectServerAsync(Mock.Of<IServerSelector>(), CancellationToken.None).GetAwaiter().GetResult());
+                }
+                else
+                {
+                    exception = Record.Exception(() => subject.SelectServer(Mock.Of<IServerSelector>(), CancellationToken.None));
+                }
+
+                var ex = exception.Should().BeOfType<TimeoutException>().Subject;
+                ex.Message.Should().StartWith($"A timeout occurred after {serverSelectionTimeout.TotalMilliseconds}ms selecting a server. Client view of cluster state is ");
+                if (connectionStringScheme == ConnectionStringScheme.MongoDBPlusSrv)
+                {
+                    ex.Message.Contains(dnsException.ToString());
+                }
+                else
+                {
+                    ex.Message.Should().NotContain(dnsException.ToString());
+                }
+            }
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void SelectServer_should_be_cancelled_by_cancellationToken(
+            [Values(ConnectionStringScheme.MongoDB, ConnectionStringScheme.MongoDBPlusSrv)] ConnectionStringScheme connectionStringScheme,
+            [Values(false, true)] bool async)
+        {
+            var settings = _settings.With(scheme: connectionStringScheme);
+            var mockDnsMonitorFactory = CreateMockDnsMonitorFactory();
+            using (var subject = CreateSubject(settings: settings, dnsMonitorFactory: mockDnsMonitorFactory.Object))
+            {
+                subject.Initialize();
+
+                Exception exception;
+                using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(100)))
+                {
+                    if (async)
+                    {
+                        exception = Record.Exception(() => subject.SelectServerAsync(Mock.Of<IServerSelector>(), cancellationTokenSource.Token).GetAwaiter().GetResult());
+                    }
+                    else
+                    {
+                        exception = Record.Exception(() => subject.SelectServer(Mock.Of<IServerSelector>(), cancellationTokenSource.Token));
+                    }
+                }
+
+                exception.Should().BeOfType<OperationCanceledException>();
+            }
+        }
+
+        [Fact]
+        public void Should_call_dispose_on_server_when_the_cluster_is_disposed()
+        {
+            _settings = _settings.With(endPoints: new[] { _endPoint });
+
+            using (var subject = CreateSubject())
+            {
+                subject.Initialize();
+                _capturedEvents.Clear();
+                subject.Dispose();
+
+                var mockServer = Mock.Get(_mockServerFactory.GetServer(_endPoint));
+                mockServer.Verify(s => s.Dispose(), Times.Once);
+
+                _capturedEvents.Next().Should().BeOfType<ClusterClosingEvent>();
+                _capturedEvents.Next().Should().BeOfType<ClusterClosedEvent>();
+                _capturedEvents.Any().Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public void ShouldMonitorStop_should_always_be_true()
+        {
+            var settings = _settings.With(scheme: ConnectionStringScheme.MongoDBPlusSrv, endPoints: new[] { new DnsEndPoint("a.b.com", 53) });
+            var mockDnsMonitorFactory = CreateMockDnsMonitorFactory();
+            using (var subject = CreateSubject(settings: settings, dnsMonitorFactory: mockDnsMonitorFactory.Object))
+            {
+                var result = ((IDnsMonitoringCluster)subject).ShouldDnsMonitorStop();
+                result.Should().BeTrue();
+            }
+        }
+
+        // private methods
+        private void AssertTryGetEventHandlerWasCalled<TEvent>(Mock<IEventSubscriber> mockEventSubscriber)
+        {
+            Action<TEvent> handler;
+            mockEventSubscriber.Verify(m => m.TryGetEventHandler(out handler), Times.Once);
+        }
+
+        private Mock<IDnsMonitorFactory> CreateMockDnsMonitorFactory()
+        {
+            var mockDnsMonitorFactory = new Mock<IDnsMonitorFactory>();
+            mockDnsMonitorFactory
+                .Setup(m => m.CreateDnsMonitor(It.IsAny<IDnsMonitoringCluster>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Mock.Of<IDnsMonitor>());
+            return mockDnsMonitorFactory;
+        }
+
+        private LoadBalancedCluster CreateSubject(ClusterSettings settings = null, IDnsMonitorFactory dnsMonitorFactory = null)
+        {
+            return dnsMonitorFactory != null
+                ? new LoadBalancedCluster(settings ?? _settings, _mockServerFactory, _capturedEvents, dnsMonitorFactory)
+                : new LoadBalancedCluster(settings ?? _settings, _mockServerFactory, _capturedEvents);
+        }
+
+        private void PublishDnsException(IDnsMonitoringCluster cluster, Exception exception)
+        {
+            cluster.ProcessDnsException(exception);
+        }
+
+        private void PublishDnsResults(IDnsMonitoringCluster cluster, params EndPoint[] endPoints)
+        {
+            cluster.ProcessDnsResults(endPoints.Cast<DnsEndPoint>().ToList());
+        }
+
+        private void PublishDescription(EndPoint endPoint)
+        {
+            var current = _mockServerFactory.GetServerDescription(endPoint);
+
+            var description = current.With(
+                state: ServerState.Connected,
+                type: ServerType.LoadBalanced);
+
+            _mockServerFactory.PublishDescription(description);
+        }
+    }
+
+    internal static class LoadBalancedClusterReflector
+    {
+        public static IDnsMonitorFactory _dnsMonitorFactory(this LoadBalancedCluster cluster) => (IDnsMonitorFactory)Reflector.GetFieldValue(cluster, nameof(_dnsMonitorFactory));
+        public static Thread _dnsMonitorThread(this LoadBalancedCluster cluster) => (Thread)Reflector.GetFieldValue(cluster, nameof(_dnsMonitorThread));
+        public static IEventSubscriber _eventSubscriber(this LoadBalancedCluster cluster) => (IEventSubscriber)Reflector.GetFieldValue(cluster, nameof(_eventSubscriber));
+        public static IClusterableServer _server(this LoadBalancedCluster cluster) => (IClusterableServer)Reflector.GetFieldValue(cluster, nameof(_server));
+        public static InterlockedInt32 _state(this LoadBalancedCluster cluster) => (InterlockedInt32)Reflector.GetFieldValue(cluster, nameof(_state));
+    }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/LoadBalancedClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/LoadBalancedClusterTests.cs
@@ -147,6 +147,17 @@ namespace MongoDB.Driver.Core.Tests.Core.Clusters
         }
 
         [Fact]
+        public void CreateInitializedServer_should_throw_if_cluster_disposed()
+        {
+            var subject = CreateSubject();
+            subject.Dispose();
+
+            var exception = Record.Exception(() => subject.CreateInitializedServer(_endPoint));
+
+            exception.Should().BeOfType<ObjectDisposedException>();
+        }
+
+        [Fact]
         public void Description_should_contain_expected_server_description()
         {
             var subject = CreateSubject();
@@ -496,6 +507,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Clusters
 
     internal static class LoadBalancedClusterReflector
     {
+        public static IClusterableServer CreateInitializedServer(this LoadBalancedCluster cluster, EndPoint endPoint) => (IClusterableServer)Reflector.Invoke(cluster, nameof(CreateInitializedServer), endPoint);
         public static IDnsMonitorFactory _dnsMonitorFactory(this LoadBalancedCluster cluster) => (IDnsMonitorFactory)Reflector.GetFieldValue(cluster, nameof(_dnsMonitorFactory));
         public static Thread _dnsMonitorThread(this LoadBalancedCluster cluster) => (Thread)Reflector.GetFieldValue(cluster, nameof(_dnsMonitorThread));
         public static IEventSubscriber _eventSubscriber(this LoadBalancedCluster cluster) => (IEventSubscriber)Reflector.GetFieldValue(cluster, nameof(_eventSubscriber));

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -61,16 +61,16 @@ namespace MongoDB.Driver.Core.Connections
 
             _mockConnectionInitializer = new Mock<IConnectionInitializer>();
             _mockConnectionInitializer
-                .Setup(i => i.Handshake(It.IsAny<IConnection>(), CancellationToken.None))
+                .Setup(i => i.SendHello(It.IsAny<IConnection>(), CancellationToken.None))
                 .Returns(_connectionDescription);
             _mockConnectionInitializer
-                .Setup(i => i.ConnectionAuthentication(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
+                .Setup(i => i.Authenticate(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
                 .Returns(_connectionDescription);
             _mockConnectionInitializer
-                .Setup(i => i.HandshakeAsync(It.IsAny<IConnection>(), CancellationToken.None))
+                .Setup(i => i.SendHelloAsync(It.IsAny<IConnection>(), CancellationToken.None))
                 .ReturnsAsync(_connectionDescription);
             _mockConnectionInitializer
-                .Setup(i => i.ConnectionAuthenticationAsync(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
+                .Setup(i => i.AuthenticateAsync(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
                 .ReturnsAsync(_connectionDescription);
 
             _subject = new BinaryConnection(
@@ -105,16 +105,16 @@ namespace MongoDB.Driver.Core.Connections
 
             var socketException = new SocketException();
             _mockConnectionInitializer
-                .Setup(i => i.Handshake(It.IsAny<IConnection>(), CancellationToken.None))
+                .Setup(i => i.SendHello(It.IsAny<IConnection>(), CancellationToken.None))
                 .Returns(connectionDescription);
             _mockConnectionInitializer
-                .Setup(i => i.HandshakeAsync(It.IsAny<IConnection>(), CancellationToken.None))
+                .Setup(i => i.SendHelloAsync(It.IsAny<IConnection>(), CancellationToken.None))
                 .ReturnsAsync(connectionDescription);
             _mockConnectionInitializer
-                .Setup(i => i.ConnectionAuthentication(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
+                .Setup(i => i.Authenticate(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
                 .Throws(socketException);
             _mockConnectionInitializer
-                .Setup(i => i.ConnectionAuthenticationAsync(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
+                .Setup(i => i.AuthenticateAsync(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
                 .ThrowsAsync(socketException);
 
             Exception exception;
@@ -164,14 +164,14 @@ namespace MongoDB.Driver.Core.Connections
             {
                 var result = new TaskCompletionSource<ConnectionDescription>();
                 result.SetException(new SocketException());
-                _mockConnectionInitializer.Setup(i => i.HandshakeAsync(It.IsAny<IConnection>(), It.IsAny<CancellationToken>()))
+                _mockConnectionInitializer.Setup(i => i.SendHelloAsync(It.IsAny<IConnection>(), It.IsAny<CancellationToken>()))
                     .Returns(result.Task);
 
                 act = () => _subject.OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
             }
             else
             {
-                _mockConnectionInitializer.Setup(i => i.Handshake(It.IsAny<IConnection>(), It.IsAny<CancellationToken>()))
+                _mockConnectionInitializer.Setup(i => i.SendHello(It.IsAny<IConnection>(), It.IsAny<CancellationToken>()))
                     .Throws<SocketException>();
 
                 act = () => _subject.Open(CancellationToken.None);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -108,8 +108,8 @@ namespace MongoDB.Driver.Core.Connections
                 .Setup(i => i.Handshake(It.IsAny<IConnection>(), CancellationToken.None))
                 .Returns(connectionDescription);
             _mockConnectionInitializer
-                .Setup(i => i.Handshake(It.IsAny<IConnection>(), CancellationToken.None))
-                .Returns(connectionDescription);
+                .Setup(i => i.HandshakeAsync(It.IsAny<IConnection>(), CancellationToken.None))
+                .ReturnsAsync(connectionDescription);
             _mockConnectionInitializer
                 .Setup(i => i.ConnectionAuthentication(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
                 .Throws(socketException);
@@ -129,7 +129,6 @@ namespace MongoDB.Driver.Core.Connections
 
             _subject.Description.Should().Be(connectionDescription);
             var ex = exception.Should().BeOfType<MongoConnectionException>().Subject;
-            // ex.ServiceId.Should().Be(serviceId); TODO: restrore when server will support serviceId
             ex.InnerException.Should().BeOfType<SocketException>();
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
@@ -79,7 +79,12 @@ namespace MongoDB.Driver.Core.Connections
             var serverId = new ServerId(new ClusterId(), _endPoint);
 
             _mockConnectionInitializer = new Mock<IConnectionInitializer>();
-            _mockConnectionInitializer.Setup(i => i.InitializeConnectionAsync(It.IsAny<IConnection>(), CancellationToken.None))
+            _mockConnectionInitializer.Setup(i => i.HandshakeAsync(It.IsAny<IConnection>(), CancellationToken.None))
+                .Returns(() => Task.FromResult(new ConnectionDescription(
+                    new ConnectionId(serverId),
+                    new IsMasterResult(new BsonDocument()),
+                    new BuildInfoResult(new BsonDocument("version", "2.6.3")))));
+            _mockConnectionInitializer.Setup(i => i.ConnectionAuthenticationAsync(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
                 .Returns(() => Task.FromResult(new ConnectionDescription(
                     new ConnectionId(serverId),
                     new IsMasterResult(new BsonDocument()),

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
@@ -79,12 +79,12 @@ namespace MongoDB.Driver.Core.Connections
             var serverId = new ServerId(new ClusterId(), _endPoint);
 
             _mockConnectionInitializer = new Mock<IConnectionInitializer>();
-            _mockConnectionInitializer.Setup(i => i.HandshakeAsync(It.IsAny<IConnection>(), CancellationToken.None))
+            _mockConnectionInitializer.Setup(i => i.SendHelloAsync(It.IsAny<IConnection>(), CancellationToken.None))
                 .Returns(() => Task.FromResult(new ConnectionDescription(
                     new ConnectionId(serverId),
                     new IsMasterResult(new BsonDocument()),
                     new BuildInfoResult(new BsonDocument("version", "2.6.3")))));
-            _mockConnectionInitializer.Setup(i => i.ConnectionAuthenticationAsync(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
+            _mockConnectionInitializer.Setup(i => i.AuthenticateAsync(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
                 .Returns(() => Task.FromResult(new ConnectionDescription(
                     new ConnectionId(serverId),
                     new IsMasterResult(new BsonDocument()),

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -47,13 +47,13 @@ namespace MongoDB.Driver.Core.Connections
             var subject = CreateSubject();
             if (async)
             {
-                Record.Exception(() => subject.ConnectionAuthenticationAsync(null, mockConnectionDescription, CancellationToken.None).GetAwaiter().GetResult()).Should().BeOfType<ArgumentNullException>();
-                Record.Exception(() => subject.ConnectionAuthenticationAsync(Mock.Of<IConnection>(), null, CancellationToken.None).GetAwaiter().GetResult()).Should().BeOfType<ArgumentNullException>();
+                Record.Exception(() => subject.AuthenticateAsync(null, mockConnectionDescription, CancellationToken.None).GetAwaiter().GetResult()).Should().BeOfType<ArgumentNullException>();
+                Record.Exception(() => subject.AuthenticateAsync(Mock.Of<IConnection>(), null, CancellationToken.None).GetAwaiter().GetResult()).Should().BeOfType<ArgumentNullException>();
             }
             else
             {
-                Record.Exception(() => subject.ConnectionAuthentication(null, mockConnectionDescription, CancellationToken.None)).Should().BeOfType<ArgumentNullException>();
-                Record.Exception(() => subject.ConnectionAuthentication(Mock.Of<IConnection>(), null, CancellationToken.None)).Should().BeOfType<ArgumentNullException>();
+                Record.Exception(() => subject.Authenticate(null, mockConnectionDescription, CancellationToken.None)).Should().BeOfType<ArgumentNullException>();
+                Record.Exception(() => subject.Authenticate(Mock.Of<IConnection>(), null, CancellationToken.None)).Should().BeOfType<ArgumentNullException>();
             }
         }
 
@@ -111,8 +111,8 @@ namespace MongoDB.Driver.Core.Connections
         {
             var subject = CreateSubject();
             var exception = async
-                ? Record.Exception(() => subject.HandshakeAsync(null, CancellationToken.None).GetAwaiter().GetResult())
-                : Record.Exception(() => subject.Handshake(null, CancellationToken.None));
+                ? Record.Exception(() => subject.SendHelloAsync(null, CancellationToken.None).GetAwaiter().GetResult())
+                : Record.Exception(() => subject.SendHello(null, CancellationToken.None));
             exception.Should().BeOfType<ArgumentNullException>();
         }
 
@@ -328,13 +328,13 @@ namespace MongoDB.Driver.Core.Connections
             ConnectionDescription result;
             if (async)
             {
-                result = connectionInitializer.HandshakeAsync(connection, cancellationToken).GetAwaiter().GetResult();
-                return connectionInitializer.ConnectionAuthenticationAsync(connection, result, cancellationToken).GetAwaiter().GetResult();
+                result = connectionInitializer.SendHelloAsync(connection, cancellationToken).GetAwaiter().GetResult();
+                return connectionInitializer.AuthenticateAsync(connection, result, cancellationToken).GetAwaiter().GetResult();
             }
             else
             {
-                result = connectionInitializer.Handshake(connection, cancellationToken);
-                return connectionInitializer.ConnectionAuthentication(connection, result, cancellationToken);
+                result = connectionInitializer.SendHello(connection, cancellationToken);
+                return connectionInitializer.Authenticate(connection, result, cancellationToken);
             }
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -30,12 +30,33 @@ using MongoDB.Driver.Core.Authentication;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.WireProtocol.Messages;
+using Moq;
 
 namespace MongoDB.Driver.Core.Connections
 {
     public class ConnectionInitializerTests
     {
         private static readonly ServerId __serverId = new ServerId(new ClusterId(), new DnsEndPoint("localhost", 27017));
+
+        [Theory]
+        [ParameterAttributeData]
+        public void ConnectionAuthentication_should_throw_an_ArgumentNullException_if_required_arguments_missed(
+            [Values(false, true)] bool async)
+        {
+            var mockConnectionDescription = new ConnectionDescription(new ConnectionId(__serverId), new IsMasterResult(new BsonDocument()), new BuildInfoResult(new BsonDocument("version", "0.0.0")));
+            var subject = CreateSubject();
+            if (async)
+            {
+                Record.Exception(() => subject.ConnectionAuthenticationAsync(null, mockConnectionDescription, CancellationToken.None).GetAwaiter().GetResult()).Should().BeOfType<ArgumentNullException>();
+                Record.Exception(() => subject.ConnectionAuthenticationAsync(Mock.Of<IConnection>(), null, CancellationToken.None).GetAwaiter().GetResult()).Should().BeOfType<ArgumentNullException>();
+            }
+            else
+            {
+                Record.Exception(() => subject.ConnectionAuthentication(null, mockConnectionDescription, CancellationToken.None)).Should().BeOfType<ArgumentNullException>();
+                Record.Exception(() => subject.ConnectionAuthentication(Mock.Of<IConnection>(), null, CancellationToken.None)).Should().BeOfType<ArgumentNullException>();
+            }
+        }
+
 
         [Theory]
         [ParameterAttributeData]
@@ -47,8 +68,8 @@ namespace MongoDB.Driver.Core.Connections
                 source: "Pathfinder", username: "Barclay", password: "Barclay-Alpha-1-7-Gamma");
             var authenticator = CreateAuthenticator(authenticatorType, credentials);
 
-            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
-            var helloDocument = subject.CreateInitialHelloCommand(new[] { authenticator });
+            var subject = CreateSubject();
+            var helloDocument = subject.CreateInitialHelloCommand(new[] { authenticator }, false);
 
             helloDocument.Should().Contain("isMaster");
             helloDocument.Should().Contain("speculativeAuthenticate");
@@ -71,7 +92,7 @@ namespace MongoDB.Driver.Core.Connections
             var authenticator = CreateAuthenticator(authenticatorType, credentials);
 
             var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: new ServerApi(ServerApiVersion.V1));
-            var helloDocument = subject.CreateInitialHelloCommand(new[] { authenticator });
+            var helloDocument = subject.CreateInitialHelloCommand(new[] { authenticator }, false);
 
             helloDocument.Should().Contain("hello");
             helloDocument.Should().Contain("speculativeAuthenticate");
@@ -85,6 +106,18 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
+        public void Handshake_should_throw_an_ArgumentNullException_if_the_connection_is_null(
+            [Values(false, true)] bool async)
+        {
+            var subject = CreateSubject();
+            var exception = async
+                ? Record.Exception(() => subject.HandshakeAsync(null, CancellationToken.None).GetAwaiter().GetResult())
+                : Record.Exception(() => subject.Handshake(null, CancellationToken.None));
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
         public void InitializeConnection_should_acquire_connectionId_from_hello_response([Values(false, true)] bool async)
         {
             var helloReply = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson("{ ok : 1, connectionId : 1 }"));
@@ -94,16 +127,8 @@ namespace MongoDB.Driver.Core.Connections
             connection.EnqueueCommandResponseMessage(helloReply);
             connection.EnqueueCommandResponseMessage(buildInfoReply);
 
-            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: new ServerApi(ServerApiVersion.V1));
-            ConnectionDescription result;
-            if (async)
-            {
-                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
-            }
-            else
-            {
-                result = subject.InitializeConnection(connection, CancellationToken.None);
-            }
+            var subject = CreateSubject(withServerApi: true);
+            var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
             var sentMessages = connection.GetSentMessages();
             sentMessages.Should().HaveCount(2);
@@ -123,16 +148,8 @@ namespace MongoDB.Driver.Core.Connections
             connection.EnqueueReplyMessage(legacyHelloReply);
             connection.EnqueueReplyMessage(buildInfoReply);
 
-            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
-            ConnectionDescription result;
-            if (async)
-            {
-                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
-            }
-            else
-            {
-                result = subject.InitializeConnection(connection, CancellationToken.None);
-            }
+            var subject = CreateSubject();
+            var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
             var sentMessages = connection.GetSentMessages();
             sentMessages.Should().HaveCount(2);
@@ -157,18 +174,11 @@ namespace MongoDB.Driver.Core.Connections
             connection.EnqueueReplyMessage(legacyHelloReply);
             connection.EnqueueReplyMessage(buildInfoReply);
 
-            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
+            var subject = CreateSubject();
             // We expect authentication to fail since we have not enqueued the expected authentication replies
             try
             {
-                if (async)
-                {
-                    subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
-                }
-                else
-                {
-                    subject.InitializeConnection(connection, CancellationToken.None);
-                }
+                _ = InitializeConnection(subject, connection, async, CancellationToken.None);
             }
             catch (InvalidOperationException ex)
             {
@@ -187,25 +197,6 @@ namespace MongoDB.Driver.Core.Connections
             speculativeAuthenticateDocument["db"].Should().Be(new BsonString(credentials.Source));
         }
 
-        [Theory]
-        [ParameterAttributeData]
-        public void InitializeConnection_should_throw_an_ArgumentNullException_if_the_connection_is_null(
-            [Values(false, true)]
-            bool async)
-        {
-            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
-            Action act;
-            if (async)
-            {
-                act = () => subject.InitializeConnectionAsync(null, CancellationToken.None).GetAwaiter().GetResult();
-            }
-            else
-            {
-                act = () => subject.InitializeConnection(null, CancellationToken.None);
-            }
-
-            act.ShouldThrow<ArgumentNullException>();
-        }
 
         [Theory]
         [ParameterAttributeData]
@@ -221,15 +212,7 @@ namespace MongoDB.Driver.Core.Connections
 
             var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi);
 
-            ConnectionDescription result;
-            if (async)
-            {
-                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
-            }
-            else
-            {
-                result = subject.InitializeConnection(connection, CancellationToken.None);
-            }
+            var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
             result.ConnectionId.ServerValue.Should().Be(1);
 
@@ -260,17 +243,9 @@ namespace MongoDB.Driver.Core.Connections
             var buildInfoReply = RawBsonDocumentHelper.FromJson("{ ok : 1, version : \"4.2.0\" }");
             connection.EnqueueReplyMessage(MessageHelper.BuildReply(buildInfoReply));
 
-            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, null);
+            var subject = CreateSubject();
 
-            ConnectionDescription result;
-            if (async)
-            {
-                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
-            }
-            else
-            {
-                result = subject.InitializeConnection(connection, CancellationToken.None);
-            }
+            var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
             result.ConnectionId.ServerValue.Should().Be(1);
 
@@ -291,7 +266,7 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
-        public void InitializeConnectionA_should_build_the_ConnectionDescription_correctly(
+        public void InitializeConnection_should_build_the_ConnectionDescription_correctly(
             [Values("noop", "zlib", "snappy", "zstd")] string compressorType,
             [Values(false, true)] bool async)
         {
@@ -307,16 +282,8 @@ namespace MongoDB.Driver.Core.Connections
             connection.EnqueueReplyMessage(buildInfoReply);
             connection.EnqueueReplyMessage(gleReply);
 
-            var subject = new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: null);
-            ConnectionDescription result;
-            if (async)
-            {
-                result = subject.InitializeConnectionAsync(connection, CancellationToken.None).GetAwaiter().GetResult();
-            }
-            else
-            {
-                result = subject.InitializeConnection(connection, CancellationToken.None);
-            }
+            var subject = CreateSubject();
+            var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
             result.ServerVersion.Should().Be(new SemanticVersion(2, 6, 3));
             result.ConnectionId.ServerValue.Should().Be(10);
@@ -337,6 +304,7 @@ namespace MongoDB.Driver.Core.Connections
             }
         }
 
+        // private methods
         private IAuthenticator CreateAuthenticator(string authenticatorType, UsernamePasswordCredential credentials)
         {
             switch (authenticatorType)
@@ -351,13 +319,32 @@ namespace MongoDB.Driver.Core.Connections
                     throw new Exception("Invalid authenticator type.");
             }
         }
+
+        private ConnectionInitializer CreateSubject(bool withServerApi = false) =>
+            new ConnectionInitializer("test", new[] { new CompressorConfiguration(CompressorType.Zlib) }, serverApi: withServerApi ? new ServerApi(ServerApiVersion.V1) : null);
+
+        private ConnectionDescription InitializeConnection(ConnectionInitializer connectionInitializer, IConnection connection, bool async, CancellationToken cancellationToken)
+        {
+            ConnectionDescription result;
+            if (async)
+            {
+                result = connectionInitializer.HandshakeAsync(connection, cancellationToken).GetAwaiter().GetResult();
+                return connectionInitializer.ConnectionAuthenticationAsync(connection, result, cancellationToken).GetAwaiter().GetResult();
+            }
+            else
+            {
+                result = connectionInitializer.Handshake(connection, cancellationToken);
+                return connectionInitializer.ConnectionAuthentication(connection, result, cancellationToken);
+            }
+        }
     }
 
     internal static class ConnectionInitializerReflector
     {
         public static BsonDocument CreateInitialHelloCommand(
             this ConnectionInitializer initializer,
-            IReadOnlyList<IAuthenticator> authenticators) =>
-                (BsonDocument)Reflector.Invoke(initializer, nameof(CreateInitialHelloCommand), authenticators);
+            IReadOnlyList<IAuthenticator> authenticators,
+            bool loadBalanced) =>
+                (BsonDocument)Reflector.Invoke(initializer, nameof(CreateInitialHelloCommand), authenticators, loadBalanced);
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
@@ -226,6 +226,7 @@ namespace MongoDB.Driver.Core.Connections
         [InlineData("{ ok: 1, isreplicaset: 0 }", ServerType.Standalone)]
         [InlineData("{ ok: 1, msg: \"isdbgrid\" }", ServerType.ShardRouter)]
         [InlineData("{ ok: 1, msg: \"isdbgrid\" }", ServerType.ShardRouter)]
+        [InlineData("{ ok: 1, serviceId: ObjectId('111111111111111111111111') }", ServerType.LoadBalanced)]
         [InlineData("{ ok: 1 }", ServerType.Standalone)]
         [InlineData("{ ok: 0 }", ServerType.Unknown)]
         public void ServerType_should_parse_document_correctly(string json, ServerType expected)
@@ -233,6 +234,20 @@ namespace MongoDB.Driver.Core.Connections
             var subject = new IsMasterResult(BsonDocument.Parse(json));
 
             subject.ServerType.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("{ }", false)]
+        [InlineData("{ serviceId : ObjectId('000000000000000000000000') }", true)]
+        public void ServiceId_should_parse_document_correctly(string json, bool shouldBeParsed)
+        {
+            var subject = new IsMasterResult(BsonDocument.Parse(json));
+
+            subject.ServiceId.HasValue.Should().Be(shouldBeParsed);
+            if (shouldBeParsed)
+            {
+                subject.ServiceId.Should().Be(ObjectId.Empty);
+            }
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ReadConcernHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ReadConcernHelperTests.cs
@@ -27,6 +27,21 @@ namespace MongoDB.Driver.Core.Operations
 {
     public class ReadConcernHelperTests
     {
+        [Fact]
+        public void GetReadConcernForCommand_should_consider_session_supported_when_logicalSessionTimeoutMinutes_is_null()
+        {
+            var session = CreateSession(
+                isInTransaction: false,
+                isCausallyConsistent: true,
+                operationTime: new BsonTimestamp(1234));
+            var connectionDescription = CreateConnectionDescription(logicalSessionTimeoutMinutes: false, serviceId: true);
+            var readConcern = ReadConcern.FromBsonDocument(BsonDocument.Parse("{}"));
+
+            var result = ReadConcernHelper.GetReadConcernForCommand(session, connectionDescription, readConcern);
+
+            result.Should().Be(new BsonDocument("afterClusterTime", new BsonTimestamp(1234)));
+        }
+
         [Theory]
         [InlineData(false, false, null, "{ level : 'majority' }", "{ level : 'majority' }")]
         [InlineData(false, false, 1234, "{ level : 'majority' }", "{ level : 'majority' }")]
@@ -47,7 +62,7 @@ namespace MongoDB.Driver.Core.Operations
                 isInTransaction: isInTransaction,
                 isCausallyConsistent: isCausallyConsistent,
                 operationTime: operationTime.HasValue ? new BsonTimestamp(operationTime.Value) : null);
-            var connectionDescription = CreateConnectionDescription(areSessionsSupported: true);
+            var connectionDescription = CreateConnectionDescription(logicalSessionTimeoutMinutes: true);
             var readConcern = ReadConcern.FromBsonDocument(BsonDocument.Parse(readConcernJson));
 
             var result = ReadConcernHelper.GetReadConcernForCommand(session, connectionDescription, readConcern);
@@ -73,7 +88,7 @@ namespace MongoDB.Driver.Core.Operations
                 currentTransaction: transaction,
                 isCausallyConsistent: isCausallyConsistent,
                 operationTime: operationTime.HasValue ? new BsonTimestamp(operationTime.Value) : null);
-            var connectionDescription = CreateConnectionDescription(areSessionsSupported: true);
+            var connectionDescription = CreateConnectionDescription(logicalSessionTimeoutMinutes: true);
 
             var result = ReadConcernHelper.GetReadConcernForFirstCommandInTransaction(session, connectionDescription);
 
@@ -82,7 +97,8 @@ namespace MongoDB.Driver.Core.Operations
 
         // private methods
         private ConnectionDescription CreateConnectionDescription(
-            bool areSessionsSupported = false)
+            bool logicalSessionTimeoutMinutes = false,
+            bool? serviceId  = null)
         {
             var clusterId = new ClusterId(1);
             var endPoint = new DnsEndPoint("localhost", 27017);
@@ -91,12 +107,13 @@ namespace MongoDB.Driver.Core.Operations
             var isMasterResult = new BsonDocument
             {
                 { "ok", 1 },
-                { "logicalSessionTimeoutMinutes", 30, areSessionsSupported }
+                { "logicalSessionTimeoutMinutes", 30, logicalSessionTimeoutMinutes },
+                { "serviceId", ObjectId.GenerateNewId(), serviceId.HasValue }
             };
             var buildInfoResult = new BsonDocument
             {
                 { "ok", 1 },
-                { "version", areSessionsSupported ? "4.0" : "3.6" }
+                { "version", logicalSessionTimeoutMinutes ? "4.0" : "3.6" }
             };
             return new ConnectionDescription(connectionId, new IsMasterResult(isMasterResult), new BuildInfoResult(buildInfoResult));
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ReadConcernHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ReadConcernHelperTests.cs
@@ -28,7 +28,7 @@ namespace MongoDB.Driver.Core.Operations
     public class ReadConcernHelperTests
     {
         [Fact]
-        public void GetReadConcernForCommand_should_consider_session_supported_when_logicalSessionTimeoutMinutes_is_null()
+        public void GetReadConcernForCommand_should_consider_session_supported_when_logicalSessionTimeoutMinutes_is_null_and_load_balanced_mode()
         {
             var session = CreateSession(
                 isInTransaction: false,

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/LoadBalancedServerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/LoadBalancedServerTests.cs
@@ -1,0 +1,463 @@
+﻿/* Copyright 2021-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core.Bindings;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.ConnectionPools;
+using MongoDB.Driver.Core.Connections;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.TestHelpers;
+using Moq;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Servers
+{
+    public class LoadBalancedTests
+    {
+        private IClusterClock _clusterClock;
+        private ClusterId _clusterId;
+        private ConnectionId _connectionId;
+        private Mock<IConnectionPool> _mockConnectionPool;
+        private Mock<IConnectionPoolFactory> _mockConnectionPoolFactory;
+        private EndPoint _endPoint;
+        private EventCapturer _capturedEvents;
+        private ServerApi _serverApi;
+        private ServerSettings _settings;
+        private LoadBalancedServer _subject;
+
+        public LoadBalancedTests()
+        {
+            _clusterId = new ClusterId();
+            _endPoint = new DnsEndPoint("localhost", 27017);
+
+            _clusterClock = new Mock<IClusterClock>().Object;
+            _mockConnectionPool = new Mock<IConnectionPool>();
+            _mockConnectionPool.Setup(p => p.AcquireConnection(It.IsAny<CancellationToken>())).Returns(new Mock<IConnectionHandle>().Object);
+            _mockConnectionPool.Setup(p => p.AcquireConnectionAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(new Mock<IConnectionHandle>().Object));
+            _mockConnectionPoolFactory = new Mock<IConnectionPoolFactory>();
+            _mockConnectionPoolFactory
+                .Setup(f => f.CreateConnectionPool(It.IsAny<ServerId>(), _endPoint))
+                .Returns(_mockConnectionPool.Object);
+
+            _capturedEvents = new EventCapturer();
+            _serverApi = new ServerApi(ServerApiVersion.V1, true, true);
+            _settings = new ServerSettings(heartbeatInterval: Timeout.InfiniteTimeSpan);
+
+            _subject = new LoadBalancedServer(_clusterId, _clusterClock, _settings, _endPoint, _mockConnectionPoolFactory.Object, _capturedEvents, _serverApi);
+            _connectionId = new ConnectionId(_subject.ServerId);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void ChannelFork_should_not_affect_operations_count([Values(false, true)] bool async)
+        {
+            IClusterableServer server = SetupServer(false, false);
+
+            var channel = async ?
+                server.GetChannelAsync(CancellationToken.None).GetAwaiter().GetResult() :
+                server.GetChannel(CancellationToken.None);
+
+            server.OutstandingOperationsCount.Should().Be(1);
+
+            var forkedChannel = channel.Fork();
+            server.OutstandingOperationsCount.Should().Be(1);
+
+            forkedChannel.Dispose();
+            server.OutstandingOperationsCount.Should().Be(1);
+
+            channel.Dispose();
+            server.OutstandingOperationsCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void Constructor_should_not_throw_when_serverApi_is_null()
+        {
+            _ = new LoadBalancedServer(_clusterId, _clusterClock, _settings, _endPoint, _mockConnectionPoolFactory.Object, _capturedEvents, serverApi: null);
+        }
+
+        [Fact]
+        public void Constructor_should_throw_when_settings_is_null()
+        {
+            var exception = Record.Exception(() => new LoadBalancedServer(_clusterId, _clusterClock, serverSettings: null, _endPoint, _mockConnectionPoolFactory.Object, _capturedEvents, _serverApi));
+
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Constructor_should_throw_when_clusterId_is_null()
+        {
+            var exception = Record.Exception(() => new LoadBalancedServer(clusterId: null, _clusterClock, serverSettings: _settings, _endPoint, _mockConnectionPoolFactory.Object, _capturedEvents, _serverApi));
+
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Constructor_should_throw_when_clusterClock_is_null()
+        {
+            var exception = Record.Exception(() => new LoadBalancedServer(_clusterId, clusterClock: null, serverSettings: _settings, _endPoint, _mockConnectionPoolFactory.Object, _capturedEvents, _serverApi));
+
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Constructor_should_throw_when_endPoint_is_null()
+        {
+            var exception = Record.Exception(() => new LoadBalancedServer(_clusterId, _clusterClock, serverSettings: _settings, endPoint: null, _mockConnectionPoolFactory.Object, _capturedEvents, _serverApi));
+
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Constructor_should_throw_when_connectionPoolFactory_is_null()
+        {
+            var exception = Record.Exception(() => new LoadBalancedServer(_clusterId, _clusterClock, serverSettings: _settings, _endPoint, connectionPoolFactory: null, _capturedEvents, _serverApi));
+
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Constructor_should_throw_when_eventSubscriber_is_null()
+        {
+            var exception = Record.Exception(() => new LoadBalancedServer(_clusterId, _clusterClock, serverSettings: _settings, _endPoint, _mockConnectionPoolFactory.Object, eventSubscriber: null, _serverApi));
+
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Dispose_should_dispose_the_server()
+        {
+            _subject.Initialize();
+            _capturedEvents.Clear();
+
+            _subject.Dispose();
+            _mockConnectionPool.Verify(p => p.Dispose(), Times.Once);
+
+            _capturedEvents.Next().Should().BeOfType<ServerClosingEvent>();
+            _capturedEvents.Next().Should().BeOfType<ServerClosedEvent>();
+            _capturedEvents.Any().Should().BeFalse();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void GetChannel_should_clear_connection_pool_when_opening_connection_throws_MongoAuthenticationException(
+            [Values(false, true)] bool async)
+        {
+            var connectionId = new ConnectionId(new ServerId(_clusterId, _endPoint));
+            var mockConnectionHandle = new Mock<IConnectionHandle>();
+
+            var mockConnectionPool = new Mock<IConnectionPool>();
+            var authenticationException = new MongoAuthenticationException(connectionId, "Invalid login.") { ServiceId = ObjectId.GenerateNewId() };
+            mockConnectionPool
+                .Setup(p => p.AcquireConnection(It.IsAny<CancellationToken>()))
+                .Throws(authenticationException);
+            mockConnectionPool
+                .Setup(p => p.AcquireConnectionAsync(It.IsAny<CancellationToken>()))
+                .Throws(authenticationException);
+            mockConnectionPool.Setup(p => p.Clear(It.IsAny<ObjectId>()));
+
+            var mockConnectionPoolFactory = new Mock<IConnectionPoolFactory>();
+            mockConnectionPoolFactory
+                .Setup(f => f.CreateConnectionPool(It.IsAny<ServerId>(), _endPoint))
+                .Returns(mockConnectionPool.Object);
+
+            var server = new LoadBalancedServer(
+                _clusterId,
+                _clusterClock,
+                _settings,
+                _endPoint,
+                mockConnectionPoolFactory.Object,
+                _capturedEvents,
+                _serverApi);
+            server.Initialize();
+
+            var exception = Record.Exception(() =>
+            {
+                if (async)
+                {
+                    server.GetChannelAsync(CancellationToken.None).GetAwaiter().GetResult();
+                }
+                else
+                {
+                    server.GetChannel(CancellationToken.None);
+                }
+            });
+
+            exception.Should().BeOfType<MongoAuthenticationException>();
+            mockConnectionPool.Verify(p => p.Clear(It.IsAny<ObjectId>()), Times.Once());
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void GetChannel_should_get_a_connection([Values(false, true)] bool async)
+        {
+            _subject.Initialize();
+
+            IChannelHandle channel;
+            if (async)
+            {
+                channel = _subject.GetChannelAsync(CancellationToken.None).GetAwaiter().GetResult();
+            }
+            else
+            {
+                channel = _subject.GetChannel(CancellationToken.None);
+            }
+
+            channel.Should().NotBeNull();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void GetChannel_should_not_increase_operations_count_on_exception(
+            [Values(false, true)] bool async,
+            [Values(false, true)] bool connectionOpenException)
+        {
+            IClusterableServer server = SetupServer(connectionOpenException, !connectionOpenException);
+
+            var exception = Record.Exception(() =>
+            {
+                if (async)
+                {
+                    server.GetChannelAsync(CancellationToken.None).GetAwaiter().GetResult();
+                }
+                else
+                {
+                    server.GetChannel(CancellationToken.None);
+                }
+            });
+
+            exception.Should().NotBeNull();
+            server.OutstandingOperationsCount.Should().Be(0);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void GetChannel_should_set_operations_count_correctly(
+            [Values(false, true)] bool async,
+            [Values(0, 1, 2, 10)] int operationsCount)
+        {
+            IClusterableServer server = SetupServer(false, false);
+
+            var channels = new List<IChannel>();
+            for (int i = 0; i < operationsCount; i++)
+            {
+                if (async)
+                {
+                    channels.Add(server.GetChannelAsync(CancellationToken.None).GetAwaiter().GetResult());
+                }
+                else
+                {
+                    channels.Add(server.GetChannel(CancellationToken.None));
+                }
+            }
+
+            server.OutstandingOperationsCount.Should().Be(operationsCount);
+
+            foreach (var channel in channels)
+            {
+                channel.Dispose();
+                server.OutstandingOperationsCount.Should().Be(--operationsCount);
+            }
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void GetChannel_should_throw_when_not_initialized(
+            [Values(false, true)] bool async)
+        {
+            Exception exception;
+            if (async)
+            {
+                exception = Record.Exception(() => _subject.GetChannelAsync(CancellationToken.None).GetAwaiter().GetResult());
+            }
+            else
+            {
+                exception = Record.Exception(() => _subject.GetChannel(CancellationToken.None));
+            }
+
+            exception.Should().BeOfType<InvalidOperationException>();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void GetChannel_should_throw_when_disposed([Values(false, true)] bool async)
+        {
+            _subject.Dispose();
+
+            Exception exception;
+            if (async)
+            {
+                exception = Record.Exception(() => _subject.GetChannelAsync(CancellationToken.None).GetAwaiter().GetResult());
+            }
+            else
+            {
+                exception = Record.Exception(() => _subject.GetChannel(CancellationToken.None));
+            }
+
+            exception.Should().BeOfType<ObjectDisposedException>();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void GetChannel_should_not_update_topology_and_clear_connection_pool_on_MongoConnectionException(
+            [Values("TimedOutSocketException", "NetworkUnreachableSocketException")] string errorType,
+            [Values(false, true)] bool async)
+        {
+            var serverId = new ServerId(_clusterId, _endPoint);
+            var connectionId = new ConnectionId(serverId);
+            var innerMostException = CoreExceptionHelper.CreateException(errorType);
+
+            var openConnectionException = new MongoConnectionException(connectionId, "Oops", new IOException("Cry", innerMostException));
+            var mockConnection = new Mock<IConnectionHandle>();
+            mockConnection.Setup(c => c.Open(It.IsAny<CancellationToken>())).Throws(openConnectionException);
+            mockConnection.Setup(c => c.OpenAsync(It.IsAny<CancellationToken>())).ThrowsAsync(openConnectionException);
+
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory.Setup(cf => cf.CreateConnection(serverId, _endPoint)).Returns(mockConnection.Object);
+
+            var connectionPoolSettings = new ConnectionPoolSettings();
+            var connectionPool = new ExclusiveConnectionPool(serverId, _endPoint, connectionPoolSettings, connectionFactory.Object, new EventAggregator());
+
+            var mockConnectionPoolFactory = new Mock<IConnectionPoolFactory>();
+            mockConnectionPoolFactory
+                .Setup(f => f.CreateConnectionPool(It.IsAny<ServerId>(), _endPoint))
+                .Returns(connectionPool);
+
+            var subject = new LoadBalancedServer(_clusterId, _clusterClock, _settings, _endPoint, mockConnectionPoolFactory.Object, _capturedEvents, _serverApi);
+            subject.Initialize();
+
+            IChannelHandle channel = null;
+            Exception exception;
+            if (async)
+            {
+                exception = Record.Exception(() => channel = subject.GetChannelAsync(CancellationToken.None).GetAwaiter().GetResult());
+            }
+            else
+            {
+                exception = Record.Exception(() => channel = subject.GetChannel(CancellationToken.None));
+            }
+
+            channel.Should().BeNull();
+            exception.Should().Be(openConnectionException);
+            subject.Description.Type.Should().Be(ServerType.LoadBalanced);
+            subject.Description.ReasonChanged.Should().Be("Initialized");
+            subject.Description.State.Should().Be(ServerState.Connected);
+
+            _mockConnectionPool.Verify(c => c.Clear(), Times.Never);
+        }
+
+        [Fact]
+        public void Initialize_should_initialize_the_server()
+        {
+            _subject.Initialize();
+            _mockConnectionPool.Verify(p => p.Initialize(), Times.Once);
+
+            _capturedEvents.Next().Should().BeOfType<ServerOpeningEvent>();
+            _capturedEvents.Next().Should().BeOfType<ServerDescriptionChangedEvent>();
+            _capturedEvents.Next().Should().BeOfType<ServerOpenedEvent>();
+            _capturedEvents.Any().Should().BeFalse();
+        }
+
+        [Fact]
+        public void Invalidate_should_not_clear_the_connection_pool()
+        {
+            _subject.Initialize();
+            _capturedEvents.Clear();
+
+            _subject.Invalidate("Test", responseTopologyDescription: null);
+            _mockConnectionPool.Verify(p => p.Clear(), Times.Never);
+            _mockConnectionPool.Verify(p => p.Clear(It.IsAny<ObjectId>()), Times.Never);
+        }
+
+        // private methods
+        private Server SetupServer(bool exceptionOnConnectionOpen, bool exceptionOnConnectionAcquire)
+        {
+            var connectionId = new ConnectionId(new ServerId(_clusterId, _endPoint));
+            var mockConnectionHandle = new Mock<IConnectionHandle>();
+
+            mockConnectionHandle
+                .Setup(c => c.Fork())
+                .Returns(mockConnectionHandle.Object);
+
+            var mockConnectionPool = new Mock<IConnectionPool>();
+            if (exceptionOnConnectionAcquire)
+            {
+                mockConnectionPool
+                    .Setup(p => p.AcquireConnection(It.IsAny<CancellationToken>()))
+                    .Throws(new TimeoutException("Timeout"));
+                mockConnectionPool
+                    .Setup(p => p.AcquireConnectionAsync(It.IsAny<CancellationToken>()))
+                    .Throws(new TimeoutException("Timeout"));
+                mockConnectionPool.Setup(p => p.Clear());
+            }
+            else if (exceptionOnConnectionOpen)
+            {
+                mockConnectionPool
+                    .Setup(p => p.AcquireConnection(It.IsAny<CancellationToken>()))
+                    .Throws(new MongoAuthenticationException(connectionId, "Invalid login."));
+                mockConnectionPool
+                    .Setup(p => p.AcquireConnectionAsync(It.IsAny<CancellationToken>()))
+                    .Throws(new MongoAuthenticationException(connectionId, "Invalid login."));
+                mockConnectionPool.Setup(p => p.Clear());
+            }
+            else
+            {
+                mockConnectionPool
+                    .Setup(p => p.AcquireConnection(It.IsAny<CancellationToken>()))
+                    .Returns(mockConnectionHandle.Object);
+                mockConnectionPool
+                    .Setup(p => p.AcquireConnectionAsync(It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(mockConnectionHandle.Object));
+                mockConnectionPool.Setup(p => p.Clear());
+            }
+
+            var mockConnectionPoolFactory = new Mock<IConnectionPoolFactory>();
+            mockConnectionPoolFactory
+                .Setup(f => f.CreateConnectionPool(It.IsAny<ServerId>(), _endPoint))
+                .Returns(mockConnectionPool.Object);
+
+            var server = new LoadBalancedServer(
+                _clusterId,
+                _clusterClock,
+                _settings,
+                _endPoint,
+                mockConnectionPoolFactory.Object,
+                _capturedEvents,
+                _serverApi);
+            server.Initialize();
+
+            return server;
+        }
+    }
+
+    internal static class LoadBalancedServerReflector
+    {
+        public static void HandleChannelException(this LoadBalancedServer server, IConnection connection, Exception ex)
+        {
+            Reflector.Invoke(server, nameof(HandleChannelException), connection, ex, checkBaseClass: true);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerFactoryTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerFactoryTests.cs
@@ -106,7 +106,7 @@ namespace MongoDB.Driver.Core.Servers
             var subject = new ServerFactory(_clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _connectionPoolFactory, _serverMonitorFactory, _eventSubscriber, _serverApi);
             var clusterClock = new Mock<IClusterClock>().Object;
 
-            Action act = () => subject.CreateServer(null, clusterClock, _endPoint);
+            Action act = () => subject.CreateServer(ClusterType.Unknown, null, clusterClock, _endPoint);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -117,7 +117,7 @@ namespace MongoDB.Driver.Core.Servers
             var subject = new ServerFactory(_clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _connectionPoolFactory, _serverMonitorFactory, _eventSubscriber, _serverApi);
             var clusterId = new ClusterId();
 
-            Action act = () => subject.CreateServer(clusterId, null, _endPoint);
+            Action act = () => subject.CreateServer(ClusterType.Unknown, clusterId, null, _endPoint);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -128,21 +128,23 @@ namespace MongoDB.Driver.Core.Servers
             var subject = new ServerFactory(_clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _connectionPoolFactory, _serverMonitorFactory, _eventSubscriber, _serverApi);
             var clusterClock = new Mock<IClusterClock>().Object;
 
-            Action act = () => subject.CreateServer(_clusterId, clusterClock, null);
+            Action act = () => subject.CreateServer(ClusterType.Unknown, _clusterId, clusterClock, null);
 
             act.ShouldThrow<ArgumentNullException>();
         }
 
-        [Fact]
-        public void CreateServer_should_return_Server()
+        [Theory]
+        [InlineData(ClusterType.LoadBalanced, typeof(LoadBalancedServer))]
+        [InlineData(ClusterType.Unknown, typeof(DefaultServer))]
+        public void CreateServer_should_return_correct_Server(ClusterType clusterType, Type expectedServerType)
         {
             var subject = new ServerFactory(_clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _connectionPoolFactory, _serverMonitorFactory, _eventSubscriber, _serverApi);
             var clusterClock = new Mock<IClusterClock>().Object;
 
-            var result = subject.CreateServer(_clusterId, clusterClock, _endPoint);
+            var result = subject.CreateServer(clusterType, _clusterId, clusterClock, _endPoint);
 
             result.Should().NotBeNull();
-            result.Should().BeOfType<Server>();
+            result.Should().BeOfType(expectedServerType);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -320,7 +320,7 @@ namespace MongoDB.Driver.Core.Servers
             capturedEvents.Any().Should().BeFalse();
         }
 
-        [Fact(Skip = "Will check this test")]
+        [Fact]
         public void ServerMonitor_should_use_serverApi()
         {
             var serverApi = new ServerApi(ServerApiVersion.V1);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -320,7 +320,7 @@ namespace MongoDB.Driver.Core.Servers
             capturedEvents.Any().Should().BeFalse();
         }
 
-        [Fact]
+        [Fact(Skip = "Will check this test")]
         public void ServerMonitor_should_use_serverApi()
         {
             var serverApi = new ServerApi(ServerApiVersion.V1);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerTests.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -50,6 +49,7 @@ namespace MongoDB.Driver.Core.Servers
         private ClusterId _clusterId;
 #pragma warning disable CS0618 // Type or member is obsolete
         private ClusterConnectionMode _clusterConnectionMode;
+        private ConnectionId _connectionId;
         private ConnectionModeSwitch _connectionModeSwitch;
 #pragma warning restore CS0618 // Type or member is obsolete
         private bool? _directConnection;
@@ -61,7 +61,7 @@ namespace MongoDB.Driver.Core.Servers
         private Mock<IServerMonitorFactory> _mockServerMonitorFactory;
         private ServerApi _serverApi;
         private ServerSettings _settings;
-        private Server _subject;
+        private DefaultServer _subject;
 
         public ServerTests()
         {
@@ -90,7 +90,8 @@ namespace MongoDB.Driver.Core.Servers
             _serverApi = new ServerApi(ServerApiVersion.V1, true, true);
             _settings = new ServerSettings(heartbeatInterval: Timeout.InfiniteTimeSpan);
 
-            _subject = new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            _subject = new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            _connectionId = new ConnectionId(_subject.ServerId);
         }
 
         [Theory]
@@ -118,7 +119,7 @@ namespace MongoDB.Driver.Core.Servers
         [Fact]
         public void Constructor_should_not_throw_when_serverApi_is_null()
         {
-            Action act = () => new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, null);
+            Action act = () => new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, null);
 
             act.ShouldNotThrow();
         }
@@ -126,7 +127,7 @@ namespace MongoDB.Driver.Core.Servers
         [Fact]
         public void Constructor_should_throw_when_settings_is_null()
         {
-            Action act = () => new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, null, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            Action act = () => new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, null, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -134,7 +135,7 @@ namespace MongoDB.Driver.Core.Servers
         [Fact]
         public void Constructor_should_throw_when_clusterId_is_null()
         {
-            Action act = () => new Server(null, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            Action act = () => new DefaultServer(null, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -142,7 +143,7 @@ namespace MongoDB.Driver.Core.Servers
         [Fact]
         public void Constructor_should_throw_when_clusterClock_is_null()
         {
-            Action act = () => new Server(_clusterId, null, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            Action act = () => new DefaultServer(_clusterId, null, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -150,7 +151,7 @@ namespace MongoDB.Driver.Core.Servers
         [Fact]
         public void Constructor_should_throw_when_endPoint_is_null()
         {
-            Action act = () => new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, null, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            Action act = () => new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, null, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -158,7 +159,7 @@ namespace MongoDB.Driver.Core.Servers
         [Fact]
         public void Constructor_should_throw_when_connectionPoolFactory_is_null()
         {
-            Action act = () => new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, null, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            Action act = () => new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, null, _mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -166,7 +167,7 @@ namespace MongoDB.Driver.Core.Servers
         [Fact]
         public void Constructor_should_throw_when_serverMonitorFactory_is_null()
         {
-            Action act = () => new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, null, _capturedEvents, _serverApi);
+            Action act = () => new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, null, _capturedEvents, _serverApi);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -174,7 +175,7 @@ namespace MongoDB.Driver.Core.Servers
         [Fact]
         public void Constructor_should_throw_when_eventSubscriber_is_null()
         {
-            Action act = () => new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, null, _serverApi);
+            Action act = () => new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, _mockConnectionPoolFactory.Object, _mockServerMonitorFactory.Object, null, _serverApi);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -216,7 +217,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Setup(f => f.CreateConnectionPool(It.IsAny<ServerId>(), _endPoint))
                 .Returns(mockConnectionPool.Object);
 
-            var server = new Server(
+            var server = new DefaultServer(
                 _clusterId,
                 _clusterClock,
                 _clusterConnectionMode,
@@ -391,7 +392,7 @@ namespace MongoDB.Driver.Core.Servers
             var mockServerMonitorFactory = new Mock<IServerMonitorFactory>();
             mockServerMonitorFactory.Setup(f => f.Create(It.IsAny<ServerId>(), _endPoint)).Returns(mockServerMonitor.Object);
 
-            var subject = new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, mockConnectionPoolFactory.Object, mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            var subject = new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, mockConnectionPoolFactory.Object, mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
             subject.Initialize();
 
             IChannelHandle channel = null;
@@ -452,7 +453,7 @@ namespace MongoDB.Driver.Core.Servers
             mockServerMonitor.SetupGet(m => m.Lock).Returns(new object());
             var mockServerMonitorFactory = new Mock<IServerMonitorFactory>();
             mockServerMonitorFactory.Setup(f => f.Create(It.IsAny<ServerId>(), _endPoint)).Returns(mockServerMonitor.Object);
-            var subject = new Server(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, mockConnectionPoolFactory.Object, mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
+            var subject = new DefaultServer(_clusterId, _clusterClock, _clusterConnectionMode, _connectionModeSwitch, _directConnection, _settings, _endPoint, mockConnectionPoolFactory.Object, mockServerMonitorFactory.Object, _capturedEvents, _serverApi);
             subject.Initialize();
             var heartbeatDescription = mockMonitorServerInitialDescription.With(reasonChanged: "Heartbeat", type: ServerType.Standalone);
             mockServerMonitor.Setup(m => m.Description).Returns(heartbeatDescription);
@@ -519,22 +520,29 @@ namespace MongoDB.Driver.Core.Servers
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData((ServerErrorCode)1, false)]
-        [InlineData(ServerErrorCode.LegacyNotPrimary, true)]
-        [InlineData(ServerErrorCode.NotWritablePrimary, true)]
-        [InlineData(ServerErrorCode.NotPrimaryNoSecondaryOk, true)]
-        [InlineData(ServerErrorCode.NotPrimaryOrSecondary, false)]
-        internal void IsNotWritablePrimary_should_return_expected_result_for_code(ServerErrorCode? code, bool expectedResult)
+        [InlineData(null, false, null)]
+        [InlineData((ServerErrorCode)1, false, null)]
+        [InlineData(ServerErrorCode.LegacyNotPrimary, true, typeof(MongoNotPrimaryException))]
+        [InlineData(ServerErrorCode.NotWritablePrimary, true, typeof(MongoNotPrimaryException))]
+        [InlineData(ServerErrorCode.NotPrimaryNoSecondaryOk, true, typeof(MongoNotPrimaryException))]
+        [InlineData(ServerErrorCode.NotPrimaryOrSecondary, false, typeof(MongoNodeIsRecoveringException))]
+        internal void IsNotWritablePrimary_should_return_expected_result_for_code(ServerErrorCode? code, bool expectedResult, Type expectedExceptionType)
         {
-            _subject.Initialize();
-
-            var result = _subject.IsNotWritablePrimary(code, null);
-
-            result.Should().Be(expectedResult);
-            if (result)
+            var commandResult = new BsonDocument
             {
-                _subject.IsRecovering(code, null).Should().BeFalse();
+                { "ok", 0 },
+                { "code", code, code != null }
+            };
+
+            var exception = ExceptionMapper.MapNotPrimaryOrNodeIsRecovering(_connectionId, new BsonDocument(), commandResult, "errmsg");
+
+            if (expectedExceptionType != null)
+            {
+                exception.Should().BeOfType(expectedExceptionType);
+            }
+            else
+            {
+                exception.Should().BeNull();
             }
         }
 
@@ -544,28 +552,39 @@ namespace MongoDB.Driver.Core.Servers
             var code = (ServerErrorCode)1;
             var message = "not master";
 
-            _subject.Initialize();
+            var commandResult = new BsonDocument
+            {
+                { "ok", 0 },
+                { "code", code }, // code takes precedence over errmsg
+                { "errmsg", message }
+            };
+            var exception = ExceptionMapper.MapNotPrimaryOrNodeIsRecovering(_connectionId, new BsonDocument(), commandResult, "errmsg");
 
-            var result = _subject.IsNotWritablePrimary(code, message);
-
-            result.Should().BeFalse();
+            exception.Should().BeNull();
         }
 
         [Theory]
-        [InlineData(null, false)]
-        [InlineData("abc", false)]
-        [InlineData("not master", true)]
-        [InlineData("not master or secondary", false)]
-        internal void IsNotWritablePrimary_should_return_expected_result_for_message(string message, bool expectedResult)
+        [InlineData(null, false, null)]
+        [InlineData("abc", false, null)]
+        [InlineData("not master", true, typeof(MongoNotPrimaryException))]
+        [InlineData("not master or secondary", false, typeof(MongoNodeIsRecoveringException))]
+        internal void IsNotWritablePrimary_should_return_expected_result_for_message(string message, bool expectedResult, Type expectedException)
         {
-            _subject.Initialize();
-
-            var result = _subject.IsNotWritablePrimary(null, message);
-
-            result.Should().Be(expectedResult);
-            if (result)
+            var commandResult = new BsonDocument
             {
-                _subject.IsRecovering(null, message).Should().BeFalse();
+                { "ok", 0 },
+                { "errmsg", message, message != null }
+            };
+
+            var exception = ExceptionMapper.MapNotPrimaryOrNodeIsRecovering(_connectionId, new BsonDocument(), commandResult, "errmsg");
+
+            if (expectedException != null)
+            {
+                exception.Should().BeOfType(expectedException);
+            }
+            else
+            {
+                exception.Should().BeNull();
             }
         }
 
@@ -574,11 +593,13 @@ namespace MongoDB.Driver.Core.Servers
         [InlineData((ServerErrorCode)1, false)]
         [InlineData(ServerErrorCode.NotWritablePrimary, true)]
         [InlineData(ServerErrorCode.InterruptedAtShutdown, true)]
-        internal void IsStateChangeError_should_return_expected_result(ServerErrorCode? code, bool expectedResult)
+        internal void IsStateChangeException_should_return_expected_result(ServerErrorCode? code, bool expectedResult)
         {
             _subject.Initialize();
 
-            var result = _subject.IsStateChangeError(code, null);
+            var mappedException = ExceptionMapper.MapNotPrimaryOrNodeIsRecovering(_connectionId, new BsonDocument(), new BsonDocument("code", code), "dummy");
+
+            var result = _subject.IsStateChangeException(mappedException);
 
             result.Should().Be(expectedResult);
         }
@@ -593,14 +614,21 @@ namespace MongoDB.Driver.Core.Servers
         [InlineData(ServerErrorCode.ShutdownInProgress, true)]
         internal void IsRecovering_should_return_expected_result_for_code(ServerErrorCode? code, bool expectedResult)
         {
-            _subject.Initialize();
-
-            var result = _subject.IsRecovering(code, null);
-
-            result.Should().Be(expectedResult);
-            if (result)
+            var commandResult = new BsonDocument
             {
-                _subject.IsNotWritablePrimary(code, null).Should().BeFalse();
+                { "ok", 0 },
+                { "code", code }
+            };
+
+            var exception = ExceptionMapper.MapNotPrimaryOrNodeIsRecovering(_connectionId, new BsonDocument(), commandResult, "errmsg");
+
+            if (expectedResult)
+            {
+                exception.Should().BeOfType<MongoNodeIsRecoveringException>();
+            }
+            else
+            {
+                exception.Should().BeNull();
             }
         }
 
@@ -610,11 +638,15 @@ namespace MongoDB.Driver.Core.Servers
             var code = (ServerErrorCode)1;
             var message = "not master or secondary";
 
-            _subject.Initialize();
+            var commandResult = new BsonDocument
+            {
+                { "ok", 0 },
+                { "code", code }, // code takes precedence over errmsg
+                { "errmsg", message }
+            };
+            var exception = ExceptionMapper.MapNotPrimaryOrNodeIsRecovering(_connectionId, new BsonDocument(), commandResult, "errmsg");
 
-            var result = _subject.IsRecovering(code, message);
-
-            result.Should().BeFalse();
+            exception.Should().BeNull();
         }
 
         [Theory]
@@ -624,14 +656,20 @@ namespace MongoDB.Driver.Core.Servers
         [InlineData("not master or secondary", true)]
         internal void IsRecovering_should_return_expected_result_for_message(string message, bool expectedResult)
         {
-            _subject.Initialize();
-
-            var result = _subject.IsRecovering(null, message);
-
-            result.Should().Be(expectedResult);
-            if (result)
+            var commandResult = new BsonDocument
             {
-                _subject.IsNotWritablePrimary(null, message).Should().BeFalse();
+                { "ok", 0 },
+                { "errmsg", message, message != null }
+            };
+            var exception = ExceptionMapper.MapNotPrimaryOrNodeIsRecovering(_connectionId, new BsonDocument(), commandResult, "errmsg");
+
+            if (expectedResult)
+            {
+                exception.Should().BeOfType<MongoNodeIsRecoveringException>();
+            }
+            else
+            {
+                exception.Should().BeNull();
             }
         }
 
@@ -676,7 +714,7 @@ namespace MongoDB.Driver.Core.Servers
                 default: throw new Exception($"Invalid exceptionTypeName: {exceptionTypeName}.");
             }
 
-            var result = _subject.ShouldInvalidateServer(new Mock<IConnectionHandle>().Object, exception, new ServerDescription(_subject.ServerId, _subject.EndPoint), out _);
+            var result = _subject.ShouldInvalidateServer(Mock.Of<IConnection>(), exception, new ServerDescription(_subject.ServerId, _subject.EndPoint), out _);
 
             result.Should().Be(expectedResult);
         }
@@ -704,9 +742,11 @@ namespace MongoDB.Driver.Core.Servers
                 { "code", () => (int)code.Value, code.HasValue },
                 { "errmsg", message, message != null }
             };
-            var exception = new MongoCommandException(connectionId, "message", command, commandResult);
+            var exception =
+                ExceptionMapper.MapNotPrimaryOrNodeIsRecovering(connectionId, command, commandResult, "errmsg") ??
+                new MongoCommandException(connectionId, "message", command, commandResult); // this needs for cases when we have just a random exception
 
-            var result = _subject.ShouldInvalidateServer(new Mock<IConnectionHandle>().Object, exception, new ServerDescription(_subject.ServerId, _subject.EndPoint), out _);
+            var result = _subject.ShouldInvalidateServer(Mock.Of<IConnection>(), exception, new ServerDescription(_subject.ServerId, _subject.EndPoint), out _);
 
             result.Should().Be(expectedResult);
         }
@@ -741,7 +781,7 @@ namespace MongoDB.Driver.Core.Servers
             var writeConcernResult = new WriteConcernResult(commandResult);
             var exception = new MongoWriteConcernException(connectionId, "message", writeConcernResult);
 
-            var result = _subject.ShouldInvalidateServer(new Mock<IConnectionHandle>().Object, exception, new ServerDescription(_subject.ServerId, _subject.EndPoint), out _);
+            var result = _subject.ShouldInvalidateServer(Mock.Of<IConnection>(), exception, new ServerDescription(_subject.ServerId, _subject.EndPoint), out _);
 
             result.Should().Be(expectedResult);
         }
@@ -793,7 +833,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Setup(f => f.CreateConnectionPool(It.IsAny<ServerId>(), _endPoint))
                 .Returns(mockConnectionPool.Object);
 
-            var server = new Server(
+            var server = new DefaultServer(
                 _clusterId,
                 _clusterClock,
                 _clusterConnectionMode,
@@ -969,38 +1009,23 @@ namespace MongoDB.Driver.Core.Servers
 
     internal static class ServerReflector
     {
-        public static void HandleChannelException(this Server server, IConnection connection, Exception ex)
+        public static void HandleChannelException(this DefaultServer server, IConnection connection, Exception ex)
         {
-            Reflector.Invoke(server, nameof(HandleChannelException), connection, ex);
+            Reflector.Invoke(server, nameof(HandleChannelException), connection, ex, checkBaseClass: true);
         }
 
-        public static bool IsNotWritablePrimary(this Server server, ServerErrorCode? code, string message)
+        public static bool IsStateChangeException(this DefaultServer server, Exception exception)
         {
-            return (bool)Reflector.Invoke(server, nameof(IsNotWritablePrimary), code, message);
+            return (bool)Reflector.Invoke(server, nameof(IsStateChangeException), exception);
         }
 
-        public static bool IsStateChangeError(this Server server, ServerErrorCode? code, string message)
-        {
-            return (bool)Reflector.Invoke(server, nameof(IsStateChangeError), code, message);
-        }
-
-        public static bool IsRecovering(this Server server, ServerErrorCode? code, string message)
-        {
-            return (bool)Reflector.Invoke(server, nameof(IsRecovering), code, message);
-        }
-
-        public static bool ShouldInvalidateServer(this Server server,
-            IConnectionHandle connection,
+        public static bool ShouldInvalidateServer(this DefaultServer server,
+            IConnection connection,
             Exception exception,
             ServerDescription description,
             out TopologyVersion responseTopologyVersion)
         {
-            var methodInfo = typeof(Server).GetMethod(nameof(ShouldInvalidateServer), BindingFlags.NonPublic | BindingFlags.Instance);
-            var parameters = new object[] { connection, exception, description, null };
-            int outParameterIndex = Array.IndexOf(parameters, null);
-            var shouldInvalidate = (bool)methodInfo.Invoke(server, parameters);
-            responseTopologyVersion = (TopologyVersion)parameters[outParameterIndex];
-            return shouldInvalidate;
+            return (bool)Reflector.Invoke(server, nameof(ShouldInvalidateServer), connection, exception, description, out responseTopologyVersion);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3302Tests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3302Tests.cs
@@ -79,7 +79,7 @@ namespace MongoDB.Driver.Core.Tests.Jira
 
             var serverFactoryMock = new Mock<IClusterableServerFactory>();
             serverFactoryMock
-                .Setup(f => f.CreateServer(It.IsAny<ClusterId>(), It.IsAny<IClusterClock>(), It.IsAny<EndPoint>()))
+                .Setup(f => f.CreateServer(It.IsAny<ClusterType>(), It.IsAny<ClusterId>(), It.IsAny<IClusterClock>(), It.IsAny<EndPoint>()))
                 .Returns(serverMock.Object);
 
             using (var cluster = new MultiServerCluster(clusterSettings, serverFactoryMock.Object, new EventCapturer()))

--- a/tests/MongoDB.Driver.Core.Tests/MongoNodeIsRecoveringExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoNodeIsRecoveringExceptionTests.cs
@@ -47,18 +47,23 @@ namespace MongoDB.Driver
             result.Result.Should().BeSameAs(_serverResult);
         }
 
-        [Fact]
-        public void constructor_should_initialize_subject_when_result_contains_code()
+        [Theory]
+        [InlineData(ServerErrorCode.InterruptedAtShutdown, true)]
+        [InlineData(ServerErrorCode.ShutdownInProgress, true)]
+        [InlineData(ServerErrorCode.NotPrimaryOrSecondary, false)]
+        [InlineData(ServerErrorCode.NotWritablePrimary, false)]
+        public void constructor_should_initialize_subject_when_result_contains_code(int code, bool isShutdownException)
         {
-            var serverResult = BsonDocument.Parse("{ ok : 0, code : 1234 }");
+            var serverResult = BsonDocument.Parse($"{{ ok : 0, code : {code} }}");
 
             var result = new MongoNodeIsRecoveringException(_connectionId, _command, serverResult);
 
             result.ConnectionId.Should().BeSameAs(_connectionId);
             result.InnerException.Should().BeNull();
-            result.Message.Should().Be("Server returned node is recovering error (code = 1234).");
+            result.Message.Should().Be($"Server returned node is recovering error (code = {code}).");
             result.Command.Should().BeSameAs(_command);
             result.Result.Should().BeSameAs(serverResult);
+            result.IsShutdownError.Should().Be(isShutdownException);
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Core.Tests/MongoWriteConcernExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/MongoWriteConcernExceptionTests.cs
@@ -13,16 +13,15 @@
 * limitations under the License.
 */
 
-#if !NETCOREAPP1_1
-using System.IO;
-#endif
+using System;
 using System.Net;
 #if !NETCOREAPP1_1
+using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
+using MongoDB.Bson.TestHelpers.EqualityComparers;
 #endif
 using FluentAssertions;
 using MongoDB.Bson;
-using MongoDB.Bson.TestHelpers.EqualityComparers;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Servers;
@@ -47,6 +46,52 @@ namespace MongoDB.Driver
             subject.Message.Should().BeSameAs(_message);
             subject.Result.Should().Be(_writeConcernResult.Response);
             subject.WriteConcernResult.Should().Be(_writeConcernResult);
+        }
+
+        [Theory]
+        [InlineData(ServerErrorCode.LegacyNotPrimary, typeof(MongoNotPrimaryException))]
+        [InlineData(ServerErrorCode.NotWritablePrimary, typeof(MongoNotPrimaryException))]
+        [InlineData(ServerErrorCode.NotPrimaryNoSecondaryOk, typeof(MongoNotPrimaryException))]
+        [InlineData("not master", typeof(MongoNotPrimaryException))]
+        [InlineData(ServerErrorCode.InterruptedAtShutdown, typeof(MongoNodeIsRecoveringException))] // IsShutdownError
+        [InlineData(ServerErrorCode.ShutdownInProgress, typeof(MongoNodeIsRecoveringException))] // IsShutdownError
+        [InlineData(ServerErrorCode.InterruptedDueToReplStateChange, typeof(MongoNodeIsRecoveringException))]
+        [InlineData(ServerErrorCode.NotPrimaryOrSecondary, typeof(MongoNodeIsRecoveringException))]
+        [InlineData(ServerErrorCode.PrimarySteppedDown, typeof(MongoNodeIsRecoveringException))]
+        [InlineData("not master or secondary", typeof(MongoNodeIsRecoveringException))]
+        [InlineData("node is recovering", typeof(MongoNodeIsRecoveringException))]
+        [InlineData(ServerErrorCode.MaxTimeMSExpired, typeof(MongoExecutionTimeoutException))]
+        [InlineData(13475, typeof(MongoExecutionTimeoutException))]
+        [InlineData(16986, typeof(MongoExecutionTimeoutException))]
+        [InlineData(16712, typeof(MongoExecutionTimeoutException))]
+        [InlineData("exceeded time limit", typeof(MongoExecutionTimeoutException))]
+        [InlineData("execution terminated", typeof(MongoExecutionTimeoutException))]
+        [InlineData(-1, null)]
+        [InlineData("test", null)]
+        public void constructor_should_should_map_writeConcernResult(object exceptionInfo, Type expectedExceptionType)
+        {
+            var response = new BsonDocument
+            {
+                {
+                    "writeConcernError",
+                    Enum.TryParse<ServerErrorCode>(exceptionInfo.ToString(), out var errorCode)
+                        ? new BsonDocument("code", (int)errorCode)
+                        : new BsonDocument("errmsg", exceptionInfo.ToString())
+                }
+            };
+            var writeConcernResult = new WriteConcernResult(response);
+            var writeConcernException = new MongoWriteConcernException(_connectionId, "dummy", writeConcernResult);
+
+            var result = writeConcernException.MappedWriteConcernResultException;
+
+            if (expectedExceptionType != null)
+            {
+                result.GetType().Should().Be(expectedExceptionType);
+            }
+            else
+            {
+                result.Should().BeNull();
+            }
         }
 
 #if !NETCOREAPP1_1

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/InitialDnsSeedlistDiscoveryTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/InitialDnsSeedlistDiscoveryTestRunner.cs
@@ -31,6 +31,7 @@ using Xunit.Abstractions;
 namespace MongoDB.Driver.Specifications.initial_dns_seedlist_discovery
 {
     [Trait("Category", "ConnectionString")]
+    [Trait("Category", "SupportLoadBalancing")]
     public class InitialDnsSeedlistDiscoveryTestRunner
     {
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.json
@@ -1,0 +1,14 @@
+{
+  "uri": "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "options": {
+    "loadBalanced": true,
+    "ssl": true,
+    "directConnection": false
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because loadBalanced=true is incompatible with replicaSet"
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-multiple-hosts.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-multiple-hosts.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?loadBalanced=true",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because loadBalanced is true but the SRV record resolves to multiple hosts"
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
@@ -1,0 +1,13 @@
+{
+  "uri": "mongodb+srv://test20.test.build.10gen.cc/",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "options": {
+    "loadBalanced": true,
+    "ssl": true
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/direct-connection-false.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/direct-connection-false.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?directConnection=false",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true,
+    "directConnection": false
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/direct-connection-true.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/direct-connection-true.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?directConnection=true",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because directConnection=true is incompatible with SRV URIs."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/loadBalanced-false-txt.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/loadBalanced-false-txt.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test21.test.build.10gen.cc/",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "loadBalanced": false,
+    "ssl": true
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/longer-parent-in-return.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/longer-parent-in-return.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test18.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.sub.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "comment": "Is correct, as returned host name shared the URI root \"test.build.10gen.cc\"."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/misformatted-option.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/misformatted-option.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test8.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because the options in the TXT record are incorrectly formatted (misses value)."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/no-results.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/no-results.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test4.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because no SRV records are present for this URI."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/not-enough-parts.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/not-enough-parts.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because host in URI does not have {hostname}, {domainname} and {tld}."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/one-result-default-port.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/one-result-default-port.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record-multiple-strings.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record-multiple-strings.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test11.test.build.10gen.cc/",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "authSource": "thisDB",
+    "ssl": true
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch1.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch1.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test14.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's part \"not-test\" mismatches URI parent part \"test\"."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch2.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch2.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test15.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's part \"not-build\" mismatches URI parent part \"build\"."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch3.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch3.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test16.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's part \"not-10gen\" mismatches URI parent part \"10gen\"."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch4.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch4.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test17.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's TLD \"not-cc\" mismatches URI TLD \"cc\"."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch5.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/parent-part-mismatch5.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test19.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because one of the returned host names' domain name parts \"evil\" mismatches \"test\"."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/returned-parent-too-short.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/returned-parent-too-short.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test13.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's parent (build.10gen.cc) misses \"test.\""
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/returned-parent-wrong.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/returned-parent-wrong.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test12.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name is too short and mismatches a parent."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/two-results-default-port.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/two-results-default-port.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/two-results-nonstandard-port.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/two-results-nonstandard-port.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test2.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27018",
+    "localhost.test.build.10gen.cc:27019"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/two-txt-records.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/two-txt-records.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test6.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because there are two TXT records."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/txt-record-not-allowed-option.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/txt-record-not-allowed-option.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test10.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because socketTimeoutMS is not an allowed option."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-ssl-option.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-ssl-option.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?ssl=false",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "authSource": "thisDB",
+    "ssl": false
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-uri-option.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-uri-option.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?authSource=otherDB",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "authSource": "otherDB",
+    "ssl": true
+  }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-unallowed-option.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-unallowed-option.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test7.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because \"ssl\" is not an allowed option."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/uri-with-port.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/uri-with-port.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc:8123/?replicaSet=repl0",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because the mongodb+srv URI includes a port."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/uri-with-two-hosts.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/initial-dns-seedlist-discovery/tests/replica-set/uri-with-two-hosts.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc,test6.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because the mongodb+srv URI includes two host names."
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/MonitoringTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/MonitoringTestRunner.cs
@@ -62,7 +62,7 @@ namespace MongoDB.Driver.Specifications.sdam_monitoring
         {
             JsonDrivenHelper.EnsureAllFieldsAreValid(phase, "outcome", "responses");
 
-            var responses = phase["responses"].AsBsonArray;
+            var responses = phase.GetValue("responses", new BsonArray()).AsBsonArray;
             foreach (BsonArray response in responses)
             {
                 ApplyResponse(response);
@@ -81,7 +81,7 @@ namespace MongoDB.Driver.Specifications.sdam_monitoring
 
             var address = response[0].AsString;
             var isMasterDocument = response[1].AsBsonDocument;
-            JsonDrivenHelper.EnsureAllFieldsAreValid(isMasterDocument, "hosts", "helloOk", "isWritablePrimary", OppressiveLanguageConstants.LegacyHelloResponseIsWritablePrimaryFieldName, "maxWireVersion", "minWireVersion", "ok", "primary", "secondary", "setName", "setVersion");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(isMasterDocument, "hosts", "isWritablePrimary", OppressiveLanguageConstants.LegacyHelloResponseIsWritablePrimaryFieldName, "helloOk", "maxWireVersion", "minWireVersion", "ok", "primary", "secondary", "setName", "setVersion");
 
             var endPoint = EndPointHelper.Parse(address);
             var isMasterResult = new IsMasterResult(isMasterDocument);
@@ -241,6 +241,9 @@ namespace MongoDB.Driver.Specifications.sdam_monitoring
                 case "Unknown":
                     actualDescription.Type.Should().Be(ClusterType.Unknown);
                     break;
+                case "LoadBalanced":
+                    actualDescription.Type.Should().Be(ClusterType.LoadBalanced);
+                    break;
                 default:
                     throw new FormatException($"Invalid topology type: \"{expectedType}\".");
             }
@@ -273,6 +276,9 @@ namespace MongoDB.Driver.Specifications.sdam_monitoring
                     break;
                 case "Standalone":
                     actualDescription.Type.Should().Be(ServerType.Standalone);
+                    break;
+                case "LoadBalancer":
+                    actualDescription.Type.Should().Be(ServerType.LoadBalanced);
                     break;
                 default:
                     actualDescription.Type.Should().Be(ServerType.Unknown);
@@ -326,7 +332,8 @@ namespace MongoDB.Driver.Specifications.sdam_monitoring
                 connectionModeSwitch: connectionString.ConnectionModeSwitch,
 #pragma warning restore CS0618
                 endPoints: Optional.Enumerable(connectionString.Hosts),
-                replicaSetName: connectionString.ReplicaSet);
+                replicaSetName: connectionString.ReplicaSet,
+                loadBalanced: connectionString.LoadBalanced);
 #pragma warning disable CS0618
             if (connectionString.ConnectionModeSwitch == ConnectionModeSwitch.UseDirectConnection)
             {

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringTestRunner.cs
@@ -284,6 +284,11 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
                 case "Unknown":
                     cluster.Description.Type.Should().Be(ClusterType.Unknown);
                     break;
+                case "LoadBalanced":
+                    cluster.Should().BeOfType<LoadBalancedCluster>();
+                    cluster.Description.Type.Should().Be(ClusterType.LoadBalanced);
+                    cluster.Description.Servers.Should().ContainSingle(c => c.Type == ServerType.LoadBalanced);
+                    break;
                 default:
                     throw new FormatException($"Invalid topology type: \"{expectedType}\".");
             }
@@ -327,30 +332,44 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
             }
             if (outcome.TryGetValue("maxSetVersion", out var maxSetVersion))
             {
-                if (_cluster is MultiServerCluster multiServerCluster)
+                switch (_cluster)
                 {
-                    multiServerCluster._maxElectionInfo_setVersion().Should().Be(maxSetVersion.AsInt32);
-                }
-                else
-                {
-                    throw new Exception($"Expected MultiServerCluster but got {_cluster.GetType()}");
+                    case MultiServerCluster multiServerCluster:
+                        multiServerCluster._maxElectionInfo_setVersion().Should().Be(maxSetVersion.AsInt32);
+                        break;
+                    case LoadBalancedCluster:
+                        // LoadBalancedCluster doesn't support maxSetVersion, so assert that there is no expected value
+                        maxSetVersion.Should().BeOfType<BsonNull>();
+                        break;
+                    default:
+                        throw new Exception($"Unsupported cluster type {_cluster.GetType()}.");
                 }
             }
             if (outcome.TryGetValue("maxElectionId", out var maxElectionId))
             {
-                if (_cluster is MultiServerCluster multiServerCluster)
+                switch (_cluster)
                 {
-                    multiServerCluster._maxElectionInfo_electionId().Should().Be(new ElectionId((ObjectId)maxElectionId));
-                }
-                else
-                {
-                    throw new Exception($"Expected MultiServerCluster but got {_cluster.GetType()}");
+                    case MultiServerCluster multiServerCluster:
+                        multiServerCluster._maxElectionInfo_electionId().Should().Be(new ElectionId((ObjectId)maxElectionId));
+                        break;
+                    case LoadBalancedCluster:
+                        // LoadBalancedCluster doesn't support maxElectionId, so assert that there is no expected value
+                        maxElectionId.Should().BeOfType<BsonNull>();
+                        break;
+                    default:
+                        throw new Exception($"Unsupported cluster type {_cluster.GetType()}.");
                 }
             }
 
-            if (outcome.Contains("setName"))
+            if (outcome.TryGetValue("setName", out var setName))
             {
-                // TODO: assert something against setName
+                // TODO: assert something against setName for non LoadBalancedCluster
+
+                if (_cluster is LoadBalancedCluster)
+                {
+                    // LoadBalancedCluster doesn't support setName, so assert that there is no expected value
+                    setName.Should().BeOfType<BsonNull>();
+                }
             }
 
             if (outcome.Contains("logicalSessionTimeoutMinutes"))
@@ -380,7 +399,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         private void VerifyServerDescription(ServerDescription actualDescription, BsonDocument expectedDescription, string phaseDescription)
         {
-            JsonDrivenHelper.EnsureAllFieldsAreValid(expectedDescription, "electionId", "pool", "setName", "setVersion", "topologyVersion", "type");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(expectedDescription, "electionId", "pool", "setName", "setVersion", "topologyVersion", "type", "logicalSessionTimeoutMinutes", "minWireVersion", "maxWireVersion");
 
             var expectedType = (string)expectedDescription["type"];
             switch (expectedType)
@@ -405,6 +424,9 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
                     break;
                 case "Standalone":
                     actualDescription.Type.Should().Be(ServerType.Standalone);
+                    break;
+                case "LoadBalancer":
+                    actualDescription.Type.Should().Be(ServerType.LoadBalanced);
                     break;
                 default:
                     actualDescription.Type.Should().Be(ServerType.Unknown);
@@ -468,6 +490,42 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
                     default: throw new FormatException($"Invalid topologyVersion BSON type: {topologyVersionValue.BsonType}.");
                 }
             }
+
+            if (expectedDescription.TryGetValue("logicalSessionTimeoutMinutes", out var logicalSessionTimeoutMinutes))
+            {
+                if (logicalSessionTimeoutMinutes is BsonNull)
+                {
+                    actualDescription.LogicalSessionTimeout.Should().NotHaveValue();
+                }
+                else
+                {
+                    actualDescription.LogicalSessionTimeout.Should().Be(TimeSpan.FromMinutes(logicalSessionTimeoutMinutes.ToInt32()));
+                }
+            }
+
+            if (expectedDescription.TryGetValue("minWireVersion", out var minWireVersion))
+            {
+                if (minWireVersion is BsonNull)
+                {
+                    actualDescription.WireVersionRange.Should().BeNull();
+                }
+                else
+                {
+                    actualDescription.WireVersionRange.Min.Should().Be(minWireVersion.ToInt32());
+                }
+            }
+
+            if (expectedDescription.TryGetValue("maxWireVersion", out var maxWireVersion))
+            {
+                if (maxWireVersion is BsonNull)
+                {
+                    actualDescription.WireVersionRange.Should().BeNull();
+                }
+                else
+                {
+                    actualDescription.WireVersionRange.Max.Should().Be(maxWireVersion.ToInt32());
+                }
+            }
         }
 
         private void VerifyServerPropertiesNotInServerDescription(IClusterableServer actualServer, BsonDocument expectedServer, string phaseDescription)
@@ -508,7 +566,8 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 #pragma warning disable CS0618 // Type or member is obsolete
                 connectionModeSwitch: connectionString.ConnectionModeSwitch,
                 endPoints: Optional.Enumerable(connectionString.Hosts),
-                replicaSetName: connectionString.ReplicaSet);
+                replicaSetName: connectionString.ReplicaSet,
+                loadBalanced: connectionString.LoadBalanced);
 
             if (settings.ConnectionModeSwitch == ConnectionModeSwitch.UseDirectConnection)
 #pragma warning restore CS0618
@@ -590,7 +649,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         public static void HandleChannelException(this Server server, IConnection connection, Exception ex)
         {
-            Reflector.Invoke(server, nameof(HandleChannelException), connection, ex);
+            Reflector.Invoke(server, nameof(HandleChannelException), connection, ex, checkBaseClass: true);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/load-balanced/discover_load_balancer.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/load-balanced/discover_load_balancer.json
@@ -1,0 +1,28 @@
+{
+  "description": "Load balancer can be discovered and only has the address property set",
+  "uri": "mongodb://a/?loadBalanced=true",
+  "phases": [
+    {
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "LoadBalancer",
+            "setName": null,
+            "setVersion": null,
+            "electionId": null,
+            "logicalSessionTimeoutMinutes": null,
+            "minWireVersion": null,
+            "maxWireVersion": null,
+            "topologyVersion": null
+          }
+        },
+        "topologyType": "LoadBalanced",
+        "setName": null,
+        "logicalSessionTimeoutMinutes": null,
+        "maxSetVersion": null,
+        "maxElectionId": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/load-balanced/discover_load_balancer.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/load-balanced/discover_load_balancer.yml
@@ -1,0 +1,25 @@
+description: "Load balancer can be discovered and only has the address property set"
+
+uri: "mongodb://a/?loadBalanced=true"
+
+phases:
+
+  # There should be no monitoring in LoadBalanced mode, so no responses are necessary to get the topology into the
+  # correct state.
+  - outcome:
+      servers:
+        a:27017:
+          type: LoadBalancer
+          setName: null
+          setVersion: null
+          electionId: null
+          logicalSessionTimeoutMinutes: null
+          minWireVersion: null
+          maxWireVersion: null
+          topologyVersion: null
+      topologyType: LoadBalanced
+      setName: null
+      logicalSessionTimeoutMinutes: null
+      maxSetVersion: null
+      maxElectionId: null
+      compatible: true

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/monitoring/load_balancer.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/monitoring/load_balancer.json
@@ -1,0 +1,93 @@
+{
+  "description": "Monitoring a load balancer",
+  "uri": "mongodb://a:27017/?loadBalanced=true",
+  "phases": [
+    {
+      "outcome": {
+        "events": [
+          {
+            "topology_opening_event": {
+              "topologyId": "42"
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "Unknown",
+                "servers": []
+              },
+              "newDescription": {
+                "topologyType": "LoadBalanced",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "server_opening_event": {
+              "topologyId": "42",
+              "address": "a:27017"
+            }
+          },
+          {
+            "server_description_changed_event": {
+              "topologyId": "42",
+              "address": "a:27017",
+              "previousDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "Unknown"
+              },
+              "newDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "LoadBalancer"
+              }
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "LoadBalanced",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              },
+              "newDescription": {
+                "topologyType": "LoadBalanced",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "LoadBalancer"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/monitoring/load_balancer.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/monitoring/load_balancer.yml
@@ -1,0 +1,65 @@
+description: "Monitoring a load balancer"
+uri: "mongodb://a:27017/?loadBalanced=true"
+phases:
+  -
+    outcome:
+      events:
+        -
+          topology_opening_event:
+            topologyId: "42"
+        -
+          topology_description_changed_event:
+            topologyId: "42"
+            previousDescription:
+              topologyType: "Unknown"
+              servers: []
+            newDescription:
+              topologyType: "LoadBalanced"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "Unknown"
+        -
+          server_opening_event:
+            topologyId: "42"
+            address: "a:27017"
+        -
+          server_description_changed_event:
+            topologyId: "42"
+            address: "a:27017"
+            previousDescription:
+              address: "a:27017"
+              arbiters: []
+              hosts: []
+              passives: []
+              type: "Unknown"
+            newDescription:
+              address: "a:27017"
+              arbiters: []
+              hosts: []
+              passives: []
+              type: "LoadBalancer"
+        -
+          topology_description_changed_event:
+            topologyId: "42"
+            previousDescription:
+              topologyType: "LoadBalanced"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "Unknown"
+            newDescription:
+              topologyType: "LoadBalanced"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "LoadBalancer"

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/InWindowTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/InWindowTestRunner.cs
@@ -103,8 +103,8 @@ namespace MongoDB.Driver.Specifications.server_selection
 
             var mockServerFactory = new Mock<IClusterableServerFactory>();
             mockServerFactory
-                .Setup(s => s.CreateServer(It.IsAny<ClusterId>(), It.IsAny<IClusterClock>(), It.IsAny<EndPoint>()))
-                .Returns<ClusterId, IClusterClock, EndPoint>((_, _, endpoint) =>
+                .Setup(s => s.CreateServer(It.IsAny<ClusterType>(), It.IsAny<ClusterId>(), It.IsAny<IClusterClock>(), It.IsAny<EndPoint>()))
+                .Returns<ClusterType, ClusterId, IClusterClock, EndPoint>((_, _, _, endpoint) =>
                 {
                     var serverDescription = clusterDescription.Servers
                         .Single(s => s.EndPoint == endpoint).

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/ServerSelectionTestHelpers.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/ServerSelectionTestHelpers.cs
@@ -32,7 +32,8 @@ namespace MongoDB.Driver.Specifications.server_selection
             ReplicaSetNoPrimary,
             Sharded,
             Single,
-            Unknown
+            Unknown,
+            LoadBalanced
         }
 
         private enum ServerTypeTest
@@ -44,7 +45,8 @@ namespace MongoDB.Driver.Specifications.server_selection
            RSOther = ServerType.ReplicaSetOther,
            Mongos = ServerType.ShardRouter,
            Standalone = ServerType.Standalone,
-           Unknown = ServerType.Unknown
+           Unknown = ServerType.Unknown,
+           LoadBalancer = ServerType.LoadBalanced
         }
 
         public enum ServerTagTest
@@ -105,6 +107,7 @@ namespace MongoDB.Driver.Specifications.server_selection
                 ClusterTypeTest.Sharded => (ClusterType.Sharded, ClusterConnectionMode.Sharded),
                 ClusterTypeTest.Single => (ClusterType.Standalone, ClusterConnectionMode.Standalone),
                 ClusterTypeTest.Unknown => (ClusterType.Unknown, ClusterConnectionMode.Automatic),
+                ClusterTypeTest.LoadBalanced => (ClusterType.LoadBalanced, ClusterConnectionMode.Automatic),
                 _ => throw new NotSupportedException($"Unknown topology type: {topologyDescription.type}")
             };
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/Nearest.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/Nearest.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "Nearest",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/Primary.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/Primary.json
@@ -1,0 +1,30 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "Primary"
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/PrimaryPreferred.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/PrimaryPreferred.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "PrimaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/Secondary.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/Secondary.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "Secondary",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/SecondaryPreferred.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/read/SecondaryPreferred.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "SecondaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/Nearest.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/Nearest.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "Nearest",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/Primary.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/Primary.json
@@ -1,0 +1,30 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "Primary"
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/PrimaryPreferred.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/PrimaryPreferred.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "PrimaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/Secondary.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/Secondary.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "Secondary",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/SecondaryPreferred.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/LoadBalanced/write/SecondaryPreferred.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "SecondaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
+++ b/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
@@ -124,9 +124,10 @@ namespace MongoDB.Driver.Tests
             Action<MongoClientSettings> clientSettingsConfigurator = null,
             bool useMultipleShardRouters = false)
         {
-            if (CoreTestConfiguration.Cluster.Description.Type != ClusterType.Sharded)
+            var clusterType = CoreTestConfiguration.Cluster.Description.Type;
+            if (clusterType != ClusterType.Sharded && clusterType != ClusterType.LoadBalanced)
             {
-                // This option has no effect for non-sharded topologies.
+                // This option has no effect for non-sharded/load balanced topologies.
                 useMultipleShardRouters = false;
             }
 

--- a/tests/MongoDB.Driver.Tests/MongoClientTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientTests.cs
@@ -407,6 +407,7 @@ namespace MongoDB.Driver.Tests
         [InlineData("{ connectionMode : 'Direct', clusterType : 'ReplicaSet', servers : [ { state : 'Connected', type : 'ReplicaSetPrimary', logicalSessionTimeoutMinutes : 30 } ] }", true)]
         [InlineData("{ directConnection : true, clusterType : 'ReplicaSet', servers : [ { state : 'Connected', type : 'ReplicaSetPrimary', logicalSessionTimeoutMinutes : 30 } ] }", true)]
         [InlineData("{ directConnection : false, clusterType : 'ReplicaSet', servers : [ { state : 'Connected', type : 'ReplicaSetPrimary', logicalSessionTimeoutMinutes : 30 } ] }", true)]
+        [InlineData("{ directConnection : false, clusterType : 'LoadBalanced', servers : [ { state : 'Connected', type : 'ReplicaSetPrimary' } ] }", true)]
         public void AreSessionsSupported_should_return_expected_result(string clusterDescriptionJson, bool? expectedResult)
         {
             var subject = new MongoClient("mongodb://localhost");

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/ChangeStreamTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/ChangeStreamTestRunner.cs
@@ -35,6 +35,7 @@ using Xunit;
 
 namespace MongoDB.Driver.Tests.Specifications.change_streams
 {
+    [Trait("Category", "SupportLoadBalancing")]
     public class ChangeStreamTestRunner
     {
         // private fields

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/ChangeStreamUnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/ChangeStreamUnifiedTestRunner.cs
@@ -21,6 +21,7 @@ using Xunit;
 
 namespace MongoDB.Driver.Tests.Specifications.change_streams
 {
+    [Trait("Category", "SupportLoadBalancing")]
     public sealed class ChangeStreamUnifiedTestRunner
     {
         [SkippableTheory]

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/legacy/change-streams-errors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/legacy/change-streams-errors.json
@@ -14,7 +14,7 @@
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
       "operations": [],
-      "expectations": [],
+      "expectations": null,
       "result": {
         "error": {
           "code": 40573
@@ -78,7 +78,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [
         {
@@ -125,7 +126,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/legacy/change-streams-resume-allowlist.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/legacy/change-streams-resume-allowlist.json
@@ -20,7 +20,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -777,7 +778,7 @@
       }
     },
     {
-      "description": "change stream resumes after NotMaster",
+      "description": "change stream resumes after NotWritablePrimary",
       "minServerVersion": "4.2",
       "maxServerVersion": "4.2.99",
       "failPoint": {
@@ -1068,7 +1069,7 @@
       }
     },
     {
-      "description": "change stream resumes after NotMasterNoSlaveOk",
+      "description": "change stream resumes after NotPrimaryNoSecondaryOk",
       "minServerVersion": "4.2",
       "maxServerVersion": "4.2.99",
       "failPoint": {
@@ -1165,7 +1166,7 @@
       }
     },
     {
-      "description": "change stream resumes after NotMasterOrSecondary",
+      "description": "change stream resumes after NotPrimaryOrSecondary",
       "minServerVersion": "4.2",
       "maxServerVersion": "4.2.99",
       "failPoint": {

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/legacy/change-streams-resume-allowlist.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/legacy/change-streams-resume-allowlist.yml
@@ -15,6 +15,7 @@ tests:
     topology: 
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -521,7 +522,7 @@ tests:
             x:
               $numberInt: "1"
   -
-    description: "change stream resumes after NotMaster"
+    description: "change stream resumes after NotWritablePrimary"
     minServerVersion: "4.2"
     maxServerVersion: "4.2.99"
     failPoint:
@@ -716,7 +717,7 @@ tests:
             x:
               $numberInt: "1"
   -
-    description: "change stream resumes after NotMasterNoSlaveOk"
+    description: "change stream resumes after NotPrimaryNoSecondaryOk"
     minServerVersion: "4.2"
     maxServerVersion: "4.2.99"
     failPoint:
@@ -781,7 +782,7 @@ tests:
             x:
               $numberInt: "1"
   -
-    description: "change stream resumes after NotMasterOrSecondary"
+    description: "change stream resumes after NotPrimaryOrSecondary"
     minServerVersion: "4.2"
     maxServerVersion: "4.2.99"
     failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/legacy/change-streams-resume-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/legacy/change-streams-resume-errorLabels.json
@@ -18,7 +18,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -111,7 +112,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -204,7 +206,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -297,7 +300,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -390,7 +394,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -483,7 +488,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -576,7 +582,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -654,7 +661,7 @@
       }
     },
     {
-      "description": "change stream resumes after NotMaster",
+      "description": "change stream resumes after NotWritablePrimary",
       "minServerVersion": "4.3.1",
       "failPoint": {
         "configureFailPoint": "failGetMoreAfterCursorCheckout",
@@ -669,7 +676,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -762,7 +770,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -855,7 +864,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -933,7 +943,7 @@
       }
     },
     {
-      "description": "change stream resumes after NotMasterNoSlaveOk",
+      "description": "change stream resumes after NotPrimaryNoSecondaryOk",
       "minServerVersion": "4.3.1",
       "failPoint": {
         "configureFailPoint": "failGetMoreAfterCursorCheckout",
@@ -948,7 +958,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1026,7 +1037,7 @@
       }
     },
     {
-      "description": "change stream resumes after NotMasterOrSecondary",
+      "description": "change stream resumes after NotPrimaryOrSecondary",
       "minServerVersion": "4.3.1",
       "failPoint": {
         "configureFailPoint": "failGetMoreAfterCursorCheckout",
@@ -1041,7 +1052,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1134,7 +1146,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1227,7 +1240,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1320,7 +1334,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1413,7 +1428,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1512,7 +1528,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1608,7 +1625,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/CrudUnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/CrudUnifiedTestRunner.cs
@@ -21,6 +21,7 @@ using Xunit;
 
 namespace MongoDB.Driver.Tests.Specifications.crud
 {
+    [Trait("Category", "SupportLoadBalancing")]
     public sealed class CrudUnifiedTestRunner
     {
         [SkippableTheory]

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsTestRunner.cs
@@ -34,6 +34,7 @@ using Xunit;
 
 namespace MongoDB.Driver.Tests.Specifications.retryable_reads
 {
+    [Trait("Category", "SupportLoadBalancing")]
     public sealed class RetryableReadsTestRunner
     {
         #region static

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/README.rst
@@ -74,9 +74,22 @@ Each YAML file has the following keys:
     version.
 
   - ``topology`` (optional): An array of server topologies against which the
-    tests can be run successfully. Valid topologies are "single", "replicaset",
-    and "sharded". If this field is omitted, the default is all topologies (i.e.
-    ``["single", "replicaset", "sharded"]``).
+    tests can be run successfully. Valid topologies are "single",
+    "replicaset", "sharded", and "load-balanced". If this field is omitted,
+    the default is all topologies (i.e. ``["single", "replicaset", "sharded",
+    "load-balanced"]``).
+
+  - ``serverless``: Optional string. Whether or not the test should be run on
+    serverless instances imitating sharded clusters. Valid values are "require",
+    "forbid", and "allow". If "require", the test MUST only be run on serverless
+    instances. If "forbid", the test MUST NOT be run on serverless instances. If
+    omitted or "allow", this option has no effect.
+
+    The test runner MUST be informed whether or not serverless is being used in
+    order to determine if this requirement is met (e.g. through an environment
+    variable or configuration option). Since the serverless proxy imitates a
+    mongos, the runner is not capable of determining this by issuing a server
+    command such as ``buildInfo`` or ``hello``.
 
 - ``database_name`` and ``collection_name``: Optional. The database and
   collection to use for testing.
@@ -84,7 +97,10 @@ Each YAML file has the following keys:
 - ``bucket_name``: Optional. The GridFS bucket name to use for testing.
 
 - ``data``: The data that should exist in the collection(s) under test before
-  each test run.
+  each test run. This will typically be an array of documents to be inserted
+  into the collection under test (i.e. ``collection_name``); however, this field
+  may also be an object mapping collection names to arrays of documents to be
+  inserted into the specified collection.
     
 - ``tests``: An array of tests that are to be run independently of each other.
   Each test will have some or all of the following fields:
@@ -126,6 +142,9 @@ GridFS Tests
 ------------
 
 GridFS tests are denoted by when the YAML file contains ``bucket_name``.
+The ``data`` field will also be an object, which maps collection names
+(e.g. ``fs.files``) to an array of documents that should be inserted into
+the specified collection.
 
 ``fs.files`` and ``fs.chunks`` should be created in the database
 specified by ``database_name``. This could be done via inserts or by
@@ -141,20 +160,63 @@ data.
 
 .. _GridFSBucket spec: https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#configurable-gridfsbucket-class
     
+
 Speeding Up Tests
 -----------------
 
-Drivers may benefit reducing `minHeartbeatFrequencyMS`_ in order to speed up
-tests. Python was able to decrease the run time of the tests greatly by lowering
-the SDAM's ``minHeartbeatFrequencyMS`` from 500ms to 50ms, thus decreasing the
-waiting time after a "not master" error:
+Drivers can greatly reduce the execution time of tests by setting `heartbeatFrequencyMS`_
+and `minHeartbeatFrequencyMS`_ (internally) to a small value (e.g. 5ms), below what
+is normally permitted in the SDAM spec. If a test specifies an explicit value for
+heartbeatFrequencyMS (e.g. client or URI options), drivers MUST use that value.
 
-.. _minHeartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms
+.. _minHeartbeatFrequencyMS: ../../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms
+.. _heartbeatFrequencyMS: ../../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms
+
 Optional Enumeration Commands
 =============================
 
 A driver only needs to test the optional enumeration commands it has chosen to
 implement (e.g. ``Database.listCollectionNames()``).
+
+PoolClearedError Retryability Test
+==================================
+
+This test will be used to ensure drivers properly retry after encountering PoolClearedErrors.
+It MUST be implemented by any driver that implements the CMAP specification.
+This test requires MongoDB 4.2.9+ for ``blockConnection`` support in the failpoint.
+
+1. Create a client with maxPoolSize=1 and retryReads=true. If testing against a
+   sharded deployment, be sure to connect to only a single mongos.
+
+2. Enable the following failpoint::
+
+     {
+         configureFailPoint: "failCommand",
+         mode: { times: 1 },
+         data: {
+             failCommands: ["find"],
+             errorCode: 91,
+             blockConnection: true,
+             blockTimeMS: 1000
+         }
+     }
+
+3. Start two threads and attempt to perform a ``findOne`` simultaneously on both.
+
+4. Verify that both ``findOne`` attempts succeed.
+
+5. Via CMAP monitoring, assert that the first check out succeeds.
+
+6. Via CMAP monitoring, assert that a PoolClearedEvent is then emitted.
+
+7. Via CMAP monitoring, assert that the second check out then fails due to a
+   connection error.
+
+8. Via Command Monitoring, assert that exactly three ``find`` CommandStartedEvents
+   were observed in total.
+
+9. Disable the failpoint.
+
 
 Changelog
 =========
@@ -165,3 +227,9 @@ Changelog
              now expressed within ``runOn`` elements.
 
              Add test-level ``useMultipleMongoses`` field.
+
+:2020-09-16: Suggest lowering heartbeatFrequencyMS in addition to minHeartbeatFrequencyMS.
+
+:2021-03-23: Add prose test for retrying PoolClearedErrors
+
+:2021-04-29: Add ``load-balanced`` to test topology requirements.

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/aggregate-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/aggregate-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -218,7 +219,7 @@
       ]
     },
     {
-      "description": "Aggregate succeeds after NotMaster",
+      "description": "Aggregate succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -311,7 +312,7 @@
       ]
     },
     {
-      "description": "Aggregate succeeds after NotMasterNoSlaveOk",
+      "description": "Aggregate succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -404,7 +405,7 @@
       ]
     },
     {
-      "description": "Aggregate succeeds after NotMasterOrSecondary",
+      "description": "Aggregate succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1055,7 +1056,7 @@
       ]
     },
     {
-      "description": "Aggregate fails after two NotMaster errors",
+      "description": "Aggregate fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1139,7 +1140,7 @@
       ]
     },
     {
-      "description": "Aggregate fails after NotMaster when retryReads is false",
+      "description": "Aggregate fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/aggregate-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/aggregate-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -52,7 +52,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Aggregate succeeds after NotMaster"
+        description: "Aggregate succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
@@ -61,7 +61,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Aggregate succeeds after NotMasterNoSlaveOk"
+        description: "Aggregate succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
@@ -70,7 +70,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Aggregate succeeds after NotMasterOrSecondary"
+        description: "Aggregate succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
@@ -133,7 +133,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Aggregate fails after two NotMaster errors"
+        description: "Aggregate fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -146,7 +146,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Aggregate fails after NotMaster when retryReads is false"
+        description: "Aggregate fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/aggregate.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/aggregate.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/aggregate.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/aggregate.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-client.watch-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-client.watch-serverErrors.json
@@ -9,8 +9,10 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
-      ]
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "retryable-reads-tests",
@@ -141,7 +143,7 @@
       ]
     },
     {
-      "description": "client.watch succeeds after NotMaster",
+      "description": "client.watch succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -196,7 +198,7 @@
       ]
     },
     {
-      "description": "client.watch succeeds after NotMasterNoSlaveOk",
+      "description": "client.watch succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -251,7 +253,7 @@
       ]
     },
     {
-      "description": "client.watch succeeds after NotMasterOrSecondary",
+      "description": "client.watch succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -636,7 +638,7 @@
       ]
     },
     {
-      "description": "client.watch fails after two NotMaster errors",
+      "description": "client.watch fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -692,7 +694,7 @@
       ]
     },
     {
-      "description": "client.watch fails after NotMaster when retryReads is false",
+      "description": "client.watch fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-client.watch-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-client.watch-serverErrors.yml
@@ -4,7 +4,8 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
+        serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -44,7 +45,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "client.watch succeeds after NotMaster"
+        description: "client.watch succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
@@ -53,7 +54,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "client.watch succeeds after NotMasterNoSlaveOk"
+        description: "client.watch succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
@@ -62,7 +63,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "client.watch succeeds after NotMasterOrSecondary"
+        description: "client.watch succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
@@ -125,7 +126,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "client.watch fails after two NotMaster errors"
+        description: "client.watch fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -138,7 +139,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "client.watch fails after NotMaster when retryReads is false"
+        description: "client.watch fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-client.watch.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-client.watch.json
@@ -9,8 +9,10 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
-      ]
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-client.watch.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-client.watch.yml
@@ -4,7 +4,8 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
+        serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.json
@@ -9,8 +9,10 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
-      ]
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "retryable-reads-tests",
@@ -133,7 +135,7 @@
       ]
     },
     {
-      "description": "db.coll.watch succeeds after NotMaster",
+      "description": "db.coll.watch succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -184,7 +186,7 @@
       ]
     },
     {
-      "description": "db.coll.watch succeeds after NotMasterNoSlaveOk",
+      "description": "db.coll.watch succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -235,7 +237,7 @@
       ]
     },
     {
-      "description": "db.coll.watch succeeds after NotMasterOrSecondary",
+      "description": "db.coll.watch succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -592,7 +594,7 @@
       ]
     },
     {
-      "description": "db.coll.watch fails after two NotMaster errors",
+      "description": "db.coll.watch fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -644,7 +646,7 @@
       ]
     },
     {
-      "description": "db.coll.watch fails after NotMaster when retryReads is false",
+      "description": "db.coll.watch fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.yml
@@ -4,7 +4,8 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
+        serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -44,7 +45,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.coll.watch succeeds after NotMaster"
+        description: "db.coll.watch succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
@@ -53,7 +54,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.coll.watch succeeds after NotMasterNoSlaveOk"
+        description: "db.coll.watch succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
@@ -62,7 +63,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.coll.watch succeeds after NotMasterOrSecondary"
+        description: "db.coll.watch succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
@@ -125,7 +126,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.coll.watch fails after two NotMaster errors"
+        description: "db.coll.watch fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -138,7 +139,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.coll.watch fails after NotMaster when retryReads is false"
+        description: "db.coll.watch fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.coll.watch.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.coll.watch.json
@@ -9,8 +9,10 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
-      ]
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.coll.watch.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.coll.watch.yml
@@ -4,7 +4,8 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
+        serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.watch-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.watch-serverErrors.json
@@ -9,8 +9,10 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
-      ]
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "retryable-reads-tests",
@@ -133,7 +135,7 @@
       ]
     },
     {
-      "description": "db.watch succeeds after NotMaster",
+      "description": "db.watch succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -184,7 +186,7 @@
       ]
     },
     {
-      "description": "db.watch succeeds after NotMasterNoSlaveOk",
+      "description": "db.watch succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -235,7 +237,7 @@
       ]
     },
     {
-      "description": "db.watch succeeds after NotMasterOrSecondary",
+      "description": "db.watch succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -592,7 +594,7 @@
       ]
     },
     {
-      "description": "db.watch fails after two NotMaster errors",
+      "description": "db.watch fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -644,7 +646,7 @@
       ]
     },
     {
-      "description": "db.watch fails after NotMaster when retryReads is false",
+      "description": "db.watch fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.watch-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.watch-serverErrors.yml
@@ -4,7 +4,8 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
+        serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -44,7 +45,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.watch succeeds after NotMaster"
+        description: "db.watch succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
@@ -53,7 +54,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.watch succeeds after NotMasterNoSlaveOk"
+        description: "db.watch succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
@@ -62,7 +63,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.watch succeeds after NotMasterOrSecondary"
+        description: "db.watch succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
@@ -125,7 +126,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.watch fails after two NotMaster errors"
+        description: "db.watch fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -138,7 +139,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "db.watch fails after NotMaster when retryReads is false"
+        description: "db.watch fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.watch.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.watch.json
@@ -9,8 +9,10 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
-      ]
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.watch.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/changeStreams-db.watch.yml
@@ -4,7 +4,8 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
+        serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/count-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/count-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -114,7 +115,7 @@
       ]
     },
     {
-      "description": "Count succeeds after NotMaster",
+      "description": "Count succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -157,7 +158,7 @@
       ]
     },
     {
-      "description": "Count succeeds after NotMasterNoSlaveOk",
+      "description": "Count succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -200,7 +201,7 @@
       ]
     },
     {
-      "description": "Count succeeds after NotMasterOrSecondary",
+      "description": "Count succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -501,7 +502,7 @@
       ]
     },
     {
-      "description": "Count fails after two NotMaster errors",
+      "description": "Count fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -544,7 +545,7 @@
       ]
     },
     {
-      "description": "Count fails after NotMaster when retryReads is false",
+      "description": "Count fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/count-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/count-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -44,7 +44,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Count succeeds after NotMaster"
+        description: "Count succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 10107 }
@@ -53,7 +53,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Count succeeds after NotMasterNoSlaveOk"
+        description: "Count succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 13435 }
@@ -62,7 +62,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Count succeeds after NotMasterOrSecondary"
+        description: "Count succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 13436 }
@@ -125,7 +125,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Count fails after two NotMaster errors"
+        description: "Count fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -138,7 +138,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Count fails after NotMaster when retryReads is false"
+        description: "Count fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/count.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/count.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/count.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/count.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/countDocuments-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/countDocuments-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -166,7 +167,7 @@
       ]
     },
     {
-      "description": "CountDocuments succeeds after NotMaster",
+      "description": "CountDocuments succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -235,7 +236,7 @@
       ]
     },
     {
-      "description": "CountDocuments succeeds after NotMasterNoSlaveOk",
+      "description": "CountDocuments succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -304,7 +305,7 @@
       ]
     },
     {
-      "description": "CountDocuments succeeds after NotMasterOrSecondary",
+      "description": "CountDocuments succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -787,7 +788,7 @@
       ]
     },
     {
-      "description": "CountDocuments fails after two NotMaster errors",
+      "description": "CountDocuments fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -856,7 +857,7 @@
       ]
     },
     {
-      "description": "CountDocuments fails after NotMaster when retryReads is false",
+      "description": "CountDocuments fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/countDocuments-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/countDocuments-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -45,7 +45,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "CountDocuments succeeds after NotMaster"
+        description: "CountDocuments succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
@@ -54,7 +54,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "CountDocuments succeeds after NotMasterNoSlaveOk"
+        description: "CountDocuments succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
@@ -63,7 +63,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "CountDocuments succeeds after NotMasterOrSecondary"
+        description: "CountDocuments succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
@@ -126,7 +126,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "CountDocuments fails after two NotMaster errors"
+        description: "CountDocuments fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -139,7 +139,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "CountDocuments fails after NotMaster when retryReads is false"
+        description: "CountDocuments fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/countDocuments.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/countDocuments.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/countDocuments.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/countDocuments.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/distinct-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/distinct-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -158,7 +159,7 @@
       ]
     },
     {
-      "description": "Distinct succeeds after NotMaster",
+      "description": "Distinct succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -221,7 +222,7 @@
       ]
     },
     {
-      "description": "Distinct succeeds after NotMasterNoSlaveOk",
+      "description": "Distinct succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -284,7 +285,7 @@
       ]
     },
     {
-      "description": "Distinct succeeds after NotMasterOrSecondary",
+      "description": "Distinct succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -725,7 +726,7 @@
       ]
     },
     {
-      "description": "Distinct fails after two NotMaster errors",
+      "description": "Distinct fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -785,7 +786,7 @@
       ]
     },
     {
-      "description": "Distinct fails after NotMaster when retryReads is false",
+      "description": "Distinct fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/distinct-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/distinct-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -50,7 +50,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Distinct succeeds after NotMaster"
+        description: "Distinct succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 10107 }
@@ -59,7 +59,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Distinct succeeds after NotMasterNoSlaveOk"
+        description: "Distinct succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 13435 }
@@ -68,7 +68,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Distinct succeeds after NotMasterOrSecondary"
+        description: "Distinct succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 13436 }
@@ -131,7 +131,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Distinct fails after two NotMaster errors"
+        description: "Distinct fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -144,7 +144,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Distinct fails after NotMaster when retryReads is false"
+        description: "Distinct fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/distinct.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/distinct.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/distinct.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/distinct.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-4.9.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-4.9.json
@@ -1,246 +1,246 @@
 {
-    "runOn": [
+  "runOn": [
+    {
+      "minServerVersion": "4.9.0"
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "EstimatedDocumentCount succeeds on first attempt",
+      "operations": [
         {
-            "minServerVersion": "4.9.0"
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
         }
-    ],
-    "database_name": "retryable-reads-tests",
-    "collection_name": "coll",
-    "data": [
+      ],
+      "expectations": [
         {
-            "_id": 1,
-            "x": 11
-        },
-        {
-            "_id": 2,
-            "x": 22
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
         }
-    ],
-    "tests": [
-        {
-            "description": "EstimatedDocumentCount succeeds on first attempt",
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
         },
-        {
-            "description": "EstimatedDocumentCount succeeds on second attempt",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "closeConnection": true
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount fails on first attempt",
-            "clientOptions": {
-                "retryReads": false
-            },
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "closeConnection": true
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "error": true
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount fails on second attempt",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 2
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "closeConnection": true
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "error": true
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
         }
-    ]
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount fails on first attempt",
+      "clientOptions": {
+        "retryReads": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount fails on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-4.9.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-4.9.json
@@ -1,911 +1,911 @@
 {
-    "runOn": [
-        {
-            "minServerVersion": "4.9.0"
+  "runOn": [
+    {
+      "minServerVersion": "4.9.0"
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "EstimatedDocumentCount succeeds after InterruptedAtShutdown",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 11600
         }
-    ],
-    "database_name": "retryable-reads-tests",
-    "collection_name": "coll",
-    "data": [
+      },
+      "operations": [
         {
-            "_id": 1,
-            "x": 11
-        },
-        {
-            "_id": 2,
-            "x": 22
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
         }
-    ],
-    "tests": [
+      ],
+      "expectations": [
         {
-            "description": "EstimatedDocumentCount succeeds after InterruptedAtShutdown",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
                 },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 11600
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
                 }
+              ]
             },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
+            "database_name": "retryable-reads-tests"
+          }
         },
         {
-            "description": "EstimatedDocumentCount succeeds after InterruptedDueToReplStateChange",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
                 },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 11602
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
                 }
+              ]
             },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after NotMaster",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 10107
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 13435
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after NotMasterOrSecondary",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 13436
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after PrimarySteppedDown",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 189
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after ShutdownInProgress",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 91
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after HostNotFound",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 7
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after HostUnreachable",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 6
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after NetworkTimeout",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 89
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after SocketException",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 9001
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount fails after two NotMaster errors",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 2
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 10107
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "error": true
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount fails after NotMaster when retryReads is false",
-            "clientOptions": {
-                "retryReads": false
-            },
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 10107
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "error": true
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
+            "database_name": "retryable-reads-tests"
+          }
         }
-    ]
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after InterruptedDueToReplStateChange",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 11602
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after NotWritablePrimary",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 10107
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after NotPrimaryNoSecondaryOk",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 13435
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after NotPrimaryOrSecondary",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 13436
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after PrimarySteppedDown",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 189
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after ShutdownInProgress",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 91
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after HostNotFound",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 7
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after HostUnreachable",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 6
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after NetworkTimeout",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 89
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after SocketException",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 9001
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount fails after two NotWritablePrimary errors",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 10107
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount fails after NotWritablePrimary when retryReads is false",
+      "clientOptions": {
+        "retryReads": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 10107
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-4.9.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-4.9.yml
@@ -41,7 +41,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount succeeds after NotMaster"
+        description: "EstimatedDocumentCount succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
@@ -50,7 +50,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk"
+        description: "EstimatedDocumentCount succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
@@ -59,7 +59,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount succeeds after NotMasterOrSecondary"
+        description: "EstimatedDocumentCount succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
@@ -122,7 +122,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount fails after two NotMaster errors"
+        description: "EstimatedDocumentCount fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -135,7 +135,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount fails after NotMaster when retryReads is false"
+        description: "EstimatedDocumentCount fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-pre4.9.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-pre4.9.json
@@ -110,7 +110,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount succeeds after NotMaster",
+      "description": "EstimatedDocumentCount succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -150,7 +150,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk",
+      "description": "EstimatedDocumentCount succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -190,7 +190,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount succeeds after NotMasterOrSecondary",
+      "description": "EstimatedDocumentCount succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -470,7 +470,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount fails after two NotMaster errors",
+      "description": "EstimatedDocumentCount fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -510,7 +510,7 @@
       ]
     },
     {
-      "description": "EstimatedDocumentCount fails after NotMaster when retryReads is false",
+      "description": "EstimatedDocumentCount fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-pre4.9.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/estimatedDocumentCount-serverErrors-pre4.9.yml
@@ -45,7 +45,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount succeeds after NotMaster"
+        description: "EstimatedDocumentCount succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 10107 }
@@ -54,7 +54,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk"
+        description: "EstimatedDocumentCount succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 13435 }
@@ -63,7 +63,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount succeeds after NotMasterOrSecondary"
+        description: "EstimatedDocumentCount succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 13436 }
@@ -126,7 +126,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount fails after two NotMaster errors"
+        description: "EstimatedDocumentCount fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -139,7 +139,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "EstimatedDocumentCount fails after NotMaster when retryReads is false"
+        description: "EstimatedDocumentCount fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/find-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/find-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -188,7 +189,7 @@
       ]
     },
     {
-      "description": "Find succeeds after NotMaster",
+      "description": "Find succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -262,7 +263,7 @@
       ]
     },
     {
-      "description": "Find succeeds after NotMasterNoSlaveOk",
+      "description": "Find succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -336,7 +337,7 @@
       ]
     },
     {
-      "description": "Find succeeds after NotMasterOrSecondary",
+      "description": "Find succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -854,7 +855,7 @@
       ]
     },
     {
-      "description": "Find fails after two NotMaster errors",
+      "description": "Find fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -911,7 +912,7 @@
       ]
     },
     {
-      "description": "Find fails after NotMaster when retryReads is false",
+      "description": "Find fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/find-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/find-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -54,7 +54,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Find succeeds after NotMaster"
+        description: "Find succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
@@ -63,7 +63,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Find succeeds after NotMasterNoSlaveOk"
+        description: "Find succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13435 }
@@ -72,7 +72,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Find succeeds after NotMasterOrSecondary"
+        description: "Find succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13436 }
@@ -135,7 +135,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Find fails after two NotMaster errors"
+        description: "Find fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -148,7 +148,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Find fails after NotMaster when retryReads is false"
+        description: "Find fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/find.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/find.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/find.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/find.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-download-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-download-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -191,7 +192,7 @@
       ]
     },
     {
-      "description": "Download succeeds after NotMaster",
+      "description": "Download succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -261,7 +262,7 @@
       ]
     },
     {
-      "description": "Download succeeds after NotMasterNoSlaveOk",
+      "description": "Download succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -331,7 +332,7 @@
       ]
     },
     {
-      "description": "Download succeeds after NotMasterOrSecondary",
+      "description": "Download succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -821,7 +822,7 @@
       ]
     },
     {
-      "description": "Download fails after two NotMaster errors",
+      "description": "Download fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -876,7 +877,7 @@
       ]
     },
     {
-      "description": "Download fails after NotMaster when retryReads is false",
+      "description": "Download fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-download-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-download-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"
@@ -59,7 +59,7 @@ tests:
              - *retryable_command_started_event
              - *find_chunks_command_started_event
     -
-        description: "Download succeeds after NotMaster"
+        description: "Download succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
@@ -69,7 +69,7 @@ tests:
              - *retryable_command_started_event
              - *find_chunks_command_started_event
     -
-        description: "Download succeeds after NotMasterNoSlaveOk"
+        description: "Download succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13435 }
@@ -79,7 +79,7 @@ tests:
              - *retryable_command_started_event
              - *find_chunks_command_started_event
     -
-        description: "Download succeeds after NotMasterOrSecondary"
+        description: "Download succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13436 }
@@ -149,7 +149,7 @@ tests:
              - *retryable_command_started_event
              - *find_chunks_command_started_event
     -
-        description: "Download fails after two NotMaster errors"
+        description: "Download fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -162,7 +162,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "Download fails after NotMaster when retryReads is false"
+        description: "Download fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-download.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-download.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-download.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-download.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-downloadByName-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-downloadByName-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -179,7 +180,7 @@
       ]
     },
     {
-      "description": "DownloadByName succeeds after NotMaster",
+      "description": "DownloadByName succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -243,7 +244,7 @@
       ]
     },
     {
-      "description": "DownloadByName succeeds after NotMasterNoSlaveOk",
+      "description": "DownloadByName succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -307,7 +308,7 @@
       ]
     },
     {
-      "description": "DownloadByName succeeds after NotMasterOrSecondary",
+      "description": "DownloadByName succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -755,7 +756,7 @@
       ]
     },
     {
-      "description": "DownloadByName fails after two NotMaster errors",
+      "description": "DownloadByName fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -804,7 +805,7 @@
       ]
     },
     {
-      "description": "DownloadByName fails after NotMaster when retryReads is false",
+      "description": "DownloadByName fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-downloadByName-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-downloadByName-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"
@@ -60,7 +60,7 @@ tests:
              - *retryable_command_started_event
              - *find_chunks_command_started_event
     -
-        description: "DownloadByName succeeds after NotMaster"
+        description: "DownloadByName succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
@@ -70,7 +70,7 @@ tests:
              - *retryable_command_started_event
              - *find_chunks_command_started_event
     -
-        description: "DownloadByName succeeds after NotMasterNoSlaveOk"
+        description: "DownloadByName succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13435 }
@@ -80,7 +80,7 @@ tests:
              - *retryable_command_started_event
              - *find_chunks_command_started_event
     -
-        description: "DownloadByName succeeds after NotMasterOrSecondary"
+        description: "DownloadByName succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13436 }
@@ -150,7 +150,7 @@ tests:
              - *retryable_command_started_event
              - *find_chunks_command_started_event
     -
-        description: "DownloadByName fails after two NotMaster errors"
+        description: "DownloadByName fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -163,7 +163,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "DownloadByName fails after NotMaster when retryReads is false"
+        description: "DownloadByName fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-downloadByName.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-downloadByName.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-downloadByName.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/gridfs-downloadByName.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollectionNames-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollectionNames-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -93,7 +94,7 @@
       ]
     },
     {
-      "description": "ListCollectionNames succeeds after NotMaster",
+      "description": "ListCollectionNames succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -130,7 +131,7 @@
       ]
     },
     {
-      "description": "ListCollectionNames succeeds after NotMasterNoSlaveOk",
+      "description": "ListCollectionNames succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -167,7 +168,7 @@
       ]
     },
     {
-      "description": "ListCollectionNames succeeds after NotMasterOrSecondary",
+      "description": "ListCollectionNames succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -426,7 +427,7 @@
       ]
     },
     {
-      "description": "ListCollectionNames fails after two NotMaster errors",
+      "description": "ListCollectionNames fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -464,7 +465,7 @@
       ]
     },
     {
-      "description": "ListCollectionNames fails after NotMaster when retryReads is false",
+      "description": "ListCollectionNames fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollectionNames-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollectionNames-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -38,7 +38,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollectionNames succeeds after NotMaster"
+        description: "ListCollectionNames succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 10107 }
@@ -47,7 +47,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollectionNames succeeds after NotMasterNoSlaveOk"
+        description: "ListCollectionNames succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13435 }
@@ -56,7 +56,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollectionNames succeeds after NotMasterOrSecondary"
+        description: "ListCollectionNames succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13436 }
@@ -119,7 +119,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollectionNames fails after two NotMaster errors"
+        description: "ListCollectionNames fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -132,7 +132,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollectionNames fails after NotMaster when retryReads is false"
+        description: "ListCollectionNames fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollectionNames.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollectionNames.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollectionNames.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollectionNames.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollections-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollections-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -93,7 +94,7 @@
       ]
     },
     {
-      "description": "ListCollections succeeds after NotMaster",
+      "description": "ListCollections succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -130,7 +131,7 @@
       ]
     },
     {
-      "description": "ListCollections succeeds after NotMasterNoSlaveOk",
+      "description": "ListCollections succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -167,7 +168,7 @@
       ]
     },
     {
-      "description": "ListCollections succeeds after NotMasterOrSecondary",
+      "description": "ListCollections succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -426,7 +427,7 @@
       ]
     },
     {
-      "description": "ListCollections fails after two NotMaster errors",
+      "description": "ListCollections fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -464,7 +465,7 @@
       ]
     },
     {
-      "description": "ListCollections fails after NotMaster when retryReads is false",
+      "description": "ListCollections fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollections-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollections-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -38,7 +38,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollections succeeds after NotMaster"
+        description: "ListCollections succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 10107 }
@@ -47,7 +47,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollections succeeds after NotMasterNoSlaveOk"
+        description: "ListCollections succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13435 }
@@ -56,7 +56,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollections succeeds after NotMasterOrSecondary"
+        description: "ListCollections succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13436 }
@@ -119,7 +119,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollections fails after two NotMaster errors"
+        description: "ListCollections fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -132,7 +132,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListCollections fails after NotMaster when retryReads is false"
+        description: "ListCollections fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollections.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollections.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollections.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listCollections.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabaseNames-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabaseNames-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -93,7 +94,7 @@
       ]
     },
     {
-      "description": "ListDatabaseNames succeeds after NotMaster",
+      "description": "ListDatabaseNames succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -130,7 +131,7 @@
       ]
     },
     {
-      "description": "ListDatabaseNames succeeds after NotMasterNoSlaveOk",
+      "description": "ListDatabaseNames succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -167,7 +168,7 @@
       ]
     },
     {
-      "description": "ListDatabaseNames succeeds after NotMasterOrSecondary",
+      "description": "ListDatabaseNames succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -426,7 +427,7 @@
       ]
     },
     {
-      "description": "ListDatabaseNames fails after two NotMaster errors",
+      "description": "ListDatabaseNames fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -464,7 +465,7 @@
       ]
     },
     {
-      "description": "ListDatabaseNames fails after NotMaster when retryReads is false",
+      "description": "ListDatabaseNames fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabaseNames-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabaseNames-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -38,7 +38,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabaseNames succeeds after NotMaster"
+        description: "ListDatabaseNames succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 10107 }
@@ -47,7 +47,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabaseNames succeeds after NotMasterNoSlaveOk"
+        description: "ListDatabaseNames succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13435 }
@@ -56,7 +56,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabaseNames succeeds after NotMasterOrSecondary"
+        description: "ListDatabaseNames succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13436 }
@@ -119,7 +119,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabaseNames fails after two NotMaster errors"
+        description: "ListDatabaseNames fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -132,7 +132,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabaseNames fails after NotMaster when retryReads is false"
+        description: "ListDatabaseNames fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabaseNames.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabaseNames.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabaseNames.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabaseNames.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabases-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabases-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -93,7 +94,7 @@
       ]
     },
     {
-      "description": "ListDatabases succeeds after NotMaster",
+      "description": "ListDatabases succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -130,7 +131,7 @@
       ]
     },
     {
-      "description": "ListDatabases succeeds after NotMasterNoSlaveOk",
+      "description": "ListDatabases succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -167,7 +168,7 @@
       ]
     },
     {
-      "description": "ListDatabases succeeds after NotMasterOrSecondary",
+      "description": "ListDatabases succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -426,7 +427,7 @@
       ]
     },
     {
-      "description": "ListDatabases fails after two NotMaster errors",
+      "description": "ListDatabases fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -464,7 +465,7 @@
       ]
     },
     {
-      "description": "ListDatabases fails after NotMaster when retryReads is false",
+      "description": "ListDatabases fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabases-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabases-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -38,7 +38,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabases succeeds after NotMaster"
+        description: "ListDatabases succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 10107 }
@@ -47,7 +47,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabases succeeds after NotMasterNoSlaveOk"
+        description: "ListDatabases succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13435 }
@@ -56,7 +56,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabases succeeds after NotMasterOrSecondary"
+        description: "ListDatabases succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13436 }
@@ -119,7 +119,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabases fails after two NotMaster errors"
+        description: "ListDatabases fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -132,7 +132,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListDatabases fails after NotMaster when retryReads is false"
+        description: "ListDatabases fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabases.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabases.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabases.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listDatabases.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listIndexes-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listIndexes-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -97,7 +98,7 @@
       ]
     },
     {
-      "description": "ListIndexes succeeds after NotMaster",
+      "description": "ListIndexes succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -136,7 +137,7 @@
       ]
     },
     {
-      "description": "ListIndexes succeeds after NotMasterNoSlaveOk",
+      "description": "ListIndexes succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -175,7 +176,7 @@
       ]
     },
     {
-      "description": "ListIndexes succeeds after NotMasterOrSecondary",
+      "description": "ListIndexes succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -448,7 +449,7 @@
       ]
     },
     {
-      "description": "ListIndexes fails after two NotMaster errors",
+      "description": "ListIndexes fails after two NotWritablePrimary errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -488,7 +489,7 @@
       ]
     },
     {
-      "description": "ListIndexes fails after NotMaster when retryReads is false",
+      "description": "ListIndexes fails after NotWritablePrimary when retryReads is false",
       "clientOptions": {
         "retryReads": false
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listIndexes-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listIndexes-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"
@@ -39,7 +39,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListIndexes succeeds after NotMaster"
+        description: "ListIndexes succeeds after NotWritablePrimary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 10107 }
@@ -48,7 +48,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListIndexes succeeds after NotMasterNoSlaveOk"
+        description: "ListIndexes succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 13435 }
@@ -57,7 +57,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListIndexes succeeds after NotMasterOrSecondary"
+        description: "ListIndexes succeeds after NotPrimaryOrSecondary"
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 13436 }
@@ -120,7 +120,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListIndexes fails after two NotMaster errors"
+        description: "ListIndexes fails after two NotWritablePrimary errors"
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
@@ -133,7 +133,7 @@ tests:
              - *retryable_command_started_event
              - *retryable_command_started_event
     -
-        description: "ListIndexes fails after NotMaster when retryReads is false"
+        description: "ListIndexes fails after NotWritablePrimary when retryReads is false"
         clientOptions:
             retryReads: false
         failPoint:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listIndexes.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listIndexes.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listIndexes.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/listIndexes.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/mapReduce.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/mapReduce.json
@@ -10,8 +10,10 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
-      ]
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/mapReduce.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/tests/mapReduce.yml
@@ -4,7 +4,9 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
+        # serverless proxy does not support mapReduce operation
+        serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/RetryableWriteTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/RetryableWriteTestRunner.cs
@@ -27,6 +27,7 @@ using Xunit.Abstractions;
 
 namespace MongoDB.Driver.Tests.Specifications.retryable_writes
 {
+    [Trait("Category", "SupportLoadBalancing")]
     public class RetryableWriteTestRunner
     {
         private readonly string _databaseName = DriverTestConfiguration.DatabaseNamespace.DatabaseName;

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/README.rst
@@ -91,6 +91,11 @@ disabled like so::
         mode: "off"
     });
 
+Speeding Up Tests
+=================
+
+See `Speeding Up Tests <../../retryable-reads/tests/README.rst#speeding-up-tests>`_ in the retryable reads spec tests.
+
 Use as Integration Tests
 ========================
 
@@ -154,9 +159,10 @@ Each YAML file has the following keys:
     version.
 
   - ``topology`` (optional): An array of server topologies against which the
-    tests can be run successfully. Valid topologies are "single", "replicaset",
-    and "sharded". If this field is omitted, the default is all topologies (i.e.
-    ``["single", "replicaset", "sharded"]``).
+    tests can be run successfully. Valid topologies are "single",
+    "replicaset", "sharded", and "load-balanced". If this field is omitted,
+    the default is all topologies (i.e. ``["single", "replicaset", "sharded",
+    "load-balanced"]``).
 
 - ``data``: The data that should exist in the collection under test before each
   test run.
@@ -322,10 +328,53 @@ and sharded clusters.
    in use MAY skip this test for sharded clusters, since ``mongos`` does not report
    this information in its ``serverStatus`` response.
 
+#. Test that drivers properly retry after encountering PoolClearedErrors. This
+   test MUST be implemented by any driver that implements the CMAP
+   specification. This test requires MongoDB 4.2.9+ for ``blockConnection`` support in the failpoint.
+
+   1. Create a client with maxPoolSize=1 and retryWrites=true. If testing
+      against a sharded deployment, be sure to connect to only a single mongos.
+
+   2. Enable the following failpoint::
+
+       {
+           configureFailPoint: "failCommand",
+           mode: { times: 1 },
+           data: {
+               failCommands: ["insert"],
+               errorCode: 91,
+               blockConnection: true,
+               blockTimeMS: 1000,
+               errorLabels: ["RetryableWriteError"]
+           }
+       }
+
+   3. Start two threads and attempt to perform an ``insertOne`` simultaneously on both.
+
+   4. Verify that both ``insertOne`` attempts succeed.
+
+   5. Via CMAP monitoring, assert that the first check out succeeds.
+
+   6. Via CMAP monitoring, assert that a PoolClearedEvent is then emitted.
+
+   7. Via CMAP monitoring, assert that the second check out then fails due to a
+      connection error.
+
+   8. Via Command Monitoring, assert that exactly three ``insert``
+      CommandStartedEvents were observed in total.
+
+   9. Disable the failpoint.
+
+
 Changelog
 =========
 
-:2019-10-21: Add ``errorLabelsContain`` and ``errorLabelsContain`` fields to ``result``
+:2021-04-23: Add ``load-balanced`` to test topology requirements.
+
+:2021-03-24: Add prose test verifying ``PoolClearedErrors`` are retried.
+
+:2019-10-21: Add ``errorLabelsContain`` and ``errorLabelsContain`` fields to
+             ``result``
 
 :2019-08-07: Add Prose Tests section
 

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteMany.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteMany.json
@@ -4,7 +4,8 @@
       "minServerVersion": "3.6",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteMany.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteMany.yml
@@ -1,7 +1,7 @@
 runOn:
     -
         minServerVersion: "3.6"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data: []
 

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],
@@ -117,7 +118,7 @@
       }
     },
     {
-      "description": "InsertOne succeeds after NotMaster",
+      "description": "InsertOne succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -166,7 +167,7 @@
       }
     },
     {
-      "description": "InsertOne succeeds after NotMasterOrSecondary",
+      "description": "InsertOne succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -215,7 +216,7 @@
       }
     },
     {
-      "description": "InsertOne succeeds after NotMasterNoSlaveOk",
+      "description": "InsertOne succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -966,7 +967,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }
@@ -56,7 +56,7 @@ tests:
                     - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }
     -
-        description: "InsertOne succeeds after NotMaster"
+        description: "InsertOne succeeds after NotWritablePrimary"
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
@@ -78,7 +78,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
     -
-        description: "InsertOne succeeds after NotMasterOrSecondary"
+        description: "InsertOne succeeds after NotPrimaryOrSecondary"
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
@@ -100,7 +100,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
     -
-        description: "InsertOne succeeds after NotMasterNoSlaveOk"
+        description: "InsertOne succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
@@ -442,6 +442,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateMany.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateMany.json
@@ -4,7 +4,8 @@
       "minServerVersion": "3.6",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateMany.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateMany.yml
@@ -1,7 +1,7 @@
 runOn:
     -
         minServerVersion: "3.6"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/TransactionUnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/TransactionUnifiedTestRunner.cs
@@ -21,7 +21,8 @@ using Xunit;
 
 namespace MongoDB.Driver.Tests.Specifications.transactions
 {
-   public sealed class TransactionUnifiedTestRunner
+    [Trait("Category", "SupportLoadBalancing")]
+    public sealed class TransactionUnifiedTestRunner
     {
         [SkippableTheory]
         [ClassData(typeof(TestCaseFactory))]

--- a/tests/MongoDB.Driver.Tests/Specifications/versioned-api/VersionedApiUnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/versioned-api/VersionedApiUnifiedTestRunner.cs
@@ -21,6 +21,7 @@ using Xunit;
 
 namespace MongoDB.Driver.Tests.Specifications.versioned_api
 {
+    [Trait("Category", "SupportLoadBalancing")]
     public sealed class VersionedApiUnifiedTestRunner
     {
         [SkippableTheory]


### PR DESCRIPTION
EG:  https://evergreen.mongodb.com/version/60de54362fbabe3344a05f95

Steps to work with LB (nginx) on windows:

1. Download nginx: http://nginx.org/en/download.html
2. Update `nginx-1.21.0\conf\nginx.conf` on:

			#user  nobody;
			worker_processes  1;
			#error_log  logs/error.log;
			#error_log  logs/error.log  notice;
			#error_log  logs/error.log  info;
			# pid        nginx/logs/nginx.pid;
			events {
				worker_connections  1024;
			}
			stream {
				server {
				   listen 17017;
				   proxy_pass single_server_backend;
				}
				server {
				   listen 17018;
				   proxy_pass multi_server_backend;
				}
				upstream multi_server_backend {
					server localhost:27017;
					server localhost:27018;
				}
				upstream single_server_backend {
					server localhost:27017;
				}
			}

pay attention on ports 17017 and 17018 that represents single mongos and two mongos accordingly.
So, to use them a driver should consume the following connection strings: mongodb://localhost17017?loadBalanced=true or mongodb://localhost17018?loadBalanced=true
3.
cd c:\
unzip nginx-1.21.0.zip
cd nginx-1.21.0
start nginx
4. Verify that nginx has been successfully launched:

		C:\nginx-1.21.0>tasklist /fi "imagename eq nginx.exe"
		Image Name                     PID Session Name        Session#    Mem Usage
		========================= ======== ================ =========== ============
		nginx.exe                     1680 Console                    1     14,188 K
		nginx.exe                    14920 Console                    1     14,356 K

5. Run server with 2 mongos:
mlaunch init --sharded 1 --replicaset --mongos 2 --setParameter enableTestCommands=1
where mongos will be launched on 27017 and 27018 ports.