### PR TITLE
CSHARP-4036: Do not error when parsing change stream event documents

### DIFF
--- a/src/MongoDB.Driver.Core/ChangeStreamDocument.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamDocument.cs
@@ -62,6 +62,14 @@ namespace MongoDB.Driver
         public CollectionNamespace CollectionNamespace => GetValue<CollectionNamespace>(nameof(CollectionNamespace), null);
 
         /// <summary>
+        /// Gets the database namespace.
+        /// </summary>
+        /// <value>
+        /// The database namespace.
+        /// </value>
+        public DatabaseNamespace DatabaseNamespace => GetValue<DatabaseNamespace>(nameof(DatabaseNamespace), null);
+
+        /// <summary>
         /// Gets the document key.
         /// </summary>
         /// <value>

--- a/src/MongoDB.Driver.Core/ChangeStreamDocumentDatabaseNamespaceSerializer.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamDocumentDatabaseNamespaceSerializer.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2018-present MongoDB Inc.
+﻿/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,21 +20,20 @@ using MongoDB.Bson.Serialization.Serializers;
 
 namespace MongoDB.Driver
 {
-    internal class ChangeStreamDocumentCollectionNamespaceSerializer : SealedClassSerializerBase<CollectionNamespace>
+    internal class ChangeStreamDocumentDatabaseNamespaceSerializer : SealedClassSerializerBase<DatabaseNamespace>
     {
         #region static
         // private static fields
-        private static readonly ChangeStreamDocumentCollectionNamespaceSerializer __instance = new ChangeStreamDocumentCollectionNamespaceSerializer();
+        private static readonly ChangeStreamDocumentDatabaseNamespaceSerializer __instance = new ChangeStreamDocumentDatabaseNamespaceSerializer();
 
         // public static properties
-        public static ChangeStreamDocumentCollectionNamespaceSerializer Instance => __instance;
+        public static ChangeStreamDocumentDatabaseNamespaceSerializer Instance => __instance;
         #endregion
 
         // public methods
-        public override CollectionNamespace Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        public override DatabaseNamespace Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
         {
             var reader = context.Reader;
-            string collectionName = null;
             string databaseName = null;
 
             reader.ReadStartDocument();
@@ -49,10 +48,6 @@ namespace MongoDB.Driver
                         databaseName = reader.ReadString();
                         break;
 
-                    case "coll" when reader.CurrentBsonType == BsonType.String:
-                        collectionName = reader.ReadString();
-                        break;
-
                     default:
                         reader.SkipValue();
                         break;
@@ -60,24 +55,21 @@ namespace MongoDB.Driver
             }
             reader.ReadEndDocument();
 
-            if (!string.IsNullOrWhiteSpace(databaseName) && !string.IsNullOrWhiteSpace(collectionName))
+            if (!string.IsNullOrWhiteSpace(databaseName))
             {
-                var databaseNamespace = new DatabaseNamespace(databaseName);
-                return new CollectionNamespace(databaseNamespace, collectionName);
+                return new DatabaseNamespace(databaseName);
             }
 
             return null;
         }
 
-        protected override void SerializeValue(BsonSerializationContext context, BsonSerializationArgs args, CollectionNamespace value)
+        protected override void SerializeValue(BsonSerializationContext context, BsonSerializationArgs args, DatabaseNamespace value)
         {
             var writer = context.Writer;
 
             writer.WriteStartDocument();
             writer.WriteName("db");
-            writer.WriteString(value.DatabaseNamespace.DatabaseName);
-            writer.WriteName("coll");
-            writer.WriteString(value.CollectionName);
+            writer.WriteString(value.DatabaseName);
             writer.WriteEndDocument();
         }
     }

--- a/src/MongoDB.Driver.Core/ChangeStreamDocumentSerializer.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamDocumentSerializer.cs
@@ -42,6 +42,7 @@ namespace MongoDB.Driver
 
             RegisterMember("ClusterTime", "clusterTime", BsonTimestampSerializer.Instance);
             RegisterMember("CollectionNamespace", "ns", ChangeStreamDocumentCollectionNamespaceSerializer.Instance);
