### PR TITLE
Revert hello-timeout blockTimeMS back to 2000ms.

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/tests/integration/hello-timeout.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/tests/integration/hello-timeout.json
@@ -22,7 +22,7 @@
           ],
           "appName": "timeoutMonitorHandshakeTest",
           "blockConnection": true,
-          "blockTimeMS": 1000
+          "blockTimeMS": 2000
         }
       },
       "clientOptions": {
@@ -126,7 +126,7 @@
                 ],
                 "appName": "timeoutMonitorCheckTest",
                 "blockConnection": true,
-                "blockTimeMS": 1000
+                "blockTimeMS": 2000
               }
             }
           }


### PR DESCRIPTION
Due to current minimal socket timeout of 500ms, server blocking failpoint duration in  is increased to 2000ms to eliminate `hello-timeout` test failures.
