### PR TITLE
CSHARP-3813 Suppress execution context flow when initializing ServerMonitor

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
@@ -152,8 +152,15 @@ namespace MongoDB.Driver.Core.Servers
                 // by using Task.Factory.StartNew we introduce a short delay before the MonitorServerAsync Task starts executing
                 // the delay is whatever time it takes for the new Task to be activated and scheduled
                 // and the delay is usually long enough for the test to get past the race condition (though not guaranteed)
-                _ = Task.Factory.StartNew(() => _ = MonitorServerAsync().ConfigureAwait(false)).ConfigureAwait(false);
-                _ = _roundTripTimeMonitor.RunAsync().ConfigureAwait(false);
+#if !NETSTANDARD1_5
+                using(_ = ExecutionContext.SuppressFlow())
+                {
+#endif
+                    _ = Task.Factory.StartNew(() => _ = MonitorServerAsync().ConfigureAwait(false)).ConfigureAwait(false);
+                    _ = _roundTripTimeMonitor.RunAsync().ConfigureAwait(false);
+#if !NETSTANDARD1_5
+                }
+#endif
             }
         }
 


### PR DESCRIPTION
I recently ran into an issue caused by the `ServerMonitor` capturing the ambient execution context. This meant it captured a reference to an `AsyncLocal` variable, resulting in a memory leak. I don't believe it's necessary to capture the context here, so (where possible) I believe flow should be suppressed.