+            RegisterMember("DatabaseNamespace", "ns", ChangeStreamDocumentDatabaseNamespaceSerializer.Instance);
             RegisterMember("DocumentKey", "documentKey", BsonDocumentSerializer.Instance);
             RegisterMember("FullDocument", "fullDocument", _documentSerializer);
             RegisterMember("OperationType", "operationType", ChangeStreamOperationTypeSerializer.Instance);

--- a/src/MongoDB.Driver.Core/ChangeStreamOperationType.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamOperationType.cs
@@ -47,6 +47,10 @@ namespace MongoDB.Driver
         /// <summary>
         /// A drop operation type.
         /// </summary>
-        Drop
+        Drop,
+        /// <summary>
+        /// A dropDatabase operation type.
+        /// </summary>
+        DropDatabase
     }
 }

--- a/src/MongoDB.Driver.Core/ChangeStreamOperationTypeSerializer.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamOperationTypeSerializer.cs
@@ -13,9 +13,9 @@
 * limitations under the License.
 */
 
+using System;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
-using System;
 
 namespace MongoDB.Driver
 {
@@ -53,7 +53,8 @@ namespace MongoDB.Driver
                 case "update": return ChangeStreamOperationType.Update;
                 case "rename": return ChangeStreamOperationType.Rename;
                 case "drop": return ChangeStreamOperationType.Drop;
-                default: throw new FormatException($"Invalid ChangeStreamOperationType: \"{stringValue}\".");
+                case "dropDatabase": return ChangeStreamOperationType.DropDatabase;
+                default: return (ChangeStreamOperationType)(-1);
             }
         }
 
@@ -71,6 +72,7 @@ namespace MongoDB.Driver
                 case ChangeStreamOperationType.Update: writer.WriteString("update"); break;
                 case ChangeStreamOperationType.Rename: writer.WriteString("rename"); break;
                 case ChangeStreamOperationType.Drop: writer.WriteString("drop"); break;
+                case ChangeStreamOperationType.DropDatabase: writer.WriteString("dropDatabase"); break;
                 default: throw new ArgumentException($"Invalid ChangeStreamOperationType: {value}.", nameof(value));
             }
         }

--- a/tests/MongoDB.Driver.Core.Tests/ChangeStreamDocumentSerializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/ChangeStreamDocumentSerializerTests.cs
@@ -36,9 +36,10 @@ namespace MongoDB.Driver
             var result = new ChangeStreamDocumentSerializer<BsonDocument>(documentSerializer);
 
             result._documentSerializer().Should().BeSameAs(documentSerializer);
-            result._memberSerializationInfo().Count.Should().Be(8);
+            result._memberSerializationInfo().Count.Should().Be(9);
             AssertRegisteredMember(result, "ClusterTime", "clusterTime", BsonTimestampSerializer.Instance);
             AssertRegisteredMember(result, "CollectionNamespace", "ns", ChangeStreamDocumentCollectionNamespaceSerializer.Instance);
+            AssertRegisteredMember(result, "DatabaseNamespace", "ns", ChangeStreamDocumentDatabaseNamespaceSerializer.Instance);
             AssertRegisteredMember(result, "DocumentKey", "documentKey", BsonDocumentSerializer.Instance);
             AssertRegisteredMember(result, "FullDocument", "fullDocument", documentSerializer);
             AssertRegisteredMember(result, "OperationType", "operationType", ChangeStreamOperationTypeSerializer.Instance);

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.json
@@ -3,6 +3,7 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
+      "minServerVersion": "3.6",
       "topologies": [
         "replicaset",
         "sharded-replicaset"
@@ -331,6 +332,311 @@
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "description": "to field is set in a rename change event",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.1"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "collection1"
+          }
+        },
+        {
+          "name": "rename",
+          "object": "collection0",
+          "arguments": {
+            "to": "collection1"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "rename",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "to": {
+              "db": "database0",
+              "coll": "collection1"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test unknown operationType MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "addedInFutureMongoDBVersion",
+                  "ns": 1
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "addedInFutureMongoDBVersion",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test newField added in response MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": 1,
+                  "ns": 1,
+                  "newField": "newFieldValue"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "newField": "newFieldValue"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test new structure in ns document MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "insert",
+                  "ns.viewOn": "db.coll"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "viewOn": "db.coll"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test modified structure in ns document MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "insert",
+                  "ns": {
+                    "db": "$ns.db",
+                    "coll": "$ns.coll",
+                    "viewOn": "db.coll"
+                  }
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0",
+              "viewOn": "db.coll"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test server error on projecting out _id",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 0
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "errorCode": 280,
+            "errorCodeName": "ChangeStreamFatalError",
+            "errorLabelsContain": [
+              "NonResumableChangeStreamError"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test projection in change stream returns expected fields",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "optype": "$operationType",
+                  "ns": 1,
+                  "newField": "value"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "optype": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "newField": "value"
+          }
         }
       ]
     }

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.yml
@@ -1,7 +1,8 @@
 description: "change-streams"
 schemaVersion: "1.0"
 runOnRequirements:
