### PR TITLE
CSHARP-3855: Remove code that implements support for server version 2.6.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/MongoDBX509Authenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/MongoDBX509Authenticator.cs
@@ -80,7 +80,6 @@ namespace MongoDB.Driver.Core.Authentication
         {
             Ensure.IsNotNull(connection, nameof(connection));
             Ensure.IsNotNull(description, nameof(description));
-            EnsureUsernameIsNotNullOrNullIsSupported(connection, description);
 
             if (description.HelloResult.SpeculativeAuthenticate != null)
             {
@@ -103,7 +102,6 @@ namespace MongoDB.Driver.Core.Authentication
         {
             Ensure.IsNotNull(connection, nameof(connection));
             Ensure.IsNotNull(description, nameof(description));
-            EnsureUsernameIsNotNullOrNullIsSupported(connection, description);
 
             if (description.HelloResult.SpeculativeAuthenticate != null)
             {
@@ -159,16 +157,6 @@ namespace MongoDB.Driver.Core.Authentication
         {
             var message = string.Format("Unable to authenticate username '{0}' using protocol '{1}'.", _username, Name);
             return new MongoAuthenticationException(connection.ConnectionId, message, ex);
-        }
-
-        private void EnsureUsernameIsNotNullOrNullIsSupported(IConnection connection, ConnectionDescription description)
-        {
-            var serverVersion = description.ServerVersion;
-            if (_username == null && !Feature.ServerExtractsUsernameFromX509Certificate.IsSupported(serverVersion))
-            {
-                var message = $"Username cannot be null for server version {serverVersion}.";
-                throw new MongoConnectionException(connection.ConnectionId, message);
-            }
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -23,11 +23,15 @@ namespace MongoDB.Driver.Core.Misc
     public class Feature
     {
         #region static
+        private static readonly Feature __aggregate = new Feature("Aggregate", new SemanticVersion(2, 2, 0));
         private static readonly Feature __aggregateAccumulator = new Feature("AggregateAccumulator", new SemanticVersion(4, 3, 4));
         private static readonly Feature __aggregateAddFields = new Feature("AggregateAddFields", new SemanticVersion(3, 4, 0));
+        private static readonly Feature __aggregateAllowDiskUse = new Feature("AggregateAllowDiskUse", new SemanticVersion(2, 6, 0));
         private static readonly Feature __aggregateBucketStage = new Feature("AggregateBucketStage", new SemanticVersion(3, 3, 11));
         private static readonly Feature __aggregateComment = new Feature("AggregateComment", new SemanticVersion(3, 6, 0, "rc0"));
         private static readonly Feature __aggregateCountStage = new Feature("AggregateCountStage", new SemanticVersion(3, 3, 11));
+        private static readonly Feature __aggregateCursorResult = new Feature("AggregateCursorResult", new SemanticVersion(2, 6, 0));
+        private static readonly Feature __aggregateExplain = new Feature("AggregateExplain", new SemanticVersion(2, 6, 0));
         private static readonly Feature __aggregateFacetStage = new Feature("AggregateFacetStage", new SemanticVersion(3, 4, 0, "rc0"));
         private static readonly Feature __aggregateFunction = new Feature("AggregateFunction", new SemanticVersion(4, 3, 4));
         private static readonly Feature __aggregateGraphLookupStage = new Feature("AggregateGraphLookupStage", new SemanticVersion(3, 4, 0, "rc0"));
@@ -35,6 +39,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __aggregateOptionsLet = new Feature("AggregateOptionsLet", new SemanticVersion(5, 0, 0, ""));
         private static readonly Feature __aggregateLet = new Feature("AggregateLet", new SemanticVersion(3, 6, 0));
         private static readonly Feature __aggregateMerge = new Feature("AggregateMerge", new SemanticVersion(4, 2, 0));
+        private static readonly Feature __aggregateOut = new Feature("AggregateOut", new SemanticVersion(2, 6, 0));
         private static readonly Feature __aggregateOutToDifferentDatabase = new Feature("AggregateOutToDifferentDatabase", new SemanticVersion(4, 3, 0));
         private static readonly Feature __aggregateToString = new Feature("AggregateToString", new SemanticVersion(4, 0, 0));
         private static readonly Feature __aggregateUnionWith = new Feature("AggregateUnionWith", new SemanticVersion(4, 3, 4));
@@ -47,6 +52,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __commandMessage = new Feature("CommandMessage", new SemanticVersion(3, 6, 0));
         private static readonly CommandsThatWriteAcceptWriteConcernFeature __commandsThatWriteAcceptWriteConcern = new CommandsThatWriteAcceptWriteConcernFeature("CommandsThatWriteAcceptWriteConcern", new SemanticVersion(3, 3, 11));
         private static readonly Feature __createIndexCommitQuorum = new Feature("CreateIndexCommitQuorum", new SemanticVersion(4, 4, 0, ""));
+        private static readonly Feature __createIndexesCommand = new Feature("CreateIndexesCommand", new SemanticVersion(2, 6, 0));
         private static readonly Feature __createIndexesUsingInsertOperations = new Feature("CreateIndexesUsingInsertOperations", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 1, ""));
         private static readonly Feature __currentOpCommand = new Feature("CurrentOpCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __documentValidation = new Feature("DocumentValidation", new SemanticVersion(3, 2, 0));
@@ -54,6 +60,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __estimatedDocumentCountByCollStats = new Feature("EstimatedDocumentCountByCollStats", new SemanticVersion(4, 9, 0, ""));
         private static readonly Feature __eval = new Feature("Eval", new SemanticVersion(0, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __explainCommand = new Feature("ExplainCommand", new SemanticVersion(3, 0, 0));
+        private static readonly Feature __failPoints = new Feature("FailPoints", new SemanticVersion(2, 4, 0));
         private static readonly Feature __failPointsBlockConnection = new Feature("FailPointsBlockConnection", new SemanticVersion(4, 2, 9));
         private static readonly Feature __failPointsFailCommand = new Feature("FailPointsFailCommand", new SemanticVersion(4, 0, 0));
         private static readonly Feature __failPointsFailCommandForSharded = new Feature("FailPointsFailCommandForSharded", new SemanticVersion(4, 1, 5));
@@ -80,6 +87,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __loadBalancedMode = new Feature("LoadBalancedMode", new SemanticVersion(5, 0, 0));
         private static readonly Feature __indexOptionsDefaults = new Feature("IndexOptionsDefaults", new SemanticVersion(3, 2, 0));
         private static readonly Feature __maxStaleness = new Feature("MaxStaleness", new SemanticVersion(3, 3, 12));
+        private static readonly Feature __maxTime = new Feature("MaxTime", new SemanticVersion(2, 6, 0));
         private static readonly Feature __mmapV1StorageEngine = new Feature("MmapV1StorageEngine", new SemanticVersion(0, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __partialIndexes = new Feature("PartialIndexes", new SemanticVersion(3, 2, 0));
         private static readonly ReadConcernFeature __readConcern = new ReadConcernFeature("ReadConcern", new SemanticVersion(3, 2, 0));
@@ -87,6 +95,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __retryableWrites = new Feature("RetryableWrites", new SemanticVersion(3, 6, 0));
         private static readonly Feature __scramSha1Authentication = new Feature("ScramSha1Authentication", new SemanticVersion(3, 0, 0));
         private static readonly Feature __scramSha256Authentication = new Feature("ScramSha256Authentication", new SemanticVersion(4, 0, 0, ""));
+        private static readonly Feature __serverExtractsUsernameFromX509Certificate = new Feature("ServerExtractsUsernameFromX509Certificate", new SemanticVersion(3, 3, 12));
         private static readonly Feature __serverReturnsResumableChangeStreamErrorLabel = new Feature("ServerReturnsResumableChangeStreamErrorLabel", new SemanticVersion(4, 3, 0));
         private static readonly Feature __serverReturnsRetryableWriteErrorLabel = new Feature("ServerReturnsRetryableWriteErrorLabel", new SemanticVersion(4, 3, 0));
         private static readonly Feature __shardedTransactions = new Feature("ShardedTransactions", new SemanticVersion(4, 1, 6));
@@ -95,8 +104,16 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __streamingHello = new Feature("StreamingHello", new SemanticVersion(4, 4, 0, ""));
         private static readonly Feature __tailableCursor = new Feature("TailableCursor", new SemanticVersion(3, 2, 0));
         private static readonly Feature __transactions = new Feature("Transactions", new SemanticVersion(4, 0, 0));
+        private static readonly Feature __userManagementCommands = new Feature("UserManagementCommands", new SemanticVersion(2, 6, 0));
         private static readonly Feature __views = new Feature("Views", new SemanticVersion(3, 3, 11));
         private static readonly Feature __wildcardIndexes = new Feature("WildcardIndexes", new SemanticVersion(4, 1, 6));
+        private static readonly Feature __writeCommands = new Feature("WriteCommands", new SemanticVersion(2, 6, 0));
+
+        /// <summary>
+        /// Gets the aggregate feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature Aggregate => __aggregate;
 
         /// <summary>
         /// Gets the aggregate accumulato feature.
@@ -107,6 +124,12 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the aggregate AddFields feature.
         /// </summary>
         public static Feature AggregateAddFields => __aggregateAddFields;
+
+        /// <summary>
+        /// Gets the aggregate allow disk use feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature AggregateAllowDiskUse => __aggregateAllowDiskUse;
 
         /// <summary>
         /// Gets the aggregate bucket stage feature.
@@ -122,6 +145,18 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the aggregate count stage feature.
         /// </summary>
         public static Feature AggregateCountStage => __aggregateCountStage;
+
+        /// <summary>
+        /// Gets the aggregate cursor result feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature AggregateCursorResult => __aggregateCursorResult;
+
+        /// <summary>
+        /// Gets the aggregate explain feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature AggregateExplain => __aggregateExplain;
 
         /// <summary>
         /// Gets the aggregate $facet stage feature.
@@ -157,6 +192,12 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the aggregate merge feature.
         /// </summary>
         public static Feature AggregateMerge => __aggregateMerge;
+
+        /// <summary>
+        /// Gets the aggregate out feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature AggregateOut => __aggregateOut;
 
         /// <summary>
         /// Gets the aggregate out to a different database feature.
@@ -219,6 +260,12 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature CreateIndexCommitQuorum => __createIndexCommitQuorum;
 
         /// <summary>
+        /// Gets the create indexes command feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature CreateIndexesCommand => __createIndexesCommand;
+
+        /// <summary>
         /// Gets the create indexes using insert operations feature.
         /// </summary>
         public static Feature CreateIndexesUsingInsertOperations => __createIndexesUsingInsertOperations;
@@ -252,6 +299,12 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the explain command feature.
         /// </summary>
         public static Feature ExplainCommand => __explainCommand;
+
+        /// <summary>
+        /// Gets the fail points feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature FailPoints => __failPoints;
 
         /// <summary>
         /// Gets the fail points block connection feature.
@@ -390,6 +443,12 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature MaxStaleness => __maxStaleness;
 
         /// <summary>
+        /// Gets the maximum time feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature MaxTime => __maxTime;
+
+        /// <summary>
         /// Gets the mmapv1 storage engine feature.
         /// </summary>
         public static Feature MmapV1StorageEngine => __mmapV1StorageEngine;
@@ -423,6 +482,12 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the scram sha256 authentication feature.
         /// </summary>
         public static Feature ScramSha256Authentication => __scramSha256Authentication;
+
+        /// <summary>
+        /// Gets the server extracts username from X509 certificate feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature ServerExtractsUsernameFromX509Certificate => __serverExtractsUsernameFromX509Certificate;
 
         /// <summary>
         /// Gets the server returns resumableChangeStream label feature.
@@ -471,6 +536,12 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature Transactions => __transactions;
 
         /// <summary>
+        /// Gets the user management commands feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature UserManagementCommands => __userManagementCommands;
+
+        /// <summary>
         /// Gets the views feature.
         /// </summary>
         public static Feature Views => __views;
@@ -479,6 +550,12 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the wildcard indexes feature.
         /// </summary>
         public static Feature WildcardIndexes => __wildcardIndexes;
+
+        /// <summary>
+        /// Gets the write commands feature.
+        /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
+        public static Feature WriteCommands => __writeCommands;
         #endregion
 
         private readonly string _name;

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -23,15 +23,11 @@ namespace MongoDB.Driver.Core.Misc
     public class Feature
     {
         #region static
-        private static readonly Feature __aggregate = new Feature("Aggregate", new SemanticVersion(2, 2, 0));
         private static readonly Feature __aggregateAccumulator = new Feature("AggregateAccumulator", new SemanticVersion(4, 3, 4));
         private static readonly Feature __aggregateAddFields = new Feature("AggregateAddFields", new SemanticVersion(3, 4, 0));
-        private static readonly Feature __aggregateAllowDiskUse = new Feature("AggregateAllowDiskUse", new SemanticVersion(2, 6, 0));
         private static readonly Feature __aggregateBucketStage = new Feature("AggregateBucketStage", new SemanticVersion(3, 3, 11));
         private static readonly Feature __aggregateComment = new Feature("AggregateComment", new SemanticVersion(3, 6, 0, "rc0"));
         private static readonly Feature __aggregateCountStage = new Feature("AggregateCountStage", new SemanticVersion(3, 3, 11));
-        private static readonly Feature __aggregateCursorResult = new Feature("AggregateCursorResult", new SemanticVersion(2, 6, 0));
-        private static readonly Feature __aggregateExplain = new Feature("AggregateExplain", new SemanticVersion(2, 6, 0));
         private static readonly Feature __aggregateFacetStage = new Feature("AggregateFacetStage", new SemanticVersion(3, 4, 0, "rc0"));
         private static readonly Feature __aggregateFunction = new Feature("AggregateFunction", new SemanticVersion(4, 3, 4));
         private static readonly Feature __aggregateGraphLookupStage = new Feature("AggregateGraphLookupStage", new SemanticVersion(3, 4, 0, "rc0"));
@@ -39,7 +35,6 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __aggregateOptionsLet = new Feature("AggregateOptionsLet", new SemanticVersion(5, 0, 0, ""));
         private static readonly Feature __aggregateLet = new Feature("AggregateLet", new SemanticVersion(3, 6, 0));
         private static readonly Feature __aggregateMerge = new Feature("AggregateMerge", new SemanticVersion(4, 2, 0));
-        private static readonly Feature __aggregateOut = new Feature("AggregateOut", new SemanticVersion(2, 6, 0));
         private static readonly Feature __aggregateOutToDifferentDatabase = new Feature("AggregateOutToDifferentDatabase", new SemanticVersion(4, 3, 0));
         private static readonly Feature __aggregateToString = new Feature("AggregateToString", new SemanticVersion(4, 0, 0));
         private static readonly Feature __aggregateUnionWith = new Feature("AggregateUnionWith", new SemanticVersion(4, 3, 4));
@@ -52,7 +47,6 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __commandMessage = new Feature("CommandMessage", new SemanticVersion(3, 6, 0));
         private static readonly CommandsThatWriteAcceptWriteConcernFeature __commandsThatWriteAcceptWriteConcern = new CommandsThatWriteAcceptWriteConcernFeature("CommandsThatWriteAcceptWriteConcern", new SemanticVersion(3, 3, 11));
         private static readonly Feature __createIndexCommitQuorum = new Feature("CreateIndexCommitQuorum", new SemanticVersion(4, 4, 0, ""));
-        private static readonly Feature __createIndexesCommand = new Feature("CreateIndexesCommand", new SemanticVersion(2, 6, 0));
         private static readonly Feature __createIndexesUsingInsertOperations = new Feature("CreateIndexesUsingInsertOperations", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 1, ""));
         private static readonly Feature __currentOpCommand = new Feature("CurrentOpCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __documentValidation = new Feature("DocumentValidation", new SemanticVersion(3, 2, 0));
@@ -60,7 +54,6 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __estimatedDocumentCountByCollStats = new Feature("EstimatedDocumentCountByCollStats", new SemanticVersion(4, 9, 0, ""));
         private static readonly Feature __eval = new Feature("Eval", new SemanticVersion(0, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __explainCommand = new Feature("ExplainCommand", new SemanticVersion(3, 0, 0));
-        private static readonly Feature __failPoints = new Feature("FailPoints", new SemanticVersion(2, 4, 0));
         private static readonly Feature __failPointsBlockConnection = new Feature("FailPointsBlockConnection", new SemanticVersion(4, 2, 9));
         private static readonly Feature __failPointsFailCommand = new Feature("FailPointsFailCommand", new SemanticVersion(4, 0, 0));
         private static readonly Feature __failPointsFailCommandForSharded = new Feature("FailPointsFailCommandForSharded", new SemanticVersion(4, 1, 5));
@@ -87,7 +80,6 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __loadBalancedMode = new Feature("LoadBalancedMode", new SemanticVersion(5, 0, 0));
         private static readonly Feature __indexOptionsDefaults = new Feature("IndexOptionsDefaults", new SemanticVersion(3, 2, 0));
         private static readonly Feature __maxStaleness = new Feature("MaxStaleness", new SemanticVersion(3, 3, 12));
-        private static readonly Feature __maxTime = new Feature("MaxTime", new SemanticVersion(2, 6, 0));
         private static readonly Feature __mmapV1StorageEngine = new Feature("MmapV1StorageEngine", new SemanticVersion(0, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __partialIndexes = new Feature("PartialIndexes", new SemanticVersion(3, 2, 0));
         private static readonly ReadConcernFeature __readConcern = new ReadConcernFeature("ReadConcern", new SemanticVersion(3, 2, 0));
@@ -95,7 +87,6 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __retryableWrites = new Feature("RetryableWrites", new SemanticVersion(3, 6, 0));
         private static readonly Feature __scramSha1Authentication = new Feature("ScramSha1Authentication", new SemanticVersion(3, 0, 0));
         private static readonly Feature __scramSha256Authentication = new Feature("ScramSha256Authentication", new SemanticVersion(4, 0, 0, ""));
-        private static readonly Feature __serverExtractsUsernameFromX509Certificate = new Feature("ServerExtractsUsernameFromX509Certificate", new SemanticVersion(3, 3, 12));
         private static readonly Feature __serverReturnsResumableChangeStreamErrorLabel = new Feature("ServerReturnsResumableChangeStreamErrorLabel", new SemanticVersion(4, 3, 0));
         private static readonly Feature __serverReturnsRetryableWriteErrorLabel = new Feature("ServerReturnsRetryableWriteErrorLabel", new SemanticVersion(4, 3, 0));
         private static readonly Feature __shardedTransactions = new Feature("ShardedTransactions", new SemanticVersion(4, 1, 6));
@@ -104,16 +95,8 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __streamingHello = new Feature("StreamingHello", new SemanticVersion(4, 4, 0, ""));
         private static readonly Feature __tailableCursor = new Feature("TailableCursor", new SemanticVersion(3, 2, 0));
         private static readonly Feature __transactions = new Feature("Transactions", new SemanticVersion(4, 0, 0));
-        private static readonly Feature __userManagementCommands = new Feature("UserManagementCommands", new SemanticVersion(2, 6, 0));
         private static readonly Feature __views = new Feature("Views", new SemanticVersion(3, 3, 11));
         private static readonly Feature __wildcardIndexes = new Feature("WildcardIndexes", new SemanticVersion(4, 1, 6));
-        private static readonly Feature __writeCommands = new Feature("WriteCommands", new SemanticVersion(2, 6, 0));
-
-        /// <summary>
-        /// Gets the aggregate feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature Aggregate => __aggregate;
 
         /// <summary>
         /// Gets the aggregate accumulato feature.
@@ -124,12 +107,6 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the aggregate AddFields feature.
         /// </summary>
         public static Feature AggregateAddFields => __aggregateAddFields;
-
-        /// <summary>
-        /// Gets the aggregate allow disk use feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature AggregateAllowDiskUse => __aggregateAllowDiskUse;
 
         /// <summary>
         /// Gets the aggregate bucket stage feature.
@@ -145,18 +122,6 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the aggregate count stage feature.
         /// </summary>
         public static Feature AggregateCountStage => __aggregateCountStage;
-
-        /// <summary>
-        /// Gets the aggregate cursor result feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature AggregateCursorResult => __aggregateCursorResult;
-
-        /// <summary>
-        /// Gets the aggregate explain feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature AggregateExplain => __aggregateExplain;
 
         /// <summary>
         /// Gets the aggregate $facet stage feature.
@@ -192,12 +157,6 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the aggregate merge feature.
         /// </summary>
         public static Feature AggregateMerge => __aggregateMerge;
-
-        /// <summary>
-        /// Gets the aggregate out feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature AggregateOut => __aggregateOut;
 
         /// <summary>
         /// Gets the aggregate out to a different database feature.
@@ -260,12 +219,6 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature CreateIndexCommitQuorum => __createIndexCommitQuorum;
 
         /// <summary>
-        /// Gets the create indexes command feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature CreateIndexesCommand => __createIndexesCommand;
-
-        /// <summary>
         /// Gets the create indexes using insert operations feature.
         /// </summary>
         public static Feature CreateIndexesUsingInsertOperations => __createIndexesUsingInsertOperations;
@@ -299,12 +252,6 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the explain command feature.
         /// </summary>
         public static Feature ExplainCommand => __explainCommand;
-
-        /// <summary>
-        /// Gets the fail points feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature FailPoints => __failPoints;
 
         /// <summary>
         /// Gets the fail points block connection feature.
@@ -443,12 +390,6 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature MaxStaleness => __maxStaleness;
 
         /// <summary>
-        /// Gets the maximum time feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature MaxTime => __maxTime;
-
-        /// <summary>
         /// Gets the mmapv1 storage engine feature.
         /// </summary>
         public static Feature MmapV1StorageEngine => __mmapV1StorageEngine;
@@ -482,12 +423,6 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the scram sha256 authentication feature.
         /// </summary>
         public static Feature ScramSha256Authentication => __scramSha256Authentication;
-
-        /// <summary>
-        /// Gets the server extracts username from X509 certificate feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature ServerExtractsUsernameFromX509Certificate => __serverExtractsUsernameFromX509Certificate;
 
         /// <summary>
         /// Gets the server returns resumableChangeStream label feature.
@@ -536,12 +471,6 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature Transactions => __transactions;
 
         /// <summary>
-        /// Gets the user management commands feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature UserManagementCommands => __userManagementCommands;
-
-        /// <summary>
         /// Gets the views feature.
         /// </summary>
         public static Feature Views => __views;
@@ -550,12 +479,6 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the wildcard indexes feature.
         /// </summary>
         public static Feature WildcardIndexes => __wildcardIndexes;
-
-        /// <summary>
-        /// Gets the write commands feature.
-        /// </summary>
-        [Obsolete("This property will be removed in a later release.")]
-        public static Feature WriteCommands => __writeCommands;
         #endregion
 
         private readonly string _name;

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -112,6 +112,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the aggregate feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature Aggregate => __aggregate;
 
         /// <summary>
@@ -127,6 +128,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the aggregate allow disk use feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature AggregateAllowDiskUse => __aggregateAllowDiskUse;
 
         /// <summary>
@@ -147,11 +149,13 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the aggregate cursor result feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature AggregateCursorResult => __aggregateCursorResult;
 
         /// <summary>
         /// Gets the aggregate explain feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature AggregateExplain => __aggregateExplain;
 
         /// <summary>
@@ -192,6 +196,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the aggregate out feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature AggregateOut => __aggregateOut;
 
         /// <summary>
@@ -257,6 +262,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the create indexes command feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature CreateIndexesCommand => __createIndexesCommand;
 
         /// <summary>
@@ -297,6 +303,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the fail points feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature FailPoints => __failPoints;
 
         /// <summary>
@@ -438,6 +445,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the maximum time feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature MaxTime => __maxTime;
 
         /// <summary>
@@ -478,6 +486,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the server extracts username from X509 certificate feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature ServerExtractsUsernameFromX509Certificate => __serverExtractsUsernameFromX509Certificate;
 
         /// <summary>
@@ -529,6 +538,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the user management commands feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature UserManagementCommands => __userManagementCommands;
 
         /// <summary>
@@ -544,6 +554,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the write commands feature.
         /// </summary>
+        [Obsolete("This property will be removed in a later release.")]
         public static Feature WriteCommands => __writeCommands;
         #endregion
 
@@ -624,6 +635,17 @@ namespace MongoDB.Driver.Core.Misc
                 var errorMessage = _notSupportedMessage ?? $"Server version {serverVersion} does not support the {_name} feature.";
                 throw new NotSupportedException(errorMessage);
             }
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            var message = $"First supported version: {_firstSupportedVersion}";
+            if (_supportRemovedVersion != null)
+            {
+                message += $", Support removed in: {_supportRemovedVersion}";
+            }
+            return message;
         }
 
         private SemanticVersion VersionBefore(SemanticVersion version)

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -563,12 +563,12 @@ namespace MongoDB.Driver.Core.Misc
         /// <inheritdoc/>
         public override string ToString()
         {
-            var message = $"First supported version: {_firstSupportedVersion}";
+            var message = $"{_name} feature added in {_firstSupportedVersion}";
             if (_supportRemovedVersion != null)
             {
-                message += $", Support removed in: {_supportRemovedVersion}";
+                message += $" and removed in {_supportRemovedVersion}";
             }
-            return message;
+            return $"{message}.";
         }
 
         private SemanticVersion VersionBefore(SemanticVersion version)

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkWriteOperationResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkWriteOperationResult.cs
@@ -71,7 +71,7 @@ namespace MongoDB.Driver.Core.Operations
         /// Gets a value indicating whether the modified count is available.
         /// </summary>
         /// <remarks>
-        /// The modified count is only available when all servers have been upgraded to 2.6 or above.
+        /// The available modified count.
         /// </remarks>
         /// <value>
         /// <c>true</c> if the modified count is available; otherwise, <c>false</c>.

--- a/src/MongoDB.Driver/BulkWriteResult.cs
+++ b/src/MongoDB.Driver/BulkWriteResult.cs
@@ -58,7 +58,7 @@ namespace MongoDB.Driver
         /// Gets a value indicating whether the modified count is available.
         /// </summary>
         /// <remarks>
-        /// The modified count is only available when all servers have been upgraded to 2.6 or above.
+        /// The available modified count.
         /// </remarks>
         public abstract bool IsModifiedCountAvailable { get; }
 

--- a/src/MongoDB.Driver/ReplaceOneResult.cs
+++ b/src/MongoDB.Driver/ReplaceOneResult.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver
         /// Gets a value indicating whether the modified count is available.
         /// </summary>
         /// <remarks>
-        /// The modified count is only available when all servers have been upgraded to 2.6 or above.
+        /// The available modified count.
         /// </remarks>
         public abstract bool IsModifiedCountAvailable { get; }
 

--- a/src/MongoDB.Driver/UpdateResult.cs
+++ b/src/MongoDB.Driver/UpdateResult.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver
         /// Gets a value indicating whether the modified count is available.
         /// </summary>
         /// <remarks>
-        /// The modified count is only available when all servers have been upgraded to 2.6 or above.
+        /// The available modified count.
         /// </remarks>
         public abstract bool IsModifiedCountAvailable { get; }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/AuthenticationHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/AuthenticationHelperTests.cs
@@ -56,7 +56,7 @@ namespace MongoDB.Driver.Core.Authentication
             var description = new ConnectionDescription(
                 new ConnectionId(new ServerId(new ClusterId(), new DnsEndPoint("localhost", 27017))),
                 new HelloResult(new BsonDocument("ok", 1)),
-                new BuildInfoResult(new BsonDocument("version", "2.8.0")));
+                new BuildInfoResult(new BsonDocument("version", "3.6.0")));
             var serverApi = new ServerApi(ServerApiVersion.V1, true, true);
 
             var mockAuthenticator = new Mock<IAuthenticator>();
@@ -90,7 +90,7 @@ namespace MongoDB.Driver.Core.Authentication
             var description = new ConnectionDescription(
                 new ConnectionId(new ServerId(new ClusterId(), new DnsEndPoint("localhost", 27017))),
                 new HelloResult(new BsonDocument("ok", 1).Add("setName", "rs").Add("arbiterOnly", true)),
-                new BuildInfoResult(new BsonDocument("version", "2.8.0")));
+                new BuildInfoResult(new BsonDocument("version", "3.6.0")));
             var serverApi = new ServerApi(ServerApiVersion.V1, true, true);
 
             var mockAuthenticator = new Mock<IAuthenticator>();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoDBCRAuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoDBCRAuthenticatorTests.cs
@@ -38,10 +38,6 @@ namespace MongoDB.Driver.Core.Authentication
             new ConnectionId(__serverId),
             new HelloResult(new BsonDocument("ok", 1).Add(OppressiveLanguageConstants.LegacyHelloResponseIsWritablePrimaryFieldName, 1)),
             new BuildInfoResult(new BsonDocument("version", "4.7.0")));
-        private static readonly ConnectionDescription __descriptionQueryWireProtocol = new ConnectionDescription(
-            new ConnectionId(__serverId),
-            new HelloResult(new BsonDocument("ok", 1).Add(OppressiveLanguageConstants.LegacyHelloResponseIsWritablePrimaryFieldName, 1)),
-            new BuildInfoResult(new BsonDocument("version", "2.6.0")));
 
         [Fact]
         public void Constructor_should_throw_an_ArgumentNullException_when_credential_is_null()
@@ -63,18 +59,19 @@ namespace MongoDB.Driver.Core.Authentication
             var subject = new MongoDBCRAuthenticator(__credential);
 #pragma warning restore 618
 
-            var reply = MessageHelper.BuildNoDocumentsReturnedReply<RawBsonDocument>();
+            var commandResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson("{ }"));
             var connection = new MockConnection(__serverId);
-            connection.EnqueueReplyMessage(reply);
+            connection.EnqueueCommandResponseMessage(commandResponse);
+            connection.Description = __descriptionCommandWireProtocol;
 
             Action act;
             if (async)
             {
-                act = () => subject.AuthenticateAsync(connection, __descriptionQueryWireProtocol, CancellationToken.None).GetAwaiter().GetResult();
+                act = () => subject.AuthenticateAsync(connection, __descriptionCommandWireProtocol, CancellationToken.None).GetAwaiter().GetResult();
             }
             else
             {
-                act = () => subject.Authenticate(connection, __descriptionQueryWireProtocol, CancellationToken.None);
+                act = () => subject.Authenticate(connection, __descriptionCommandWireProtocol, CancellationToken.None);
             }
 
             act.ShouldThrow<MongoAuthenticationException>();
@@ -90,25 +87,26 @@ namespace MongoDB.Driver.Core.Authentication
             var subject = new MongoDBCRAuthenticator(__credential);
 #pragma warning restore 618
 
-            var getNonceReply = MessageHelper.BuildReply<RawBsonDocument>(
+            var getNonceCommandResponse = MessageHelper.BuildCommandResponse(
                 RawBsonDocumentHelper.FromJson("{nonce: \"2375531c32080ae8\", ok: 1}"));
-            var authenticateReply = MessageHelper.BuildReply<RawBsonDocument>(
+            var authenticateCommandResponse = MessageHelper.BuildCommandResponse(
                 RawBsonDocumentHelper.FromJson("{ok: 1}"));
 
             var connection = new MockConnection(__serverId);
-            connection.EnqueueReplyMessage(getNonceReply);
-            connection.EnqueueReplyMessage(authenticateReply);
+            connection.EnqueueCommandResponseMessage(getNonceCommandResponse);
+            connection.EnqueueCommandResponseMessage(authenticateCommandResponse);
+            connection.Description = __descriptionCommandWireProtocol;
 
             var expectedRequestId = RequestMessage.CurrentGlobalRequestId + 1;
 
             Action act;
             if (async)
             {
-                act = () => subject.AuthenticateAsync(connection, __descriptionQueryWireProtocol, CancellationToken.None).GetAwaiter().GetResult();
+                act = () => subject.AuthenticateAsync(connection, __descriptionCommandWireProtocol, CancellationToken.None).GetAwaiter().GetResult();
             }
             else
             {
-                act = () => subject.Authenticate(connection, __descriptionQueryWireProtocol, CancellationToken.None);
+                act = () => subject.Authenticate(connection, __descriptionCommandWireProtocol, CancellationToken.None);
             }
 
             act.ShouldNotThrow();
@@ -122,8 +120,8 @@ namespace MongoDB.Driver.Core.Authentication
             actualRequestId0.Should().BeInRange(expectedRequestId, expectedRequestId + 10);
             actualRequestId1.Should().BeInRange(actualRequestId0 + 1, actualRequestId0 + 11);
 
-            sentMessages[0].Should().Be("{opcode: \"query\", requestId: " + actualRequestId0 + ", database: \"source\", collection: \"$cmd\", batchSize: -1, secondaryOk: true, query: {getnonce: 1}}");
-            sentMessages[1].Should().Be("{opcode: \"query\", requestId: " + actualRequestId1 + ", database: \"source\", collection: \"$cmd\", batchSize: -1, secondaryOk: true, query: {authenticate: 1, user: \"user\", nonce: \"2375531c32080ae8\", key: \"21742f26431831d5cfca035a08c5bdf6\"}}");
+            sentMessages[0].Should().Be("{ \"opcode\" : \"opmsg\", \"requestId\" : " + actualRequestId0 + ", \"responseTo\" : 0, \"sections\" : [{ \"payloadType\" : 0, \"document\" : { \"getnonce\" : 1, \"$db\" : \"source\" } }] }");
+            sentMessages[1].Should().Be("{ \"opcode\" : \"opmsg\", \"requestId\" : " + actualRequestId1 + ", \"responseTo\" : 0, \"sections\" : [{ \"payloadType\" : 0, \"document\" : { \"authenticate\" : 1, \"user\" : \"user\", \"nonce\" : \"2375531c32080ae8\", \"key\" : \"21742f26431831d5cfca035a08c5bdf6\", \"$db\" : \"source\" } }] }");
         }
 
         [Theory]
@@ -169,67 +167,6 @@ namespace MongoDB.Driver.Core.Authentication
             var expectedServerApiString = useServerApi ? ", apiVersion : \"1\", apiStrict : true, apiDeprecationErrors : true" : "";
             sentMessages[0].Should().Be($"{{ opcode : \"opmsg\", requestId : {actualRequestId0}, responseTo : 0, sections : [ {{ payloadType : 0, document : {{ getnonce : 1, $db : \"source\"{expectedServerApiString} }} }} ] }}");
             sentMessages[1].Should().Be($"{{ opcode : \"opmsg\", requestId : {actualRequestId1}, responseTo : 0, sections : [ {{ payloadType : 0, document : {{ authenticate : 1, user : \"user\", nonce : \"2375531c32080ae8\", key : \"21742f26431831d5cfca035a08c5bdf6\", $db : \"source\"{expectedServerApiString} }} }} ] }}");
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        public void Authenticate_should_send_serverApi_with_command_wire_protocol_if_serverApi_is_provided(
-            [Values(false, true)] bool useServerApi,
-            [Values(false, true)] bool async)
-        {
-            var serverApi = useServerApi ? new ServerApi(ServerApiVersion.V1, true, true) : null;
-
-#pragma warning disable 618
-            var subject = new MongoDBCRAuthenticator(__credential, serverApi);
-#pragma warning restore 618
-
-            var connection = new MockConnection(__serverId);
-            var getNonceReply = RawBsonDocumentHelper.FromJson("{nonce: \"2375531c32080ae8\", ok: 1}");
-            var authenticateReply = RawBsonDocumentHelper.FromJson("{ok: 1}");
-            if (useServerApi)
-            {
-                connection.EnqueueCommandResponseMessage(MessageHelper.BuildCommandResponse(getNonceReply));
-                connection.EnqueueCommandResponseMessage(MessageHelper.BuildCommandResponse(authenticateReply));
-            }
-            else
-            {
-                connection.EnqueueReplyMessage(MessageHelper.BuildReply(getNonceReply));
-                connection.EnqueueReplyMessage(MessageHelper.BuildReply(authenticateReply));
-            }
-
-            connection.Description = __descriptionQueryWireProtocol;
-
-            var expectedRequestId = RequestMessage.CurrentGlobalRequestId + 1;
-
-            if (async)
-            {
-                subject.AuthenticateAsync(connection, __descriptionQueryWireProtocol, CancellationToken.None).GetAwaiter().GetResult();
-            }
-            else
-            {
-                subject.Authenticate(connection, __descriptionQueryWireProtocol, CancellationToken.None);
-            }
-
-            SpinWait.SpinUntil(() => connection.GetSentMessages().Count >= 2, TimeSpan.FromSeconds(5)).Should().BeTrue();
-
-            var sentMessages = MessageHelper.TranslateMessagesToBsonDocuments(connection.GetSentMessages());
-            sentMessages.Count.Should().Be(2);
-
-            var actualRequestId0 = sentMessages[0]["requestId"].AsInt32;
-            var actualRequestId1 = sentMessages[1]["requestId"].AsInt32;
-            actualRequestId0.Should().BeInRange(expectedRequestId, expectedRequestId + 10);
-            actualRequestId1.Should().BeInRange(actualRequestId0 + 1, actualRequestId0 + 11);
-
-            if (useServerApi)
-            {
-                sentMessages[0].Should().Be($"{{opcode : \"opmsg\", requestId : {actualRequestId0}, responseTo : 0, sections : [{{ \"payloadType\" : 0, \"document\" : {{ \"getnonce\" : 1, \"$db\" : \"source\", \"apiVersion\" : \"1\", \"apiStrict\" : true, \"apiDeprecationErrors\" : true }} }}]}}");
-                sentMessages[1].Should().Be($"{{opcode : \"opmsg\", requestId : {actualRequestId1}, responseTo : 0, sections : [{{ \"payloadType\" : 0, \"document\" : {{ \"authenticate\" : 1, \"user\" : \"user\", \"nonce\" : \"2375531c32080ae8\", \"key\" : \"21742f26431831d5cfca035a08c5bdf6\", \"$db\" : \"source\", \"apiVersion\" : \"1\", \"apiStrict\" : true, \"apiDeprecationErrors\" : true }} }}]}}");
-            }
-            else
-            {
-                sentMessages[0].Should().Be($"{{ opcode : \"query\", requestId : {actualRequestId0}, database : \"source\", collection : \"$cmd\", batchSize : -1, secondaryOk : true, query : {{ getnonce : 1 }} }}");
-                sentMessages[1].Should().Be($"{{ opcode : \"query\", requestId : {actualRequestId1}, database : \"source\", collection : \"$cmd\", batchSize : -1, secondaryOk : true, query : {{ authenticate : 1, user : \"user\", nonce : \"2375531c32080ae8\", key : \"21742f26431831d5cfca035a08c5bdf6\" }} }}");
-            }
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
@@ -1232,7 +1232,7 @@ namespace MongoDB.Driver.Core.Clusters
                 state: ServerState.Connected,
                 tags: null,
                 type: serverType,
-                version: new SemanticVersion(2, 6, 3),
+                version: new SemanticVersion(3, 6, 0),
                 wireVersionRange: new Range<int>(0, int.MaxValue));
 
             var currentClusterDescription = cluster.Description;

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -56,7 +56,7 @@ namespace MongoDB.Driver.Core.Connections
             var serverId = new ServerId(new ClusterId(), _endPoint);
             var connectionId = new ConnectionId(serverId);
             var helloResult = new HelloResult(new BsonDocument { { "ok", 1 }, { "maxMessageSizeBytes", 48000000 } });
-            var buildInfoResult = new BuildInfoResult(new BsonDocument { { "ok", 1 }, { "version", "2.6.3" } });
+            var buildInfoResult = new BuildInfoResult(new BsonDocument { { "ok", 1 }, { "version", "3.6.0" } });
             _connectionDescription = new ConnectionDescription(connectionId, helloResult, buildInfoResult);
 
             _mockConnectionInitializer = new Mock<IConnectionInitializer>();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BinaryConnection_CommandEventTests.cs
@@ -86,12 +86,12 @@ namespace MongoDB.Driver.Core.Connections
                 .Returns(() => Task.FromResult(new ConnectionDescription(
                     new ConnectionId(serverId),
                     new HelloResult(new BsonDocument()),
-                    new BuildInfoResult(new BsonDocument("version", "2.6.3")))));
+                    new BuildInfoResult(new BsonDocument("version", "3.6.0")))));
             _mockConnectionInitializer.Setup(i => i.AuthenticateAsync(It.IsAny<IConnection>(), It.IsAny<ConnectionDescription>(), CancellationToken.None))
                 .Returns(() => Task.FromResult(new ConnectionDescription(
                     new ConnectionId(serverId),
                     new HelloResult(new BsonDocument()),
-                    new BuildInfoResult(new BsonDocument("version", "2.6.3")))));
+                    new BuildInfoResult(new BsonDocument("version", "3.6.0")))));
 
             _subject = new BinaryConnection(
                 serverId: serverId,

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/BuildInfoResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/BuildInfoResultTests.cs
@@ -55,11 +55,11 @@ namespace MongoDB.Driver.Core.Connections
         {
             var doc = new BsonDocument
             {
-                { "version", "2.6.3" }
+                { "version", "3.6.0" }
             };
             var subject = new BuildInfoResult(doc);
 
-            subject.ServerVersion.Should().Be(new SemanticVersion(2, 6, 3));
+            subject.ServerVersion.Should().Be(new SemanticVersion(3, 6, 0));
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ClientDocumentHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ClientDocumentHelperTests.cs
@@ -44,7 +44,7 @@ namespace MongoDB.Driver.Core.Connections
         public void CreateClientDocument_with_args_should_return_expected_result(
             [Values(null, "app1", "app2")]
             string applicationName,
-            [Values("{ name : 'mongo-csharp-driver', version : '2.4.0' }", "{ name : 'mongo-csharp-driver', version : '2.4.1' }")]
+            [Values("{ name : 'mongo-csharp-driver', version : '3.6.0' }", "{ name : 'mongo-csharp-driver', version : '3.6.1' }")]
             string driverDocumentString,
             [Values(
                 "{ type : 'Windows', name : 'Windows 10', architecture : 'x86_64', version : '10.0' }",
@@ -75,7 +75,7 @@ namespace MongoDB.Driver.Core.Connections
         [Theory]
         [ParameterAttributeData]
         public void CreateDriverDocument_with_args_should_return_expected_result(
-            [Values("2.4.0", "2.4.1")]
+            [Values("3.6.0", "3.6.1")]
             string driverVersion)
         {
             var result = ClientDocumentHelper.CreateDriverDocument(driverVersion);
@@ -184,7 +184,7 @@ namespace MongoDB.Driver.Core.Connections
                 { "driver", new BsonDocument
                     {
                         { "name", "mongo-csharp-driver" },
-                        { "version", "2.4.x" }
+                        { "version", "3.6.x" }
                     }
                 },
                 { "os", new BsonDocument

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionDescriptionTests.cs
@@ -28,7 +28,7 @@ namespace MongoDB.Driver.Core.Connections
     public class ConnectionDescriptionTests
     {
         private static readonly BuildInfoResult __buildInfoResult = new BuildInfoResult(BsonDocument.Parse(
-            "{ ok: 1, version: \"2.6.3\" }"
+            "{ ok: 1, version: \"3.6.0\" }"
         ));
 
         private static readonly IEnumerable<CompressorType> __compressors = new[] { CompressorType.Zlib, CompressorType.ZStandard };
@@ -92,8 +92,8 @@ namespace MongoDB.Driver.Core.Connections
             var connectionId2 = new ConnectionId(new ServerId(new ClusterId(), new DnsEndPoint("localhost", 27018)), 10);
             var helloResult1 = new HelloResult(new BsonDocument("x", 1));
             var helloResult2 = new HelloResult(new BsonDocument("x", 2));
-            var buildInfoResult1 = new BuildInfoResult(new BsonDocument("version", "2.6.3"));
-            var buildInfoResult2 = new BuildInfoResult(new BsonDocument("version", "2.4.10"));
+            var buildInfoResult1 = new BuildInfoResult(new BsonDocument("version", "3.6.0"));
+            var buildInfoResult2 = new BuildInfoResult(new BsonDocument("version", "4.0.0"));
 
             var subject1 = new ConnectionDescription(connectionId1, helloResult1, buildInfoResult1);
             var subject2 = new ConnectionDescription(connectionId1, helloResult1, buildInfoResult1);
@@ -155,7 +155,7 @@ namespace MongoDB.Driver.Core.Connections
             var connectionId1 = new ConnectionId(serverId, 1);
             var connectionId2 = new ConnectionId(serverId, 1).WithServerValue(2);
             var helloResult = new HelloResult(new BsonDocument());
-            var buildInfoResult = new BuildInfoResult(new BsonDocument("version", "2.6.0"));
+            var buildInfoResult = new BuildInfoResult(new BsonDocument("version", "3.6.0"));
             var subject = new ConnectionDescription(connectionId1, helloResult, buildInfoResult);
 
             var result = subject.WithConnectionId(connectionId2);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -273,7 +273,7 @@ namespace MongoDB.Driver.Core.Connections
             var legacyHelloReply = MessageHelper.BuildReply<RawBsonDocument>(
                 RawBsonDocumentHelper.FromJson($"{{ ok: 1, compression: ['{compressorType}'] }}"));
             var buildInfoReply = MessageHelper.BuildReply<RawBsonDocument>(
-                RawBsonDocumentHelper.FromJson("{ ok: 1, version: \"2.6.3\" }"));
+                RawBsonDocumentHelper.FromJson("{ ok: 1, version: \"3.6.0\" }"));
             var gleReply = MessageHelper.BuildReply<RawBsonDocument>(
                 RawBsonDocumentHelper.FromJson("{ ok: 1, connectionId: 10 }"));
 
@@ -285,7 +285,7 @@ namespace MongoDB.Driver.Core.Connections
             var subject = CreateSubject();
             var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
-            result.ServerVersion.Should().Be(new SemanticVersion(2, 6, 3));
+            result.ServerVersion.Should().Be(new SemanticVersion(3, 6, 0));
             result.ConnectionId.ServerValue.Should().Be(10);
             result.AvailableCompressors.Count.Should().Be(1);
             result.AvailableCompressors.Should().Contain(ToCompressorTypeEnum(compressorType));

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloHelperTests.cs
@@ -42,7 +42,7 @@ namespace MongoDB.Driver.Core.Connections
         [Theory]
         [ParameterAttributeData]
         public void AddClientDocumentToCommand_with_custom_document_should_return_expected_result(
-            [Values("{ client : { driver : 'dotnet', version : '2.4.0' }, os : { type : 'Windows' } }")]
+            [Values("{ client : { driver : 'dotnet', version : '3.6.0' }, os : { type : 'Windows' } }")]
             string clientDocumentString)
         {
             var clientDocument = BsonDocument.Parse(clientDocumentString);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Helpers/ServerDescriptionHelper.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Helpers/ServerDescriptionHelper.cs
@@ -37,7 +37,7 @@ namespace MongoDB.Driver.Core.Helpers
                 state: ServerState.Connected,
                 tags: tags,
                 type: serverType,
-                version: new SemanticVersion(2, 6, 3),
+                version: new SemanticVersion(3, 6, 0),
                 wireVersionRange: wireVersionRange ?? new Range<int>(6, 14));
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateOperationTests.cs
@@ -304,8 +304,7 @@ namespace MongoDB.Driver.Core.Operations
         public void CreateCommand_should_return_the_expected_result()
         {
             var subject = new AggregateOperation<BsonDocument>(_collectionNamespace, __pipeline, __resultSerializer, _messageEncoderSettings);
-            var serverVersion = Feature.AggregateCursorResult.FirstSupportedVersion;
-            var connectionDescription = OperationTestHelper.CreateConnectionDescription(serverVersion);
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription();
             var session = OperationTestHelper.CreateSession();
 
             var result = subject.CreateCommand(connectionDescription, session);
@@ -330,8 +329,7 @@ namespace MongoDB.Driver.Core.Operations
                 AllowDiskUse = allowDiskUse
             };
 
-            var serverVersion = Feature.AggregateCursorResult.FirstSupportedVersion;
-            var connectionDescription = OperationTestHelper.CreateConnectionDescription(serverVersion);
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription();
 
             var session = OperationTestHelper.CreateSession();
 
@@ -357,8 +355,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 BatchSize = batchSize
             };
-            var serverVersion = Feature.AggregateCursorResult.FirstSupportedVersion;
-            var connectionDescription = OperationTestHelper.CreateConnectionDescription(serverVersion);
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription();
             var session = OperationTestHelper.CreateSession();
 
             var result = subject.CreateCommand(connectionDescription, session);
@@ -512,8 +509,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 MaxTime = TimeSpan.FromTicks(maxTimeTicks)
             };
-            var serverVersion = Feature.AggregateCursorResult.FirstSupportedVersion;
-            var connectionDescription = OperationTestHelper.CreateConnectionDescription(serverVersion);
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription();
             var session = OperationTestHelper.CreateSession();
 
             var result = subject.CreateCommand(connectionDescription, session);
@@ -598,33 +594,6 @@ namespace MongoDB.Driver.Core.Operations
                 { "pipeline", new BsonArray(__pipeline) },
                 { "readConcern", expectedReadConcernDocument },
                 { "cursor", new BsonDocument() }
-            };
-            result.Should().Be(expectedResult);
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        public void CreateCommand_should_return_the_expected_result_when_UseCursor_is_set(
-            [Values(null, false, true)]
-            bool? useCursor)
-        {
-            var subject = new AggregateOperation<BsonDocument>(_collectionNamespace, __pipeline, __resultSerializer, _messageEncoderSettings)
-            {
-#pragma warning disable 618
-                UseCursor = useCursor
-#pragma warning restore 618
-            };
-            var serverVersion = Feature.AggregateCursorResult.FirstSupportedVersion;
-            var connectionDescription = OperationTestHelper.CreateConnectionDescription(serverVersion);
-            var session = OperationTestHelper.CreateSession();
-
-            var result = subject.CreateCommand(connectionDescription, session);
-
-            var expectedResult = new BsonDocument
-            {
-                { "aggregate", _collectionNamespace.CollectionName },
-                { "pipeline", new BsonArray(__pipeline) },
-                { "cursor", () => new BsonDocument(), useCursor.GetValueOrDefault(true) }
             };
             result.Should().Be(expectedResult);
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateToCollectionOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateToCollectionOperationTests.cs
@@ -554,7 +554,6 @@ namespace MongoDB.Driver.Core.Operations
             switch (lastStageName)
             {
                 case "$out":
-                    RequireServer.Check().Supports(Feature.AggregateOut);
                     if (usingDifferentOutputDatabase)
                     {
                         RequireServer.Check().Supports(Feature.AggregateOutToDifferentDatabase);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ListCollectionsOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ListCollectionsOperationTests.cs
@@ -205,7 +205,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)]
             bool async)
         {
-            RequireServer.Check().VersionLessThan("2.7.0");
+            RequireServer.Check();
             var filter = new BsonDocument("name", new BsonRegularExpression("^abc"));
             var subject = new ListCollectionsOperation(_databaseNamespace, _messageEncoderSettings)
             {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ListCollectionsOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ListCollectionsOperationTests.cs
@@ -201,24 +201,6 @@ namespace MongoDB.Driver.Core.Operations
 
         [SkippableTheory]
         [ParameterAttributeData]
-        public void Execute_should_throw_when_filter_name_is_not_a_string_and_connected_to_older_server(
-            [Values(false, true)]
-            bool async)
-        {
-            RequireServer.Check();
-            var filter = new BsonDocument("name", new BsonRegularExpression("^abc"));
-            var subject = new ListCollectionsOperation(_databaseNamespace, _messageEncoderSettings)
-            {
-                Filter = filter
-            };
-
-            Action action = () => ExecuteOperation(subject, async);
-
-            action.ShouldThrow<NotSupportedException>();
-        }
-
-        [SkippableTheory]
-        [ParameterAttributeData]
         public void Execute_should_send_session_id_when_supported(
             [Values(false, true)] bool async)
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ListCollectionsUsingQueryOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ListCollectionsUsingQueryOperationTests.cs
@@ -180,7 +180,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)]
             bool async)
         {
-            RequireServer.Check().VersionLessThan("2.7.0").ClusterTypes(ClusterType.Standalone, ClusterType.ReplicaSet);
+            RequireServer.Check().ClusterTypes(ClusterType.Standalone, ClusterType.ReplicaSet);
             var filter = new BsonDocument("name", new BsonRegularExpression("^abc"));
             var subject = new ListCollectionsUsingQueryOperation(_databaseNamespace, _messageEncoderSettings)
             {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerDescriptionTests.cs
@@ -77,8 +77,8 @@ namespace MongoDB.Driver.Core.Servers
             var state = ServerState.Connected;
             var tags = new TagSet(new[] { new Tag("x", "a") });
             var type = ServerType.ReplicaSetPrimary;
-            var version = new SemanticVersion(2, 6, 3);
-            var wireVersionRange = new Range<int>(2, 3);
+            var version = new SemanticVersion(3, 6, 0);
+            var wireVersionRange = new Range<int>(6, 14);
 
             var subject = new ServerDescription(
                 __serverId,
@@ -180,8 +180,8 @@ namespace MongoDB.Driver.Core.Servers
             var state = ServerState.Connected;
             var tags = new TagSet(new[] { new Tag("x", "a") });
             var type = ServerType.ReplicaSetPrimary;
-            var version = new SemanticVersion(2, 6, 3);
-            var wireVersionRange = new Range<int>(2, 3);
+            var version = new SemanticVersion(3, 6, 0);
+            var wireVersionRange = new Range<int>(6, 14);
 
             var subject = new ServerDescription(
                 serverId,
@@ -331,8 +331,8 @@ namespace MongoDB.Driver.Core.Servers
             var state = ServerState.Connected;
             var tags = new TagSet(new[] { new Tag("x", "a") });
             var type = ServerType.ReplicaSetPrimary;
-            var version = new SemanticVersion(2, 6, 3);
-            var wireVersionRange = new Range<int>(2, 3);
+            var version = new SemanticVersion(3, 6, 0);
+            var wireVersionRange = new Range<int>(6, 14);
 
             var subject = new ServerDescription(
                 __serverId,
@@ -421,8 +421,8 @@ namespace MongoDB.Driver.Core.Servers
             var state = ServerState.Connected;
             var tags = new TagSet(new[] { new Tag("x", "a") });
             var type = ServerType.ReplicaSetPrimary;
-            var version = new SemanticVersion(2, 6, 3);
-            var wireVersionRange = new Range<int>(0, 2);
+            var version = new SemanticVersion(3, 6, 0);
+            var wireVersionRange = new Range<int>(6, 14);
 
             var subject = new ServerDescription(
                 __serverId,

--- a/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3173Tests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3173Tests.cs
@@ -282,7 +282,7 @@ namespace MongoDB.Driver.Core.Tests.Jira
             bool streamable)
         {
             var connectionId = new ConnectionId(serverId);
-            var serverVersion = streamable ? "4.4" : "2.6";
+            var serverVersion = streamable ? "4.4" : "3.6";
             var helloDocument = new BsonDocument
             {
                 { "ok", 1 },
@@ -311,7 +311,7 @@ namespace MongoDB.Driver.Core.Tests.Jira
             }
             else
             {
-                commandResponseAction = () => { return MessageHelper.BuildReply(new RawBsonDocument(helloDocument.ToBson())); };
+                commandResponseAction = () => { return MessageHelper.BuildCommandResponse(new RawBsonDocument(helloDocument.ToBson())); };
             }
 
             if (isHealthy)

--- a/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3302Tests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3302Tests.cs
@@ -277,7 +277,7 @@ namespace MongoDB.Driver.Core.Tests.Jira
             ServerId serverId)
         {
             var connectionId = new ConnectionId(serverId);
-            var serverVersion = "2.6";
+            var serverVersion = "3.6";
             var baseDocument = new BsonDocument
             {
                 { "ok", 1 },
@@ -312,7 +312,7 @@ namespace MongoDB.Driver.Core.Tests.Jira
             {
                 var helloDocument = primaries.Contains(serverId) ? primaryDocument : secondaryDocument;
 
-                ResponseMessage result = MessageHelper.BuildReply(new RawBsonDocument(helloDocument.ToBson()));
+                ResponseMessage result = MessageHelper.BuildCommandResponse(new RawBsonDocument(helloDocument.ToBson()));
                 return Task.FromResult(result);
             }
 

--- a/tests/MongoDB.Driver.Examples/UpdatePrimer.cs
+++ b/tests/MongoDB.Driver.Examples/UpdatePrimer.cs
@@ -16,8 +16,6 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Bson;
-using MongoDB.Bson.TestHelpers.XunitExtensions;
-using MongoDB.Driver.Core;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using Xunit;
 
@@ -28,7 +26,7 @@ namespace MongoDB.Driver.Examples
         [SkippableFact]
         public async Task UpdateTopLevelFields()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             AltersCollection();
 
             // @begin: update-top-level-fields
@@ -79,7 +77,7 @@ namespace MongoDB.Driver.Examples
         [SkippableFact]
         public async Task UpdateMultipleDocuments()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             AltersCollection();
 
             // @begin: update-multiple-documents

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoCollectionTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoCollectionTests.cs
@@ -211,7 +211,6 @@ namespace MongoDB.Driver.Tests
             switch (lastStageName)
             {
                 case "$out":
-                    RequireServer.Check().Supports(Feature.AggregateOut);
                     BsonValue outValue;
                     if (usingDifferentOutputDatabase)
                     {

--- a/tests/MongoDB.Driver.Tests/AuthenticationTests.cs
+++ b/tests/MongoDB.Driver.Tests/AuthenticationTests.cs
@@ -336,15 +336,7 @@ namespace MongoDB.Driver.Tests
             CreateX509DatabaseUser(DriverTestConfiguration.Client, userName);
 
             var settings = DriverTestConfiguration.GetClientSettings().Clone();
-            var serverVersion = CoreTestConfiguration.ServerVersion;
-            if (Feature.ServerExtractsUsernameFromX509Certificate.IsSupported(serverVersion))
-            {
-                settings.Credential = MongoCredential.CreateMongoX509Credential();
-            }
-            else
-            {
-                settings.Credential = MongoCredential.CreateMongoX509Credential(userName);
-            }
+            settings.Credential = MongoCredential.CreateMongoX509Credential();
             settings.SslSettings = settings.SslSettings.Clone();
             settings.SslSettings.ClientCertificates = new[] { clientCertificate };
 

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/MongoQueryableTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/MongoQueryableTests.cs
@@ -182,7 +182,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests
         [SkippableFact]
         public void Distinct_document_followed_by_where()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Distinct()
                 .Where(x => x.A == "Awesome");
@@ -196,7 +196,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests
         [SkippableFact]
         public void Distinct_document_preceded_by_select_where()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Select(x => new { x.A, x.B })
                 .Where(x => x.A == "Awesome")
@@ -212,7 +212,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests
         [SkippableFact]
         public void Distinct_document_preceded_by_where_select()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Where(x => x.A == "Awesome")
                 .Select(x => new { x.A, x.B })
@@ -227,7 +227,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests
         [SkippableFact]
         public void Distinct_field_preceded_by_where_select()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Where(x => x.A == "Awesome")
                 .Select(x => x.A)
@@ -242,7 +242,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests
         [SkippableFact]
         public void Distinct_field_preceded_by_select_where()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Select(x => x.A)
                 .Where(x => x == "Awesome")
@@ -937,7 +937,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests
         [SkippableFact]
         public void Select_method_with_predicated_any()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Select(x => x.G.Any(g => g.D == "Don't"));
 
@@ -1093,7 +1093,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests
         [SkippableFact]
         public void Select_method_computed_array()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Select(x => x.M.Select(i => i + 1));
 
@@ -1105,7 +1105,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests
         [SkippableFact]
         public void Select_syntax_computed_array()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = from x in CreateQuery()
                         select x.M.Select(i => i + 1);
 

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/Translators/AggregateProjectTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/Translators/AggregateProjectTranslatorTests.cs
@@ -91,7 +91,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_allElementsTrue()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.All(g => g.E.F > 30) });
 
@@ -103,7 +103,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_anyElementTrue()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.Any() });
 
@@ -115,7 +115,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_anyElementTrue_with_predicate()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.Any(g => g.E.F > 40) });
 
@@ -127,7 +127,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_anyElementTrue_using_Contains()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.L.Contains(5) });
 
@@ -139,7 +139,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_anyElementTrue_using_Contains_on_a_local_collection()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var local = new[] { 11, 33, 55 };
             var result = Project(x => new { Result = local.Contains(x.C.E.F) });
@@ -384,7 +384,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_concat()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.4.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.A + x.B });
 
@@ -396,7 +396,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_concat_flattened()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.4.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.A + " " + x.B });
 
@@ -694,7 +694,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_literal_when_a_constant_strings_begins_with_a_dollar()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.A == "$1" });
 
@@ -754,7 +754,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_map_with_document()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.Select(g => g.D + "0") });
 
