### PR TITLE
CSHARP-3661: Remove oppressive language from the documentation.

### DIFF
--- a/Docs/reference/content/reference/driver/crud/compression.md
+++ b/Docs/reference/content/reference/driver/crud/compression.md
@@ -16,7 +16,7 @@ The C# driver supports compression of messages to and from MongoDB servers. The 
 * [Zlib](https://zlib.net/): Zlib compression can be used when connecting to MongoDB servers starting with the 3.6 release.
 * [Zstandard](https://facebook.github.io/zstd/): Zstandard compression can be used when connecting to MongoDB servers starting with the 4.2 release.
 
-The driver will negotiate which, if any, compression algorithm is used based on capabilities advertised by the server in the [ismaster]({{<docsref "reference/command/isMaster/">}}) command response. 
+The driver will negotiate which, if any, compression algorithm is used based on capabilities advertised by the server in the [hello]({{<docsref "reference/command/hello/">}}) or legacy hello command response. 
 
 ### Specify compression via `Connection String`
 

--- a/Docs/reference/content/reference/driver_core/index.md
+++ b/Docs/reference/content/reference/driver_core/index.md
@@ -23,7 +23,7 @@ Connection pooling is provided for every server that is discovered. There are a 
 
 ### Server Monitoring
 
-Each server that is discovered is monitored. By default, this monitoring happens every 10 seconds and consists of an `{ ismaster: 1 }` call followed by a `{ buildinfo: 1 }` call. When servers go down, the frequency of these calls will be increased to 500 milliseconds. See the [Server Discovery and Monitoring Specification](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-summary.rst) for more information.
+Each server that is discovered is monitored. By default, this monitoring happens every 10 seconds and consists of a `{ hello: 1 }` (or legacy hello) call followed by a `{ buildInfo: 1 }` call. When servers go down, the frequency of these calls will be increased to 500 milliseconds. See the [Server Discovery and Monitoring Specification](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-summary.rst) for more information.
 
 ### Server Selection
 
@@ -31,7 +31,7 @@ An API is provided to allow for robust and configurable server selection capabil
 
 ### Operations
 
-A large number of operations have been implemented for everything from a generic command like "ismaster" to the extremely complicated bulk write ("insert", "update", and "delete") commands and presented as instantiatable classes. These classes handle version checking the server to ensure that they will function against all versions of the server in which they exist as well as ensuring that subsequent correlated operations (such as get more's for cursors) function correctly.
+A large number of operations have been implemented for everything from a generic command like "hello" to the extremely complicated bulk write ("insert", "update", and "delete") commands and presented as instantiatable classes. These classes handle version checking the server to ensure that they will function against all versions of the server in which they exist as well as ensuring that subsequent correlated operations (such as get more's for cursors) function correctly.
 
 ### Bindings
 

--- a/Docs/reference/content/what_is_new.md
+++ b/Docs/reference/content/what_is_new.md
@@ -56,7 +56,7 @@ The main new features in 2.11.0 support new features in MongoDB 4.4.0. These fea
 * Support for shorter SCRAM (Salted Challenge Response Authentication Mechanism) conversations
 * Support for speculative SCRAM and MONGODB-X509 authentication
 * Support for the `CommitQuorum` option in `createIndexes`
-* Support for [hedged reads](https://docs.mongodb.com/master/core/read-preference-hedge-option/index.html)
+* Support for [hedged reads](https://docs.mongodb.com/manual/core/read-preference-hedge-option/)
 
 Other new additions and updates in this beta include:
 

--- a/Docs/reference/themes/mongodb/static/js/navbar.js
+++ b/Docs/reference/themes/mongodb/static/js/navbar.js
@@ -1,7 +1,7 @@
 $(function() {
     var docsExcludedNav = window.docsExcludedNav;
 
-    /* Checks a whitelist for non-leaf nodes that should trigger a full page reload */
+    /* Checks an allow list for non-leaf nodes that should trigger a full page reload */
     function requiresPageload($node) {
         if (!docsExcludedNav || !docsExcludedNav.length) {
             return false;


### PR DESCRIPTION
The only remaining occurrences of oppressive language in our docs are in the following places:

- the API docs (which will be handled in CSHARP-3660)
- third-party dependencies (jquery.js, underscore.js, etc.)
- explanation that `slaveOk=true` must be replaced with `readPreference` in What's New?