### PR TITLE
CSHARP-2088: Publish PDBs and sources on symbolsource.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -529,13 +529,13 @@ Task("PackageNugetPackages")
         }
     });
 
-Task("PushToMyGet")
+Task("PushToNuGet")
     .Does(() =>
     {
-        var mygetApiKey = EnvironmentVariable("MYGETAPIKEY");
-        if (mygetApiKey == null)
+        var nugetApiKey = EnvironmentVariable("NUGETAPIKEY");
+        if (nugetApiKey == null)
         {
-            throw new Exception("MYGETAPIKEY environment variable missing");
+            throw new Exception("NUGETAPIKEY environment variable missing");
         }
 
         var packageFiles = new List<FilePath>();
@@ -558,8 +558,8 @@ Task("PushToMyGet")
 
         NuGetPush(packageFiles, new NuGetPushSettings
         {
-            ApiKey = mygetApiKey,
-            Source = "https://www.myget.org/F/mongodb/api/v3/index.json"
+            ApiKey = nugetApiKey,
+            Source = "https://api.nuget.org/v3/index.json"
         });
     });
 

--- a/build.cake
+++ b/build.cake
@@ -77,13 +77,12 @@ Task("Build")
                { "SourceRevisionId", gitVersion.Sha }
            }
         };
-        if (target.ToLowerInvariant().StartsWith("package") || target.ToLowerInvariant().StartsWith("release"))
+
+        var lowerTarget = target.ToLowerInvariant();
+        if (lowerTarget.StartsWith("package") || lowerTarget.StartsWith("release"))
         {
             Console.WriteLine("Build continuousIntegration is enabled");
-            if (settings.MSBuildSettings == null)
-            {
-                settings.MSBuildSettings = new DotNetCoreMSBuildSettings();
-            }
+            settings.MSBuildSettings = new DotNetCoreMSBuildSettings();
             // needs to make nupkg package deterministic. Should be used only during package release
             settings.MSBuildSettings.SetContinuousIntegrationBuild(continuousIntegrationBuild: true);
         }

--- a/build.cake
+++ b/build.cake
@@ -83,7 +83,7 @@ Task("Build")
         {
             Console.WriteLine("Build continuousIntegration is enabled");
             settings.MSBuildSettings = new DotNetCoreMSBuildSettings();
-            // needs to make nupkg package deterministic. Should be used only during package release
+            // needs to make nupkg package deterministic. Used for package release
             settings.MSBuildSettings.SetContinuousIntegrationBuild(continuousIntegrationBuild: true);
         }
         DotNetCoreBuild(solutionFullPath, settings);
@@ -522,7 +522,7 @@ Task("PackageNugetPackages")
                 NoBuild = true, // SetContinuousIntegrationBuild is enabled for nupkg on the Build step
                 IncludeSymbols = true,
                 MSBuildSettings = new DotNetCoreMSBuildSettings()
-                    .SetContinuousIntegrationBuild(continuousIntegrationBuild: true)
+                    .SetContinuousIntegrationBuild(continuousIntegrationBuild: true) // needs to make snupkg package deterministic
                     .WithProperty("PackageVersion", gitVersion.LegacySemVer)
             };
             DotNetCorePack(projectPath, settings);

--- a/build.cake
+++ b/build.cake
@@ -66,7 +66,7 @@ Task("Restore")
 
 Task("Build")
     .IsDependentOn("Restore")