@@ -766,7 +766,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_map_with_value()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.C.E.I.Select(i => i + "0") });
 
@@ -802,7 +802,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_millisecond()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.4.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.J.Millisecond });
 
@@ -1050,7 +1050,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_size_greater_than_zero_from_any()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.M.Any() });
 
@@ -1062,7 +1062,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_size_from_an_array()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.M.Length });
 
@@ -1074,7 +1074,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_size_from_Count_extension_method()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.M.Count() });
 
@@ -1086,7 +1086,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_size_from_LongCount_extension_method()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.M.LongCount() });
 
@@ -1098,7 +1098,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_size_from_Count_property_on_Generic_ICollection()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.L.Count });
 
@@ -1110,7 +1110,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_difference()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.C.E.I.Except(new[] { "it", "not in here" }) });
 
@@ -1122,7 +1122,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_difference_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = new[] { "it", "not in here" }.Except(x.C.E.I) });
 
@@ -1134,7 +1134,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_equals()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.L.SetEquals(new[] { 1, 3, 5 }) });
 
@@ -1146,7 +1146,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_equals_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var set = new HashSet<int>(new[] { 1, 3, 5 });
 
             var result = Project(x => new { Result = set.SetEquals(x.L) });
@@ -1159,7 +1159,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_intersection()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.C.E.I.Intersect(new[] { "it", "not in here" }) });
 
