### PR TITLE
CSHARP-4108: Inherited comment causes OperationFailure on MongoDB <4.4.0

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -69,6 +69,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __findAndModifyWriteConcern = new Feature("FindAndModifyWriteConcern", WireVersion.Server32);
         private static readonly Feature __findCommand = new Feature("FindCommand", WireVersion.Server32);
         private static readonly Feature __geoNearCommand = new Feature("GeoNearCommand", WireVersion.Zero, WireVersion.Server42);
+        private static readonly Feature __getMoreComment = new Feature("GetMoreComment", WireVersion.Server44);
         private static readonly Feature __groupCommand = new Feature("GroupCommand", WireVersion.Zero, WireVersion.Server42);
         private static readonly Feature __hedgedReads = new Feature("HedgedReads", WireVersion.Server44);
         private static readonly Feature __hiddenIndex = new Feature("HiddenIndex", WireVersion.Server44);
@@ -367,6 +368,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the geoNear command feature.
         /// </summary>
         public static Feature GeoNearCommand => __geoNearCommand;
+
+        /// <summary>
+        /// Gets the getMore comment feature.
+        /// </summary>
+        public static Feature GetMoreComment => __getMoreComment;
 
         /// <summary>
         /// Gets the group command feature.

--- a/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs
@@ -327,7 +327,7 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
-        private BsonDocument CreateGetMoreCommand()
+        private BsonDocument CreateGetMoreCommand(ConnectionDescription connectionDescription)
         {
             var command = new BsonDocument
             {
@@ -335,7 +335,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "collection", _collectionNamespace.CollectionName },
                 { "batchSize", () => CalculateGetMoreNumberToReturn(), _batchSize > 0 || _limit > 0 },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
-                { "comment", _comment, _comment != null },
+                { "comment", _comment, _comment != null && Feature.GetMoreComment.IsSupported(connectionDescription.MaxWireVersion) },
             };
 
             return command;
@@ -354,7 +354,7 @@ namespace MongoDB.Driver.Core.Operations
 
         private CursorBatch<TDocument> ExecuteGetMoreCommand(IChannelHandle channel, CancellationToken cancellationToken)
         {
-            var command = CreateGetMoreCommand();
+            var command = CreateGetMoreCommand(channel.ConnectionDescription);
             BsonDocument result;
             try
             {
@@ -382,7 +382,7 @@ namespace MongoDB.Driver.Core.Operations
 
         private async Task<CursorBatch<TDocument>> ExecuteGetMoreCommandAsync(IChannelHandle channel, CancellationToken cancellationToken)
         {
-            var command = CreateGetMoreCommand();
+            var command = CreateGetMoreCommand(channel.ConnectionDescription);
             BsonDocument result;
             try
             {

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.json
@@ -168,7 +168,6 @@
       "description": "Test with document comment - pre 4.4",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
           "maxServerVersion": "4.2.99"
         }
       ],
@@ -212,11 +211,6 @@
     },
     {
       "description": "Test with string comment",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "3.6.0"
-        }
-      ],
       "operations": [
         {
           "name": "createChangeStream",
@@ -255,7 +249,97 @@
         {
           "minServerVersion": "4.4.0",
           "topologies": [
-            "single",
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": {
+              "key": "value"
+            }
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": 1
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection0",
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test that comment is not set on getMore - pre 4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.3.99",
+          "topologies": [
             "replicaset"
           ]
         }
@@ -325,7 +409,9 @@
                     ]
                   },
                   "collection": "collection0",
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 },
                 "commandName": "getMore",
                 "databaseName": "database0"

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams.yml
@@ -98,8 +98,7 @@ tests:
 
   - description: "Test with document comment - pre 4.4"
     runOnRequirements:
-      - minServerVersion: "3.6.0"
-        maxServerVersion: "4.2.99"
+      - maxServerVersion: "4.2.99"
     operations:
       - name: createChangeStream
         object: *collection0
@@ -119,8 +118,6 @@ tests:
                 comment: *comment0
 
   - description: "Test with string comment"
-    runOnRequirements:
-      - minServerVersion: "3.6.0"
     operations:
       - name: createChangeStream
         object: *collection0
@@ -141,7 +138,55 @@ tests:
   - description: "Test that comment is set on getMore"
     runOnRequirements:
       - minServerVersion: "4.4.0"
