### PR TITLE
CSHARP-3800: Fix flaky RetryableReadsProseTests.PoolClearedError_read_retryablity_test

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsProseTests.cs
@@ -109,7 +109,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
 
             // wait for 2 CommandSucceededEvent events, meaning that all other events should be received
             eventCapturer.WaitForOrThrowIfTimeout(
-                events => events.Count(e => e is CommandSucceededEvent) == 2,
+                events => events.OfType<CommandSucceededEvent>().Count() == 2,
                 eventsWaitTimeout);
 
             eventCapturer.Events.OfType<CommandStartedEvent>().Count().Should().Be(3);

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/PoolClearRetryability.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/PoolClearRetryability.cs
@@ -112,7 +112,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
 
             // wait for 2 CommandSucceededEvent events, meaning that all other events should be received
             eventCapturer.WaitForOrThrowIfTimeout(
-                events => events.Count(e => e is CommandSucceededEvent) == 2,
+                events => events.OfType<CommandSucceededEvent>().Count() == 2,
                 eventsWaitTimeout);
 
             eventCapturer.Events.OfType<CommandStartedEvent>().Count().Should().Be(3);


### PR DESCRIPTION
The main root causes are fixed in CSHARP-3814, CSHARP-3815, CSHARP-3816.

[EG](https://evergreen.mongodb.com/version/61365c973e8e862904a19c92)