@@ -1171,7 +1171,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_intersection_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = new[] { "it", "not in here" }.Intersect(x.C.E.I) });
 
@@ -1183,7 +1183,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_is_subset()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.L.IsSubsetOf(new[] { 1, 3, 5 }) });
 
@@ -1195,7 +1195,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_is_subset_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var set = new HashSet<int>(new[] { 1, 3, 5 });
 
             var result = Project(x => new { Result = set.IsSubsetOf(x.L) });
@@ -1208,7 +1208,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_union()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.C.E.I.Union(new[] { "it", "not in here" }) });
 
@@ -1220,7 +1220,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_set_union_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = new[] { "it", "not in here" }.Union(x.C.E.I) });
 
@@ -1660,7 +1660,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Should_translate_array_projection_complex()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.Select(y => new { y.E.F, y.E.H }) });
 

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/Translators/PredicateTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/Translators/PredicateTranslatorTests.cs
@@ -480,7 +480,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
         [SkippableFact]
         public void Any_with_a_predicate_on_scalars()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             Assert(
                 x => x.C.E.I.Any(i => i.StartsWith("ick")),

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTestsOnLinq3/MongoQueryableTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTestsOnLinq3/MongoQueryableTests.cs
@@ -1035,7 +1035,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3
         [SkippableFact]
         public void Select_method_with_predicated_any()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Select(x => x.G.Any(g => g.D == "Don't"));
 
@@ -1191,7 +1191,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3
         [SkippableFact]
         public void Select_method_computed_array()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = CreateQuery()
                 .Select(x => x.M.Select(i => i + 1));
 
@@ -1203,7 +1203,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3
         [SkippableFact]
         public void Select_syntax_computed_array()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var query = from x in CreateQuery()
                         select x.M.Select(i => i + 1);
 

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTestsOnLinq3/Translators/AggregateProjectTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTestsOnLinq3/Translators/AggregateProjectTranslatorTests.cs
@@ -92,7 +92,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_allElementsTrue()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.All(g => g.E.F > 30) });
 
