### PR TITLE
CSHARP-3698: Calling cursor.next() and cursor.close() concurrently in Load Balanced mode uses the same connection simultaneously.

### DIFF
--- a/Docs/reference/content/reference/driver/crud/reading.md
+++ b/Docs/reference/content/reference/driver/crud/reading.md
@@ -41,6 +41,8 @@ var count = await collection.CountDocumentsAsync(new BsonDocument());
 
 Finding all the documents in a collection is done with an empty filter and the method [`Find`]({{< apiref "M_MongoDB_Driver_IMongoCollectionExtensions_Find__1" >}}). Once we have a cursor (of type [`IAsyncCursor<TDocument>`]({{< apiref "T_MongoDB_Driver_IAsyncCursor_1" >}})), we can iterate it like we manually iterate an [`IEnumerable<TDocument>`]({{< msdnref "9eekhta0" >}}).
 
+{{% note class="important" %}}All cursor implementations are not designed to be thread safe.{{% /note %}}
+
 ```csharp
 var filter = new BsonDocument();
 using (var cursor = collection.Find(filter).ToCursor())


### PR DESCRIPTION
This PR does **not** affect the current release.