### PR TITLE
CSHARP-3927: Drivers should check out an implicit session only after checking out a connection

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
@@ -329,8 +329,7 @@ namespace MongoDB.Driver.Core.Clusters
         public ICoreSessionHandle StartSession(CoreSessionOptions options)
         {
             options = options ?? new CoreSessionOptions();
-            var serverSession = AcquireServerSession();
-            var session = new CoreSession(this, serverSession, options);
+            var session = new CoreSession(this, _serverSessionPool, options);
             return new CoreSessionHandle(session);
         }
 

--- a/src/MongoDB.Driver.Core/Core/Clusters/LoadBalancedCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/LoadBalancedCluster.cs
@@ -230,8 +230,7 @@ namespace MongoDB.Driver.Core.Clusters
             ThrowIfDisposed();
 
             options = options ?? new CoreSessionOptions();
-            var serverSession = AcquireServerSession();
-            var session = new CoreSession(this, serverSession, options);
+            var session = new CoreSession(this, _serverSessionPool, options);
             return new CoreSessionHandle(session);
         }
 

--- a/src/MongoDB.Driver/ClientSessionHandle.cs
+++ b/src/MongoDB.Driver/ClientSessionHandle.cs
@@ -19,7 +19,6 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Misc;
-using MongoDB.Driver.Support;
 
 namespace MongoDB.Driver
 {
@@ -35,7 +34,7 @@ namespace MongoDB.Driver
         private readonly ICoreSessionHandle _coreSession;
         private bool _disposed;
         private readonly ClientSessionOptions _options;
-        private readonly IServerSession _serverSession;
+        private IServerSession _serverSession;
 
         // constructors
         /// <summary>
@@ -54,7 +53,6 @@ namespace MongoDB.Driver
             _client = client;
             _options = options;
             _coreSession = coreSession;
-            _serverSession = new ServerSession(coreSession.ServerSession);
             _clock = clock;
         }
 
@@ -78,7 +76,18 @@ namespace MongoDB.Driver
         public ClientSessionOptions Options => _options;
 
         /// <inheritdoc />
-        public IServerSession ServerSession => _serverSession;
+        public IServerSession ServerSession
+        {
+            get
+            {
+                if (_serverSession == null)
+                {
+                    _serverSession = new ServerSession(_coreSession.ServerSession);
+                }
+
+                return _serverSession;
+            }
+        }
 
         /// <inheritdoc />
         public ICoreSessionHandle WrappedCoreSession => _coreSession;
@@ -126,7 +135,7 @@ namespace MongoDB.Driver
             if (!_disposed)
             {
                 _coreSession.Dispose();
-                _serverSession.Dispose();
+                _serverSession?.Dispose();
                 _disposed = true;
             }
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Bindings/CoreSessionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Bindings/CoreSessionTests.cs
@@ -40,7 +40,9 @@ namespace MongoDB.Driver.Core.Bindings
             var serverSession = Mock.Of<ICoreServerSession>();
             var options = new CoreSessionOptions();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var result = new CoreSession(cluster, serverSession, options);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             result.Cluster.Should().BeSameAs(cluster);
             result.CurrentTransaction.Should().BeNull();
@@ -440,7 +442,9 @@ namespace MongoDB.Driver.Core.Bindings
             cluster = cluster ?? CreateMockReplicaSetCluster();
             serverSession = serverSession ?? Mock.Of<ICoreServerSession>();
             options = options ?? new CoreSessionOptions();
+#pragma warning disable CS0618 // Type or member is obsolete
             return new CoreSession(cluster, serverSession, options);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private CoreSession CreateSubject(ClusterDescription clusterDescription)

--- a/tests/MongoDB.Driver.Tests/ClientSessionHandleTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClientSessionHandleTests.cs
@@ -252,7 +252,9 @@ namespace MongoDB.Driver.Tests
             var cluster = Mock.Of<ICluster>();
             var coreServerSession = new CoreServerSession();
             var options = new ClientSessionOptions();
+#pragma warning disable CS0618 // Type or member is obsolete
             var coreSession = new CoreSession(cluster, coreServerSession, options.ToCore());
+#pragma warning restore CS0618 // Type or member is obsolete
             var coreSessionHandle = new CoreSessionHandle(coreSession);
             var subject = CreateSubject(coreSession: coreSessionHandle);
             coreSessionHandle.ReferenceCount().Should().Be(1);

--- a/tests/MongoDB.Driver.Tests/MockOperationExecutor.cs
+++ b/tests/MongoDB.Driver.Tests/MockOperationExecutor.cs
@@ -181,7 +181,9 @@ namespace MongoDB.Driver.Tests
             var cluster = Mock.Of<ICluster>();
             var options = new ClientSessionOptions();
             var coreServerSession = new CoreServerSession();
+#pragma warning disable CS0618 // Type or member is obsolete
             var coreSession = new CoreSession(cluster, coreServerSession, options.ToCore(isImplicit: true));
+#pragma warning restore CS0618 // Type or member is obsolete
             var coreSessionHandle = new CoreSessionHandle(coreSession);
             return new ClientSessionHandle(_client, options, coreSessionHandle);
         }

--- a/tests/MongoDB.Driver.Tests/MongoClientTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientTests.cs
@@ -425,7 +425,9 @@ namespace MongoDB.Driver.Tests
             var options = new ClientSessionOptions();
             var cluster = Mock.Of<ICluster>();
             var coreServerSession = new CoreServerSession();
+#pragma warning disable CS0618 // Type or member is obsolete
             var coreSession = new CoreSession(cluster, coreServerSession, options.ToCore());
+#pragma warning restore CS0618 // Type or member is obsolete
             var coreSessionHandle = new CoreSessionHandle(coreSession);
             return new ClientSessionHandle(client, options, coreSessionHandle);
         }

--- a/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
@@ -3755,7 +3755,9 @@ namespace MongoDB.Driver
                 var cluster = Mock.Of<ICluster>();
                 var options = new ClientSessionOptions();
                 var coreServerSession = new CoreServerSession();
+#pragma warning disable CS0618 // Type or member is obsolete
                 var coreSession = new CoreSession(cluster, coreServerSession, options.ToCore());
+#pragma warning restore CS0618 // Type or member is obsolete
                 var coreSessionHandle = new CoreSessionHandle(coreSession);
                 return new ClientSessionHandle(client, options, coreSessionHandle);
             }

--- a/tests/MongoDB.Driver.Tests/MongoDatabaseImplTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoDatabaseImplTests.cs
@@ -1452,7 +1452,9 @@ namespace MongoDB.Driver
                 var cluster = Mock.Of<ICluster>();
                 var options = new ClientSessionOptions();
                 var coreServerSession = new CoreServerSession();
+#pragma warning disable CS0618 // Type or member is obsolete
                 var coreSession = new CoreSession(cluster, coreServerSession, options.ToCore());
+#pragma warning restore CS0618 // Type or member is obsolete
                 var coreSessionHandle = new CoreSessionHandle(coreSession);
                 return new ClientSessionHandle(_client, options, coreSessionHandle);
             }


### PR DESCRIPTION
[EG](https://evergreen.mongodb.com/version/620544200305b97e469d3658)