@@ -104,7 +104,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_anyElementTrue()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.Any() });
 
@@ -116,7 +116,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_anyElementTrue_with_predicate()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.Any(g => g.E.F > 40) });
 
@@ -128,7 +128,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_anyElementTrue_using_Contains()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.L.Contains(5) });
 
@@ -140,7 +140,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_anyElementTrue_using_Contains_on_a_local_collection()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var local = new[] { 11, 33, 55 };
             var result = Project(x => new { Result = local.Contains(x.C.E.F) });
@@ -385,7 +385,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_concat()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.4.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.A + x.B });
 
@@ -397,7 +397,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_concat_flattened()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.4.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.A + " " + x.B });
 
@@ -683,7 +683,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_literal_when_a_constant_strings_begins_with_a_dollar()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.A == "$1" });
 
@@ -743,7 +743,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_map_with_document()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.Select(g => g.D + "0") });
 
@@ -755,7 +755,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_map_with_value()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.C.E.I.Select(i => i + "0") });
 
@@ -791,7 +791,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_millisecond()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.4.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.J.Millisecond });
 
@@ -1136,7 +1136,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_size_greater_than_zero_from_any()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.M.Any() });
 
@@ -1148,7 +1148,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_size_from_an_array()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.M.Length });
 
@@ -1160,7 +1160,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_size_from_Count_extension_method()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.M.Count() });
 
