### PR TITLE
CSHARP-3910: LINQ3: Missing calls to PartialEvaluator.

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/LinqProviderAdapterV3.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/LinqProviderAdapterV3.cs
@@ -46,6 +46,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation
             IBsonSerializerRegistry serializerRegistry,
             ExpressionTranslationOptions translationOptions)
         {
+            expression = (Expression<Func<TSource, TResult>>)PartialEvaluator.EvaluatePartially(expression);
             var context = TranslationContext.Create(expression, sourceSerializer);
             var translation = ExpressionToAggregationExpressionTranslator.TranslateLambdaBody(context, expression, sourceSerializer, asRoot: true);
             var simplifiedAst = AstSimplifier.Simplify(translation.Ast);
@@ -115,6 +116,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation
             IBsonSerializer<TDocument> documentSerializer,
             IBsonSerializerRegistry serializerRegistry)
         {
+            expression = (Expression<Func<TDocument, bool>>)PartialEvaluator.EvaluatePartially(expression);
             var context = TranslationContext.Create(expression, documentSerializer);
             var filter = ExpressionToFilterTranslator.TranslateLambda(context, expression, documentSerializer);
             filter = AstSimplifier.SimplifyAndConvert(filter);
@@ -148,6 +150,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation
             IBsonSerializerRegistry serializerRegistry,
             ExpressionTranslationOptions translationOptions)
         {
+            expression = (Expression<Func<TInput, TOutput>>)PartialEvaluator.EvaluatePartially(expression);
             var context = TranslationContext.Create(expression, inputSerializer);
             var translation = ExpressionToAggregationExpressionTranslator.TranslateLambdaBody(context, expression, inputSerializer, asRoot: true);
             var (projectStage, projectionSerializer) = ProjectionHelper.CreateProjectStage(translation);

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp3910Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp3910Tests.cs
@@ -1,0 +1,51 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using FluentAssertions;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
+{
+    public class CSharp3910Tests
+    {
+        [Fact]
+        public void Filter_expression_needing_partial_evaluation_should_work()
+        {
+            var client = DriverTestConfiguration.Linq3Client;
+            var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
+            var collection = database.GetCollection<Entity>("csharp3910");
+
+            database.DropCollection("csharp3910");
+            collection.InsertMany(new[]
+            {
+                new Entity { Id = 1, Description = "Alpha" },
+                new Entity { Id = 2, Description = "Alpha2" },
+                new Entity { Id = 3, Description = "Bravo" },
+                new Entity { Id = 4, Description = "Charlie" }
+            });
+
+            var param = "A";
+            var result = collection.DeleteMany(mvi => mvi.Description.StartsWith(string.Format("{0}", param)));
+
+            result.DeletedCount.Should().Be(2);
+        }
+
+        public class Entity
+        {
+            public int Id { get; set; }
+            public string Description { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Evergreen patch build:

https://evergreen.mongodb.com/version/616db14857e85a24c4febd31