### PR TITLE
CSHARP-4082: Include full stack trace when LINQ3 MongoQuery.ToString() encounters an unexpected exception.

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/MongoQuery.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/MongoQuery.cs
@@ -20,8 +20,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using MongoDB.Bson;
-using MongoDB.Driver.Linq;
 using MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecutableQueryTranslators;
 
 namespace MongoDB.Driver.Linq.Linq3Implementation
@@ -108,9 +106,13 @@ namespace MongoDB.Driver.Linq.Linq3Implementation
                 var executableQuery = ExpressionToExecutableQueryTranslator.Translate<TDocument, TOutput>(_provider, _expression);
                 return executableQuery.ToString();
             }
-            catch (Exception ex)
+            catch (ExpressionNotSupportedException ex)
             {
                 return ex.Message;
+            }
+            catch (Exception ex)
+            {
+                return ex.ToString();
             }
         }
     }


### PR DESCRIPTION
Attempting to repro CSHARP-3614 (among others), the following output is displayed:

```
Cannot find serializer for null.
```

With this change, the full (and much more informative) stack trace is included:

```
System.InvalidOperationException: Cannot find serializer for null.
   at MongoDB.Driver.Linq.Linq3Implementation.Serializers.KnownSerializers.KnownSerializersRegistry.GetSerializer(Expression expression, IBsonSerializer defaultSerializer) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Serializers/KnownSerializers/KnownSerializersRegistry.cs:line 43
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.ConstantExpressionToAggregationExpressionTranslator.Translate(TranslationContext context, ConstantExpression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ConstantExpressionToAggregationExpressionTranslator.cs:line 50
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.ExpressionToAggregationExpressionTranslator.Translate(TranslationContext context, Expression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ExpressionToAggregationExpressionTranslator.cs:line 65
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.BinaryExpressionToAggregationExpressionTranslator.Translate(TranslationContext context, BinaryExpression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/BinaryExpressionToAggregationExpressionTranslator.cs:line 50
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.ExpressionToAggregationExpressionTranslator.Translate(TranslationContext context, Expression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ExpressionToAggregationExpressionTranslator.cs:line 54
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.ConditionalExpressionToAggregationExpressionTranslator.Translate(TranslationContext context, ConditionalExpression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ConditionalExpressionToAggregationExpressionTranslator.cs:line 28
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.ExpressionToAggregationExpressionTranslator.Translate(TranslationContext context, Expression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ExpressionToAggregationExpressionTranslator.cs:line 63
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.MemberInitExpressionToAggregationExpressionTranslator.Translate(TranslationContext context, MemberInitExpression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MemberInitExpressionToAggregationExpressionTranslator.cs:line 56
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.ExpressionToAggregationExpressionTranslator.Translate(TranslationContext context, Expression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ExpressionToAggregationExpressionTranslator.cs:line 69
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.ExpressionToAggregationExpressionTranslator.TranslateLambdaBody(TranslationContext context, LambdaExpression lambdaExpression, IBsonSerializer parameterSerializer, Boolean asRoot) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ExpressionToAggregationExpressionTranslator.cs:line 115
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToPipelineTranslators.SelectMethodToPipelineTranslator.Translate(TranslationContext context, MethodCallExpression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToPipelineTranslators/SelectMethodToPipelineTranslator.cs:line 44
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToPipelineTranslators.ExpressionToPipelineTranslator.Translate(TranslationContext context, Expression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToPipelineTranslators/ExpressionToPipelineTranslator.cs:line 55
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecutableQueryTranslators.ExpressionToExecutableQueryTranslator.Translate[TDocument,TOutput](MongoQueryProvider`1 provider, Expression expression) in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToExecutableQueryTranslators/ExpressionToExecutableQueryTranslator.cs:line 34
   at MongoDB.Driver.Linq.Linq3Implementation.MongoQuery`2.ToString() in /Users/james/Dropbox/code/mongodb/mongo-csharp-driver/src/MongoDB.Driver/Linq/Linq3Implementation/MongoQuery.cs:line 108
```

For cases where we know that an expression is not supported, we still display the abbreviated error message.