@@ -1172,7 +1172,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_size_from_LongCount_extension_method()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.M.LongCount() });
 
@@ -1184,7 +1184,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_size_from_Count_property_on_Generic_ICollection()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.L.Count });
 
@@ -1196,7 +1196,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_difference()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.C.E.I.Except(new[] { "it", "not in here" }) });
 
@@ -1208,7 +1208,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_difference_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = new[] { "it", "not in here" }.Except(x.C.E.I) });
 
@@ -1220,7 +1220,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_equals()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.L.SetEquals(new[] { 1, 3, 5 }) });
 
@@ -1232,7 +1232,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_equals_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var set = new HashSet<int>(new[] { 1, 3, 5 });
 
             var result = Project(x => new { Result = set.SetEquals(x.L) });
@@ -1245,7 +1245,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_intersection()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.C.E.I.Intersect(new[] { "it", "not in here" }) });
 
@@ -1257,7 +1257,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_intersection_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = new[] { "it", "not in here" }.Intersect(x.C.E.I) });
 
@@ -1269,7 +1269,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_is_subset()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.L.IsSubsetOf(new[] { 1, 3, 5 }) });
 
@@ -1281,7 +1281,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_is_subset_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
             var set = new HashSet<int>(new[] { 1, 3, 5 });
 
             var result = Project(x => new { Result = set.IsSubsetOf(x.L) });
