### PR TITLE
CSHARP-3816: Trigger cluster update before clearing the pool and after un-pausing

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
@@ -208,13 +208,13 @@ namespace MongoDB.Driver.Core.Servers
             // This synchronization technically can be violated by calling server.Invalidate not under _monitor.Lock.
             // Therefore _currentDescription and ConnectionPool state can get out of sync.
 
-            var descriptionChangedEvent = new ServerDescriptionChangedEventArgs(_currentDescription, newDescription);
+            var serverDescriptionChangedEvent = new ServerDescriptionChangedEventArgs(_currentDescription, newDescription);
             _currentDescription = newDescription;
 
             if (newDescription.HeartbeatException != null || forceClearConnectionPool)
             {
                 // propagate event to upper levels
-                TriggerServerDescriptionChanged(this, descriptionChangedEvent);
+                TriggerServerDescriptionChanged(this, serverDescriptionChangedEvent);
 
                 // pool must be cleared on after cluster update
                 ConnectionPool.Clear();
@@ -232,7 +232,7 @@ namespace MongoDB.Driver.Core.Servers
                 }
 
                 // propagate event to upper levels
-                TriggerServerDescriptionChanged(this, descriptionChangedEvent);
+                TriggerServerDescriptionChanged(this, serverDescriptionChangedEvent);
             }
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerTests.cs
@@ -676,6 +676,32 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
+        [Fact]
+        internal void SetDescription_should_trigger_update_before_pool_clear()
+        {
+            var onDescriptionChangedCalled = false;
+            EventHandler<ServerDescriptionChangedEventArgs> onDescriptionChanged =  (_, __) =>
+            {
+                _mockConnectionPool.Verify(pool => pool.Clear(), Times.Never);
+                onDescriptionChangedCalled = true;
+            };
+
+            try
+            {
+                _subject.DescriptionChanged += onDescriptionChanged;
+
+                _subject.Initialize();
+                _subject.Invalidate("Test reason", null);
+
+                _mockConnectionPool.Verify(pool => pool.Clear(), Times.Once);
+                onDescriptionChangedCalled.Should().BeTrue();
+            }
+            finally
+            {
+                _subject.DescriptionChanged -= onDescriptionChanged;
+            }
+        }
+
         [Theory]
         [InlineData(nameof(EndOfStreamException), true)]
         [InlineData(nameof(Exception), false)]


### PR DESCRIPTION
[EG](https://evergreen.mongodb.com/version/6126a79b3627e05eb3a5a0fa)