### PR TITLE
CSHARP-4115: Case insensitive string comparison support for LINQ translator

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodCallExpressionToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodCallExpressionToAggregationExpressionTranslator.cs
@@ -32,6 +32,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 case "Any": return AnyMethodToAggregationExpressionTranslator.Translate(context, expression);
                 case "Average": return AverageMethodToAggregationExpressionTranslator.Translate(context, expression);
                 case "Ceiling": return CeilingMethodToAggregationExpressionTranslator.Translate(context, expression);
+                case "Compare": return CompareMethodToAggregationExpressionTranslator.Translate(context, expression);
                 case "CompareTo": return CompareToMethodToAggregationExpressionTranslator.Translate(context, expression);
                 case "Concat": return ConcatMethodToAggregationExpressionTranslator.Translate(context, expression);
                 case "Contains": return ContainsMethodToAggregationExpressionTranslator.Translate(context, expression);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/CompareMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/CompareMethodToAggregationExpressionTranslator.cs
@@ -1,0 +1,105 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.Ast.Expressions;
+using MongoDB.Driver.Linq.Linq3Implementation.ExtensionMethods;
+using MongoDB.Driver.Linq.Linq3Implementation.Misc;
+
+namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.MethodTranslators
+{
+    internal static class CompareMethodToAggregationExpressionTranslator
+    {
+        public static AggregationExpression Translate(TranslationContext context, MethodCallExpression expression)
+        {
+            var method = expression.Method;
+
+            if (IsStringCompareMethod(method))
+            {
+                return TranslateStringCompareMethod(context, expression);
+            }
+
+            throw new ExpressionNotSupportedException(expression);
+        }
+
+        private static bool IsStringCompareMethod(MethodInfo method)
+        {
+            return method.DeclaringType == typeof(string);
+        }
+
+        private static AggregationExpression TranslateStringCompareMethod(TranslationContext context, MethodCallExpression expression)
+        {
+            var method = expression.Method;
+            var arguments = expression.Arguments;
+
+            Expression lhsExpression;
+            Expression rhsExpression;
+            Expression comparisonTypeExpression = null;
+            if (method.IsStatic)
+            {
+                lhsExpression = arguments[0];
+                rhsExpression = arguments[1];
+                if (arguments.Count == 3)
+                {
+                    comparisonTypeExpression = arguments[2];
+                }
+            }
+            else
+            {
+                lhsExpression = expression.Object;
+                rhsExpression = arguments[0];
+                if (arguments.Count == 2)
+                {
+                    comparisonTypeExpression = arguments[1];
+                }
+            }
+
+            StringComparison comparisonType = StringComparison.Ordinal;
+            if (comparisonTypeExpression != null)
+            {
+                comparisonType = comparisonTypeExpression.GetConstantValue<StringComparison>(containingExpression: expression);
+            }
+
+            var lhsTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, lhsExpression);
+            var rhsTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, rhsExpression);
+
+            AstExpression ast;
+            switch (comparisonType)
+            {
+                case StringComparison.CurrentCulture:
+                case StringComparison.Ordinal:
+                    ast = AstExpression.Cmp(lhsTranslation.Ast, rhsTranslation.Ast);
+                    break;
+
+                case StringComparison.CurrentCultureIgnoreCase:
+                case StringComparison.OrdinalIgnoreCase:
+                    ast = AstExpression.StrCaseCmp(lhsTranslation.Ast, rhsTranslation.Ast);
+                    break;
+
+                default:
+                    goto notSupported;
+            }
+
+            return new AggregationExpression(expression, ast, new BooleanSerializer());
+
+        notSupported:
+            throw new ExpressionNotSupportedException(expression);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/Translators/AggregateProjectTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/Translators/AggregateProjectTranslatorTests.cs
@@ -1446,6 +1446,26 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
             result.Value.Result.Should().BeTrue();
         }
 
+        [Fact]
+        public void Should_translate_string_case_insensitive_compare()
+        {
+            var result = Project(x => new { Result = string.Compare(x.B, "balloon", StringComparison.OrdinalIgnoreCase) > 0});
+
+            result.Projection.Should().Be("{ Result: { \"gt\": [{ \"$strcasecmp\": [\"$B\", \"balloon\"] }, 0] }, _id: 0 }");
+
+            result.Value.Result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_translate_string_case_sensitive_compare()
+        {
+            var result = Project(x => new { Result = string.Compare(x.B, "balloon", StringComparison.Ordinal) > 0});
+
+            result.Projection.Should().Be("{ Result: { \"gt\": [{ \"$cmp\": [\"$B\", \"balloon\"] }, 0] }, _id: 0 }");
+
+            result.Value.Result.Should().BeTrue();
+        }
+
         [Theory]
         [InlineData(StringComparison.CurrentCulture)]
         [InlineData(StringComparison.CurrentCultureIgnoreCase)]


### PR DESCRIPTION
The LINQ translator does not recognize calls to `String.Compare(a, b, StringComparison.OrdinalIgnoreCase)` in the LINQ translator.  This means that it's not possible to create a LINQ query that does a case insensitive string comparison; only case sensitive string equals works today.

The goal is to convert this:
`String.Compare(a, "value", StringComparison.OrdinalIgnoreCase) >= 0`

Into this:
`{ $expr: { $gte: [ { $strcasecmp: [ \"$a\", \"value\" ] }, 0 ]} }`

This patch implements this feature in a similar method to the way String.Equals is implemented today.

Unfortunately, as I'm a new contributor, I haven't yet figured out how to run the tests prior to submitting a PR.  It looks like there are environment variables and AWS keys that must be set up for the tests to function correctly - is it possible for me to run these tests standalone?

Potential improvements:
* Modify the "CompareTo" translator to also support CompareTo calls of type String; today it only recognizes generic $cmp
* Add a function into FilterBuilder called `.StrCaseCmp` to allow casual users to make these calls via shorthand