### PR TITLE
CSHARP-3875: Update netstandard2.1 to run on netcoreapp3.1 to remove netcoreapp3.0 out of support warnings

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -168,7 +168,7 @@ Task("Test")
         {
             case "testnet472": settings.Framework = "net472"; break;
             case "testnetstandard20": settings.Framework = "netcoreapp2.1"; break;
-            case "testnetstandard21": settings.Framework = "netcoreapp3.0"; break;
+            case "testnetstandard21": settings.Framework = "netcoreapp3.1"; break;
         }
         DotNetCoreTest(
             testProject.FullPath,
@@ -334,7 +334,7 @@ Task("TestGssapi")
         {
             case "testgssapinet472": settings.Framework = "net472"; break;
             case "testgssapinetstandard20": settings.Framework = "netcoreapp2.1"; break;
-            case "testgssapinetstandard21": settings.Framework = "netcoreapp3.0"; break;
+            case "testgssapinetstandard21": settings.Framework = "netcoreapp3.1"; break;
         }
         DotNetCoreTest(
             testProject.FullPath,
@@ -364,7 +364,7 @@ Task("TestServerless")
             {
                 case "testserverlessnet472": settings.Framework = "net472"; break;
                 case "testserverlessnetstandard20": settings.Framework = "netcoreapp2.1"; break;
-                case "testserverlessnetstandard21": settings.Framework = "netcoreapp3.0"; break;
+                case "testserverlessnetstandard21": settings.Framework = "netcoreapp3.1"; break;
             }
             DotNetCoreTest(
                 testProject.FullPath,
@@ -394,7 +394,7 @@ Task("TestLoadBalanced")
         switch (target.ToLowerInvariant()) // target can be not only moniker related
         {
             case "testloadbalancednetstandard20": settings.Framework = "netcoreapp2.1"; break;
-            case "testloadbalancednetstandard21": settings.Framework = "netcoreapp3.0"; break;
+            case "testloadbalancednetstandard21": settings.Framework = "netcoreapp3.1"; break;
         }
 
         DotNetCoreTest(

--- a/tests/AstrolabeWorkloadExecutor/AstrolabeWorkloadExecutor.csproj
+++ b/tests/AstrolabeWorkloadExecutor/AstrolabeWorkloadExecutor.csproj
@@ -5,8 +5,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
+++ b/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Bson.Tests/Jira/CSharp301Tests.cs
+++ b/tests/MongoDB.Bson.Tests/Jira/CSharp301Tests.cs
@@ -60,10 +60,10 @@ namespace MongoDB.Bson.Tests.Jira
         {
             var c = new C { Id = 1, Obj = new Hashtable { } };
             var json = c.ToJson();
-#if NET472 || NETCOREAPP3_0
+#if NET472 || NETCOREAPP3_1
             // Hashtable is situated in well-known libraries for:
             // - NET472: mscorlib
-            // - NETCOREAPP3_0: System.Private.CoreLib
+            // - NETCOREAPP3_1: System.Private.CoreLib
             var discriminator = "System.Collections.Hashtable";
 #else
             var discriminator = typeof(Hashtable).AssemblyQualifiedName;
@@ -81,10 +81,10 @@ namespace MongoDB.Bson.Tests.Jira
         {
             var c = new C { Id = 1, Obj = new Hashtable { { "x", 1 } } };
             var json = c.ToJson();
-#if NET472 || NETCOREAPP3_0
+#if NET472 || NETCOREAPP3_1
             // Hashtable is situated in well-known libraries for:
             // - NET472: mscorlib
-            // - NETCOREAPP3_0: System.Private.CoreLib
+            // - NETCOREAPP3_1: System.Private.CoreLib
             var discriminator = "System.Collections.Hashtable";
 #else
             var discriminator = typeof(Hashtable).AssemblyQualifiedName;

--- a/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
+++ b/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/CollectionSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/CollectionSerializerTests.cs
@@ -310,8 +310,8 @@ namespace MongoDB.Bson.Tests.Serialization.CollectionSerializers
             var arrayListDiscriminator = "System.Collections.ArrayList";
             var queueDiscriminator = "System.Collections.Queue";
             var stackDiscriminator = "System.Collections.Stack";
-#elif NETCOREAPP3_0
-            // In netcore3.0 ArrayList is situated in System.Private.CoreLib that is a well-known library
+#elif NETCOREAPP3_1
+            // In netcore3.1 ArrayList is situated in System.Private.CoreLib that is a well-known library
             var arrayListDiscriminator = "System.Collections.ArrayList";
             var queueDiscriminator = typeof(Queue).AssemblyQualifiedName;
             var stackDiscriminator = typeof(Stack).AssemblyQualifiedName;
@@ -342,8 +342,8 @@ namespace MongoDB.Bson.Tests.Serialization.CollectionSerializers
             var arrayListDiscriminator = "System.Collections.ArrayList";
             var queueDiscriminator = "System.Collections.Queue";
             var stackDiscriminator = "System.Collections.Stack";
-#elif NETCOREAPP3_0
-            // In netcore3.0 ArrayList is situated in System.Private.CoreLib that is a well-known library
+#elif NETCOREAPP3_1
+            // In netcore3.1 ArrayList is situated in System.Private.CoreLib that is a well-known library
             var arrayListDiscriminator = "System.Collections.ArrayList";
             var queueDiscriminator = typeof(Queue).AssemblyQualifiedName;
             var stackDiscriminator = typeof(Stack).AssemblyQualifiedName;

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/NetPrimitiveSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/NetPrimitiveSerializerTests.cs
@@ -1130,7 +1130,7 @@ namespace MongoDB.Bson.Tests.Serialization
             var json = obj.ToJson();
             var expected = "{ 'D' : #D, 'I' : 0, 'L' : NumberLong(0), 'S' : '#S' }";
             expected = expected.Replace("#D", "-1.7976931348623157E+308");
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             expected = expected.Replace("#S", "-3.4028235E+38");
 #else
             expected = expected.Replace("#S", "-3.40282347E+38");
@@ -1233,7 +1233,7 @@ namespace MongoDB.Bson.Tests.Serialization
             var expected = "{ 'D' : #D, 'I' : 0, 'L' : NumberLong(0), 'S' : '#S' }";
             expected = expected.Replace("#D", "1.7976931348623157E+308");
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             expected = expected.Replace("#S", "3.4028235E+38");
 #else
             expected = expected.Replace("#S", "3.40282347E+38");

--- a/tests/MongoDB.Bson.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Bson.Tests/TargetFrameworkTests.cs
@@ -33,7 +33,7 @@ namespace MongoDB.Bson.Tests
         {
 #if NETCOREAPP2_1
             return "netstandard20";
-#elif NETCOREAPP3_0
+#elif NETCOREAPP3_1
             return "netstandard21";
 #elif NET472
             return "net472";

--- a/tests/MongoDB.Driver.Core.Tests/Core/NativeLibraryLoader/NativeLibraryLoaderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/NativeLibraryLoader/NativeLibraryLoaderTests.cs
@@ -78,8 +78,8 @@ namespace MongoDB.Driver.Core.Tests.Core.NativeLibraryLoader
         private string GetTargetFrameworkMonikerName() =>
 #if NETCOREAPP2_1
             "netcoreapp2.1";
-#elif NETCOREAPP3_0
-            "netcoreapp3.0";
+#elif NETCOREAPP3_1
+            "netcoreapp3.1";
 #elif NET472
             "net472";
 #endif

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Core.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/TargetFrameworkTests.cs
@@ -33,7 +33,7 @@ namespace MongoDB.Driver.Core.Tests
         {
 #if NETCOREAPP2_1
             return "netstandard20";
-#elif NETCOREAPP3_0
+#elif NETCOREAPP3_1
             return "netstandard21";
 #elif NET472
             return "net472";

--- a/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
+++ b/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.GridFS.Tests/MongoDB.Driver.GridFS.Tests.csproj
+++ b/tests/MongoDB.Driver.GridFS.Tests/MongoDB.Driver.GridFS.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.GridFS.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/TargetFrameworkTests.cs
@@ -33,7 +33,7 @@ namespace MongoDB.Driver.GridFS.Tests
         {
 #if NETCOREAPP2_1
             return "netstandard20";
-#elif NETCOREAPP3_0
+#elif NETCOREAPP3_1
             return "netstandard21";
 #elif NET472
             return "net472";

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoDB.Driver.Legacy.Tests.csproj
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoDB.Driver.Legacy.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Legacy.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/TargetFrameworkTests.cs
@@ -33,7 +33,7 @@ namespace MongoDB.Driver.Tests
         {
 #if NETCOREAPP2_1
             return "netstandard20";
-#elif NETCOREAPP3_0
+#elif NETCOREAPP3_1
             return "netstandard21";
 #elif NET472
             return "net472";

--- a/tests/MongoDB.Driver.TestConsoleApplication/MongoDB.Driver.TestConsoleApplication.csproj
+++ b/tests/MongoDB.Driver.TestConsoleApplication/MongoDB.Driver.TestConsoleApplication.csproj
@@ -5,8 +5,8 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsWindows)'!='true'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Tests/TargetFrameworkTests.cs
@@ -33,7 +33,7 @@ namespace MongoDB.Driver.Tests
         {
 #if NETCOREAPP2_1
             return "netstandard20";
-#elif NETCOREAPP3_0
+#elif NETCOREAPP3_1
             return "netstandard21";
 #elif NET472
             return "net472";


### PR DESCRIPTION
Running the full suite overnight to verify that updating from `netcoreapp3.0` to `netcoreapp3.1` to run tests doesn't break anything. It shouldn't because the build servers didn't have `netcoreapp3.0` installed and have been running tests on `netcoreapp3.1` for awhile now.