-        topologies: [ single, replicaset ]
+        # Topologies are limited because of potentially empty getMore responses
+        # on sharded clusters.
+        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
+        topologies: [ replicaset ]
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          comment: &commentDoc
+            key: "value"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &new_document
+            _id: 1
+            a: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: *commentDoc
+          - commandStartedEvent:
+              command:
+                insert: *collection0
+                documents:
+                  - *new_document
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0
+                comment: *commentDoc
+              commandName: getMore
+              databaseName: *database0
+
+  - description: "Test that comment is not set on getMore - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.3.99"
+        # Topologies are limited because of potentially empty getMore responses
+        # on sharded clusters.
+        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
+        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -175,7 +220,7 @@ tests:
               command:
                 getMore: { $$type: [ int, long ] }
                 collection: *collection0
-                comment: "comment"
+                comment: { $$exists: false }
               commandName: getMore
               databaseName: *database0
 
@@ -289,6 +334,9 @@ tests:
             viewOn: "db.coll"
 
   - description: "Test server error on projecting out _id"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        # Server returns an error if _id is modified on versions 4.2 and higher
     operations:
       - name: createChangeStream
         object: *collection0

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate.json
@@ -330,11 +330,128 @@
       "description": "aggregate with comment sets comment on getMore",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.4.0",
-          "topologies": [
-            "single",
-            "replicaset"
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ],
+            "batchSize": 2,
+            "comment": {
+              "content": "test"
+            }
+          },
+          "object": "collection0",
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
+            }
           ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ],
+                  "cursor": {
+                    "batchSize": 2
+                  },
+                  "comment": {
+                    "content": "test"
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "aggregate-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "content": "test"
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "aggregate-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "content": "test"
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "aggregate-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregate with comment does not set comment on getMore - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.3.99"
         }
       ],
       "operations": [
@@ -415,7 +532,9 @@
                   },
                   "collection": "coll0",
                   "batchSize": 2,
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 },
                 "commandName": "getMore",
                 "databaseName": "aggregate-tests"
@@ -432,7 +551,9 @@
                   },
                   "collection": "coll0",
                   "batchSize": 2,
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 },
                 "commandName": "getMore",
                 "databaseName": "aggregate-tests"

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate.yml
@@ -128,7 +128,51 @@ tests:
   - description: "aggregate with comment sets comment on getMore"
     runOnRequirements:
       - minServerVersion: "4.4.0"
-        topologies: [ single, replicaset ]
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          batchSize: 2
+          comment: *comment0
+        object: *collection0
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+                cursor: { batchSize: 2 }
+                comment: *comment0
+              commandName: aggregate
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: *comment0
+              commandName: getMore
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: *comment0
+              commandName: getMore
+              databaseName: *database0Name
+
+  - description: "aggregate with comment does not set comment on getMore - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.3.99"
     operations:
       - name: aggregate
         arguments:
@@ -158,7 +202,7 @@ tests:
                 getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
                 batchSize: 2
-                comment: "comment"
+                comment: { $$exists: false }
               commandName: getMore
               databaseName: *database0Name
           - commandStartedEvent:
@@ -166,6 +210,6 @@ tests:
                 getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
                 batchSize: 2
-                comment: "comment"
+                comment: { $$exists: false }
               commandName: getMore
               databaseName: *database0Name

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/find-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/find-comment.json
@@ -198,11 +198,112 @@
       "description": "find with comment sets comment on getMore",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.4.0",
-          "topologies": [
-            "single",
-            "replicaset"
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "batchSize": 2,
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
+            }
           ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "batchSize": 2,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "find with comment does not set comment on getMore - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.3.99"
         }
       ],
       "operations": [
@@ -271,7 +372,9 @@
                   },
                   "collection": "coll0",
                   "batchSize": 2,
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 }
               }
             },
@@ -286,7 +389,9 @@
                   },
                   "collection": "coll0",
                   "batchSize": 2,
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 }
               }
             }

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/find-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/find-comment.yml
@@ -76,7 +76,7 @@ tests:
         object: *collection0
         arguments:
           filter: *filter
-          comment: &comment { key: "value"}
+          comment: *comment
         expectError:
           isClientError: false
     expectEvents:
@@ -91,7 +91,45 @@ tests:
   - description: "find with comment sets comment on getMore"
     runOnRequirements:
       - minServerVersion: "4.4.0"
-        topologies: [ single, replicaset ]
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: &filter_get_more { _id: { $gt: 1 } }
+          batchSize: 2
+          comment: *comment
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: { $gt: 1 } }
+                batchSize: 2
+                comment: *comment
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: *comment
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: *comment
+
+  - description: "find with comment does not set comment on getMore - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.3.99"
     operations:
       - name: find
         object: *collection0
@@ -119,10 +157,10 @@ tests:
                 getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
                 batchSize: 2
-                comment: "comment"
+                comment: { $$exists: false }
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
                 batchSize: 2
-                comment: "comment"
+                comment: { $$exists: false }


### PR DESCRIPTION
Also
CSHARP-4109: Test getMore with comment on all topologies