@@ -1294,7 +1294,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_union()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.C.E.I.Union(new[] { "it", "not in here" }) });
 
@@ -1306,7 +1306,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_set_union_reversed()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = new[] { "it", "not in here" }.Union(x.C.E.I) });
 
@@ -1744,7 +1744,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Should_translate_array_projection_complex()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             var result = Project(x => new { Result = x.G.Select(y => new { y.E.F, y.E.H }) });
 

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTestsOnLinq3/Translators/PredicateTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTestsOnLinq3/Translators/PredicateTranslatorTests.cs
@@ -482,7 +482,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
         [SkippableFact]
         public void Any_with_a_predicate_on_scalars()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("2.6.0");
+            RequireServer.Check();
 
             Assert(
                 x => x.C.E.I.Any(i => i.StartsWith("ick")),

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/FindOneAndReplaceTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/FindOneAndReplaceTest.cs
@@ -90,20 +90,6 @@ namespace MongoDB.Driver.Tests.Specifications.crud
         protected override void VerifyCollection(IMongoCollection<BsonDocument> collection, BsonArray expectedData)
         {
             var data = collection.FindSync("{}").ToList();
-
-            if (ClusterDescription.Servers[0].Version < new SemanticVersion(2, 6, 0) && _options.IsUpsert)
-            {
-                foreach (var doc in data)
-                {
-                    doc.Remove("_id");
-                }
-
-                foreach (var doc in expectedData.Cast<BsonDocument>())
-                {
-                    doc.Remove("_id");
-                }
-            }
-
             data.Should().BeEquivalentTo(expectedData);
         }
     }

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/ReplaceOneTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/ReplaceOneTest.cs
@@ -82,30 +82,12 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                 actualResult.ModifiedCount.Should().Be(expectedResult.ModifiedCount);
             }
             actualResult.MatchedCount.Should().Be(expectedResult.MatchedCount);
