### PR TITLE
CSHARP-1541: Add support for $comment for profiling

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Operations/AggregateExplainOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/AggregateExplainOperation.cs
@@ -162,7 +162,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "collation", () => _collation.ToBsonDocument(), _collation != null },
                 { "hint", () => _hint, _hint != null },
-                { "comment", () => _comment, _comment != null }
+                { "comment", _comment, _comment != null }
             };
         }
 

--- a/src/MongoDB.Driver.Core/Core/Operations/AggregateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/AggregateOperation.cs
@@ -27,7 +27,6 @@ using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
-using MongoDB.Shared;
 
 namespace MongoDB.Driver.Core.Operations
 {
@@ -42,7 +41,7 @@ namespace MongoDB.Driver.Core.Operations
         private int? _batchSize;
         private Collation _collation;
         private readonly CollectionNamespace _collectionNamespace;
-        private string _comment;
+        private BsonValue _comment;
         private readonly DatabaseNamespace _databaseNamespace;
         private BsonValue _hint;
         private BsonDocument _let;
@@ -140,7 +139,7 @@ namespace MongoDB.Driver.Core.Operations
         /// <value>
         /// The comment.
         /// </value>
-        public string Comment
+        public BsonValue Comment
         {
             get { return _comment; }
             set { _comment = value; }
@@ -355,9 +354,9 @@ namespace MongoDB.Driver.Core.Operations
                 { "allowDiskUse", () => _allowDiskUse.Value, _allowDiskUse.HasValue },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "collation", () => _collation.ToBsonDocument(), _collation != null },
-                { "hint", () => _hint, _hint != null },
-                { "let", () => _let, _let != null },
-                { "comment", () => _comment, _comment != null },
+                { "hint", _hint, _hint != null },
+                { "let", _let, _let != null },
+                { "comment", _comment, _comment != null },
                 { "readConcern", readConcern, readConcern != null },
                 {
                     "cursor",

--- a/src/MongoDB.Driver.Core/Core/Operations/AggregateToCollectionOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/AggregateToCollectionOperation.cs
@@ -25,7 +25,6 @@ using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
-using MongoDB.Shared;
 
 namespace MongoDB.Driver.Core.Operations
 {
@@ -39,7 +38,7 @@ namespace MongoDB.Driver.Core.Operations
         private bool? _bypassDocumentValidation;
         private Collation _collation;
         private readonly CollectionNamespace _collectionNamespace;
-        private string _comment;
+        private BsonValue _comment;
         private readonly DatabaseNamespace _databaseNamespace;
         private BsonValue _hint;
         private BsonDocument _let;
@@ -133,7 +132,7 @@ namespace MongoDB.Driver.Core.Operations
         /// <value>
         /// The comment.
         /// </value>
-        public string Comment
+        public BsonValue Comment
         {
             get { return _comment; }
             set { _comment = value; }
@@ -295,9 +294,9 @@ namespace MongoDB.Driver.Core.Operations
                 { "readConcern", readConcern, readConcern != null },
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "cursor", new BsonDocument() },
-                { "hint", () => _hint, _hint != null },
-                { "let", () => _let, _let != null },
-                { "comment", () => _comment, _comment != null }
+                { "hint", _hint, _hint != null },
+                { "let", _let, _let != null },
+                { "comment", _comment, _comment != null }
             };
         }
 

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkDeleteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkDeleteOperation.cs
@@ -44,6 +44,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             return new RetryableDeleteCommandOperation(CollectionNamespace, batch.Requests, MessageEncoderSettings)
             {
+                Comment = Comment,
                 IsOrdered = IsOrdered,
                 Let = _let,
                 MaxBatchCount = MaxBatchCount,

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkInsertOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkInsertOperation.cs
@@ -38,6 +38,7 @@ namespace MongoDB.Driver.Core.Operations
             return new RetryableInsertCommandOperation<InsertRequest>(CollectionNamespace, batch.Requests, InsertRequestSerializer.Instance, MessageEncoderSettings)
             {
                 BypassDocumentValidation = BypassDocumentValidation,
+                Comment = Comment,
                 IsOrdered = IsOrdered,
                 MaxBatchCount = MaxBatchCount,
                 RetryRequested = RetryRequested,

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
@@ -35,6 +35,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private bool? _bypassDocumentValidation;
         private readonly CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private bool _isOrdered = true;
         private BsonDocument _let;
         private int? _maxBatchCount;
@@ -100,6 +101,18 @@ namespace MongoDB.Driver.Core.Operations
         public CollectionNamespace CollectionNamespace
         {
             get { return _collectionNamespace; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -261,6 +274,7 @@ namespace MongoDB.Driver.Core.Operations
             var requests = batch.Requests.Cast<DeleteRequest>();
             return new BulkDeleteOperation(_collectionNamespace, requests, _messageEncoderSettings)
             {
+                Comment = _comment,
                 IsOrdered = _isOrdered,
                 Let = _let,
                 MaxBatchCount = _maxBatchCount,
@@ -276,6 +290,7 @@ namespace MongoDB.Driver.Core.Operations
             return new BulkInsertOperation(_collectionNamespace, requests, _messageEncoderSettings)
             {
                 BypassDocumentValidation = _bypassDocumentValidation,
+                Comment = _comment,
                 IsOrdered = _isOrdered,
                 MaxBatchCount = _maxBatchCount,
                 MaxBatchLength = _maxBatchLength,
@@ -291,6 +306,7 @@ namespace MongoDB.Driver.Core.Operations
             return new BulkUpdateOperation(_collectionNamespace, requests, _messageEncoderSettings)
             {
                 BypassDocumentValidation = _bypassDocumentValidation,
+                Comment = _comment,
                 IsOrdered = _isOrdered,
                 Let = _let,
                 MaxBatchCount = _maxBatchCount,

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
@@ -32,6 +32,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private bool? _bypassDocumentValidation;
         private CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private bool _isOrdered = true;
         private int? _maxBatchCount;
         private int? _maxBatchLength;
@@ -69,6 +70,12 @@ namespace MongoDB.Driver.Core.Operations
         public CollectionNamespace CollectionNamespace
         {
             get { return _collectionNamespace; }
+        }
+
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         public bool IsOrdered

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkUpdateOperation.cs
@@ -44,6 +44,7 @@ namespace MongoDB.Driver.Core.Operations
             return new RetryableUpdateCommandOperation(CollectionNamespace, batch.Requests, MessageEncoderSettings)
             {
                 BypassDocumentValidation = BypassDocumentValidation,
+                Comment = Comment,
                 IsOrdered = IsOrdered,
                 Let = _let,
                 MaxBatchCount = MaxBatchCount,

--- a/src/MongoDB.Driver.Core/Core/Operations/ChangeStreamOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ChangeStreamOperation.cs
@@ -85,6 +85,7 @@ namespace MongoDB.Driver.Core.Operations
         // private fields
         private int? _batchSize;
         private Collation _collation;
+        private BsonValue _comment;
         private readonly CollectionNamespace _collectionNamespace;
         private readonly DatabaseNamespace _databaseNamespace;
         private ChangeStreamFullDocumentOption _fullDocument = ChangeStreamFullDocumentOption.Default;
@@ -172,6 +173,15 @@ namespace MongoDB.Driver.Core.Operations
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -395,6 +405,7 @@ namespace MongoDB.Driver.Core.Operations
 
             operation.BatchSize = _batchSize;
             operation.Collation = _collation;
+            operation.Comment = _comment;
             operation.MaxAwaitTime = _maxAwaitTime;
             operation.ReadConcern = _readConcern;
 

--- a/src/MongoDB.Driver.Core/Core/Operations/CountDocumentsOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CountDocumentsOperation.cs
@@ -34,6 +34,7 @@ namespace MongoDB.Driver.Core.Operations
         // private fields
         private Collation _collation;
         private readonly CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private BsonDocument _filter;
         private BsonValue _hint;
         private long? _limit;
@@ -67,6 +68,19 @@ namespace MongoDB.Driver.Core.Operations
             get { return _collation; }
             set { _collation = value; }
         }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
+        }
+
         /// <summary>
         /// Gets the collection namespace.
         /// </summary>
@@ -201,6 +215,7 @@ namespace MongoDB.Driver.Core.Operations
             var operation = new AggregateOperation<BsonDocument>(_collectionNamespace, pipeline, BsonDocumentSerializer.Instance, _messageEncoderSettings)
             {
                 Collation = _collation,
+                Comment = _comment,
                 Hint = _hint,
                 MaxTime = _maxTime,
                 ReadConcern = _readConcern,

--- a/src/MongoDB.Driver.Core/Core/Operations/CountOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CountOperation.cs
@@ -22,7 +22,6 @@ using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
-using MongoDB.Shared;
 
 namespace MongoDB.Driver.Core.Operations
 {
@@ -34,6 +33,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private Collation _collation;
         private readonly CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private BsonDocument _filter;
         private BsonValue _hint;
         private long? _limit;
@@ -76,6 +76,18 @@ namespace MongoDB.Driver.Core.Operations
         public CollectionNamespace CollectionNamespace
         {
             get { return _collectionNamespace; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -184,6 +196,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "hint", _hint, _hint != null },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "collation", () => _collation.ToBsonDocument(), _collation != null },
+                { "comment", _comment, _comment != null },
                 { "readConcern", readConcern, readConcern != null }
             };
         }

--- a/src/MongoDB.Driver.Core/Core/Operations/CreateCollectionOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CreateCollectionOperation.cs
@@ -35,6 +35,7 @@ namespace MongoDB.Driver.Core.Operations
         private bool? _capped;
         private Collation _collation;
         private readonly CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private TimeSpan? _expireAfter;
         private BsonDocument _indexOptionDefaults;
         private long? _maxDocuments;
@@ -99,6 +100,18 @@ namespace MongoDB.Driver.Core.Operations
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -281,12 +294,13 @@ namespace MongoDB.Driver.Core.Operations
                 { "size", () => _maxSize.Value, _maxSize.HasValue },
                 { "max", () => _maxDocuments.Value, _maxDocuments.HasValue },
                 { "flags", () => (int)flags.Value, flags.HasValue },
-                { "storageEngine", () => _storageEngine, _storageEngine != null },
+                { "storageEngine", _storageEngine, _storageEngine != null },
                 { "indexOptionDefaults", _indexOptionDefaults, _indexOptionDefaults != null },
                 { "validator", _validator, _validator != null },
                 { "validationAction", () => _validationAction.Value.ToString().ToLowerInvariant(), _validationAction.HasValue },
                 { "validationLevel", () => _validationLevel.Value.ToString().ToLowerInvariant(), _validationLevel.HasValue },
                 { "collation", () => _collation.ToBsonDocument(), _collation != null },
+                { "comment",  _comment, _comment != null },
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "expireAfterSeconds", () => _expireAfter.Value.TotalSeconds, _expireAfter.HasValue },
                 { "timeseries", () => _timeSeriesOptions.ToBsonDocument(), _timeSeriesOptions != null }

--- a/src/MongoDB.Driver.Core/Core/Operations/CreateIndexesOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CreateIndexesOperation.cs
@@ -34,6 +34,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private readonly CollectionNamespace _collectionNamespace;
         private CreateIndexCommitQuorum _commitQuorum;
+        private BsonValue _comment;
         private TimeSpan? _maxTime;
         private readonly MessageEncoderSettings _messageEncoderSettings;
         private readonly IEnumerable<CreateIndexRequest> _requests;
@@ -66,6 +67,15 @@ namespace MongoDB.Driver.Core.Operations
         public CollectionNamespace CollectionNamespace
         {
             get { return _collectionNamespace; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -155,6 +165,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             return new CreateIndexesUsingCommandOperation(_collectionNamespace, _requests, _messageEncoderSettings)
             {
+                Comment = _comment,
                 CommitQuorum = _commitQuorum,
                 MaxTime = _maxTime,
                 WriteConcern = _writeConcern

--- a/src/MongoDB.Driver.Core/Core/Operations/CreateIndexesUsingCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CreateIndexesUsingCommandOperation.cs
@@ -35,6 +35,7 @@ namespace MongoDB.Driver.Core.Operations
     {
         // fields
         private readonly CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private CreateIndexCommitQuorum _commitQuorum;
         private TimeSpan? _maxTime;
         private readonly MessageEncoderSettings _messageEncoderSettings;
@@ -68,6 +69,18 @@ namespace MongoDB.Driver.Core.Operations
         public CollectionNamespace CollectionNamespace
         {
             get { return _collectionNamespace; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -168,6 +181,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "indexes", new BsonArray(_requests.Select(request => request.CreateIndexDocument())) },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "writeConcern", writeConcern, writeConcern != null },
+                { "comment", _comment, _comment != null },
                 { "commitQuorum", () => _commitQuorum.ToBsonValue(), _commitQuorum != null }
             };
         }

--- a/src/MongoDB.Driver.Core/Core/Operations/DistinctOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/DistinctOperation.cs
@@ -37,6 +37,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private Collation _collation;
         private CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private BsonDocument _filter;
         private string _fieldName;
         private TimeSpan? _maxTime;
@@ -73,6 +74,19 @@ namespace MongoDB.Driver.Core.Operations
             get { return _collation; }
             set { _collation = value; }
         }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
+        }
+
         /// <summary>
         /// Gets the collection namespace.
         /// </summary>
@@ -207,6 +221,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "query", _filter, _filter != null },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "collation", () => _collation.ToBsonDocument(), _collation != null },
+                { "comment", _comment, _comment != null },
                 { "readConcern", readConcern, readConcern != null }
             };
         }

--- a/src/MongoDB.Driver.Core/Core/Operations/DropIndexOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/DropIndexOperation.cs
@@ -19,10 +19,8 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Bindings;
-using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
-using MongoDB.Shared;
 
 namespace MongoDB.Driver.Core.Operations
 {
@@ -33,6 +31,7 @@ namespace MongoDB.Driver.Core.Operations
     {
         // fields
         private readonly CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private readonly string _indexName;
         private TimeSpan? _maxTime;
         private readonly MessageEncoderSettings _messageEncoderSettings;
@@ -79,6 +78,18 @@ namespace MongoDB.Driver.Core.Operations
         public CollectionNamespace CollectionNamespace
         {
             get { return _collectionNamespace; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -134,7 +145,8 @@ namespace MongoDB.Driver.Core.Operations
                 { "dropIndexes", _collectionNamespace.CollectionName },
                 { "index", _indexName },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
-                { "writeConcern", writeConcern, writeConcern != null }
+                { "writeConcern", writeConcern, writeConcern != null },
+                { "comment", _comment, _comment != null }
             };
         }
 

--- a/src/MongoDB.Driver.Core/Core/Operations/FindAndModifyOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindAndModifyOperationBase.cs
@@ -13,9 +13,6 @@
 * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,6 +35,7 @@ namespace MongoDB.Driver.Core.Operations
     {
         // fields
         private Collation _collation;
+        private BsonValue _comment;
         private readonly CollectionNamespace _collectionNamespace;
         private readonly MessageEncoderSettings _messageEncoderSettings;
         private readonly IBsonSerializer<TResult> _resultSerializer;
@@ -69,6 +67,18 @@ namespace MongoDB.Driver.Core.Operations
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndDeleteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndDeleteOperation.cs
@@ -147,6 +147,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
+                { "comment", Comment, Comment != null },
                 { "hint", _hint, _hint != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue },
                 { "let", _let, _let != null }

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
@@ -204,7 +204,8 @@ namespace MongoDB.Driver.Core.Operations
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
-                { "hint", () => _hint, _hint != null },
+                { "comment", Comment, Comment != null },
+                { "hint", _hint, _hint != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue },
                 { "let", _let, _let != null }
             };

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
@@ -219,7 +219,8 @@ namespace MongoDB.Driver.Core.Operations
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
-                { "hint", () => _hint, _hint != null },
+                { "comment", Comment, Comment != null },
+                { "hint", _hint, _hint != null },
                 { "arrayFilters", () => new BsonArray(_arrayFilters), _arrayFilters != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue },
                 { "let", _let, _let != null }

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOperation.cs
@@ -48,7 +48,7 @@ namespace MongoDB.Driver.Core.Operations
         private int? _batchSize;
         private Collation _collation;
         private readonly CollectionNamespace _collectionNamespace;
-        private string _comment;
+        private BsonValue _comment;
         private CursorType _cursorType;
         private BsonDocument _filter;
         private int? _firstBatchSize;
@@ -159,7 +159,7 @@ namespace MongoDB.Driver.Core.Operations
         /// <value>
         /// The comment.
         /// </value>
-        public string Comment
+        public BsonValue Comment
         {
             get { return _comment; }
             set { _comment = value; }

--- a/src/MongoDB.Driver.Core/Core/Operations/ListCollectionsOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ListCollectionsOperation.cs
@@ -33,6 +33,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private bool? _authorizedCollections;
         private int? _batchSize;
+        private BsonValue _comment;
         private BsonDocument _filter;
         private readonly DatabaseNamespace _databaseNamespace;
         private readonly MessageEncoderSettings _messageEncoderSettings;
@@ -76,6 +77,15 @@ namespace MongoDB.Driver.Core.Operations
         {
             get => _batchSize;
             set => _batchSize = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -194,7 +204,8 @@ namespace MongoDB.Driver.Core.Operations
                 { "filter", _filter, _filter != null },
                 { "nameOnly", () => _nameOnly.Value, _nameOnly.HasValue },
                 { "cursor", () => new BsonDocument("batchSize", _batchSize.Value), _batchSize.HasValue },
-                { "authorizedCollections", () => _authorizedCollections.Value, _authorizedCollections.HasValue }
+                { "authorizedCollections", () => _authorizedCollections.Value, _authorizedCollections.HasValue },
+                { "comment", _comment, _comment != null }
             };
             return new ReadCommandOperation<BsonDocument>(_databaseNamespace, command, BsonDocumentSerializer.Instance, _messageEncoderSettings)
             {

--- a/src/MongoDB.Driver.Core/Core/Operations/ListDatabasesOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ListDatabasesOperation.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver.Core.Operations
     {
         // fields
         private bool? _authorizedDatabases;
+        private BsonValue _comment;
         private BsonDocument _filter;
         private MessageEncoderSettings _messageEncoderSettings;
         private bool? _nameOnly;
@@ -57,6 +58,18 @@ namespace MongoDB.Driver.Core.Operations
         {
             get { return _authorizedDatabases; }
             set { _authorizedDatabases = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -133,7 +146,8 @@ namespace MongoDB.Driver.Core.Operations
                 { "listDatabases", 1 },
                 { "filter", _filter, _filter != null },
                 { "nameOnly", _nameOnly, _nameOnly != null },
-                { "authorizedDatabases", _authorizedDatabases, _authorizedDatabases != null }
+                { "authorizedDatabases", _authorizedDatabases, _authorizedDatabases != null },
+                { "comment", _comment, _comment != null }
             };
         }
 

--- a/src/MongoDB.Driver.Core/Core/Operations/ListIndexesOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ListIndexesOperation.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private int? _batchSize;
         private readonly CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private readonly MessageEncoderSettings _messageEncoderSettings;
         private bool _retryRequested;
 
@@ -70,6 +71,18 @@ namespace MongoDB.Driver.Core.Operations
         public CollectionNamespace CollectionNamespace
         {
             get { return _collectionNamespace; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -128,6 +141,7 @@ namespace MongoDB.Driver.Core.Operations
             return new ListIndexesUsingCommandOperation(_collectionNamespace, _messageEncoderSettings)
             {
                 BatchSize = _batchSize,
+                Comment = _comment,
                 RetryRequested = _retryRequested // might be overridden by retryable read context
             };
         }

--- a/src/MongoDB.Driver.Core/Core/Operations/ListIndexesUsingCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ListIndexesUsingCommandOperation.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -21,7 +20,6 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Bindings;
-using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
@@ -36,6 +34,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private int? _batchSize;
         private readonly CollectionNamespace _collectionNamespace;
+        private BsonValue _comment;
         private readonly MessageEncoderSettings _messageEncoderSettings;
         private bool _retryRequested;
 
@@ -75,6 +74,18 @@ namespace MongoDB.Driver.Core.Operations
         public CollectionNamespace CollectionNamespace
         {
             get { return _collectionNamespace; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>
@@ -170,7 +181,8 @@ namespace MongoDB.Driver.Core.Operations
             var command = new BsonDocument
             {
                 { "listIndexes", _collectionNamespace.CollectionName },
-                { "cursor", () => new BsonDocument("batchSize", _batchSize.Value), _batchSize.HasValue }
+                { "cursor", () => new BsonDocument("batchSize", _batchSize.Value), _batchSize.HasValue },
+                { "comment", _comment, _comment != null },
             };
             return new ReadCommandOperation<BsonDocument>(databaseNamespace, command, BsonDocumentSerializer.Instance, _messageEncoderSettings)
             {

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableDeleteCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableDeleteCommandOperation.cs
@@ -106,6 +106,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 { "delete", _collectionNamespace.CollectionName },
                 { "ordered", IsOrdered },
+                { "comment", Comment, Comment != null },
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "txnNumber", () => transactionNumber.Value, transactionNumber.HasValue },
                 { "let", _let, _let != null }

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableInsertCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableInsertCommandOperation.cs
@@ -20,7 +20,6 @@ using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Bindings;
-using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.WireProtocol.Messages;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
@@ -115,6 +114,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "insert", _collectionNamespace.CollectionName },
                 { "ordered", IsOrdered },
                 { "bypassDocumentValidation", () => _bypassDocumentValidation, _bypassDocumentValidation.HasValue },
+                { "comment", Comment, Comment != null },
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "txnNumber", () => transactionNumber.Value, transactionNumber.HasValue }
             };

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
@@ -21,7 +21,6 @@ using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Bindings;
-using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Operations.ElementNameValidators;
 using MongoDB.Driver.Core.WireProtocol.Messages;
@@ -118,6 +117,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "update", _collectionNamespace.CollectionName },
                 { "ordered", IsOrdered },
                 { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue },
+                { "comment", Comment, Comment != null },
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "txnNumber", () => transactionNumber.Value, transactionNumber.HasValue },
                 { "let", _let, _let != null }

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableWriteCommandOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableWriteCommandOperationBase.cs
@@ -22,7 +22,6 @@ using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Bindings;
-using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.WireProtocol;
 using MongoDB.Driver.Core.WireProtocol.Messages;
@@ -36,6 +35,7 @@ namespace MongoDB.Driver.Core.Operations
     public abstract class RetryableWriteCommandOperationBase : IWriteOperation<BsonDocument>, IRetryableWriteOperation<BsonDocument>
     {
         // private fields
+        private BsonValue _comment;
         private readonly DatabaseNamespace _databaseNamespace;
         private bool _isOrdered = true;
         private int? _maxBatchCount;
@@ -58,6 +58,18 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         // public properties
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
+        }
+
         /// <summary>
         /// Gets the database namespace.
         /// </summary>

--- a/src/MongoDB.Driver/AggregateOptions.cs
+++ b/src/MongoDB.Driver/AggregateOptions.cs
@@ -29,7 +29,7 @@ namespace MongoDB.Driver
         private int? _batchSize;
         private bool? _bypassDocumentValidation;
         private Collation _collation;
-        private string _comment;
+        private BsonValue _comment;
         private BsonValue _hint;
         private BsonDocument _let;
         private TimeSpan? _maxAwaitTime;
@@ -73,11 +73,10 @@ namespace MongoDB.Driver
             get { return _collation; }
             set { _collation = value; }
         }
-
         /// <summary>
         /// Gets or sets the comment.
         /// </summary>
-        public string Comment
+        public BsonValue Comment
         {
             get { return _comment; }
             set { _comment = value; }

--- a/src/MongoDB.Driver/BulkWriteOptions.cs
+++ b/src/MongoDB.Driver/BulkWriteOptions.cs
@@ -24,6 +24,7 @@ namespace MongoDB.Driver
     {
         // fields
         private bool? _bypassDocumentValidation;
+        private BsonValue _comment;
         private bool _isOrdered;
         private BsonDocument _let;
 
@@ -44,6 +45,15 @@ namespace MongoDB.Driver
         {
             get { return _bypassDocumentValidation; }
             set { _bypassDocumentValidation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/ChangeStreamHelper.cs
+++ b/src/MongoDB.Driver/ChangeStreamHelper.cs
@@ -149,6 +149,7 @@ namespace MongoDB.Driver
 
             operation.BatchSize = options.BatchSize;
             operation.Collation = options.Collation;
+            operation.Comment = options.Comment;
             operation.FullDocument = options.FullDocument;
             operation.MaxAwaitTime = options.MaxAwaitTime;
             operation.ReadConcern = readConcern;

--- a/src/MongoDB.Driver/ChangeStreamOptions.cs
+++ b/src/MongoDB.Driver/ChangeStreamOptions.cs
@@ -13,9 +13,9 @@
 * limitations under the License.
 */
 
+using System;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
-using System;
 
 namespace MongoDB.Driver
 {
@@ -27,6 +27,7 @@ namespace MongoDB.Driver
         // private fields
         private int? _batchSize;
         private Collation _collation;
+        private BsonValue _comment;
         private ChangeStreamFullDocumentOption _fullDocument = ChangeStreamFullDocumentOption.Default;
         private TimeSpan? _maxAwaitTime;
         private BsonDocument _resumeAfter;
@@ -56,6 +57,18 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/CountOptions.cs
+++ b/src/MongoDB.Driver/CountOptions.cs
@@ -26,6 +26,7 @@ namespace MongoDB.Driver
     {
         // fields
         private Collation _collation;
+        private BsonValue _comment;
         private BsonValue _hint;
         private long? _limit;
         private TimeSpan? _maxTime;
@@ -39,6 +40,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/CreateManyIndexesOptions.cs
+++ b/src/MongoDB.Driver/CreateManyIndexesOptions.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
@@ -24,10 +25,21 @@ namespace MongoDB.Driver
     public class CreateManyIndexesOptions
     {
         // private fields
+        private BsonValue _comment;
         private CreateIndexCommitQuorum _commitQuorum;
         private TimeSpan? _maxTime;
 
         // public properties
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value> The comment.</value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
+        }
+
         /// <summary>
         /// Gets or sets the commit quorum.
         /// </summary>

--- a/src/MongoDB.Driver/DeleteOptions.cs
+++ b/src/MongoDB.Driver/DeleteOptions.cs
@@ -24,6 +24,7 @@ namespace MongoDB.Driver
     {
         // fields
         private Collation _collation;
+        private BsonValue _comment;
         private BsonValue _hint;
         private BsonDocument _let;
 
@@ -35,6 +36,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/DistinctOptions.cs
+++ b/src/MongoDB.Driver/DistinctOptions.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
@@ -25,6 +26,7 @@ namespace MongoDB.Driver
     {
         // fields
         private Collation _collation;
+        private BsonValue _comment;
         private TimeSpan? _maxTime;
 
         // properties
@@ -35,6 +37,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/DropIndexOptions.cs
+++ b/src/MongoDB.Driver/DropIndexOptions.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
@@ -23,7 +24,20 @@ namespace MongoDB.Driver
     /// </summary>
     public class DropIndexOptions
     {
+        private BsonValue _comment;
         private TimeSpan? _maxTime;
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        /// <value>
+        /// The comment.
+        /// </value>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
+        }
 
         /// <summary>
         /// Gets or sets the maximum time.

--- a/src/MongoDB.Driver/FindOneAndDeleteOptions.cs
+++ b/src/MongoDB.Driver/FindOneAndDeleteOptions.cs
@@ -28,6 +28,7 @@ namespace MongoDB.Driver
     {
         // fields
         private Collation _collation;
+        private BsonValue _comment;
         private BsonValue _hint;
         private BsonDocument _let;
         private TimeSpan? _maxTime;
@@ -42,6 +43,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/FindOneAndReplaceOptions.cs
+++ b/src/MongoDB.Driver/FindOneAndReplaceOptions.cs
@@ -29,6 +29,7 @@ namespace MongoDB.Driver
         // fields
         private bool? _bypassDocumentValidation;
         private Collation _collation;
+        private BsonValue _comment;
         private BsonValue _hint;
         private bool _isUpsert;
         private BsonDocument _let;
@@ -63,6 +64,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/FindOneAndUpdateOptions.cs
+++ b/src/MongoDB.Driver/FindOneAndUpdateOptions.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver
         private IEnumerable<ArrayFilterDefinition> _arrayFilters;
         private bool? _bypassDocumentValidation;
         private Collation _collation;
+        private BsonValue _comment;
         private BsonValue _hint;
         private bool _isUpsert;
         private BsonDocument _let;
@@ -77,6 +78,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/FindOptions.cs
+++ b/src/MongoDB.Driver/FindOptions.cs
@@ -29,7 +29,7 @@ namespace MongoDB.Driver
         private bool? _allowPartialResults;
         private int? _batchSize;
         private Collation _collation;
-        private string _comment;
+        private BsonValue _comment;
         private CursorType _cursorType;
         private BsonValue _hint;
         private BsonDocument _let;
@@ -92,7 +92,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the comment.
         /// </summary>
-        public string Comment
+        public BsonValue Comment
         {
             get { return _comment; }
             set { _comment = value; }

--- a/src/MongoDB.Driver/InsertManyOptions.cs
+++ b/src/MongoDB.Driver/InsertManyOptions.cs
@@ -13,10 +13,7 @@
 * limitations under the License.
  * 
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using MongoDB.Bson;
 
 namespace MongoDB.Driver
 {
@@ -27,6 +24,7 @@ namespace MongoDB.Driver
     {
         // fields
         private bool? _bypassDocumentValidation;
+        private BsonValue _comment;
         private bool _isOrdered;
 
         // constructors
@@ -46,6 +44,15 @@ namespace MongoDB.Driver
         {
             get { return _bypassDocumentValidation; }
             set { _bypassDocumentValidation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/InsertOneOptions.cs
+++ b/src/MongoDB.Driver/InsertOneOptions.cs
@@ -13,10 +13,7 @@
 * limitations under the License.
  * 
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using MongoDB.Bson;
 
 namespace MongoDB.Driver
 {
@@ -25,6 +22,8 @@ namespace MongoDB.Driver
     /// </summary>
     public sealed class InsertOneOptions
     {
+        private BsonValue _comment;
+
         // private fields
         private bool? _bypassDocumentValidation;
 
@@ -36,6 +35,15 @@ namespace MongoDB.Driver
         {
             get { return _bypassDocumentValidation; }
             set { _bypassDocumentValidation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
     }
 }

--- a/src/MongoDB.Driver/ListCollectionNamesOptions.cs
+++ b/src/MongoDB.Driver/ListCollectionNamesOptions.cs
@@ -24,6 +24,7 @@ namespace MongoDB.Driver
     {
         // fields
         private bool? authorizedCollections;
+        private BsonValue _comment;
         private FilterDefinition<BsonDocument> _filter;
 
         // properties
@@ -34,6 +35,15 @@ namespace MongoDB.Driver
         {
             get { return authorizedCollections; }
             set { authorizedCollections = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/ListCollectionsOptions.cs
+++ b/src/MongoDB.Driver/ListCollectionsOptions.cs
@@ -24,6 +24,7 @@ namespace MongoDB.Driver
     {
         // fields
         private int? _batchSize;
+        private BsonValue _comment;
         private FilterDefinition<BsonDocument> _filter;
 
         // properties
@@ -34,6 +35,15 @@ namespace MongoDB.Driver
         {
             get { return _batchSize; }
             set { _batchSize = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/ListDatabaseNamesOptions.cs
+++ b/src/MongoDB.Driver/ListDatabaseNamesOptions.cs
@@ -24,6 +24,7 @@ namespace MongoDB.Driver
     {
         // fields
         private bool? _authorizedDatabases;
+        private BsonValue _comment;
         private FilterDefinition<BsonDocument> _filter;
 
         // properties
@@ -34,6 +35,15 @@ namespace MongoDB.Driver
         {
             get { return _authorizedDatabases; }
             set { _authorizedDatabases = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/ListDatabasesOptions.cs
+++ b/src/MongoDB.Driver/ListDatabasesOptions.cs
@@ -24,6 +24,7 @@ namespace MongoDB.Driver
     {
         // fields
         private bool? _authorizedDatabases;
+        private BsonValue _comment;
         private FilterDefinition<BsonDocument> _filter;
         private bool? _nameOnly;
 
@@ -35,6 +36,15 @@ namespace MongoDB.Driver
         {
             get { return _authorizedDatabases; }
             set { _authorizedDatabases = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/ListIndexesOptions.cs
+++ b/src/MongoDB.Driver/ListIndexesOptions.cs
@@ -13,6 +13,8 @@
 * limitations under the License.
 */
 
+using MongoDB.Bson;
+
 namespace MongoDB.Driver
 {
     /// <summary>
@@ -21,6 +23,7 @@ namespace MongoDB.Driver
     public sealed class ListIndexesOptions
     {
         private int? _batchSize;
+        private BsonValue _comment;
 
         /// <summary>
         /// Gets or sets the batch size.
@@ -29,6 +32,15 @@ namespace MongoDB.Driver
         {
             get => _batchSize;
             set => _batchSize = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
     }
 }

--- a/src/MongoDB.Driver/MongoClient.cs
+++ b/src/MongoDB.Driver/MongoClient.cs
@@ -506,6 +506,7 @@ namespace MongoDB.Driver
             return new ListDatabasesOperation(messageEncoderSettings)
             {
                 AuthorizedDatabases = options.AuthorizedDatabases,
+                Comment = options.Comment,
                 Filter = options.Filter?.Render(BsonDocumentSerializer.Instance, BsonSerializer.SerializerRegistry, _linqProvider),
                 NameOnly = options.NameOnly,
                 RetryRequested = _settings.RetryReads
@@ -519,6 +520,7 @@ namespace MongoDB.Driver
             {
                 listDatabasesOptions.AuthorizedDatabases = options.AuthorizedDatabases;
                 listDatabasesOptions.Filter = options.Filter;
+                listDatabasesOptions.Comment = options.Comment;
             }
 
             return listDatabasesOptions;

--- a/src/MongoDB.Driver/MongoCollectionBase.cs
+++ b/src/MongoDB.Driver/MongoCollectionBase.cs
@@ -192,6 +192,7 @@ namespace MongoDB.Driver
             {
                 var bulkWriteOptions = new BulkWriteOptions
                 {
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = bulkWriteFunc(new[] { model }, bulkWriteOptions);
@@ -235,6 +236,7 @@ namespace MongoDB.Driver
             {
                 var bulkWriteOptions = new BulkWriteOptions
                 {
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = await bulkWriteFuncAsync(new[] { model }, bulkWriteOptions).ConfigureAwait(false);
@@ -278,6 +280,7 @@ namespace MongoDB.Driver
             {
                 var bulkWriteOptions = new BulkWriteOptions
                 {
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = bulkWrite(new[] { model }, bulkWriteOptions);
@@ -321,6 +324,7 @@ namespace MongoDB.Driver
             {
                 var bulkWriteOptions = new BulkWriteOptions
                 {
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = await bulkWriteAsync(new[] { model }, bulkWriteOptions).ConfigureAwait(false);
@@ -472,7 +476,8 @@ namespace MongoDB.Driver
             {
                 var bulkWriteOptions = options == null ? null : new BulkWriteOptions
                 {
-                    BypassDocumentValidation = options.BypassDocumentValidation
+                    BypassDocumentValidation = options.BypassDocumentValidation,
+                    Comment = options.Comment
                 };
                 bulkWrite(new[] { model }, bulkWriteOptions);
             }
@@ -510,7 +515,8 @@ namespace MongoDB.Driver
             {
                 var bulkWriteOptions = options == null ? null : new BulkWriteOptions
                 {
-                    BypassDocumentValidation = options.BypassDocumentValidation
+                    BypassDocumentValidation = options.BypassDocumentValidation,
+                    Comment = options.Comment
                 };
                 await bulkWriteAsync(new[] { model }, bulkWriteOptions).ConfigureAwait(false);
             }
@@ -540,6 +546,7 @@ namespace MongoDB.Driver
             BulkWriteOptions bulkWriteOptions = options == null ? null : new BulkWriteOptions
             {
                 BypassDocumentValidation = options.BypassDocumentValidation,
+                Comment = options.Comment,
                 IsOrdered = options.IsOrdered
             };
             bulkWrite(models, bulkWriteOptions);
@@ -565,6 +572,7 @@ namespace MongoDB.Driver
             var bulkWriteOptions = options == null ? null : new BulkWriteOptions
             {
                 BypassDocumentValidation = options.BypassDocumentValidation,
+                Comment = options.Comment,
                 IsOrdered = options.IsOrdered
             };
             return bulkWriteAsync(models, bulkWriteOptions);
@@ -643,6 +651,7 @@ namespace MongoDB.Driver
                 var bulkWriteOptions = new BulkWriteOptions
                 {
                     BypassDocumentValidation = options.BypassDocumentValidation,
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = bulkWrite(new[] { model }, bulkWriteOptions);
@@ -698,6 +707,7 @@ namespace MongoDB.Driver
                 var bulkWriteOptions = new BulkWriteOptions
                 {
                     BypassDocumentValidation = options.BypassDocumentValidation,
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = await bulkWriteAsync(new[] { model }, bulkWriteOptions).ConfigureAwait(false);
@@ -740,6 +750,7 @@ namespace MongoDB.Driver
                 var bulkWriteOptions = new BulkWriteOptions
                 {
                     BypassDocumentValidation = options.BypassDocumentValidation,
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = bulkWrite(new[] { model }, bulkWriteOptions);
@@ -782,6 +793,7 @@ namespace MongoDB.Driver
                 var bulkWriteOptions = new BulkWriteOptions
                 {
                     BypassDocumentValidation = options.BypassDocumentValidation,
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = await bulkWriteAsync(new[] { model }, bulkWriteOptions).ConfigureAwait(false);
@@ -824,6 +836,7 @@ namespace MongoDB.Driver
                 var bulkWriteOptions = new BulkWriteOptions
                 {
                     BypassDocumentValidation = options.BypassDocumentValidation,
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = bulkWrite(new[] { model }, bulkWriteOptions);
@@ -866,6 +879,7 @@ namespace MongoDB.Driver
                 var bulkWriteOptions = new BulkWriteOptions
                 {
                     BypassDocumentValidation = options.BypassDocumentValidation,
+                    Comment = options.Comment,
                     Let = options.Let
                 };
                 var result = await bulkWriteAsync(new[] { model }, bulkWriteOptions).ConfigureAwait(false);

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -894,6 +894,7 @@ namespace MongoDB.Driver
                 _messageEncoderSettings)
             {
                 BypassDocumentValidation = options.BypassDocumentValidation,
+                Comment = options.Comment,
                 IsOrdered = options.IsOrdered,
                 Let = options.Let,
                 RetryRequested = _database.Client.Settings.RetryWrites,
@@ -920,6 +921,7 @@ namespace MongoDB.Driver
             return new CountDocumentsOperation(_collectionNamespace, _messageEncoderSettings)
             {
                 Collation = options.Collation,
+                Comment = options.Comment,
                 Filter = filter.Render(_documentSerializer, _settings.SerializerRegistry, _linqProvider),
                 Hint = options.Hint,
                 Limit = options.Limit,
@@ -935,6 +937,7 @@ namespace MongoDB.Driver
             return new CountOperation(_collectionNamespace, _messageEncoderSettings)
             {
                 Collation = options.Collation,
+                Comment = options.Comment,
                 Filter = filter.Render(_documentSerializer, _settings.SerializerRegistry, _linqProvider),
                 Hint = options.Hint,
                 Limit = options.Limit,
@@ -957,6 +960,7 @@ namespace MongoDB.Driver
                 _messageEncoderSettings)
             {
                 Collation = options.Collation,
+                Comment = options.Comment,
                 Filter = filter.Render(_documentSerializer, _settings.SerializerRegistry, _linqProvider),
                 MaxTime = options.MaxTime,
                 ReadConcern = _settings.ReadConcern,
@@ -985,6 +989,7 @@ namespace MongoDB.Driver
                 _messageEncoderSettings)
             {
                 Collation = options.Collation,
+                Comment = options.Comment,
                 Hint = options.Hint,
                 Let = options.Let,
                 MaxTime = options.MaxTime,
@@ -1009,6 +1014,7 @@ namespace MongoDB.Driver
             {
                 BypassDocumentValidation = options.BypassDocumentValidation,
                 Collation = options.Collation,
+                Comment = options.Comment,
                 Hint = options.Hint,
                 IsUpsert = options.IsUpsert,
                 Let = options.Let,
@@ -1036,6 +1042,7 @@ namespace MongoDB.Driver
                 ArrayFilters = RenderArrayFilters(options.ArrayFilters),
                 BypassDocumentValidation = options.BypassDocumentValidation,
                 Collation = options.Collation,
+                Comment = options.Comment,
                 Hint = options.Hint,
                 IsUpsert = options.IsUpsert,
                 Let = options.Let,
@@ -1596,6 +1603,7 @@ namespace MongoDB.Driver
             {
                 return new CreateIndexesOperation(_collection._collectionNamespace, requests, _collection._messageEncoderSettings)
                 {
+                    Comment = options?.Comment,
                     CommitQuorum = options?.CommitQuorum,
                     MaxTime = options?.MaxTime,
                     WriteConcern = _collection.Settings.WriteConcern
@@ -1643,6 +1651,7 @@ namespace MongoDB.Driver
             {
                 return new DropIndexOperation(_collection._collectionNamespace, "*", _collection._messageEncoderSettings)
                 {
+                    Comment = options?.Comment,
                     MaxTime = options?.MaxTime,
                     WriteConcern = _collection.Settings.WriteConcern
                 };
@@ -1652,6 +1661,7 @@ namespace MongoDB.Driver
             {
                 return new DropIndexOperation(_collection._collectionNamespace, name, _collection._messageEncoderSettings)
                 {
+                    Comment = options?.Comment,
                     MaxTime = options?.MaxTime,
                     WriteConcern = _collection.Settings.WriteConcern
                 };
@@ -1662,6 +1672,7 @@ namespace MongoDB.Driver
                 return new ListIndexesOperation(_collection._collectionNamespace, _collection._messageEncoderSettings)
                 {
                     BatchSize = options?.BatchSize,
+                    Comment = options?.Comment,
                     RetryRequested = _collection.Database.Client.Settings.RetryReads
                 };
             }

--- a/src/MongoDB.Driver/MongoDatabaseImpl.cs
+++ b/src/MongoDB.Driver/MongoDatabaseImpl.cs
@@ -694,6 +694,7 @@ namespace MongoDB.Driver
             return new ListCollectionsOperation(_databaseNamespace, messageEncoderSettings)
             {
                 AuthorizedCollections = options?.AuthorizedCollections,
+                Comment = options?.Comment,
                 Filter = options?.Filter?.Render(_settings.SerializerRegistry.GetSerializer<BsonDocument>(), _settings.SerializerRegistry, _linqProvider),
                 NameOnly = true,
                 RetryRequested = _client.Settings.RetryReads
@@ -706,6 +707,7 @@ namespace MongoDB.Driver
             return new ListCollectionsOperation(_databaseNamespace, messageEncoderSettings)
             {
                 BatchSize = options?.BatchSize,
+                Comment = options?.Comment,
                 Filter = options?.Filter?.Render(_settings.SerializerRegistry.GetSerializer<BsonDocument>(), _settings.SerializerRegistry, _linqProvider),
                 RetryRequested = _client.Settings.RetryReads
             };

--- a/src/MongoDB.Driver/ReplaceOptions.cs
+++ b/src/MongoDB.Driver/ReplaceOptions.cs
@@ -58,6 +58,7 @@ namespace MongoDB.Driver
         // fields
         private bool? _bypassDocumentValidation;
         private Collation _collation;
+        private BsonValue _comment;
         private BsonValue _hint;
         private bool _isUpsert;
         private BsonDocument _let;
@@ -79,6 +80,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/UpdateOptions.cs
+++ b/src/MongoDB.Driver/UpdateOptions.cs
@@ -27,6 +27,7 @@ namespace MongoDB.Driver
         private IEnumerable<ArrayFilterDefinition> _arrayFilters;
         private bool? _bypassDocumentValidation;
         private Collation _collation;
+        private BsonValue _comment;
         private BsonValue _hint;
         private bool _isUpsert;
         private BsonDocument _let;
@@ -60,6 +61,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the comment.
+        /// </summary>
+        public BsonValue Comment
+        {
+            get { return _comment; }
+            set { _comment = value; }
         }
 
         /// <summary>

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateOperationTests.cs
@@ -190,7 +190,7 @@ namespace MongoDB.Driver.Core.Operations
         public void Comment_get_and_set_should_work()
         {
             var subject = new AggregateOperation<BsonDocument>(_collectionNamespace, __pipeline, __resultSerializer, _messageEncoderSettings);
-            var value = "test";
+            var value = (BsonValue)"test";
 
             subject.Comment = value;
             var result = subject.Comment;
@@ -731,7 +731,7 @@ namespace MongoDB.Driver.Core.Operations
 
                 var profileEntries = profile.Find(new BsonDocument("command.aggregate", new BsonDocument("$exists", true)));
                 profileEntries.Should().HaveCount(1);
-                profileEntries[0]["command"]["comment"].AsString.Should().Be(subject.Comment);
+                profileEntries[0]["command"]["comment"].Should().Be(subject.Comment);
             }
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateToCollectionOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateToCollectionOperationTests.cs
@@ -181,7 +181,7 @@ namespace MongoDB.Driver.Core.Operations
         public void Comment_get_and_set_should_work()
         {
             var subject = new AggregateToCollectionOperation(_collectionNamespace, __pipeline, _messageEncoderSettings);
-            var value = "test";
+            var value = (BsonValue)"test";
 
             subject.Comment = value;
             var result = subject.Comment;
@@ -724,7 +724,7 @@ namespace MongoDB.Driver.Core.Operations
 
                 var profileEntries = profile.Find(new BsonDocument("command.aggregate", new BsonDocument("$exists", true)));
                 profileEntries.Should().HaveCount(1);
-                profileEntries[0]["command"]["comment"].AsString.Should().Be(subject.Comment);
+                profileEntries[0]["command"]["comment"].Should().Be(subject.Comment);
             }
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOperationTests.cs
@@ -111,11 +111,12 @@ namespace MongoDB.Driver.Core.Operations
             string value)
         {
             var subject = new FindOperation<BsonDocument>(_collectionNamespace, BsonDocumentSerializer.Instance, _messageEncoderSettings);
+            var bsonValue = (BsonValue)value;
 
-            subject.Comment = value;
+            subject.Comment = bsonValue;
             var result = subject.Comment;
 
-            result.Should().BeSameAs(value);
+            result.Should().BeSameAs(bsonValue);
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
@@ -28,7 +28,6 @@ using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Connections;
-using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Operations;
 using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
@@ -1350,7 +1349,7 @@ namespace MongoDB.Driver
             operation.BatchSize.Should().Be(options.BatchSize);
             operation.Collation.Should().BeSameAs(options.Collation);
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
-            operation.Comment.Should().Be("funny");
+            operation.Comment.Should().Be((BsonValue)"funny");
             operation.CursorType.Should().Be(MongoDB.Driver.Core.Operations.CursorType.TailableAwait);
             operation.Filter.Should().Be(filterDocument);
             operation.Let.Should().Be(options.Let);
@@ -1443,7 +1442,7 @@ namespace MongoDB.Driver
             operation.BatchSize.Should().Be(options.BatchSize);
             operation.Collation.Should().BeSameAs(options.Collation);
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
-            operation.Comment.Should().Be("funny");
+            operation.Comment.Should().Be((BsonValue)"funny");
             operation.CursorType.Should().Be(MongoDB.Driver.Core.Operations.CursorType.TailableAwait);
             operation.Filter.Should().Be(new BsonDocument("x", 1));
             operation.Let.Should().Be(options.Let);

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.json
@@ -1,10 +1,21 @@
 {
   "description": "change-streams",
   "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset"
+      ]
+    }
+  ],
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
       }
     },
     {
@@ -34,10 +45,7 @@
       "description": "Test array truncation",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.7",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.7"
         }
       ],
       "operations": [
@@ -109,6 +117,134 @@
               ]
             }
           }
+        }
+      ]
+    },
+    {
+      "description": "Test with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": {
+              "name": "test1"
+            }
+          },
+          "saveResultAsEntity": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": {
+                    "name": "test1"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test with document comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": {
+              "name": "test1"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": {
+                    "name": "test1"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": "comment"
+          },
+          "saveResultAsEntity": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.yml
@@ -1,8 +1,12 @@
 description: "change-streams"
 schemaVersion: "1.0"
+runOnRequirements:
+  - topologies: [ replicaset, sharded-replicaset ]
 createEntities:
   - client:
       id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
   - database:
       id: &database0 database0
       client: *client0
@@ -15,11 +19,11 @@ initialData:
   - collectionName: *collection0
     databaseName: *database0
     documents: []
+
 tests:
   - description: "Test array truncation"
     runOnRequirements:
       - minServerVersion: "4.7"
-        topologies: [replicaset]
     operations:
       - name: insertOne
         object: *collection0
@@ -70,3 +74,65 @@ tests:
             ]
           }
         }
+
+  - description: "Test with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          comment: &comment0 { name: "test1" }
+        saveResultAsEntity: &changeStream0 changeStream0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: *comment0
+
+  - description: "Test with document comment - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.2.99"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          comment: &comment0 { name: "test1" }
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: *comment0
+
+  - description: "Test with string comment"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          comment: "comment"
+        saveResultAsEntity: &changeStream0 changeStream0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: "comment"

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate.json
@@ -161,6 +161,286 @@
           ]
         }
       ]
+    },
+    {
+      "description": "aggregate with a string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ],
+            "comment": "comment"
+          },
+          "object": "collection0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregate with a document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ],
+            "comment": {
+              "content": "test"
+            }
+          },
+          "object": "collection0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ],
+                  "comment": {
+                    "content": "test"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregate with a document comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ],
+            "comment": {
+              "content": "test"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ],
+                  "comment": {
+                    "content": "test"
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "aggregate-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregate with comment does not set comment on getMore",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ],
+            "batchSize": 2,
+            "comment": "comment"
+          },
+          "object": "collection0",
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ],
+                  "cursor": {
+                    "batchSize": 2
+                  },
+                  "comment": "comment"
+                },
+                "commandName": "aggregate",
+                "databaseName": "aggregate-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "aggregate-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "aggregate-tests"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate.yml
@@ -66,3 +66,105 @@ tests:
               commandName: getMore
               databaseName: *database0Name
 
+  - description: "aggregate with a string comment"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          comment: "comment"
+        object: *collection0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } } } ]
+                comment: "comment"
+
+  - description: "aggregate with a document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          comment: &comment0 { content: "test" }
+        object: *collection0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } } } ]
+                comment: *comment0
+
+  - description: "aggregate with a document comment - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.2.99"
+    operations:
+      - name: aggregate
+        object: *collection0
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          comment: *comment0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+                comment: *comment0
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: "aggregate with comment does not set comment on getMore"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          batchSize: 2
+          comment: "comment"
+        object: *collection0
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+                cursor: { batchSize: 2 }
+                comment: "comment"
+              commandName: aggregate
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: { $$exists: false }
+              commandName: getMore
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: { $$exists: false }
+              commandName: getMore
+              databaseName: *database0Name

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/bulkWrite-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/bulkWrite-comment.json
@@ -1,0 +1,494 @@
+{
+  "description": "bulkWrite-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-v2"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "BulkWrite_comment"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "BulkWrite_comment",
+      "databaseName": "crud-v2",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 5,
+                    "x": "inserted"
+                  }
+                }
+              },
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "x": "replaced"
+                  }
+                }
+              },
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "update": {
+                    "$set": {
+                      "x": "updated"
+                    }
+                  }
+                }
+              },
+              {
+                "deleteOne": {
+                  "filter": {
+                    "_id": 3
+                  }
+                }
+              }
+            ],
+            "comment": "comment"
+          },
+          "expectResult": {
+            "deletedCount": 1,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 5
+              }
+            },
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "BulkWrite_comment",
+                  "documents": [
+                    {
+                      "_id": 5,
+                      "x": "inserted"
+                    }
+                  ],
+                  "ordered": true,
+                  "comment": "comment"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "BulkWrite_comment",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "x": "replaced"
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": 2
+                      },
+                      "u": {
+                        "$set": {
+                          "x": "updated"
+                        }
+                      }
+                    }
+                  ],
+                  "ordered": true,
+                  "comment": "comment"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "BulkWrite_comment",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": 3
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "BulkWrite_comment",
+          "databaseName": "crud-v2",
+          "documents": [
+            {
+              "_id": 1,
+              "x": "replaced"
+            },
+            {
+              "_id": 2,
+              "x": "updated"
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": "inserted"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 5,
+                    "x": "inserted"
+                  }
+                }
+              },
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "x": "replaced"
+                  }
+                }
+              },
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "update": {
+                    "$set": {
+                      "x": "updated"
+                    }
+                  }
+                }
+              },
+              {
+                "deleteOne": {
+                  "filter": {
+                    "_id": 3
+                  }
+                }
+              }
+            ],
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": {
+            "deletedCount": 1,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 5
+              }
+            },
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "BulkWrite_comment",
+                  "documents": [
+                    {
+                      "_id": 5,
+                      "x": "inserted"
+                    }
+                  ],
+                  "ordered": true,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "BulkWrite_comment",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "x": "replaced"
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": 2
+                      },
+                      "u": {
+                        "$set": {
+                          "x": "updated"
+                        }
+                      }
+                    }
+                  ],
+                  "ordered": true,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "BulkWrite_comment",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": 3
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "BulkWrite_comment",
+          "databaseName": "crud-v2",
+          "documents": [
+            {
+              "_id": 1,
+              "x": "replaced"
+            },
+            {
+              "_id": 2,
+              "x": "updated"
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": "inserted"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 5,
+                    "x": "inserted"
+                  }
+                }
+              },
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "x": "replaced"
+                  }
+                }
+              },
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "update": {
+                    "$set": {
+                      "x": "updated"
+                    }
+                  }
+                }
+              },
+              {
+                "deleteOne": {
+                  "filter": {
+                    "_id": 3
+                  }
+                }
+              }
+            ],
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "BulkWrite_comment",
+                  "documents": [
+                    {
+                      "_id": 5,
+                      "x": "inserted"
+                    }
+                  ],
+                  "ordered": true,
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "BulkWrite_comment",
+          "databaseName": "crud-v2",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/bulkWrite-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/bulkWrite-comment.yml
@@ -1,0 +1,166 @@
+description: bulkWrite-comment
+schemaVersion: '1.0'
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database0 database0
+      client: client0
+      databaseName: &database_name crud-v2
+  - collection:
+      id: &collection0 collection0
+      database: database0
+      collectionName: &collection_name BulkWrite_comment
+
+initialData: &initial_data
+  - collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - _id: 1
+        x: 11
+      - _id: 2
+        x: 22
+      - _id: 3
+        x: 33
+      - _id: 4
+        x: 44
+
+tests:
+  - description: 'BulkWrite with string comment'
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests: &requests
+            - insertOne:
+                document: &inserted_document
+                  _id: 5
+                  x: "inserted"
+            - replaceOne:
+                filter: &replaceOne_filter
+                  _id: 1
+                replacement: &replacement { _id: 1, x: "replaced" }
+            - updateOne:
+                filter: &updateOne_filter
+                  _id: 2
+                update: &update { $set: {x: "updated"} }
+            - deleteOne:
+                filter: &deleteOne_filter
+                  _id: 3
+          comment: &string_comment "comment"
+        expectResult: &expect_results
+          deletedCount: 1
+          insertedCount: 1
+          insertedIds: { $$unsetOrMatches: { 0: 5} }
+          matchedCount: 2
+          modifiedCount: 2
+          upsertedCount: 0
+          upsertedIds: {  }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents:
+                  - *inserted_document
+                ordered: true
+                comment: *string_comment
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  - q: *replaceOne_filter
+                    u: *replacement
+                  - q: *updateOne_filter
+                    u: *update
+                ordered: true
+                comment: *string_comment
+          - commandStartedEvent:
+              command:
+                delete: *collection_name
+                deletes:
+                  - q: *deleteOne_filter
+                    limit: 1
+                ordered: true
+                comment: *string_comment
+    outcome: &outcome
+      - collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - _id: 1
+            x: "replaced"
+          - _id: 2
+            x: "updated"
+          - _id: 4
+            x: 44
+          - _id: 5
+            x: "inserted"
+
+  - description: 'BulkWrite with document comment'
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests: *requests
+          comment: &document_comment { key: "value" }
+        expectResult: *expect_results
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents:
+                  - *inserted_document
+                ordered: true
+                comment: *document_comment
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  - q: *replaceOne_filter
+                    u: *replacement
+                  - q: *updateOne_filter
+                    u: *update
+                ordered: true
+                comment: *document_comment
+          - commandStartedEvent:
+              command:
+                delete: *collection_name
+                deletes:
+                  - q: *deleteOne_filter
+                    limit: 1
+                ordered: true
+                comment: *document_comment
+    outcome: *outcome
+
+  - description: 'BulkWrite with comment - pre 4.4'
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests: *requests
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents:
+                  - *inserted_document
+                ordered: true
+                comment: "comment"
+    outcome: *initial_data

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/deleteMany-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/deleteMany-comment.json
@@ -1,0 +1,244 @@
+{
+  "description": "deleteMany-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2,
+          "name": "name2"
+        },
+        {
+          "_id": 3,
+          "name": "name3"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "deleteMany with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "comment": "comment"
+          },
+          "expectResult": {
+            "deletedCount": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "limit": 0
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "deleteMany with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": {
+            "deletedCount": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "limit": 0
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "deleteMany with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "limit": 0
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2,
+              "name": "name2"
+            },
+            {
+              "_id": 3,
+              "name": "name3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/deleteMany-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/deleteMany-comment.yml
@@ -1,0 +1,96 @@
+description: "deleteMany-comment"
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2, name: "name2" }
+      - { _id: 3, name: "name3" }
+
+tests:
+  - description: "deleteMany with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: deleteMany
+        object: *collection0
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          comment: "comment"
+        expectResult: &expect_result
+          deletedCount: 2
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 0
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+
+  - description: "deleteMany with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: deleteMany
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: &comment { key: "value" }
+        expectResult: *expect_result
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 0
+                comment: *comment
+    outcome: *outcome
+
+  - description: "deleteMany with comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: deleteMany
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 0
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/deleteOne-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/deleteOne-comment.json
@@ -1,0 +1,242 @@
+{
+  "description": "deleteOne-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2,
+          "name": "name"
+        },
+        {
+          "_id": 3,
+          "name": "name"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "deleteOne with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": "comment"
+          },
+          "expectResult": {
+            "deletedCount": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2,
+              "name": "name"
+            },
+            {
+              "_id": 3,
+              "name": "name"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "deleteOne with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": {
+            "deletedCount": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2,
+              "name": "name"
+            },
+            {
+              "_id": 3,
+              "name": "name"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "deleteOne with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2,
+              "name": "name"
+            },
+            {
+              "_id": 3,
+              "name": "name"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/deleteOne-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/deleteOne-comment.yml
@@ -1,0 +1,97 @@
+description: "deleteOne-comment"
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2, name: "name" }
+      - { _id: 3, name: "name" }
+
+tests:
+  - description: "deleteOne with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: deleteOne
+        object: *collection0
+        arguments:
+          filter: &filter { _id: 1 }
+          comment: "comment"
+        expectResult: &expect_result
+          deletedCount: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 1
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 2, name: "name" }
+          - { _id: 3, name: "name" }
+
+  - description: "deleteOne with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: deleteOne
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: &comment { key: "value" }
+        expectResult: *expect_result
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 1
+                comment: *comment
+    outcome: *outcome
+
+  - description: "deleteOne with comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: deleteOne
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 1
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/find-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/find-comment.json
@@ -1,0 +1,298 @@
+{
+  "description": "find-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        },
+        {
+          "_id": 6,
+          "x": 66
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "find with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": "comment"
+          },
+          "expectResult": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {
+                    "_id": 1
+                  },
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "find with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {
+                    "_id": 1
+                  },
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "find with document comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99",
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {
+                    "_id": 1
+                  },
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "find with comment does not set comment on getMore",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "batchSize": 2,
+            "comment": "comment"
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "batchSize": 2,
+                  "comment": "comment"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/find-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/find-comment.yml
@@ -1,0 +1,127 @@
+description: "find-comment"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+      - { _id: 4, x: 44 }
+      - { _id: 5, x: 55 }
+      - { _id: 6, x: 66 }
+
+tests:
+  - description: "find with string comment"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: &filter
+            _id: 1
+          comment: "comment"
+        expectResult: &expect_result
+          - { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: *filter
+                comment: "comment"
+
+  - description: "find with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: &comment { key: "value"}
+        expectResult: *expect_result
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: *filter
+                comment: *comment
+
+  - description: "find with document comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+        minServerVersion: "3.6"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: &comment { key: "value"}
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: *filter
+                comment: *comment
+
+  - description: "find with comment does not set comment on getMore"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: &filter_get_more { _id: { $gt: 1 } }
+          batchSize: 2
+          comment: "comment"
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: { $gt: 1 } }
+                batchSize: 2
+                comment: "comment"
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: { $$exists: false }
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: { $$exists: false }

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndDelete-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndDelete-comment.json
@@ -1,0 +1,211 @@
+{
+  "description": "findOneAndDelete-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "findOneAndDelete with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndDelete",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": "comment"
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "remove": true,
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndDelete with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndDelete",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "remove": true,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndDelete with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2.0",
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndDelete",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "remove": true,
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndDelete-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndDelete-comment.yml
@@ -1,0 +1,96 @@
+description: "findOneAndDelete-comment"
+schemaVersion: "1.0"
+
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2 }
+
+tests:
+  - description: "findOneAndDelete with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: findOneAndDelete
+        object: *collection0
+        arguments:
+          filter: &filter
+            _id: 1
+          comment: "comment"
+        expectResult:
+          _id: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                remove: true
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 2 }
+
+  - description: "findOneAndDelete with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: findOneAndDelete
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: &comment { key: "value"}
+        expectResult:
+          _id: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                remove: true
+                comment: *comment
+    outcome: *outcome
+
+  - description: "findOneAndDelete with comment - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "4.2.0" # findAndModify option validation was introduced in 4.2
+        maxServerVersion: "4.2.99"
+    operations:
+      - name: findOneAndDelete
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                remove: true
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndReplace-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndReplace-comment.json
@@ -1,0 +1,234 @@
+{
+  "description": "findOneAndReplace-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "findOneAndReplace with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 5
+            },
+            "comment": "comment"
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "x": 5
+                  },
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 5
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndReplace with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 5
+            },
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "x": 5
+                  },
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 5
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndReplace with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2.0",
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 5
+            },
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "x": 5
+                  },
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndReplace-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndReplace-comment.yml
@@ -1,0 +1,101 @@
+description: "findOneAndReplace-comment"
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2 }
+
+tests:
+  - description: "findOneAndReplace with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: &filter
+            _id: 1
+          replacement: &replacement
+            x: 5
+          comment: "comment"
+        expectResult:
+          _id: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                update: *replacement
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 5 }
+          - { _id: 2 }
+
+  - description: "findOneAndReplace with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          comment: &comment { key: "value"}
+        expectResult:
+          _id: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                update: *replacement
+                comment: *comment
+    outcome: *outcome
+
+
+  - description: "findOneAndReplace with comment - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "4.2.0" # findAndModify option validation was introduced in 4.2
+        maxServerVersion: "4.2.99"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                update: *replacement
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndUpdate-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndUpdate-comment.json
@@ -1,0 +1,228 @@
+{
+  "description": "findOneAndUpdate-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "findOneAndUpdate with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "x": 5
+                }
+              }
+            ],
+            "comment": "comment"
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 5
+                      }
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndUpdate with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "x": 5
+                }
+              }
+            ],
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 5
+                      }
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndUpdate with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2.0",
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "x": 5
+                }
+              }
+            ],
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 5
+                      }
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndUpdate-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/findOneAndUpdate-comment.yml
@@ -1,0 +1,95 @@
+description: "findOneAndUpdate-comment"
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2 }
+
+tests:
+  - description: "findOneAndUpdate with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: &filter
+            _id: 1
+          update: &update
+            - $set: {x: 5 }
+          comment: "comment"
+        expectResult:
+          _id: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                update: *update
+                comment: "comment"
+
+  - description: "findOneAndUpdate with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: &filter
+            _id: 1
+          update: &update
+            - $set: {x: 5 }
+          comment: &comment { key: "value"}
+        expectResult:
+          _id: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                update: *update
+                comment: *comment
+
+  - description: "findOneAndUpdate with comment - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "4.2.0" # findAndModify option validation was introduced in 4.2
+        maxServerVersion: "4.2.99"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: *filter
+          update: *update
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: *filter
+                update: *update
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/insertMany-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/insertMany-comment.json
@@ -1,0 +1,225 @@
+{
+  "description": "insertMany-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "insertMany with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2,
+                "x": 22
+              }
+            ],
+            "comment": "comment"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertMany with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2,
+                "x": 22
+              }
+            ],
+            "comment": {
+              "key": "value"
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertMany with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2,
+                "x": 22
+              }
+            ],
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/insertMany-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/insertMany-comment.yml
@@ -1,0 +1,92 @@
+description: "insertMany-comment"
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "insertMany with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            - &document { _id: 2, x: 22 }
+          comment: "comment"
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *document
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+
+  - description: "insertMany with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            - *document
+          comment: &comment { key: "value" }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *document
+                comment: *comment
+    outcome: *outcome
+
+  - description: "insertMany with comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            - *document
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *document
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/insertOne-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/insertOne-comment.json
@@ -1,0 +1,219 @@
+{
+  "description": "insertOne-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "insertOne with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2,
+              "x": 22
+            },
+            "comment": "comment"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertOne with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2,
+              "x": 22
+            },
+            "comment": {
+              "key": "value"
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertOne with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2,
+              "x": 22
+            },
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/insertOne-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/insertOne-comment.yml
@@ -1,0 +1,90 @@
+description: "insertOne-comment"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "insertOne with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &document { _id: 2, x: 22 }
+          comment: "comment"
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *document
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+
+  - description: "insertOne with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: *document
+          comment: &comment { key: "value" }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *document
+                comment: *comment
+    outcome: *outcome
+
+  - description: "insertOne with comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: *document
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *document
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/replaceOne-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/replaceOne-comment.json
@@ -1,0 +1,229 @@
+{
+  "description": "replaceOne-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "ReplaceOne with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 22
+            },
+            "comment": "comment"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "x": 22
+                      }
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ReplaceOne with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 22
+            },
+            "comment": {
+              "key": "value"
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "x": 22
+                      }
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ReplaceOne with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 22
+            },
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "x": 22
+                      }
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/replaceOne-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/replaceOne-comment.yml
@@ -1,0 +1,98 @@
+description: "replaceOne-comment"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "ReplaceOne with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: &filter { _id: 1 }
+          replacement: &replacement { x: 22 }
+          comment: "comment"
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *replacement
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 22 }
+
+  - description: "ReplaceOne with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          comment: &comment { key: "value" }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *replacement
+                comment: *comment
+    outcome: *outcome
+
+  - description: "ReplaceOne with comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *replacement
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/updateMany-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/updateMany-comment.json
@@ -1,0 +1,244 @@
+{
+  "description": "updateMany-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateMany with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 22
+              }
+            },
+            "comment": "comment"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 22
+                        }
+                      },
+                      "multi": true
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "UpdateMany with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 22
+              }
+            },
+            "comment": {
+              "key": "value"
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 22
+                        }
+                      },
+                      "multi": true
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "UpdateMany with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 22
+              }
+            },
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 22
+                        }
+                      },
+                      "multi": true
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/updateMany-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/updateMany-comment.yml
@@ -1,0 +1,100 @@
+description: "updateMany-comment"
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "UpdateMany with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: &filter { _id: 1 }
+          update: &update { $set: {x: 22} }
+          comment: "comment"
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *update
+                    multi: true
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 22 }
+
+  - description: "UpdateMany with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: *filter
+          update: *update
+          comment: &comment { key: "value" }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *update
+                    multi: true
+                comment: *comment
+    outcome: *outcome
+
+  - description: "UpdateMany with comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: *filter
+          update: *update
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *update
+                    multi: true
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/updateOne-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/updateOne-comment.json
@@ -1,0 +1,241 @@
+{
+  "description": "updateOne-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 22
+              }
+            },
+            "comment": "comment"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 22
+                        }
+                      }
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "UpdateOne with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 22
+              }
+            },
+            "comment": {
+              "key": "value"
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 22
+                        }
+                      }
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "UpdateOne with comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 22
+              }
+            },
+            "comment": "comment"
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 22
+                        }
+                      }
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/updateOne-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/updateOne-comment.yml
@@ -1,0 +1,97 @@
+description: "updateOne-comment"
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "UpdateOne with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: &filter { _id: 1 }
+          update: &update { $set: {x: 22} }
+          comment: "comment"
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *update
+                comment: "comment"
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 22 }
+
+  - description: "UpdateOne with document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: *filter
+          update: *update
+          comment: &comment { key: "value" }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *update
+                comment: *comment
+    outcome: *outcome
+
+  - description: "UpdateOne with comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: *filter
+          update: *update
+          comment: "comment"
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  -
+                    q: *filter
+                    u: *update
+                comment: "comment"
+    outcome: *initialData

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedValueMatcher.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedValueMatcher.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
         {
             try
             {
-                AssertValuesMatch(actual, expected, isRoot: true);
+                AssertValuesMatch(actual, expected, isRoot: true, isRecursiveCall: false);
             }
             catch (XunitException exception)
             {
@@ -50,7 +50,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
             }
         }
 
