### PR TITLE
CSHARP-3434: Fixed OCSP tests in Evergreen.

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -521,6 +521,7 @@ functions:
   run-valid-ocsp-server-ca-responder:
     - command: shell.exec
       params:
+        working_dir: mongo-csharp-driver
         script: |
           ${PREPARE_SHELL}
           evergreen/prepare-ocsp.sh
@@ -539,6 +540,7 @@ functions:
   run-valid-ocsp-server-delegate-responder:
     - command: shell.exec
       params:
+        working_dir: mongo-csharp-driver
         script: |
           ${PREPARE_SHELL}
           evergreen/prepare-ocsp.sh
@@ -557,6 +559,7 @@ functions:
   run-revoked-ocsp-server-ca-responder:
     - command: shell.exec
       params:
+        working_dir: mongo-csharp-driver
         script: |
           ${PREPARE_SHELL}
           evergreen/prepare-ocsp.sh
@@ -577,6 +580,7 @@ functions:
   run-revoked-ocsp-server-delegate-responder:
     - command: shell.exec
       params:
+        working_dir: mongo-csharp-driver
         script: |
           ${PREPARE_SHELL}
           evergreen/prepare-ocsp.sh

--- a/evergreen/prepare-ocsp.sh
+++ b/evergreen/prepare-ocsp.sh
@@ -11,6 +11,7 @@ if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
   /cygdrive/c/python/python38/python.exe -m venv ./venv
   ./venv/Scripts/pip3 install -r ${DRIVERS_TOOLS}/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
 else
+  echo "$0 needs to be updated to run on non-Windows platforms"
   # Need to ensure on Linux python is installed in the correct place and visible to the script.
   # https://jira.mongodb.org/browse/CSHARP-3255
   # /opt/python/2.7/bin/python -m venv ./venv


### PR DESCRIPTION
When the `evergreen/prepare-ocsp.sh` script was extracted from `evergreen/evergreen.yml`, the working directory was not set to `mongo-csharp-driver`. Thus Evergreen was trying to run the script from the wrong directory and couldn't find it.