### PR TITLE
CSHARP-4001: Upgrade to DnsClient.NET 1.6.0, which includes the fix for duplicate DNS responses.

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -175,7 +175,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.4.0" />
+    <PackageReference Include="DnsClient" Version="1.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.3.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />


### PR DESCRIPTION
Straightforward upgrade to DnsClient.NET. I was able to connect to MongoDB Atlas using `mongodb+srv://` in a test project. Open to suggestions of anything else I should verify before merging.