-  - topologies: [ replicaset, sharded-replicaset ]
+  - minServerVersion: "3.6"
+    topologies: [ replicaset, sharded-replicaset ]
 createEntities:
   - client:
       id: &client0 client0
@@ -177,3 +178,151 @@ tests:
                 comment: "comment"
               commandName: getMore
               databaseName: *database0
+
+  - description: "to field is set in a rename change event"
+    runOnRequirements:
+      - minServerVersion: "4.0.1"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: &collection1 collection1
+      - name: rename
+        object: *collection0
+        arguments:
+          to: *collection1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: rename
+          ns:
+            db: *database0
+            coll: *collection0
+          to:
+            db: *database0
+            coll: *collection1
+
+  - description: "Test unknown operationType MUST NOT err"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          # using $project to simulate future changes to ChangeStreamDocument structure
+          pipeline: [ { $project: { operationType: "addedInFutureMongoDBVersion", ns: 1 } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "addedInFutureMongoDBVersion"
+          ns:
+            db: *database0
+            coll: *collection0
+
+  - description: "Test newField added in response MUST NOT err"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          # using $project to simulate future changes to ChangeStreamDocument structure
+          pipeline: [ { $project: { operationType: 1, ns: 1, newField: "newFieldValue" } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+          newField: "newFieldValue"
+
+  - description: "Test new structure in ns document MUST NOT err"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          # using $project to simulate future changes to ChangeStreamDocument structure
+          pipeline: [ { $project: { operationType: "insert", "ns.viewOn": "db.coll" } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            viewOn: "db.coll"
+
+  - description: "Test modified structure in ns document MUST NOT err"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          # using $project to simulate future changes to ChangeStreamDocument structure
+          pipeline: [ { $project: { operationType: "insert", ns: { db: "$ns.db", coll: "$ns.coll", viewOn: "db.coll" } } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+            viewOn: "db.coll"
+
+  - description: "Test server error on projecting out _id"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: [ { $project: { _id: 0 } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          errorCode: 280
+          errorCodeName: "ChangeStreamFatalError"
+          errorLabelsContain: [ "NonResumableChangeStreamError" ]
+
+
+  - description: "Test projection in change stream returns expected fields"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: [ { $project: { optype: "$operationType", ns: 1, newField: "value" } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          optype: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+          newField: "value"

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedIterateUntilDocumentOrErrorOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedIterateUntilDocumentOrErrorOperation.cs
@@ -103,33 +103,9 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         public BsonDocument Convert<T>(T value) =>
             value switch
             {
-                ChangeStreamDocument<BsonDocument> changeStreamResult =>
-                    new BsonDocument
-                    {
-                        { "operationType", changeStreamResult.OperationType.ToString().ToLowerInvariant() },
-                        { "ns", ConvertNamespace(changeStreamResult.CollectionNamespace) },
-                        { "fullDocument", () => changeStreamResult.FullDocument, changeStreamResult.FullDocument != null },
-                        { "updateDescription", () => ConvertUpdateDescription(changeStreamResult.UpdateDescription), changeStreamResult.UpdateDescription != null }
-                    },
+                ChangeStreamDocument<BsonDocument> changeStreamResult => changeStreamResult.BackingDocument,
                 BsonDocument bsonDocument => bsonDocument,
                 _ => throw new FormatException($"Unsupported enumerator document {value.GetType().Name}.")
-            };
-
-        private BsonValue ConvertNamespace(CollectionNamespace collectionNamespace)
-        {
-            return new BsonDocument
-            {
-                { "db", collectionNamespace.DatabaseNamespace.DatabaseName },
-                { "coll", collectionNamespace.CollectionName }
-            };
-        }
-
-        private BsonDocument ConvertUpdateDescription(ChangeStreamUpdateDescription updateDescription) =>
-            new BsonDocument
-            {
-                { "updatedFields", () => updateDescription.UpdatedFields, updateDescription.UpdatedFields != null },
-                { "removedFields", () => new BsonArray(updateDescription.RemovedFields), updateDescription.RemovedFields != null },
-                { "truncatedArrays", () => updateDescription.TruncatedArrays, updateDescription.TruncatedArrays != null },
             };
     }
 }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedRenameCollectionOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedRenameCollectionOperation.cs
@@ -1,0 +1,96 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.Tests.UnifiedTestOperations
+{
+    public sealed class UnifiedRenameCollectionOperation : IUnifiedEntityTestOperation
+    {
+        private readonly IMongoDatabase _database;
+        private readonly string _newName;
+        private readonly string _oldName;
+
+        public UnifiedRenameCollectionOperation(IMongoDatabase database, string oldName, string newName)
+        {
+            _database = database;
+            _newName = newName;
+            _oldName = oldName;
+        }
+
+        public OperationResult Execute(CancellationToken cancellationToken)
+        {
+            try
+            {
+                _database.RenameCollection(oldName: _oldName, newName: _newName, cancellationToken: cancellationToken);
+
+                return OperationResult.Empty();
+            }
+            catch (Exception exception)
+            {
+                return OperationResult.FromException(exception);
+            }
+        }
+
+        public async Task<OperationResult> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _database.RenameCollectionAsync(oldName: _oldName, newName: _newName, cancellationToken: cancellationToken);
+
+                return OperationResult.Empty();
+            }
+            catch (Exception exception)
+            {
+                return OperationResult.FromException(exception);
+            }
+        }
+    }
+
+    public class UnifiedRenameCollectionOperationBuilder
+    {
+        private readonly UnifiedEntityMap _entityMap;
+
+        public UnifiedRenameCollectionOperationBuilder(UnifiedEntityMap entityMap)
+        {
+            _entityMap = entityMap;
+        }
+
+        public UnifiedRenameCollectionOperation Build(string targetCollectionId, BsonDocument arguments)
+        {
+            var collection = _entityMap.GetCollection(targetCollectionId);
+            var database = collection.Database;
+            var oldName = collection.CollectionNamespace.CollectionName;
+            string newName = null;
+
+            foreach (var argument in arguments)
+            {
+                switch (argument.Name)
+                {
+                    case "to":
+                        newName = argument.Value.AsString;
+                        break;
+                    default:
+                        throw new FormatException($"Invalid RenameCollectionOperation argument name: '{argument.Name}'.");
+                }
+            }
+
+            return new UnifiedRenameCollectionOperation(database, oldName, newName);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestOperationFactory.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestOperationFactory.cs
@@ -143,6 +143,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                             return new UnifiedInsertOneOperationBuilder(_entityMap).Build(targetEntityId, operationArguments);
                         case "listIndexes":
                             return new UnifiedListIndexesOperationBuilder(_entityMap).Build(targetEntityId, operationArguments);
+                        case "rename":
+                            return new UnifiedRenameCollectionOperationBuilder(_entityMap).Build(targetEntityId, operationArguments);
                         case "replaceOne":
                             return new UnifiedReplaceOneOperationBuilder(_entityMap).Build(targetEntityId, operationArguments);
                         case "updateMany":


### PR DESCRIPTION
CSHARP-4117: Change Stream event document missing "to" field for rename events

[EG](https://evergreen.mongodb.com/version/625471743e8e86172730bd47)