### PR TITLE
CSHARP-3972: BulkDeleteOperation ignores isOrdered parameter

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
@@ -249,6 +249,7 @@ namespace MongoDB.Driver.Core.Operations
             var requests = batch.Requests.Cast<DeleteRequest>();
             return new BulkDeleteOperation(_collectionNamespace, requests, _messageEncoderSettings)
             {
+                IsOrdered = _isOrdered,
                 MaxBatchCount = _maxBatchCount,
                 MaxBatchLength = _maxBatchLength,
                 WriteConcern = batch.WriteConcern,


### PR DESCRIPTION
[EG](https://spruce.mongodb.com/version/61980964d6d80a7a2743552b)
Jira ticket: [CSHARP-3972](https://jira.mongodb.org/browse/CSHARP-3972) 