### PR TITLE
CSHARP-3659: Use hello command for monitoring (including RTT) if supported.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/HelloHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/HelloHelper.cs
@@ -43,17 +43,18 @@ namespace MongoDB.Driver.Core.Connections
             return command.Add("compression", compressorsArray);
         }
 
-        internal static BsonDocument CreateCommand(ServerApi serverApi, TopologyVersion topologyVersion = null, TimeSpan? maxAwaitTime = null, bool loadBalanced = false)
+        internal static BsonDocument CreateCommand(ServerApi serverApi, bool helloOk = false, TopologyVersion topologyVersion = null, TimeSpan? maxAwaitTime = null, bool loadBalanced = false)
         {
             Ensure.That(
                 (topologyVersion == null && !maxAwaitTime.HasValue) ||
                 (topologyVersion != null && maxAwaitTime.HasValue),
                 $"Both {nameof(topologyVersion)} and {nameof(maxAwaitTime)} must be filled or null.");
 
-            var helloCommandName = serverApi != null ? "hello" : OppressiveLanguageConstants.LegacyHelloCommandName;
+            var helloCommandName = helloOk || serverApi != null ? "hello" : OppressiveLanguageConstants.LegacyHelloCommandName;
             return new BsonDocument
             {
                 { helloCommandName, 1 },
+                { "helloOk", true },
                 { "topologyVersion", () => topologyVersion.ToBsonDocument(), topologyVersion != null },
                 { "maxAwaitTimeMS", () => (long)maxAwaitTime.Value.TotalMilliseconds, maxAwaitTime.HasValue },
                 { "loadBalanced", true, loadBalanced }

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -451,6 +451,17 @@ namespace MongoDB.Driver.Core.Connections
             get { return _wrapped; }
         }
 
+        /// <summary>
+        /// Gets whether the server support the hello command.
+        /// </summary>
+        /// <value>
+        /// True if helloOk:true was included in the response; false otherwise.
+        /// </value>
+        public bool HelloOk
+        {
+            get { return _wrapped.GetValue("helloOk", false).ToBoolean(); }
+        }
+
         // methods
         /// <inheritdoc/>
         public bool Equals(IsMasterResult other)

--- a/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
@@ -98,10 +98,8 @@ namespace MongoDB.Driver.Core.Servers
         {
             // generate initial server description
             var newDescription = _baseDescription
-                .With(
-                    type: ServerType.LoadBalanced,
-                    reasonChanged: "Initialized",
-                    state: ServerState.Connected);
+                .With(reasonChanged: "Initialized",
+                    state: ServerState.Connected, type: ServerType.LoadBalanced);
             var oldDescription = Interlocked.CompareExchange(ref _currentDescription, value: newDescription, comparand: _currentDescription);
             var eventArgs = new ServerDescriptionChangedEventArgs(oldDescription, newDescription);
 

--- a/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/LoadBalancedServer.cs
@@ -98,8 +98,10 @@ namespace MongoDB.Driver.Core.Servers
         {
             // generate initial server description
             var newDescription = _baseDescription
-                .With(reasonChanged: "Initialized",
-                    state: ServerState.Connected, type: ServerType.LoadBalanced);
+                .With(
+                    type: ServerType.LoadBalanced,
+                    reasonChanged: "Initialized",
+                    state: ServerState.Connected);
             var oldDescription = Interlocked.CompareExchange(ref _currentDescription, value: newDescription, comparand: _currentDescription);
             var eventArgs = new ServerDescriptionChangedEventArgs(oldDescription, newDescription);
 

--- a/src/MongoDB.Driver.Core/Core/Servers/RoundTripTimeMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/RoundTripTimeMonitor.cs
@@ -87,6 +87,7 @@ namespace MongoDB.Driver.Core.Servers
 
         public async Task RunAsync()
         {
+            var helloOk = false;
             while (!_cancellationToken.IsCancellationRequested)
             {
                 try
@@ -97,13 +98,14 @@ namespace MongoDB.Driver.Core.Servers
                     }
                     else
                     {
-                        var helloCommand = HelloHelper.CreateCommand(_serverApi);
+                        var helloCommand = HelloHelper.CreateCommand(_serverApi, helloOk);
                         var helloProtocol = HelloHelper.CreateProtocol(helloCommand, _serverApi);
 
                         var stopwatch = Stopwatch.StartNew();
                         var helloResult = await HelloHelper.GetResultAsync(_roundTripTimeConnection, helloProtocol, _cancellationToken).ConfigureAwait(false);
                         stopwatch.Stop();
                         AddSample(stopwatch.Elapsed);
+                        helloOk = helloResult.HelloOk;
                     }
                 }
                 catch (Exception)

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerDescription.cs
@@ -476,6 +476,7 @@ namespace MongoDB.Driver.Core.Servers
                 EndPointHelper.Equals(_endPoint, other._endPoint) &&
                 Equals(_heartbeatException, other._heartbeatException) &&
                 _heartbeatInterval == other._heartbeatInterval &&
+                _helloOk == other._helloOk &&
                 _lastHeartbeatTimestamp == other.LastHeartbeatTimestamp &&
                 _lastUpdateTimestamp == other._lastUpdateTimestamp &&
                 _lastWriteTimestamp == other._lastWriteTimestamp &&
@@ -505,6 +506,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Hash(_endPoint)
                 .Hash(_heartbeatException)
                 .Hash(_heartbeatInterval)
+                .Hash(_helloOk)
                 .Hash(_lastHeartbeatTimestamp)
                 .Hash(_lastUpdateTimestamp)
                 .Hash(_lastWriteTimestamp)
@@ -666,6 +668,7 @@ namespace MongoDB.Driver.Core.Servers
                 electionId: _electionId,
                 heartbeatException: heartbeatException,
                 heartbeatInterval: _heartbeatInterval,
+                helloOk: _helloOk,
                 lastHeartbeatTimestamp: DateTime.UtcNow,
                 lastUpdateTimestamp: DateTime.UtcNow,
                 lastWriteTimestamp: _lastWriteTimestamp,

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerDescription.cs
@@ -54,6 +54,7 @@ namespace MongoDB.Driver.Core.Servers
         private readonly EndPoint _endPoint;
         private readonly Exception _heartbeatException;
         private readonly TimeSpan _heartbeatInterval;
+        private readonly bool _helloOk;
         private readonly DateTime? _lastHeartbeatTimestamp;
         private readonly DateTime _lastUpdateTimestamp;
         private readonly DateTime? _lastWriteTimestamp;
@@ -84,6 +85,7 @@ namespace MongoDB.Driver.Core.Servers
         /// <param name="electionId">The election identifier.</param>
         /// <param name="heartbeatException">The heartbeat exception.</param>
         /// <param name="heartbeatInterval">The heartbeat interval.</param>
+        /// <param name="helloOk">Whether the server supports the hello command.</param>
         /// <param name="lastHeartbeatTimestamp">The last heartbeat timestamp.</param>
         /// <param name="lastUpdateTimestamp">The last update timestamp.</param>
         /// <param name="lastWriteTimestamp">The last write timestamp.</param>
@@ -109,6 +111,7 @@ namespace MongoDB.Driver.Core.Servers
             Optional<ElectionId> electionId = default(Optional<ElectionId>),
             Optional<Exception> heartbeatException = default(Optional<Exception>),
             Optional<TimeSpan> heartbeatInterval = default(Optional<TimeSpan>),
+            Optional<bool> helloOk = default(Optional<bool>),
             Optional<DateTime?> lastHeartbeatTimestamp = default(Optional<DateTime?>),
             Optional<DateTime> lastUpdateTimestamp = default(Optional<DateTime>),
             Optional<DateTime?> lastWriteTimestamp = default(Optional<DateTime?>),
@@ -138,6 +141,7 @@ namespace MongoDB.Driver.Core.Servers
             _endPoint = endPoint;
             _heartbeatException = heartbeatException.WithDefault(null);
             _heartbeatInterval = heartbeatInterval.WithDefault(TimeSpan.Zero);
+            _helloOk = helloOk.WithDefault(false);
             _lastHeartbeatTimestamp = lastHeartbeatTimestamp.WithDefault(null);
             _lastUpdateTimestamp = lastUpdateTimestamp.WithDefault(DateTime.UtcNow);
             _lastWriteTimestamp = lastWriteTimestamp.WithDefault(null);
@@ -218,6 +222,17 @@ namespace MongoDB.Driver.Core.Servers
         public TimeSpan HeartbeatInterval
         {
             get { return _heartbeatInterval; }
+        }
+
+        /// <summary>
+        /// Whether the server supports the hello command.
+        /// </summary>
+        /// <value>
+        /// True if the server responded with helloOk:true; false otherwise.
+        /// </value>
+        public bool HelloOk
+        {
+            get { return _helloOk; }
         }
 
         /// <summary>
@@ -563,6 +578,7 @@ namespace MongoDB.Driver.Core.Servers
         /// <param name="electionId">The election identifier.</param>
         /// <param name="heartbeatException">The heartbeat exception.</param>
         /// <param name="heartbeatInterval">The heartbeat interval.</param>
+        /// <param name="helloOk">Whether the server supports the hello command.</param>
         /// <param name="lastHeartbeatTimestamp">The last heartbeat timestamp.</param>
         /// <param name="lastUpdateTimestamp">The last update timestamp.</param>
         /// <param name="lastWriteTimestamp">The last write timestamp.</param>
@@ -585,6 +601,7 @@ namespace MongoDB.Driver.Core.Servers
             Optional<string> reasonChanged = default(Optional<string>),
             Optional<TimeSpan> averageRoundTripTime = default(Optional<TimeSpan>),
             Optional<EndPoint> canonicalEndPoint = default(Optional<EndPoint>),
+            Optional<bool> helloOk = default(Optional<bool>),
             Optional<ElectionId> electionId = default(Optional<ElectionId>),
             Optional<Exception> heartbeatException = default(Optional<Exception>),
             Optional<TimeSpan> heartbeatInterval = default(Optional<TimeSpan>),
@@ -613,6 +630,7 @@ namespace MongoDB.Driver.Core.Servers
                 electionId: electionId.WithDefault(_electionId),
                 heartbeatException: heartbeatException.WithDefault(_heartbeatException),
                 heartbeatInterval: heartbeatInterval.WithDefault(_heartbeatInterval),
+                helloOk: helloOk.WithDefault(_helloOk),
                 lastHeartbeatTimestamp: lastHeartbeatTimestamp.WithDefault(_lastHeartbeatTimestamp),
                 lastUpdateTimestamp: lastUpdateTimestamp.WithDefault(DateTime.UtcNow),
                 lastWriteTimestamp: lastWriteTimestamp.WithDefault(_lastWriteTimestamp),

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
@@ -167,7 +167,7 @@ namespace MongoDB.Driver.Core.Servers
         }
 
         // private methods
-        private CommandWireProtocol<BsonDocument> InitializeHelloProtocol(IConnection connection)
+        private CommandWireProtocol<BsonDocument> InitializeHelloProtocol(IConnection connection, bool helloOk)
         {
             BsonDocument helloCommand;
             var commandResponseHandling = CommandResponseHandling.Return;
@@ -178,11 +178,11 @@ namespace MongoDB.Driver.Core.Servers
 
                 var veryLargeHeartbeatInterval = TimeSpan.FromDays(1); // the server doesn't support Infinite value, so we set just a big enough value
                 var maxAwaitTime = _serverMonitorSettings.HeartbeatInterval == Timeout.InfiniteTimeSpan ? veryLargeHeartbeatInterval : _serverMonitorSettings.HeartbeatInterval;
-                helloCommand = HelloHelper.CreateCommand(_serverApi, connection.Description.IsMasterResult.TopologyVersion, maxAwaitTime);
+                helloCommand = HelloHelper.CreateCommand(_serverApi, helloOk, connection.Description.IsMasterResult.TopologyVersion, maxAwaitTime);
             }
             else
             {
-                helloCommand = HelloHelper.CreateCommand(_serverApi);
+                helloCommand = HelloHelper.CreateCommand(_serverApi, helloOk);
             }
 
             return HelloHelper.CreateProtocol(helloCommand, _serverApi, commandResponseHandling);
@@ -289,7 +289,6 @@ namespace MongoDB.Driver.Core.Servers
         private async Task HeartbeatAsync(CancellationToken cancellationToken)
         {
             CommandWireProtocol<BsonDocument> helloProtocol = null;
-
             bool processAnother = true;
             while (processAnother && !cancellationToken.IsCancellationRequested)
             {
@@ -321,7 +320,14 @@ namespace MongoDB.Driver.Core.Servers
                     }
                     else
                     {
-                        helloProtocol = helloProtocol ?? InitializeHelloProtocol(connection);
+                        // If MoreToCome is true, that means we are streaming hello or legacy hello results and must
+                        // continue using the existing helloProtocol object.
+                        // Otherwise helloProtocol has either not been initialized or we may need to switch between
+                        // heartbeat commands based on the last heartbeat response.
+                        if (helloProtocol is not {MoreToCome: true})
+                        {
+                            helloProtocol = InitializeHelloProtocol(connection, previousDescription?.HelloOk ?? false);
+                        }
                         heartbeatHelloResult = await GetHelloResultAsync(connection, helloProtocol, cancellationToken).ConfigureAwait(false);
                     }
                 }
@@ -370,6 +376,7 @@ namespace MongoDB.Driver.Core.Servers
                         averageRoundTripTime: averageRoundTripTimeRounded,
                         canonicalEndPoint: heartbeatHelloResult.Me,
                         electionId: heartbeatHelloResult.ElectionId,
+                        helloOk: heartbeatHelloResult.HelloOk,
                         lastWriteTimestamp: heartbeatHelloResult.LastWriteTimestamp,
                         logicalSessionTimeout: heartbeatHelloResult.LogicalSessionTimeout,
                         maxBatchCount: heartbeatHelloResult.MaxBatchCount,

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
@@ -324,7 +324,7 @@ namespace MongoDB.Driver.Core.Servers
                         // continue using the existing helloProtocol object.
                         // Otherwise helloProtocol has either not been initialized or we may need to switch between
                         // heartbeat commands based on the last heartbeat response.
-                        if (helloProtocol is not {MoreToCome: true})
+                        if (helloProtocol == null || helloProtocol.MoreToCome == false)
                         {
                             helloProtocol = InitializeHelloProtocol(connection, previousDescription?.HelloOk ?? false);
                         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
@@ -1195,9 +1195,9 @@ namespace MongoDB.Driver.Core.Clusters
 
             var serverDescription = current.With(
                 averageRoundTripTime: TimeSpan.FromMilliseconds(10),
-                replicaSetConfig: serverType.IsReplicaSetMember() ? config : null,
                 canonicalEndPoint: canonicalEndPoint,
                 electionId: electionId,
+                replicaSetConfig: serverType.IsReplicaSetMember() ? config : null,
                 state: ServerState.Connected,
                 tags: null,
                 type: serverType,

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloHelperTests.cs
@@ -34,7 +34,7 @@ namespace MongoDB.Driver.Core.Connections
         [InlineData(true, true, "{ hello : 1, helloOk : true }")]
         public void CreateCommand_should_return_correct_hello_command(bool useServerApiVersion, bool helloOk, string expectedResult)
         {
-            ServerApi serverApi = useServerApiVersion? new ServerApi(ServerApiVersion.V1) : null;
+            var serverApi = useServerApiVersion ? new ServerApi(ServerApiVersion.V1) : null;
             var command = HelloHelper.CreateCommand(serverApi, helloOk);
             command.Should().Be(expectedResult);
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloHelperTests.cs
@@ -21,23 +21,22 @@ using Xunit;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Core.Connections
 {
     public class HelloHelperTests
     {
-        [Fact]
-        public void CreateCommand_with_ServerApi_should_return_hello_command()
+        [Theory]
+        [InlineData(true, false, "{ hello : 1, helloOk : true }")]
+        [InlineData(false, false, "{ isMaster : 1, helloOk : true }")]
+        [InlineData(false, true, "{ hello : 1, helloOk : true }")]
+        [InlineData(true, true, "{ hello : 1, helloOk : true }")]
+        public void CreateCommand_should_return_correct_hello_command(bool useServerApiVersion, bool helloOk, string expectedResult)
         {
-            var command = HelloHelper.CreateCommand(new ServerApi(ServerApiVersion.V1));
-            command.Should().Be($"{{ hello : 1 }}");
-        }
-
-        [Fact]
-        public void CreateCommand_without_ServerApi_should_return_legacy_hello_command()
-        {
-            var command = HelloHelper.CreateCommand(null);
-            command.Should().Be($"{{ isMaster : 1 }}");
+            ServerApi serverApi = useServerApiVersion? new ServerApi(ServerApiVersion.V1) : null;
+            var command = HelloHelper.CreateCommand(serverApi, helloOk);
+            command.Should().Be(expectedResult);
         }
 
         [Theory]
@@ -50,7 +49,7 @@ namespace MongoDB.Driver.Core.Connections
             var command = HelloHelper.CreateCommand(null);
             var result = HelloHelper.AddClientDocumentToCommand(command, clientDocument);
 
-            result.Should().Be($"{{ isMaster : 1, client : {clientDocumentString} }}");
+            result.Should().Be($"{{ {OppressiveLanguageConstants.LegacyHelloCommandName} : 1, helloOk : true, client : {clientDocumentString} }}");
         }
 
         [Fact]
@@ -62,11 +61,12 @@ namespace MongoDB.Driver.Core.Connections
             var result = HelloHelper.AddClientDocumentToCommand(command, subjectClientDocument);
 
             var names = result.Names.ToList();
-            names.Count.Should().Be(2);
+            names.Count.Should().Be(3);
             names[0].Should().Be("isMaster");
-            names[1].Should().Be("client");
+            names[1].Should().Be("helloOk");
+            names[2].Should().Be("client");
             result[0].Should().Be(1);
-            var clientDocument = result[1].AsBsonDocument;
+            var clientDocument = result[2].AsBsonDocument;
             var clientDocumentNames = clientDocument.Names.ToList();
             clientDocumentNames.Count.Should().Be(4);
             clientDocumentNames[0].Should().Be("application");
@@ -97,7 +97,7 @@ namespace MongoDB.Driver.Core.Connections
             var result = HelloHelper.AddCompressorsToCommand(command, compressors);
 
             var expectedCompressions = string.Join(",", compressorsParameters.Select(c => $"'{CompressorTypeMapper.ToServerName(c)}'"));
-            result.Should().Be(BsonDocument.Parse($"{{ isMaster : 1, compression: [{expectedCompressions}] }}"));
+            result.Should().Be(BsonDocument.Parse($"{{ {OppressiveLanguageConstants.LegacyHelloCommandName} : 1, helloOk : true, compression: [{expectedCompressions}] }}"));
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
@@ -293,5 +293,30 @@ namespace MongoDB.Driver.Core.Connections
                 new DnsEndPoint("localhost", 1003));
             config.Version.Should().Be(20);
         }
+
+        [Fact]
+        public void HelloOk_should_return_true_when_response_contains_helloOk_true()
+        {
+            var doc = new BsonDocument
+            {
+                { "ok", 1 },
+                { "helloOk", true }
+            };
+
+            var subject = new IsMasterResult(doc);
+            subject.HelloOk.Should().BeTrue();
+        }
+
+        [Fact]
+        public void HelloOk_should_return_false_when_response_does_not_contain_helloOk()
+        {
+            var doc = new BsonDocument
+            {
+                { "ok", 1 }
+            };
+
+            var subject = new IsMasterResult(doc);
+            subject.HelloOk.Should().BeFalse();
+        }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/RoundTripTimeMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/RoundTripTimeMonitorTests.cs
@@ -176,7 +176,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Servers
             sentMessages.Count.Should().Be(1);
 
             var requestId = sentMessages[0]["requestId"].AsInt32;
-            sentMessages[0].Should().Be($"{{ \"opcode\" : \"opmsg\", \"requestId\" : {requestId}, \"responseTo\" : 0, \"sections\" : [{{ \"payloadType\" : 0, \"document\" : {{ \"hello\" : 1, \"$db\" : \"admin\", \"$readPreference\" : {{ \"mode\" : \"primaryPreferred\" }}, \"apiVersion\" : \"1\" }} }}] }}");
+            sentMessages[0].Should().Be($"{{ \"opcode\" : \"opmsg\", \"requestId\" : {requestId}, \"responseTo\" : 0, \"sections\" : [{{ \"payloadType\" : 0, \"document\" : {{ \"hello\" : 1, \"helloOk\" : true, \"$db\" : \"admin\", \"$readPreference\" : {{ \"mode\" : \"primaryPreferred\" }}, \"apiVersion\" : \"1\" }} }}] }}");
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerDescriptionTests.cs
@@ -153,6 +153,7 @@ namespace MongoDB.Driver.Core.Servers
         [InlineData("CanonicalEndPoint")]
         [InlineData("ElectionId")]
         [InlineData("EndPoint")]
+        [InlineData("HelloOk")]
         [InlineData("LogicalSessionTimeout")]
         [InlineData("ReplicaSetConfig")]
         [InlineData("ServerId")]
@@ -167,6 +168,8 @@ namespace MongoDB.Driver.Core.Servers
             var canonicalEndPoint = new DnsEndPoint("localhost", 27017);
             var electionId = new ElectionId(ObjectId.GenerateNewId());
             var endPoint = new DnsEndPoint("localhost", 27017);
+            var helloOk = false;
+            var lastUpdateTimestamp = DateTime.UtcNow;
             var logicalSessionTimeout = TimeSpan.FromMinutes(1);
             var replicaSetConfig = new ReplicaSetConfig(
                 new[] { new DnsEndPoint("localhost", 27017), new DnsEndPoint("localhost", 27018) },
@@ -187,6 +190,9 @@ namespace MongoDB.Driver.Core.Servers
                 type: type,
                 averageRoundTripTime: averageRoundTripTime,
                 canonicalEndPoint: canonicalEndPoint,
+                electionId: electionId,
+                helloOk: helloOk,
+                lastUpdateTimestamp: lastUpdateTimestamp,
                 logicalSessionTimeout: logicalSessionTimeout,
                 replicaSetConfig: replicaSetConfig,
                 tags: tags,
@@ -199,6 +205,7 @@ namespace MongoDB.Driver.Core.Servers
                 case "CanonicalEndPoint": canonicalEndPoint = new DnsEndPoint("localhost", 27018); break;
                 case "ElectionId": electionId = new ElectionId(ObjectId.Empty); break;
                 case "EndPoint": endPoint = new DnsEndPoint(endPoint.Host, endPoint.Port + 1); serverId = new ServerId(__clusterId, endPoint); break;
+                case "HelloOk": helloOk = !helloOk; break;
                 case "LogicalSessionTimeout": logicalSessionTimeout = TimeSpan.FromMinutes(2); break;
                 case "ReplicaSetConfig": replicaSetConfig = new ReplicaSetConfig(replicaSetConfig.Members, "newname", replicaSetConfig.Primary, replicaSetConfig.Version); break;
                 case "State": state = ServerState.Disconnected; break;
@@ -217,6 +224,8 @@ namespace MongoDB.Driver.Core.Servers
                 averageRoundTripTime: averageRoundTripTime,
                 canonicalEndPoint: canonicalEndPoint,
                 electionId: electionId,
+                helloOk: helloOk,
+                lastUpdateTimestamp: lastUpdateTimestamp,
                 logicalSessionTimeout: logicalSessionTimeout,
                 replicaSetConfig: replicaSetConfig,
                 tags: tags,

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerDescriptionTests.cs
@@ -50,6 +50,7 @@ namespace MongoDB.Driver.Core.Servers
             subject.CanonicalEndPoint.Should().BeNull();
             subject.ElectionId.Should().BeNull();
             subject.EndPoint.Should().Be(__endPoint);
+            subject.HelloOk.Should().BeFalse();
             subject.LogicalSessionTimeout.Should().NotHaveValue();
             subject.ReplicaSetConfig.Should().BeNull();
             subject.ServerId.Should().Be(__serverId);
@@ -66,6 +67,7 @@ namespace MongoDB.Driver.Core.Servers
             var averageRoundTripTime = TimeSpan.FromSeconds(1);
             var canonicalEndPoint = new DnsEndPoint("localhost", 27017);
             var electionId = new ElectionId(ObjectId.GenerateNewId());
+            var helloOk = true;
             var logicalSessionTimeout = TimeSpan.FromMinutes(1);
             var replicaSetConfig = new ReplicaSetConfig(
                 new[] { new DnsEndPoint("localhost", 27017), new DnsEndPoint("localhost", 27018) },
@@ -86,6 +88,7 @@ namespace MongoDB.Driver.Core.Servers
                 averageRoundTripTime: averageRoundTripTime,
                 canonicalEndPoint: canonicalEndPoint,
                 electionId: electionId,
+                helloOk: helloOk,
                 logicalSessionTimeout: logicalSessionTimeout,
                 replicaSetConfig: replicaSetConfig,
                 tags: tags,
@@ -96,6 +99,7 @@ namespace MongoDB.Driver.Core.Servers
             subject.CanonicalEndPoint.Should().Be(canonicalEndPoint);
             subject.ElectionId.Should().Be(electionId);
             subject.EndPoint.Should().Be(__endPoint);
+            subject.HelloOk.Should().Be(helloOk);
             subject.LogicalSessionTimeout.Should().Be(logicalSessionTimeout);
             subject.ReplicaSetConfig.Should().Be(replicaSetConfig);
             subject.ServerId.Should().Be(__serverId);
@@ -280,6 +284,7 @@ namespace MongoDB.Driver.Core.Servers
         [InlineData("ElectionId")]
         [InlineData("HeartbeatException")]
         [InlineData("HeartbeatInterval")]
+        [InlineData("HelloOk")]
         [InlineData("LastUpdateTimestamp")]
         [InlineData("LastWriteTimestamp")]
         [InlineData("LogicalSessionTimeout")]
@@ -300,6 +305,7 @@ namespace MongoDB.Driver.Core.Servers
             var electionId = new ElectionId(ObjectId.GenerateNewId());
             var heartbeatException = new Exception();
             var heartbeatInterval = TimeSpan.FromSeconds(10);
+            var helloOk = false;
             var lastUpdateTimestamp = DateTime.UtcNow;
             var lastWriteTimestamp = DateTime.UtcNow;
             var logicalSessionTimeout = TimeSpan.FromMinutes(1);
@@ -326,6 +332,7 @@ namespace MongoDB.Driver.Core.Servers
                 electionId: electionId,
                 heartbeatException: heartbeatException,
                 heartbeatInterval: heartbeatInterval,
+                helloOk: helloOk,
                 lastUpdateTimestamp: lastUpdateTimestamp,
                 lastWriteTimestamp: lastWriteTimestamp,
                 logicalSessionTimeout: logicalSessionTimeout,
@@ -347,6 +354,7 @@ namespace MongoDB.Driver.Core.Servers
                 case "ElectionId": electionId = new ElectionId(ObjectId.Empty); break;
                 case "HeartbeatException": heartbeatException = new Exception("NewMessage"); break;
                 case "HeartbeatInterval": heartbeatInterval = TimeSpan.FromSeconds(11); break;
+                case "HelloOk": helloOk = !helloOk; break;
                 case "LastUpdateTimestamp": lastUpdateTimestamp = lastUpdateTimestamp.Add(TimeSpan.FromSeconds(1)); break;
                 case "LastWriteTimestamp": lastWriteTimestamp = lastWriteTimestamp.Add(TimeSpan.FromSeconds(1)); break;
                 case "LogicalSessionTimeout": logicalSessionTimeout = TimeSpan.FromMinutes(2); break;
@@ -368,6 +376,7 @@ namespace MongoDB.Driver.Core.Servers
                 electionId: electionId,
                 heartbeatException: heartbeatException,
                 heartbeatInterval: heartbeatInterval,
+                helloOk: helloOk,
                 lastUpdateTimestamp: lastUpdateTimestamp,
                 lastWriteTimestamp: lastWriteTimestamp,
                 logicalSessionTimeout: logicalSessionTimeout,
@@ -392,6 +401,7 @@ namespace MongoDB.Driver.Core.Servers
         public void With_should_return_same_instance_when_all_fields_are_equal()
         {
             var averageRoundTripTime = TimeSpan.FromSeconds(1);
+            var helloOk = true;
             var lastUpdateTimestamp = DateTime.UtcNow;
             var replicaSetConfig = new ReplicaSetConfig(
                 new[] { new DnsEndPoint("localhost", 27017), new DnsEndPoint("localhost", 27018) },
@@ -408,6 +418,7 @@ namespace MongoDB.Driver.Core.Servers
                 __serverId,
                 __endPoint,
                 averageRoundTripTime: averageRoundTripTime,
+                helloOk: helloOk,
                 lastUpdateTimestamp: lastUpdateTimestamp,
                 replicaSetConfig: replicaSetConfig,
                 state: state,
@@ -418,6 +429,7 @@ namespace MongoDB.Driver.Core.Servers
 
             var result = subject.With(
                 averageRoundTripTime: averageRoundTripTime,
+                helloOk: helloOk,
                 lastUpdateTimestamp: lastUpdateTimestamp,
                 replicaSetConfig: replicaSetConfig,
                 state: ServerState.Connected,

--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringProseTests.cs
@@ -175,7 +175,6 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring
         // private methods
         private DisposableMongoClient CreateClient(EventCapturer eventCapturer, TimeSpan heartbeatInterval, string applicationName = null)
         {
-            var clonedClient = DriverTestConfiguration.Client.Settings.Clone();
             return DriverTestConfiguration.CreateDisposableClient(
                 (clientSettings) =>
                 {
@@ -194,8 +193,8 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring
         }
     }
 
-    internal static class ServerMonitorRelfector
-    { 
+    internal static class ServerMonitorReflector
+    {
         public static IRoundTripTimeMonitor _roundTripTimeMonitor(this IServerMonitor serverMonitor)
         {
             return (IRoundTripTimeMonitor)Reflector.GetFieldValue(serverMonitor, nameof(_roundTripTimeMonitor));


### PR DESCRIPTION
We look at the previous hello/legacy hello response to determine whether hello or legacy hello should be used for the next heartbeat or RTT command. The only slight complexity is that we re-use the previous command/protocol if we are streaming heartbeats from the server.