### PR TITLE
CSHARP-2877 / CSHARP-3889: Added upgrade warning for 2.11.0+

### DIFF
--- a/Docs/reference/content/upgrading.md
+++ b/Docs/reference/content/upgrading.md
@@ -11,6 +11,10 @@ title = "Upgrading"
 
 ## Breaking Changes
 
-### Backwards compatibility with driver version 2.7.0–2.12.x
+### Backwards compatibility with driver version 2.7.0–2.13.x
 
-No known backward compatibility issues.
+Starting in 2.11.0, ``BsonSerializer.Serialize`` will throw an
+``InvalidOperationException`` when attempting to serialize an array at
+the root of a BSON document. Prior versions would allow this invalid operation.
+See https://jira.mongodb.org/browse/CSHARP-2877 and
+https://jira.mongodb.org/browse/CSHARP-3889 for more details.


### PR DESCRIPTION
Added upgrade warning for 2.11.0+ as `BsonSerializer.Serialize` no longer allows arrays at the root of a BSON document.