-    .Does<BuildConfig >((buildConfig) =>
+    .Does<BuildConfig>((buildConfig) =>
     {
        var settings = new DotNetCoreBuildSettings
        {
@@ -783,7 +783,7 @@ Task("TestsPackaging")
     })
     .DeferOnError();
 
-Setup<BuildConfig >(
+Setup<BuildConfig>(
     setupContext => 
     {
         var lowerTarget = target.ToLowerInvariant();
@@ -796,17 +796,17 @@ Setup<BuildConfig >(
         };
         var isReleaseMode = lowerTarget.StartsWith("package") || lowerTarget == "release";
         Console.WriteLine($"Framework: {framework ?? "null (not set)"}, IsReleaseMode: {isReleaseMode}");
-        return new BuildConfig (isReleaseMode, framework);
+        return new BuildConfig(isReleaseMode, framework);
     });
 
 RunTarget(target);
 
-public class BuildConfig 
+public class BuildConfig
 {
     public bool IsReleaseMode { get; }
     public string Framework { get; }
 
-    public BuildConfig (bool isReleaseMode, string framework)
+    public BuildConfig(bool isReleaseMode, string framework)
     {
         IsReleaseMode = isReleaseMode;
         Framework = framework;

--- a/build.cake
+++ b/build.cake
@@ -83,7 +83,7 @@ Task("Build")
         {
             Console.WriteLine("Build continuousIntegration is enabled");
             settings.MSBuildSettings = new DotNetCoreMSBuildSettings();
-            // needs to make nupkg package deterministic. Used for package release
+            // configure deterministic build for better compatibility with debug symbols (used in Package/Build tasks). Affects: *.nupkg
             settings.MSBuildSettings.SetContinuousIntegrationBuild(continuousIntegrationBuild: true);
         }
         DotNetCoreBuild(solutionFullPath, settings);
@@ -522,7 +522,8 @@ Task("PackageNugetPackages")
                 NoBuild = true, // SetContinuousIntegrationBuild is enabled for nupkg on the Build step
                 IncludeSymbols = true,
                 MSBuildSettings = new DotNetCoreMSBuildSettings()
-                    .SetContinuousIntegrationBuild(continuousIntegrationBuild: true) // needs to make snupkg package deterministic
+                    // configure deterministic build for better compatibility with debug symbols (used in Package/Build tasks). Affects: *.snupkg
+                    .SetContinuousIntegrationBuild(continuousIntegrationBuild: true) 
                     .WithProperty("PackageVersion", gitVersion.LegacySemVer)
             };
             DotNetCorePack(projectPath, settings);

--- a/build.cake
+++ b/build.cake
@@ -66,7 +66,7 @@ Task("Restore")
 
 Task("Build")
     .IsDependentOn("Restore")
-    .Does<BuildData>((buildData) =>
+    .Does<BuildConfig >((buildConfig) =>
     {
        var settings = new DotNetCoreBuildSettings
        {
@@ -79,7 +79,7 @@ Task("Build")
            }
         };
 
-        if (buildData.IsReleaseMode)
+        if (buildConfig.IsReleaseMode)
         {
             Console.WriteLine("Build continuousIntegration is enabled");
             settings.MSBuildSettings = new DotNetCoreMSBuildSettings();
@@ -132,7 +132,7 @@ Task("Test")
     .IsDependentOn("Build")
     .DoesForEach(
         items: GetFiles("./**/*.Tests.csproj").Where(name => !name.ToString().Contains("Atlas")),
-        action: (BuildData buildData, Path testProject) =>
+        action: (BuildConfig buildConfig, Path testProject) =>
     {
         if (Environment.GetEnvironmentVariable("MONGODB_API_VERSION") != null &&
             testProject.ToString().Contains("Legacy"))
@@ -168,7 +168,7 @@ Task("Test")
             Configuration = configuration,
             Loggers = CreateLoggers(),
             ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
-            Framework = buildData.Framework
+            Framework = buildConfig.Framework
         };
 
         DotNetCoreTest(
@@ -320,7 +320,7 @@ Task("TestGssapi")
     .IsDependentOn("Build")
     .DoesForEach(
         items: GetFiles("./**/MongoDB.Driver.Tests.csproj"),
-        action: (BuildData buildData, Path testProject) =>
+        action: (BuildConfig buildConfig, Path testProject) =>
     {
         var settings = new DotNetCoreTestSettings
         {
@@ -329,7 +329,7 @@ Task("TestGssapi")
             Configuration = configuration,
             ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
             Filter = "Category=\"GssapiMechanism\"",
-            Framework = buildData.Framework
+            Framework = buildConfig.Framework
         };
 
         DotNetCoreTest(
@@ -346,7 +346,7 @@ Task("TestServerless")
     .IsDependentOn("Build")
     .DoesForEach(
         items: GetFiles("./**/MongoDB.Driver.Tests.csproj"),
-        action: (BuildData buildData, Path testProject) =>
+        action: (BuildConfig buildConfig, Path testProject) =>
         {
             var settings = new DotNetCoreTestSettings
             {
@@ -355,7 +355,7 @@ Task("TestServerless")
                 Configuration = configuration,
                 ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
                 Filter = "Category=\"Serverless\"",
-                Framework = buildData.Framework
+                Framework = buildConfig.Framework
             };
 
             DotNetCoreTest(
@@ -372,7 +372,7 @@ Task("TestLoadBalanced")
     .IsDependentOn("Build")
     .DoesForEach(
         items: GetFiles("./**/*.Tests.csproj"),
-        action: (BuildData buildData, Path testProject) =>
+        action: (BuildConfig buildConfig, Path testProject) =>
      {
         var settings = new DotNetCoreTestSettings
         {
@@ -381,7 +381,7 @@ Task("TestLoadBalanced")
             Configuration = configuration,
             ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
             Filter = "Category=\"SupportLoadBalancing\"",
-            Framework = buildData.Framework
+            Framework = buildConfig.Framework
         };
 
         DotNetCoreTest(
@@ -397,7 +397,7 @@ Task("TestCsfleWithMockedKms")
     .IsDependentOn("Build")
     .DoesForEach(
         items: GetFiles("./**/*.Tests.csproj"),
-        action: (BuildData buildData, Path testProject) =>
+        action: (BuildConfig buildConfig, Path testProject) =>
     {
         var settings = new DotNetCoreTestSettings
         {
@@ -407,7 +407,7 @@ Task("TestCsfleWithMockedKms")
             Loggers = CreateLoggers(),
             ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
             Filter = "Category=\"CSFLE\"",
-            Framework = buildData.Framework
+            Framework = buildConfig.Framework
         };
 
         DotNetCoreTest(
@@ -783,7 +783,7 @@ Task("TestsPackaging")
     })
     .DeferOnError();
 
-Setup<BuildData>(
+Setup<BuildConfig >(
     setupContext => 
     {
         var lowerTarget = target.ToLowerInvariant();
@@ -796,17 +796,17 @@ Setup<BuildData>(
         };
         var isReleaseMode = lowerTarget.StartsWith("package") || lowerTarget == "release";
         Console.WriteLine($"Framework: {framework ?? "null (not set)"}, IsReleaseMode: {isReleaseMode}");
-        return new BuildData(isReleaseMode, framework);
+        return new BuildConfig (isReleaseMode, framework);
     });
 
 RunTarget(target);
 
-public class BuildData
+public class BuildConfig 
 {
     public bool IsReleaseMode { get; }
     public string Framework { get; }
 
-    public BuildData(bool isReleaseMode, string framework)
+    public BuildConfig (bool isReleaseMode, string framework)
     {
         IsReleaseMode = isReleaseMode;
         Framework = framework;

--- a/build.config
+++ b/build.config
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-CAKE_VERSION=1.2.0
+CAKE_VERSION=1.3.0
 DOTNET_VERSION=5.0.401

--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -29,8 +29,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!--obj-->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">

--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -27,6 +27,10 @@
     <PackageTags>mongodb;mongo;nosql;bson</PackageTags>
     <PackageLanguage>en-US</PackageLanguage>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!--obj-->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">
@@ -48,6 +52,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -28,6 +28,10 @@
     <PackageTags>mongodb;mongo;nosql</PackageTags>
     <PackageLanguage>en-US</PackageLanguage>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!--obj-->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -178,6 +182,10 @@
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.3.0" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -30,8 +30,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!--obj-->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
+++ b/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
@@ -27,6 +27,10 @@
     <PackageTags>mongodb;mongo;nosql;gridfs</PackageTags>
     <PackageLanguage>en-US</PackageLanguage>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!--obj-->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">
@@ -47,6 +51,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
+++ b/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
@@ -29,8 +29,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!--obj-->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">

--- a/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
+++ b/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
@@ -28,6 +28,10 @@
     <PackageTags></PackageTags>
     <PackageLanguage>en-US</PackageLanguage>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!--obj-->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">
@@ -36,6 +40,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
+++ b/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
@@ -30,8 +30,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!--obj-->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -29,8 +29,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!--obj-->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -27,6 +27,10 @@
     <PackageTags>mongodb;mongo;nosql</PackageTags>
     <PackageLanguage>en-US</PackageLanguage>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!--obj-->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">
@@ -47,6 +51,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.3.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="1.1.0" />
+    <package id="Cake" version="1.3.0" />
 </packages>


### PR DESCRIPTION
Some notes:
1. Currently I temporally switched back to myget for tests reasons, probably we will know that it works with nuget only during next release.
2. In the scope of this ticket I also fixed nuget package warnings from [here](https://jira.mongodb.org/browse/CSHARP-3802) and [here](https://jira.mongodb.org/browse/CSHARP-3047). Steps that I took more or less taken from [here](https://lurumad.github.io/using-source-link-in-net-projects-and-how-to-configure-visual-studio-to-use-it).
After this PR, the nuget package manager should look like this:
![image](https://user-images.githubusercontent.com/44870738/143359998-79a5be41-e55b-4284-9607-04cd334472d5.png)

NOTE: it looks like myget doesn't work correctly with the above package validation, all nuget packages that I checked (including external) were red. Probably it's only myget issue. Will check it after release :) 

3. I needed to update cake to 1.3.0, to be able to configure `ContinuousIntegration` field that required to make package deterministic. Some article about it [here](https://blog.paranoidcoding.com/2016/04/05/deterministic-builds-in-roslyn.html).
4. What should be checked after package creating:
![image](https://user-images.githubusercontent.com/44870738/143364564-1dbecaf3-a943-4180-b9ac-e19f1823cc52.png)
where `Url` means the git repository that will be used to download source file and `Commit` a particular commit (make sure that it's pushed).
5. How it should be configured:
5.1. While we use myget in testing, this source `https://www.myget.org/F/mongodb/api/v3/index.json` should be added to nuget package manager.
5.2. Consume the test package in the consumer application
5.3. Make sure that VS has the same configuration:
![image](https://user-images.githubusercontent.com/44870738/143364964-807f4404-89ff-41f6-a176-d3263ec0be81.png)
5.4. Make sure that myget symbol server `https://www.myget.org/F/mongodb/api/v2/symbolpackage` is added to VS here:
![image](https://user-images.githubusercontent.com/44870738/143365111-0fc688af-f4f1-48eb-8498-49943fa1736c.png)
NOTE: I think when we will use nuget.org symbol server, it should be enough just to enable default nuget symbol server