-
-            if (ClusterDescription.Servers[0].Version >= new SemanticVersion(2, 6, 0) || !_options.IsUpsert)
-            {
-                actualResult.UpsertedId.Should().Be(expectedResult.UpsertedId);
-            }
+            actualResult.UpsertedId.Should().Be(expectedResult.UpsertedId);
         }
 
         protected override void VerifyCollection(IMongoCollection<BsonDocument> collection, BsonArray expectedData)
         {
             var data = collection.FindSync("{}").ToList();
-
-            if (ClusterDescription.Servers[0].Version < new SemanticVersion(2, 6, 0) && _options.IsUpsert)
-            {
-                foreach (var doc in data)
-                {
-                    doc.Remove("_id");
-                }
-
-                foreach (var doc in expectedData.Cast<BsonDocument>())
-                {
-                    doc.Remove("_id");
-                }
-            }
-
             data.Should().BeEquivalentTo(expectedData);
         }
     }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/FindOneAndReplaceTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/FindOneAndReplaceTest.cs
@@ -90,16 +90,6 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes
             _serverVersion = collection.Database.Client.Cluster.Description.Servers[0].Version;
         }
 
-        protected override void VerifyCollectionContents(List<BsonDocument> actualContents, List<BsonDocument> expectedContents)
-        {
-            if (_serverVersion < new SemanticVersion(2, 6, 0) && _options.IsUpsert)
-            {
-                RemoveIds(actualContents);
-                RemoveIds(expectedContents);
-            }
-            base.VerifyCollectionContents(actualContents, expectedContents);
-        }
-
         protected override void VerifyResult(BsonDocument result)
         {
             _result.Should().Be(result);


### PR DESCRIPTION
Some notes:

1. I didn't touch legacy.
2. Changes (mostly in auth tests) not related to 2.6 directly are caused by changes in some test helpers where I removed using server 2.6

Full EG: https://evergreen.mongodb.com/version/61a15ca3d6d80a0f59f0c904