### PR TITLE
CSHARP-4090 / CSHARP-4092

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/StringMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/StringMethod.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
     {
         // private static fields
         private static readonly MethodInfo __contains;
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER
         private static readonly MethodInfo __containsWithComparisonType;
 #endif
         private static readonly MethodInfo __endsWith;
@@ -75,7 +75,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
         static StringMethod()
         {
             __contains = ReflectionInfo.Method((string s, string value) => s.Contains(value));
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER
             __containsWithComparisonType = ReflectionInfo.Method((string s, string value, StringComparison comparisonType) => s.Contains(value, comparisonType));
 #endif
             __endsWith = ReflectionInfo.Method((string s, string value) => s.EndsWith(value));
@@ -125,7 +125,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
 
         // public properties
         public static MethodInfo Contains => __contains;
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER
         public static MethodInfo ContainsWithComparisonType => __containsWithComparisonType;
 #endif
         public static MethodInfo EndsWith => __endsWith;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/StringMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/StringMethod.cs
@@ -24,6 +24,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
     {
         // private static fields
         private static readonly MethodInfo __contains;
+#if NETSTANDARD2_1
+        private static readonly MethodInfo __containsWithComparisonType;
+#endif
         private static readonly MethodInfo __endsWith;
         private static readonly MethodInfo __endsWithWithComparisonType;
         private static readonly MethodInfo __endsWithWithIgnoreCaseAndCulture;
@@ -72,6 +75,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
         static StringMethod()
         {
             __contains = ReflectionInfo.Method((string s, string value) => s.Contains(value));
+#if NETSTANDARD2_1
+            __containsWithComparisonType = ReflectionInfo.Method((string s, string value, StringComparison comparisonType) => s.Contains(value, comparisonType));
+#endif
             __endsWith = ReflectionInfo.Method((string s, string value) => s.EndsWith(value));
             __endsWithWithComparisonType = ReflectionInfo.Method((string s, string value, StringComparison comparisonType) => s.EndsWith(value, comparisonType));
             __endsWithWithIgnoreCaseAndCulture = ReflectionInfo.Method((string s, string value, bool ignoreCase, CultureInfo culture) => s.EndsWith(value, ignoreCase, culture));
@@ -119,6 +125,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
 
         // public properties
         public static MethodInfo Contains => __contains;
+#if NETSTANDARD2_1
+        public static MethodInfo ContainsWithComparisonType => __containsWithComparisonType;
+#endif
         public static MethodInfo EndsWith => __endsWith;
         public static MethodInfo EndsWithWithComparisonType => __endsWithWithComparisonType;
         public static MethodInfo EndsWithWithIgnoreCaseAndCulture => __endsWithWithIgnoreCaseAndCulture;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/ContainsMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/ContainsMethodToAggregationExpressionTranslator.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Linq.Expressions;
+using System.Reflection;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Linq.Linq3Implementation.Ast.Expressions;
 using MongoDB.Driver.Linq.Linq3Implementation.Misc;
@@ -23,10 +24,23 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 {
     internal static class ContainsMethodToAggregationExpressionTranslator
     {
+        private static readonly MethodInfo[] __containsMethods;
+
+        static ContainsMethodToAggregationExpressionTranslator()
+        {
+            __containsMethods = new[]
+            {
+                StringMethod.Contains,
+#if NETSTANDARD2_1
+                StringMethod.ContainsWithComparisonType
+#endif
+            };
+        }
+
         // public methods
         public static AggregationExpression Translate(TranslationContext context, MethodCallExpression expression)
         {
-            if (expression.Method.Is(StringMethod.Contains))
+            if (expression.Method.IsOneOf(__containsMethods))
             {
                 return StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator.Translate(context, expression);
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/ContainsMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/ContainsMethodToAggregationExpressionTranslator.cs
@@ -31,7 +31,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             __containsMethods = new[]
             {
                 StringMethod.Contains,
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER
                 StringMethod.ContainsWithComparisonType
 #endif
             };

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 StringMethod.StartsWithWithComparisonType,
                 StringMethod.StartsWithWithIgnoreCaseAndCulture,
                 StringMethod.Contains,
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER
                 StringMethod.ContainsWithComparisonType,
 #endif
                 StringMethod.EndsWith,
@@ -49,7 +49,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             __withComparisonTypeMethods = new[]
             {
                 StringMethod.StartsWithWithComparisonType,
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER
                 StringMethod.ContainsWithComparisonType,
 #endif
                 StringMethod.EndsWithWithComparisonType

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/StartsWithContainsOrEndsWithMethodToAggregationExpressionTranslator.cs
@@ -14,12 +14,10 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver.Linq.Linq3Implementation.Ast;
 using MongoDB.Driver.Linq.Linq3Implementation.Ast.Expressions;
 using MongoDB.Driver.Linq.Linq3Implementation.ExtensionMethods;
 using MongoDB.Driver.Linq.Linq3Implementation.Misc;
@@ -40,6 +38,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 StringMethod.StartsWithWithComparisonType,
                 StringMethod.StartsWithWithIgnoreCaseAndCulture,
                 StringMethod.Contains,
+#if NETSTANDARD2_1
+                StringMethod.ContainsWithComparisonType,
+#endif
                 StringMethod.EndsWith,
                 StringMethod.EndsWithWithComparisonType,
                 StringMethod.EndsWithWithIgnoreCaseAndCulture
@@ -48,6 +49,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             __withComparisonTypeMethods = new[]
             {
                 StringMethod.StartsWithWithComparisonType,
+#if NETSTANDARD2_1
+                StringMethod.ContainsWithComparisonType,
+#endif
                 StringMethod.EndsWithWithComparisonType
             };
 
@@ -86,7 +90,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 if (ignoreCase)
                 {
                     stringAst = AstExpression.ToLower(stringAst);
-                    substringAst = AstExpression.ToLower(stringAst);
+                    substringAst = AstExpression.ToLower(substringAst);
                 }
                 var ast = CreateAst(method.Name, stringAst, substringAst);
                 return new AggregationExpression(expression, ast, new BooleanSerializer());
@@ -118,7 +122,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 {
                     var (stringVar, stringSimpleAst) = AstExpression.UseVarIfNotSimple("string", stringAst);
                     var (substringVar, substringSimpleAst) = AstExpression.UseVarIfNotSimple("substring", substringAst);
-                    var startAst = AstExpression.Subtract(AstExpression.StrLenCP(stringSimpleAst), AstExpression.StrLenCP(substringSimpleAst));                      
+                    var startAst = AstExpression.Subtract(AstExpression.StrLenCP(stringSimpleAst), AstExpression.StrLenCP(substringSimpleAst));
                     var ast = AstExpression.Gte(AstExpression.IndexOfCP(stringSimpleAst, substringSimpleAst, startAst), 0);
                     return AstExpression.Let(stringVar, substringVar, ast);
                 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp4090Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp4090Tests.cs
@@ -1,0 +1,149 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver.Linq;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
+{
+    public class CSharp4090Tests : Linq3IntegrationTest
+    {
+        [Fact]
+        public void String_starts_with_with_current_culture_ignore_case_should_work()
+        {
+            var collection = GetCollection<C>();
+            collection.Database.DropCollection(collection.CollectionNamespace.CollectionName);
+
+            var id = new ObjectId("0102030405060708090a0b0c");
+            collection.InsertMany(
+                new[]
+                {
+                    new C { Id = id, Text = "Apple-Orange-Banana", Match = "apple" },
+                    new C { Id = new ObjectId("000000000000000000000000"), Text = "Apple-Kiwi-Pear", Match = "mango" }
+                });
+
+            var find = collection.Find(x => x.Text.StartsWith(x.Match, StringComparison.CurrentCultureIgnoreCase));
+
+            var rendered = find.ToString();
+            rendered.Should().Be("find({ \"$expr\" : { \"$eq\" : [{ \"$indexOfCP\" : [{ \"$toLower\" : \"$Text\" }, { \"$toLower\" : \"$Match\" }] }, 0] } })");
+
+            var results = find.ToList();
+            results.Count.Should().Be(1);
+            results[0].Id.Should().Be(id);
+        }
+
+        [Theory]
+        [InlineData(StringComparison.InvariantCulture)]
+        [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+        [InlineData(StringComparison.Ordinal)]
+        [InlineData(StringComparison.OrdinalIgnoreCase)]
+        public void Should_throw_not_supported_exception_for_starts_with_with_unsupported_string_comparison_type(StringComparison comparison)
+        {
+            var collection = GetCollection<C>();
+
+            var exception = Record.Exception(() => collection.Find(x => x.Text.StartsWith("orange", comparison)).ToList());
+
+            exception.Should().BeOfType<ExpressionNotSupportedException>();
+        }
+
+#if NETCOREAPP3_1
+        [Fact]
+        public void String_contains_with_current_culture_ignore_case_should_work()
+        {
+            var collection = GetCollection<C>();
+            collection.Database.DropCollection(collection.CollectionNamespace.CollectionName);
+
+            var id = new ObjectId("0102030405060708090a0b0c");
+            collection.InsertMany(
+                new[]
+                {
+                    new C { Id = id, Text = "Apple-Orange-Banana", Match = "orange" },
+                    new C { Id = new ObjectId("000000000000000000000000"), Text = "Apple-Kiwi-Pear", Match = "mango" }
+                });
+
+            var find = collection.Find(x => x.Text.Contains(x.Match, StringComparison.CurrentCultureIgnoreCase));
+
+            var rendered = find.ToString();
+            rendered.Should().Be("find({ \"$expr\" : { \"$gte\" : [{ \"$indexOfCP\" : [{ \"$toLower\" : \"$Text\" }, { \"$toLower\" : \"$Match\" }] }, 0] } })");
+
+            var results = find.ToList();
+            results.Count.Should().Be(1);
+            results[0].Id.Should().Be(id);
+        }
+
+        [Theory]
+        [InlineData(StringComparison.InvariantCulture)]
+        [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+        [InlineData(StringComparison.Ordinal)]
+        [InlineData(StringComparison.OrdinalIgnoreCase)]
+        public void Should_throw_not_supported_exception_for_contains_with_unsupported_string_comparison_type(StringComparison comparison)
+        {
+            var collection = GetCollection<C>();
+
+            var exception = Record.Exception(() => collection.Find(x => x.Text.Contains("orange", comparison)).ToList());
+
+            exception.Should().BeOfType<ExpressionNotSupportedException>();
+        }
+#endif
+
+        [Fact]
+        public void String_ends_with_with_current_culture_ignore_case_should_work()
+        {
+            var collection = GetCollection<C>();
+            collection.Database.DropCollection(collection.CollectionNamespace.CollectionName);
+
+            var id = new ObjectId("0102030405060708090a0b0c");
+            collection.InsertMany(
+                new[]
+                {
+                    new C { Id = id, Text = "Apple-Orange-Banana", Match = "banana" },
+                    new C { Id = new ObjectId("000000000000000000000000"), Text = "Apple-Kiwi-Pear", Match = "mango" }
+                });
+
+            var find = collection.Find(x => x.Text.EndsWith(x.Match, StringComparison.CurrentCultureIgnoreCase));
+
+            var rendered = find.ToString();
+            rendered.Should().Be("find({ \"$expr\" : { \"$let\" : { \"vars\" : { \"string\" : { \"$toLower\" : \"$Text\" }, \"substring\" : { \"$toLower\" : \"$Match\" } }, \"in\" : { \"$gte\" : [{ \"$indexOfCP\" : [\"$$string\", \"$$substring\", { \"$subtract\" : [{ \"$strLenCP\" : \"$$string\" }, { \"$strLenCP\" : \"$$substring\" }] }] }, 0] } } } })");
+
+            var results = find.ToList();
+            results.Count.Should().Be(1);
+            results[0].Id.Should().Be(id);
+        }
+
+        [Theory]
+        [InlineData(StringComparison.InvariantCulture)]
+        [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+        [InlineData(StringComparison.Ordinal)]
+        [InlineData(StringComparison.OrdinalIgnoreCase)]
+        public void Should_throw_not_supported_exception_for_ends_with_with_unsupported_string_comparison_type(StringComparison comparison)
+        {
+            var collection = GetCollection<C>();
+
+            var exception = Record.Exception(() => collection.Find(x => x.Text.EndsWith("orange", comparison)).ToList());
+
+            exception.Should().BeOfType<ExpressionNotSupportedException>();
+        }
+
+        public class C
+        {
+            public ObjectId Id { get; set; }
+            public string Text { get; set; }
+            public string Match { get; set; }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp4090Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp4090Tests.cs
@@ -15,7 +15,6 @@
 
 using System;
 using FluentAssertions;
-using MongoDB.Bson;
 using MongoDB.Driver.Linq;
 using Xunit;
 
@@ -29,12 +28,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
             var collection = GetCollection<C>();
             collection.Database.DropCollection(collection.CollectionNamespace.CollectionName);
 
-            var id = new ObjectId("0102030405060708090a0b0c");
             collection.InsertMany(
                 new[]
                 {
-                    new C { Id = id, Text = "Apple-Orange-Banana", Match = "apple" },
-                    new C { Id = new ObjectId("000000000000000000000000"), Text = "Apple-Kiwi-Pear", Match = "mango" }
+                    new C { Id = 100, Text = "Apple-Orange-Banana", Match = "apple" },
+                    new C { Id = 101, Text = "Apple-Kiwi-Pear", Match = "mango" }
                 });
 
             var find = collection.Find(x => x.Text.StartsWith(x.Match, StringComparison.CurrentCultureIgnoreCase));
@@ -44,7 +42,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
 
             var results = find.ToList();
             results.Count.Should().Be(1);
-            results[0].Id.Should().Be(id);
+            results[0].Id.Should().Be(100);
         }
 
         [Theory]
@@ -61,19 +59,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
             exception.Should().BeOfType<ExpressionNotSupportedException>();
         }
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void String_contains_with_current_culture_ignore_case_should_work()
         {
             var collection = GetCollection<C>();
             collection.Database.DropCollection(collection.CollectionNamespace.CollectionName);
 
-            var id = new ObjectId("0102030405060708090a0b0c");
             collection.InsertMany(
                 new[]
                 {
-                    new C { Id = id, Text = "Apple-Orange-Banana", Match = "orange" },
-                    new C { Id = new ObjectId("000000000000000000000000"), Text = "Apple-Kiwi-Pear", Match = "mango" }
+                    new C { Id = 100, Text = "Apple-Orange-Banana", Match = "orange" },
+                    new C { Id = 101, Text = "Apple-Kiwi-Pear", Match = "mango" }
                 });
 
             var find = collection.Find(x => x.Text.Contains(x.Match, StringComparison.CurrentCultureIgnoreCase));
@@ -83,7 +80,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
 
             var results = find.ToList();
             results.Count.Should().Be(1);
-            results[0].Id.Should().Be(id);
+            results[0].Id.Should().Be(100);
         }
 
         [Theory]
@@ -107,12 +104,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
             var collection = GetCollection<C>();
             collection.Database.DropCollection(collection.CollectionNamespace.CollectionName);
 
-            var id = new ObjectId("0102030405060708090a0b0c");
             collection.InsertMany(
                 new[]
                 {
-                    new C { Id = id, Text = "Apple-Orange-Banana", Match = "banana" },
-                    new C { Id = new ObjectId("000000000000000000000000"), Text = "Apple-Kiwi-Pear", Match = "mango" }
+                    new C { Id = 100, Text = "Apple-Orange-Banana", Match = "banana" },
+                    new C { Id = 101, Text = "Apple-Kiwi-Pear", Match = "mango" }
                 });
 
             var find = collection.Find(x => x.Text.EndsWith(x.Match, StringComparison.CurrentCultureIgnoreCase));
@@ -122,7 +118,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
 
             var results = find.ToList();
             results.Count.Should().Be(1);
-            results[0].Id.Should().Be(id);
+            results[0].Id.Should().Be(100);
         }
 
         [Theory]
@@ -141,7 +137,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
 
         public class C
         {
-            public ObjectId Id { get; set; }
+            public int Id { get; set; }
             public string Text { get; set; }
             public string Match { get; set; }
         }


### PR DESCRIPTION
CSHARP-4090: Implement support for string.Contains(match, StringComparison).
CSHARP-4092: Fix case-insensitive StartsWith/EndsWith to generate correct MQL.