### PR TITLE
CSHARP-3765: Clean-up a stop step for LB and Serverless tests.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 using System.Linq;
 using Cake.Common.Tools.DotNetCore.DotNetCoreVerbosity;
 
-var defaultTarget = "Default";
+const string defaultTarget = "Default";
 var target = Argument("target", defaultTarget);
 var configuration = Argument("configuration", "Release");
 

--- a/build.cake
+++ b/build.cake
@@ -9,7 +9,8 @@ using System.Text.RegularExpressions;
 using System.Linq;
 using Cake.Common.Tools.DotNetCore.DotNetCoreVerbosity;
 
-var target = Argument("target", "Default");
+var defaultTarget = "Default";
+var target = Argument("target", defaultTarget);
 var configuration = Argument("configuration", "Release");
 
 var gitVersion = GitVersion();
@@ -167,7 +168,7 @@ Task("Test")
             case "testnetstandard15": settings.Framework = "netcoreapp1.1"; break;
             case "testnetstandard20": settings.Framework = "netcoreapp2.1"; break;
             case "testnetstandard21": settings.Framework = "netcoreapp3.0"; break;
-            default: throw new ArgumentException($"Unexpected target: \"{target}\".");
+            default: ThrowIfNotDefaultTarget(target); break;
         }
         DotNetCoreTest(
             testProject.FullPath,
@@ -335,7 +336,7 @@ Task("TestGssapi")
             case "testgssapinetstandard15": settings.Framework = "netcoreapp1.1"; break;
             case "testgssapinetstandard20": settings.Framework = "netcoreapp2.1"; break;
             case "testgssapinetstandard21": settings.Framework = "netcoreapp3.0"; break;
-            default: throw new ArgumentException($"Unexpected target: \"{target}\".");
+            default: ThrowIfNotDefaultTarget(target); break;
         }
         DotNetCoreTest(
             testProject.FullPath,
@@ -368,7 +369,7 @@ Task("TestServerless")
                 case "testserverlessnetstandard15": settings.Framework = "netcoreapp1.1"; break;
                 case "testserverlessnetstandard20": settings.Framework = "netcoreapp2.1"; break;
                 case "testserverlessnetstandard21": settings.Framework = "netcoreapp3.0"; break;
-                default: throw new ArgumentException($"Unexpected target: \"{target}\".");
+                default: ThrowIfNotDefaultTarget(target); break;
             }
             DotNetCoreTest(
                 testProject.FullPath,
@@ -562,3 +563,11 @@ Task("DumpGitVersion")
     });
 
 RunTarget(target);
+
+void ThrowIfNotDefaultTarget(string @value)
+{
+    if (@value != defaultTarget)
+    {
+       throw new ArgumentException($"Unexpected target: \"{target}\".");
+    }
+}

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -622,17 +622,19 @@ functions:
       params:
         file: serverless-expansion.yml
 
-  delete-serverless-instance:
+  delete-serverless-instance-if-configured:
     - command: shell.exec
       params:
         script: |
-          ${PREPARE_SHELL}
-          set +o xtrace # Disable tracing
-          SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
-          SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-          SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-          SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \
-            bash ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
+          if [ "" != "${SERVERLESS}" ]; then
+            ${PREPARE_SHELL}
+            set +o xtrace # Disable tracing
+            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
+            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
+            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
+            SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \
+              bash ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
+          fi
 
   publish-snapshot:
     - command: shell.exec
@@ -710,7 +712,7 @@ pre:
 post:
   # Removed, causing timeouts
   # - func: upload-working-dir
-  - func: delete-serverless-instance
+  - func: delete-serverless-instance-if-configured
   - func: upload-mo-artifacts
   - func: upload-test-results
   - func: cleanup

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -259,16 +259,13 @@ functions:
         working_dir: "mongo-csharp-driver"
         script: |
           ${PREPARE_SHELL}
-          SSL=${SSL} \
-          OS=${OS} \ 
-            evergreen/add-certs-if-needed.sh
-          AUTH="${AUTH}" \
-          SSL="${SSL}" \
+          SSL=${SSL} OS=${OS} evergreen/add-certs-if-needed.sh
+          AUTH="${AUTH}" SSL="${SSL}" \
           FRAMEWORK=${FRAMEWORK} \
           OS=${OS} \
           SINGLE_MONGOS_LB_URI="${SINGLE_MONGOS_LB_URI}" \
           MULTI_MONGOS_LB_URI="${MULTI_MONGOS_LB_URI}" \
-            evergreen/run-load-balancer-tests.sh
+          evergreen/run-load-balancer-tests.sh
 
   stop-load-balancer:
     - command: shell.exec

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -259,13 +259,16 @@ functions:
         working_dir: "mongo-csharp-driver"
         script: |
           ${PREPARE_SHELL}
-          SSL=${SSL} OS=${OS} evergreen/add-certs-if-needed.sh
-          AUTH="${AUTH}" SSL="${SSL}" \
+          SSL=${SSL} \
+          OS=${OS} \ 
+            evergreen/add-certs-if-needed.sh
+          AUTH="${AUTH}" \
+          SSL="${SSL}" \
           FRAMEWORK=${FRAMEWORK} \
           OS=${OS} \
           SINGLE_MONGOS_LB_URI="${SINGLE_MONGOS_LB_URI}" \
           MULTI_MONGOS_LB_URI="${MULTI_MONGOS_LB_URI}" \
-          evergreen/run-load-balancer-tests.sh
+            evergreen/run-load-balancer-tests.sh
 
   stop-load-balancer:
     - command: shell.exec
@@ -764,27 +767,27 @@ tasks:
         - func: bootstrap-mongo-orchestration
         - func: run-load-balancer
         - func: run-load-balancer-tests
-        - func: stop-load-balancer
           vars:
             FRAMEWORK: netstandard15
+        - func: stop-load-balancer
 
     - name: test-load-balancer-netstandard20
       commands:
         - func: bootstrap-mongo-orchestration
         - func: run-load-balancer
         - func: run-load-balancer-tests
-        - func: stop-load-balancer
           vars:
             FRAMEWORK: netstandard20
+        - func: stop-load-balancer
         
     - name: test-load-balancer-netstandard21
       commands:
         - func: bootstrap-mongo-orchestration
         - func: run-load-balancer
         - func: run-load-balancer-tests
-        - func: stop-load-balancer
           vars:
             FRAMEWORK: netstandard21
+        - func: stop-load-balancer
 
     - name: atlas-connectivity-tests
       commands:


### PR DESCRIPTION
I didn't make any changes for LB since when I make the same change for stopping LB, the whole scripts fails with this error https://evergreen.mongodb.com/task_log_raw/dot_net_driver_load_balancer_tests_secure__version~latest_os~ubuntu_1804_topology~sharded_cluster_auth~auth_ssl~ssl_test_load_balancer_netstandard21_patch_a563175b58fffa0f0ca754c735caa4e32234aaad_6105f384d1fe071f0cb0c6d9_21_08_01_01_06_30/0?type=T#L1614. It looks like stopping logic should be done in the same scope as the main steps. Yes, if something will fail, the stopping logic won't be called. I asked @durran how we can make deal with this, since in the node he applied the same change