-        private void AssertValuesMatch(BsonValue actual, BsonValue expected, bool isRoot)
+        private void AssertValuesMatch(BsonValue actual, BsonValue expected, bool isRoot, bool isRecursiveCall = true)
         {
             if (expected.IsBsonDocument &&
                 expected.AsBsonDocument.ElementCount == 1 &&
@@ -158,7 +158,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
 
                 for (int i = 0; i < expectedArray.Count; i++)
                 {
-                    AssertValuesMatch(actualArray[i], expectedArray[i], isRoot: false);
+                    AssertValuesMatch(actualArray[i], expectedArray[i], isRoot: isRoot && !isRecursiveCall);
                 }
             }
             else if (expected.IsNumeric)

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedAggregateOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedAggregateOperation.cs
@@ -188,6 +188,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                         options ??= new AggregateOptions();
                         options.BatchSize = argument.Value.ToInt32();
                         break;
+                    case "comment":
+                        options ??= new AggregateOptions();
+                        options.Comment = argument.Value;
+                        break;
                     case "let":
                         options ??= new AggregateOptions();
                         options.Let = argument.Value.AsBsonDocument;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedBulkWriteOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedBulkWriteOperation.cs
@@ -107,6 +107,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new BulkWriteOptions();
+                        options.Comment = argument.Value;
+                        break;
                     case "ordered":
                         options ??= new BulkWriteOptions();
                         options.IsOrdered = argument.Value.AsBoolean;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateChangeStreamOnCollectionOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateChangeStreamOnCollectionOperation.cs
@@ -89,8 +89,12 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 switch (argument.Name)
                 {
                     case "batchSize":
-                        options = options ?? new ChangeStreamOptions();
+                        options ??= new ChangeStreamOptions();
                         options.BatchSize = argument.Value.AsInt32;
+                        break;
+                    case "comment":
+                        options ??= new ChangeStreamOptions();
+                        options.Comment = argument.Value;
                         break;
                     case "pipeline":
                         var stages = argument.Value.AsBsonArray.Cast<BsonDocument>();

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDeleteManyOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDeleteManyOperation.cs
@@ -85,6 +85,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new DeleteOptions();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = new BsonDocumentFilterDefinition<BsonDocument>(argument.Value.AsBsonDocument);
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDeleteOneOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDeleteOneOperation.cs
@@ -93,6 +93,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new DeleteOptions();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = new BsonDocumentFilterDefinition<BsonDocument>(argument.Value.AsBsonDocument);
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFindOneAndDeleteOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFindOneAndDeleteOperation.cs
@@ -85,6 +85,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new FindOneAndDeleteOptions<BsonDocument>();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = new BsonDocumentFilterDefinition<BsonDocument>(argument.Value.AsBsonDocument);
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFindOneAndReplaceOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFindOneAndReplaceOperation.cs
@@ -89,6 +89,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new FindOneAndReplaceOptions<BsonDocument>();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = new BsonDocumentFilterDefinition<BsonDocument>(argument.Value.AsBsonDocument);
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFindOneAndUpdateOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFindOneAndUpdateOperation.cs
@@ -98,6 +98,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new FindOneAndUpdateOptions<BsonDocument>();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = new BsonDocumentFilterDefinition<BsonDocument>(argument.Value.AsBsonDocument);
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFindOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFindOperation.cs
@@ -105,6 +105,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                         options ??= new FindOptions<BsonDocument>();
                         options.BatchSize = argument.Value.AsInt32;
                         break;
+                    case "comment":
+                        options ??= new FindOptions<BsonDocument>();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = new BsonDocumentFilterDefinition<BsonDocument>(argument.Value.AsBsonDocument);
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedInsertManyOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedInsertManyOperation.cs
@@ -105,6 +105,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new InsertManyOptions();
+                        options.Comment = argument.Value;
+                        break;
                     case "documents":
                         documents = argument.Value.AsBsonArray.Cast<BsonDocument>().ToList();
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedInsertOneOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedInsertOneOperation.cs
@@ -104,8 +104,12 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 switch (argument.Name)
                 {
                     case "bypassDocumentValidation":
-                        options = options ?? new InsertOneOptions();
+                        options ??= new InsertOneOptions();
                         options.BypassDocumentValidation = argument.Value.AsBoolean;
+                        break;
+                    case "comment":
+                        options ??= new InsertOneOptions();
+                        options.Comment = argument.Value;
                         break;
                     case "document":
                         document = argument.Value.AsBsonDocument;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedReplaceOneOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedReplaceOneOperation.cs
@@ -89,6 +89,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new ReplaceOptions();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = new BsonDocumentFilterDefinition<BsonDocument>(argument.Value.AsBsonDocument);
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedUpdateManyOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedUpdateManyOperation.cs
@@ -112,6 +112,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new UpdateOptions();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = argument.Value.AsBsonDocument;
                         break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedUpdateOneOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedUpdateOneOperation.cs
@@ -112,6 +112,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options ??= new UpdateOptions();
+                        options.Comment = argument.Value;
+                        break;
                     case "filter":
                         filter = argument.Value.AsBsonDocument;
                         break;


### PR DESCRIPTION
[EG](https://spruce.mongodb.com/version/6213f18f5623435871e5c99)

Done together with [CSHARP-4043](https://jira.mongodb.org/browse/CSHARP-4043)
Follow up work in [CSHARP-4067](https://jira.mongodb.org/browse/CSHARP-4067)