### PR TITLE
CSHARP-3786: Tests for client-side errors with snapshot reads use incorrect syntax for test.expectEvents.

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
@@ -70,7 +70,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     },
     {
       "description": "Client error on aggregate with snapshot",
@@ -88,7 +93,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     },
     {
       "description": "Client error on distinct with snapshot",
@@ -107,7 +117,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     }
   ]
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
@@ -41,7 +41,9 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []
 
 - description: Client error on aggregate with snapshot
   operations:
@@ -53,7 +55,9 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []
 
 - description: Client error on distinct with snapshot
   operations:
@@ -66,4 +70,6 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []


### PR DESCRIPTION
Simply tests sync.