### PR TITLE
CSHARP-3996: Fix cleanup-test-resources on Linux and Macos.

### DIFF
--- a/evergreen/cleanup-test-resources.sh
+++ b/evergreen/cleanup-test-resources.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -o xtrace   # Write all commands first to stderr
 
 # Environment variables used as input:

--- a/evergreen/compile.sh
+++ b/evergreen/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail

--- a/evergreen/get-python-path.sh
+++ b/evergreen/get-python-path.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Find the version of python on the system.
 #
 # Environment variables used as input:

--- a/evergreen/publish.sh
+++ b/evergreen/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # DO NOT ECHO COMMANDS AS THEY CONTAIN SECRETS!
 

--- a/evergreen/run-atlas-connectivity-tests.sh
+++ b/evergreen/run-atlas-connectivity-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # DO NOT set xtrace
 set -o errexit  # Exit the script with error if any of the commands fail

--- a/evergreen/run-atlas-data-lake-test.sh
+++ b/evergreen/run-atlas-data-lake-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o xtrace
 set -o errexit  # Exit the script with error if any of the commands fail

--- a/evergreen/run-gssapi-auth-tests.sh
+++ b/evergreen/run-gssapi-auth-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Don't trace since the URI contains a password that shouldn't show up in the logs
 set -o errexit  # Exit the script with error if any of the commands fail

--- a/evergreen/run-load-balancer-tests.sh
+++ b/evergreen/run-load-balancer-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o xtrace  # Write all commands first to stderr
 set -o errexit # Exit the script with error if any of the commands fail

--- a/evergreen/run-plain-auth-tests.sh
+++ b/evergreen/run-plain-auth-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Don't trace since the URI contains a password that shouldn't show up in the logs
 set -o errexit  # Exit the script with error if any of the commands fail

--- a/evergreen/set-temp-fle-aws-creds.sh
+++ b/evergreen/set-temp-fle-aws-creds.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Obtains temporary AWS credentials for CSFLE testing.
 #
 # Run with a . to add environment variables to the current shell:

--- a/evergreen/set-virtualenv.sh
+++ b/evergreen/set-virtualenv.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Find the version of python on the system.
 # If the directory "venv" exists, start the virtual environment.
 # Otherwise, install a new virtual environment.


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/61b7e7463627e00295e8b335