### PR TITLE
CSHARP-4034: Change streams support for user-facing PIT pre- and post-images

### DIFF
--- a/src/MongoDB.Driver.Core/ChangeStreamDocument.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamDocument.cs
@@ -100,6 +100,28 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Gets the full document before change.
+        /// </summary>
+        /// <value>
+        /// The full document before change.
+        /// </value>
+        public TDocument FullDocumentBeforeChange
+        {
+            get
+            {
+                // if TDocument is BsonDocument avoid deserializing it again to prevent possible duplicate element name errors
+                if (typeof(TDocument) == typeof(BsonDocument) && BackingDocument.TryGetValue("fullDocumentBeforeChange", out var fullDocumentBeforeChange))
+                {
+                    return (TDocument)(object)fullDocumentBeforeChange.AsBsonDocument;
+                }
+                else
+                {
+                    return GetValue<TDocument>(nameof(FullDocumentBeforeChange), default(TDocument));
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets the type of the operation.
         /// </summary>
         /// <value>

--- a/src/MongoDB.Driver.Core/ChangeStreamDocumentSerializer.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamDocumentSerializer.cs
@@ -45,6 +45,7 @@ namespace MongoDB.Driver
             RegisterMember("DatabaseNamespace", "ns", ChangeStreamDocumentDatabaseNamespaceSerializer.Instance);
             RegisterMember("DocumentKey", "documentKey", BsonDocumentSerializer.Instance);
             RegisterMember("FullDocument", "fullDocument", _documentSerializer);
+            RegisterMember("FullDocumentBeforeChange", "fullDocumentBeforeChange", _documentSerializer);
             RegisterMember("OperationType", "operationType", ChangeStreamOperationTypeSerializer.Instance);
             RegisterMember("RenameTo", "to", ChangeStreamDocumentCollectionNamespaceSerializer.Instance);
             RegisterMember("ResumeToken", "_id", BsonDocumentSerializer.Instance);

--- a/src/MongoDB.Driver.Core/ChangeStreamFullDocumentBeforeChangeOption.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamFullDocumentBeforeChangeOption.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2017-present MongoDB Inc.
+﻿/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,32 +16,30 @@
 namespace MongoDB.Driver
 {
     /// <summary>
-    /// Change stream FullDocument option.
+    /// Change stream FullDocumentBeforeChange option.
     /// </summary>
-    public enum ChangeStreamFullDocumentOption
+    public enum ChangeStreamFullDocumentBeforeChangeOption
     {
         /// <summary>
         /// Do not send this option to the server.
-        /// Server's default is to not return the full document.
+        /// Server's default is to not return the full document before change.
         /// </summary>
         Default = 0,
 
         /// <summary>
-        /// The change stream for partial updates will include both a delta describing the
-        /// changes to the document as well as a copy of the entire document that was
-        /// changed from some time after the change occurred.
+        /// Do not return the full document before change.
         /// </summary>
-        UpdateLookup,
+        Off,
 
         /// <summary>
-        /// Returns the post-image of the modified document for replace and update change events
-        /// if the post-image for this event is available.
+        /// Returns the pre-image of the modified document for replace, update and delete
+        /// change events if the pre-image for this event is available.
         /// </summary>
         WhenAvailable,
 
         /// <summary>
         /// Same behavior as 'whenAvailable' except that
-        /// an error is raised if the post-image is not available.
+        /// an error is raised if the pre-image is not available.
         /// </summary>
         Required
     }

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -48,6 +48,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __bypassDocumentValidation = new Feature("BypassDocumentValidation", WireVersion.Server32);
         private static readonly Feature __changeStreamStage = new Feature("ChangeStreamStage", WireVersion.Server36);
         private static readonly Feature __changeStreamPostBatchResumeToken = new Feature("ChangeStreamPostBatchResumeToken", WireVersion.Server40);
+        private static readonly Feature __changeStreamPrePostImages = new Feature("ChangeStreamPrePostImages", WireVersion.Server60);
         private static readonly Feature __clientSideEncryption = new Feature("ClientSideEncryption", WireVersion.Server42);
         private static readonly Feature __collation = new Feature("Collation", WireVersion.Server34);
         private static readonly Feature __commandMessage = new Feature("CommandMessage", WireVersion.Server36);
@@ -253,6 +254,12 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the change stream post batch resume token feature.
         /// </summary>
         public static Feature ChangeStreamPostBatchResumeToken => __changeStreamPostBatchResumeToken;
+
+        /// <summary>
+        /// Gets the change stream pre post images feature.
+        /// </summary>
+        public static Feature ChangeStreamPrePostImages => __changeStreamPrePostImages;
+        
 
         /// <summary>
         /// Gets the client side encryption feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/WireVersion.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/WireVersion.cs
@@ -80,6 +80,14 @@ namespace MongoDB.Driver.Core.Misc
         /// Wire version 15.
         /// </summary>
         public const int Server52 = 15;
+        /// <summary>
+        /// Wire version 16.
+        /// </summary>
+        public const int Server53 = 16;
+        /// <summary>
+        /// Wire version 17.
+        /// </summary>
+        public const int Server60 = 17;
 
         #region static
         private static List<WireVersionInfo> __knownWireVersions = new()
@@ -105,6 +113,8 @@ namespace MongoDB.Driver.Core.Misc
             new WireVersionInfo(wireVersion: 13, major: 5, minor: 0),
             new WireVersionInfo(wireVersion: 14, major: 5, minor: 1),
             new WireVersionInfo(wireVersion: 15, major: 5, minor: 2),
+            new WireVersionInfo(wireVersion: 16, major: 5, minor: 3),
+            new WireVersionInfo(wireVersion: 17, major: 6, minor: 0),
         };
 
         private static Range<int> __supportedWireVersionRange = CreateSupportedWireVersionRange(minWireVersion: 6, maxWireVersion: 15);

--- a/src/MongoDB.Driver.Core/Core/Operations/ChangeStreamOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ChangeStreamOperation.cs
@@ -89,6 +89,7 @@ namespace MongoDB.Driver.Core.Operations
         private readonly CollectionNamespace _collectionNamespace;
         private readonly DatabaseNamespace _databaseNamespace;
         private ChangeStreamFullDocumentOption _fullDocument = ChangeStreamFullDocumentOption.Default;
+        private ChangeStreamFullDocumentBeforeChangeOption _fullDocumentBeforeChangeOption = ChangeStreamFullDocumentBeforeChangeOption.Default;
         private TimeSpan? _maxAwaitTime;
         private readonly MessageEncoderSettings _messageEncoderSettings;
         private readonly IReadOnlyList<BsonDocument> _pipeline;
@@ -210,6 +211,18 @@ namespace MongoDB.Driver.Core.Operations
         {
             get { return _fullDocument; }
             set { _fullDocument = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the full document before change option.
+        /// </summary>
+        /// <value>
+        /// The full document before change option.
+        /// </value>
+        public ChangeStreamFullDocumentBeforeChangeOption FullDocumentBeforeChange
+        {
+            get { return _fullDocumentBeforeChangeOption; }
+            set { _fullDocumentBeforeChangeOption = value; }
         }
 
         /// <summary>
@@ -417,6 +430,7 @@ namespace MongoDB.Driver.Core.Operations
             var changeStreamOptions = new BsonDocument
             {
                 { "fullDocument", () => ToString(_fullDocument), _fullDocument != ChangeStreamFullDocumentOption.Default },
+                { "fullDocumentBeforeChange", () => ToString(_fullDocumentBeforeChangeOption), _fullDocumentBeforeChangeOption != ChangeStreamFullDocumentBeforeChangeOption.Default },
                 { "allChangesForCluster", true, _collectionNamespace == null && _databaseNamespace == null },
                 { "startAfter", _startAfter, _startAfter != null},
                 { "startAtOperationTime", _startAtOperationTime, _startAtOperationTime != null },
@@ -468,14 +482,22 @@ namespace MongoDB.Driver.Core.Operations
             return null;
         }
 
-        private string ToString(ChangeStreamFullDocumentOption fullDocument)
-        {
-            switch (fullDocument)
+        private string ToString(ChangeStreamFullDocumentOption fullDocument) =>
+            fullDocument switch
             {
-                case ChangeStreamFullDocumentOption.Default: return "default";
-                case ChangeStreamFullDocumentOption.UpdateLookup: return "updateLookup";
-                default: throw new ArgumentException($"Invalid FullDocument option: {fullDocument}.", nameof(fullDocument));
-            }
-        }
+                ChangeStreamFullDocumentOption.UpdateLookup => "updateLookup",
+                ChangeStreamFullDocumentOption.WhenAvailable => "whenAvailable",
+                ChangeStreamFullDocumentOption.Required => "required",
+                _ => throw new ArgumentException($"Invalid FullDocument option: {fullDocument}.", nameof(fullDocument))
+            };
+
+        private string ToString(ChangeStreamFullDocumentBeforeChangeOption fullDocumentBeforeChange) =>
+            fullDocumentBeforeChange switch
+            {
+                ChangeStreamFullDocumentBeforeChangeOption.Off => "off",
+                ChangeStreamFullDocumentBeforeChangeOption.WhenAvailable => "whenAvailable",
+                ChangeStreamFullDocumentBeforeChangeOption.Required => "required",
+                _ => throw new ArgumentException($"Invalid FullDocumentBeforeChange option: {fullDocumentBeforeChange}.", nameof(fullDocumentBeforeChange))
+            };
     }
 }

--- a/src/MongoDB.Driver/ChangeStreamHelper.cs
+++ b/src/MongoDB.Driver/ChangeStreamHelper.cs
@@ -151,6 +151,7 @@ namespace MongoDB.Driver
             operation.Collation = options.Collation;
             operation.Comment = options.Comment;
             operation.FullDocument = options.FullDocument;
+            operation.FullDocumentBeforeChange = options.FullDocumentBeforeChange;
             operation.MaxAwaitTime = options.MaxAwaitTime;
             operation.ReadConcern = readConcern;
             operation.ResumeAfter = options.ResumeAfter;

--- a/src/MongoDB.Driver/ChangeStreamOptions.cs
+++ b/src/MongoDB.Driver/ChangeStreamOptions.cs
@@ -29,6 +29,7 @@ namespace MongoDB.Driver
         private Collation _collation;
         private BsonValue _comment;
         private ChangeStreamFullDocumentOption _fullDocument = ChangeStreamFullDocumentOption.Default;
+        private ChangeStreamFullDocumentBeforeChangeOption _fullDocumentBeforeChange = ChangeStreamFullDocumentBeforeChangeOption.Default;
         private TimeSpan? _maxAwaitTime;
         private BsonDocument _resumeAfter;
         private BsonDocument _startAfter;
@@ -81,6 +82,18 @@ namespace MongoDB.Driver
         {
             get { return _fullDocument; }
             set { _fullDocument = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the full document before change.
+        /// </summary>
+        /// <value>
+        /// The full document before change.
+        /// </value>
+        public ChangeStreamFullDocumentBeforeChangeOption FullDocumentBeforeChange
+        {
+            get { return _fullDocumentBeforeChange; }
+            set { _fullDocumentBeforeChange = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/CreateCollectionOptions.cs
+++ b/src/MongoDB.Driver/CreateCollectionOptions.cs
@@ -69,7 +69,6 @@ namespace MongoDB.Driver
             set { _capped = value; }
         }
 
-
         /// <summary>
         /// Gets or sets a timespan indicating how long documents in a time series collection should be retained.
         /// </summary>

--- a/tests/MongoDB.Driver.Core.Tests/Core/Misc/WireVersionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Misc/WireVersionTests.cs
@@ -46,7 +46,9 @@ namespace MongoDB.Driver.Core.Tests.Core.Misc
 
         [Theory]
         [InlineData(99, null, null)]
-        [InlineData(16, null, null)]
+        [InlineData(18, null, null)]
+        [InlineData(17, 6, 0)]
+        [InlineData(16, 5, 3)]
         [InlineData(15, 5, 2)]
         [InlineData(14, 5, 1)]
         [InlineData(10, 4, 7)]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ChangeStreamOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ChangeStreamOperationTests.cs
@@ -13,10 +13,15 @@
 * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Bson.TestHelpers;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
@@ -24,11 +29,6 @@ using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using MongoDB.Bson.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Core.Operations
@@ -50,6 +50,7 @@ namespace MongoDB.Driver.Core.Operations
             subject.CollectionNamespace.Should().BeNull();
             subject.DatabaseNamespace.Should().Be(databaseNamespace);
             subject.FullDocument.Should().Be(ChangeStreamFullDocumentOption.Default);
+            subject.FullDocumentBeforeChange.Should().Be(ChangeStreamFullDocumentBeforeChangeOption.Default);
             subject.MaxAwaitTime.Should().NotHaveValue();
             subject.MessageEncoderSettings.Should().BeSameAs(messageEncoderSettings);
             subject.Pipeline.Should().Equal(pipeline);
@@ -136,6 +137,7 @@ namespace MongoDB.Driver.Core.Operations
             subject.CollectionNamespace.Should().BeSameAs(collectionNamespace);
             subject.DatabaseNamespace.Should().BeNull();
             subject.FullDocument.Should().Be(ChangeStreamFullDocumentOption.Default);
+            subject.FullDocumentBeforeChange.Should().Be(ChangeStreamFullDocumentBeforeChangeOption.Default);
             subject.MaxAwaitTime.Should().NotHaveValue();
             subject.MessageEncoderSettings.Should().BeSameAs(messageEncoderSettings);
             subject.Pipeline.Should().Equal(pipeline);
@@ -256,6 +258,19 @@ namespace MongoDB.Driver.Core.Operations
 
             subject.FullDocument = value;
             var result = subject.FullDocument;
+
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void FullDocumentBeforeChange_get_and_set_should_work(
+          [Values(ChangeStreamFullDocumentBeforeChangeOption.Default, ChangeStreamFullDocumentBeforeChangeOption.WhenAvailable)] ChangeStreamFullDocumentBeforeChangeOption value)
+        {
+            var subject = CreateSubject();
+
+            subject.FullDocumentBeforeChange = value;
+            var result = subject.FullDocumentBeforeChange;
 
             result.Should().Be(value);
         }
@@ -412,6 +427,7 @@ namespace MongoDB.Driver.Core.Operations
                 change.CollectionNamespace.Should().BeNull();
                 change.DocumentKey.Should().BeNull();
                 change.FullDocument.Should().BeNull();
+                change.FullDocumentBeforeChange.Should().BeNull();
                 change.RenameTo.Should().BeNull();
                 change.ResumeToken.Should().NotBeNull();
                 change.UpdateDescription.Should().BeNull();
@@ -443,6 +459,7 @@ namespace MongoDB.Driver.Core.Operations
                 change.CollectionNamespace.Should().Be(_collectionNamespace);
                 change.DocumentKey.Should().Be("{ _id : 1 }");
                 change.FullDocument.Should().BeNull();
+                change.FullDocumentBeforeChange.Should().BeNull();
                 change.RenameTo.Should().BeNull();
                 change.ResumeToken.Should().NotBeNull();
                 change.UpdateDescription.Should().BeNull();
@@ -475,9 +492,58 @@ namespace MongoDB.Driver.Core.Operations
                 change.CollectionNamespace.Should().Be(_collectionNamespace);
                 change.DocumentKey.Should().Be("{ _id : 2 }");
                 change.FullDocument.Should().Be("{ _id : 2, x : 2 }");
+                change.FullDocumentBeforeChange.Should().BeNull();
                 change.RenameTo.Should().BeNull();
                 change.ResumeToken.Should().NotBeNull();
                 change.UpdateDescription.Should().BeNull();
+            }
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_should_return_expected_results_for_pre_post_images(
+            [Values(false, true)] bool async,
+            [Values(ChangeStreamFullDocumentOption.Default, ChangeStreamFullDocumentOption.Required, ChangeStreamFullDocumentOption.WhenAvailable)] ChangeStreamFullDocumentOption fullDocument,
+            [Values(ChangeStreamFullDocumentBeforeChangeOption.Required, ChangeStreamFullDocumentOption.WhenAvailable)] ChangeStreamFullDocumentBeforeChangeOption fullDocumentBeforeChange)
+        {
+            RequireServer.Check().
+                ClusterTypes(ClusterType.ReplicaSet).
+                Supports(Feature.ChangeStreamPrePostImages);
+
+            EnsureDatabaseExists();
+            DropCollection();
+            CreateCollection(_collectionNamespace, true);
+
+            var pipeline = new[] { BsonDocument.Parse("{ $match : { operationType : \"update\" } }") };
+            var resultSerializer = new ChangeStreamDocumentSerializer<BsonDocument>(BsonDocumentSerializer.Instance);
+            var messageEncoderSettings = new MessageEncoderSettings();
+            var subject = new ChangeStreamOperation<ChangeStreamDocument<BsonDocument>>(_collectionNamespace, pipeline, resultSerializer, messageEncoderSettings);
+            subject.FullDocument = fullDocument;
+            subject.FullDocumentBeforeChange = fullDocumentBeforeChange;
+            var validateFullDocument = fullDocument != ChangeStreamFullDocumentOption.Default;
+
+            Insert("{ _id : 1, x : 1 }");
+
+            using (var cursor = ExecuteOperation(subject, async))
+            using (var enumerator = new AsyncCursorEnumerator<ChangeStreamDocument<BsonDocument>>(cursor, CancellationToken.None))
+            {
+                Update("{ _id : 1 }", "{ $set : { x : 2  } }");
+
+                enumerator.MoveNext().Should().BeTrue();
+                var change = enumerator.Current;
+                change.OperationType.Should().Be(ChangeStreamOperationType.Update);
+                change.CollectionNamespace.Should().Be(_collectionNamespace);
+                change.DocumentKey.Should().Be("{ _id : 1 }");
+                change.FullDocumentBeforeChange.Should().Be("{ _id : 1, x : 1 }");
+                change.RenameTo.Should().BeNull();
+                change.ResumeToken.Should().NotBeNull();
+                change.UpdateDescription.RemovedFields.Should().BeEmpty();
+                change.UpdateDescription.UpdatedFields.Should().Be("{ x : 2 }");
+
+                if (validateFullDocument)
+                {
+                    change.FullDocument.Should().Be("{ _id : 1, x : 2 }");
+                }
             }
         }
 
@@ -521,6 +587,7 @@ namespace MongoDB.Driver.Core.Operations
                 while (changeStreamDocument == null);
 
                 changeStreamDocument.FullDocument.Should().Be(document);
+                changeStreamDocument.FullDocumentBeforeChange.Should().BeNull();
             }
         }
 
@@ -553,6 +620,7 @@ namespace MongoDB.Driver.Core.Operations
                 change.CollectionNamespace.Should().Be(_collectionNamespace);
                 change.DocumentKey.Should().Be("{ _id : 1 }");
                 change.FullDocument.Should().Be(fullDocument == ChangeStreamFullDocumentOption.Default ? null : "{ _id : 1, x : 2 }");
+                change.FullDocumentBeforeChange.Should().BeNull();
                 change.RenameTo.Should().BeNull();
                 change.ResumeToken.Should().NotBeNull();
                 change.UpdateDescription.RemovedFields.Should().BeEmpty();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateCollectionOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateCollectionOperationTests.cs
@@ -22,7 +22,6 @@ using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
-using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
 using Xunit;
 
 namespace MongoDB.Driver.Core.Operations

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/OperationTestBase.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/OperationTestBase.cs
@@ -24,7 +24,6 @@ using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Events;
-using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
 using Xunit;
@@ -66,10 +65,22 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
-        protected void CreateCollection(CollectionNamespace collectionNamespace)
+        protected void CreateCollection(CollectionNamespace collectionNamespace, bool changeStreamPreAndPostImages = false)
         {
             var operation = new CreateCollectionOperation(collectionNamespace, _messageEncoderSettings);
             ExecuteOperation(operation);
+
+            if (changeStreamPreAndPostImages)
+            {
+                var command = new BsonDocument()
+                {
+                    { "collMod", _collectionNamespace.CollectionName },
+                    { "changeStreamPreAndPostImages", new BsonDocument() { { "enabled", true } } }
+                };
+
+                var collModOperation = new WriteCommandOperation<BsonDocument>(_collectionNamespace.DatabaseNamespace, command, BsonDocumentSerializer.Instance, _messageEncoderSettings);
+                ExecuteOperation(collModOperation);
+            }
         }
 
         protected void Delete(BsonDocument filter)

--- a/tests/MongoDB.Driver.Tests/ChangeStreamHelperTests.cs
+++ b/tests/MongoDB.Driver.Tests/ChangeStreamHelperTests.cs
@@ -35,6 +35,7 @@ namespace MongoDB.Driver.Tests
                 BatchSize = 123,
                 Collation = new Collation("en-us"),
                 FullDocument = ChangeStreamFullDocumentOption.UpdateLookup,
+                FullDocumentBeforeChange = ChangeStreamFullDocumentBeforeChangeOption.WhenAvailable,
                 MaxAwaitTime = TimeSpan.FromSeconds(123),
                 ResumeAfter = new BsonDocument(),
                 StartAfter = new BsonDocument(),
@@ -51,6 +52,7 @@ namespace MongoDB.Driver.Tests
             result.CollectionNamespace.Should().BeNull();
             result.DatabaseNamespace.Should().BeNull();
             result.FullDocument.Should().Be(options.FullDocument);
+            result.FullDocumentBeforeChange.Should().Be(options.FullDocumentBeforeChange);
             result.MaxAwaitTime.Should().Be(options.MaxAwaitTime);
             result.MessageEncoderSettings.Should().BeSameAs(messageEncoderSettings);
             result.Pipeline.Should().Equal(renderedPipeline.Documents);
@@ -74,6 +76,7 @@ namespace MongoDB.Driver.Tests
                 BatchSize = 123,
                 Collation = new Collation("en-us"),
                 FullDocument = ChangeStreamFullDocumentOption.UpdateLookup,
+                FullDocumentBeforeChange = ChangeStreamFullDocumentBeforeChangeOption.Required,
                 MaxAwaitTime = TimeSpan.FromSeconds(123),
                 ResumeAfter = new BsonDocument(),
                 StartAfter = new BsonDocument(),
@@ -90,6 +93,7 @@ namespace MongoDB.Driver.Tests
             result.CollectionNamespace.Should().BeNull();
             result.DatabaseNamespace.Should().BeSameAs(databaseNamespace);
             result.FullDocument.Should().Be(options.FullDocument);
+            result.FullDocumentBeforeChange.Should().Be(options.FullDocumentBeforeChange);
             result.MaxAwaitTime.Should().Be(options.MaxAwaitTime);
             result.MessageEncoderSettings.Should().BeSameAs(messageEncoderSettings);
             result.Pipeline.Should().Equal(renderedPipeline.Documents);
@@ -115,6 +119,7 @@ namespace MongoDB.Driver.Tests
                 BatchSize = 123,
                 Collation = new Collation("en-us"),
                 FullDocument = ChangeStreamFullDocumentOption.UpdateLookup,
+                FullDocumentBeforeChange = ChangeStreamFullDocumentBeforeChangeOption.Off,
                 MaxAwaitTime = TimeSpan.FromSeconds(123),
                 ResumeAfter = new BsonDocument(),
                 StartAfter = new BsonDocument(),
@@ -131,6 +136,7 @@ namespace MongoDB.Driver.Tests
             result.CollectionNamespace.Should().BeSameAs(collectionNamespace);
             result.DatabaseNamespace.Should().BeNull();
             result.FullDocument.Should().Be(options.FullDocument);
+            result.FullDocumentBeforeChange.Should().Be(options.FullDocumentBeforeChange);
             result.MaxAwaitTime.Should().Be(options.MaxAwaitTime);
             result.MessageEncoderSettings.Should().BeSameAs(messageEncoderSettings);
             result.Pipeline.Should().Equal(renderedPipeline.Documents);

--- a/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
@@ -3515,7 +3515,8 @@ namespace MongoDB.Driver
             [Values(false, true)] bool usingSession,
             [Values(null, 1)] int? batchSize,
             [Values(null, "a")] string locale,
-            [Values(ChangeStreamFullDocumentOption.Default, ChangeStreamFullDocumentOption.UpdateLookup)] ChangeStreamFullDocumentOption fullDocument,
+            [Values(ChangeStreamFullDocumentOption.Default, ChangeStreamFullDocumentOption.WhenAvailable, ChangeStreamFullDocumentOption.UpdateLookup, ChangeStreamFullDocumentOption.Required)] ChangeStreamFullDocumentOption fullDocument,
+            [Values(ChangeStreamFullDocumentBeforeChangeOption.Default, ChangeStreamFullDocumentBeforeChangeOption.Off, ChangeStreamFullDocumentBeforeChangeOption.WhenAvailable, ChangeStreamFullDocumentBeforeChangeOption.Required)] ChangeStreamFullDocumentBeforeChangeOption fullDocumentBeforeChange,
             [Values(null, 1)] int? maxAwaitTimeMS,
             [Values(null, ReadConcernLevel.Local)] ReadConcernLevel? readConcernLevel,
             [Values(null, "{ a : 1 }")] string resumeAferString,
@@ -3540,6 +3541,7 @@ namespace MongoDB.Driver
                 BatchSize = batchSize,
                 Collation = collation,
                 FullDocument = fullDocument,
+                FullDocumentBeforeChange = fullDocumentBeforeChange,
                 MaxAwaitTime = maxAwaitTime,
                 ResumeAfter = resumeAfter,
                 StartAfter = startAfter,
@@ -3579,6 +3581,7 @@ namespace MongoDB.Driver
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
             operation.DatabaseNamespace.Should().BeNull();
             operation.FullDocument.Should().Be(options.FullDocument);
+            operation.FullDocumentBeforeChange.Should().Be(options.FullDocumentBeforeChange);
             operation.MaxAwaitTime.Should().Be(options.MaxAwaitTime);
             operation.MessageEncoderSettings.Should().NotBeNull();
             operation.Pipeline.Should().HaveCount(1);
@@ -3636,6 +3639,7 @@ namespace MongoDB.Driver
             operation.Collation.Should().Be(defaultOptions.Collation);
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
             operation.FullDocument.Should().Be(defaultOptions.FullDocument);
+            operation.FullDocumentBeforeChange.Should().Be(defaultOptions.FullDocumentBeforeChange);
             operation.MaxAwaitTime.Should().Be(defaultOptions.MaxAwaitTime);
             operation.MessageEncoderSettings.Should().NotBeNull();
             operation.Pipeline.Should().HaveCount(1);

--- a/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
@@ -13,15 +13,14 @@
 * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using Moq;
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace MongoDB.Driver.Tests
@@ -32,8 +31,12 @@ namespace MongoDB.Driver.Tests
         [Theory]
         [InlineData(ChangeStreamFullDocumentOption.Default, null, "{ $changeStream : { } }")]
         [InlineData(ChangeStreamFullDocumentOption.UpdateLookup, null, "{ $changeStream : { fullDocument : \"updateLookup\" } }")]
+        [InlineData(ChangeStreamFullDocumentOption.WhenAvailable, null, "{ $changeStream : { fullDocument : \"whenAvailable\" } }")]
+        [InlineData(ChangeStreamFullDocumentOption.Required, null, "{ $changeStream : { fullDocument : \"required\" } }")]
         [InlineData(ChangeStreamFullDocumentOption.Default, "{ a : 1 }", "{ $changeStream : { resumeAfter : { a : 1 } } }")]
         [InlineData(ChangeStreamFullDocumentOption.UpdateLookup, "{ a : 1 }", "{ $changeStream : { fullDocument : \"updateLookup\", resumeAfter : { a : 1 } } }")]
+        [InlineData(ChangeStreamFullDocumentOption.WhenAvailable, "{ a : 1 }", "{ $changeStream : { fullDocument : \"whenAvailable\", resumeAfter : { a : 1 } } }")]
+        [InlineData(ChangeStreamFullDocumentOption.Required, "{ a : 1 }", "{ $changeStream : { fullDocument : \"required\", resumeAfter : { a : 1 } } }")]
         public void ChangeStream_should_add_the_expected_stage(
             ChangeStreamFullDocumentOption fullDocument,
             string resumeAfterString,

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams-pre_and_post_images.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams-pre_and_post_images.json
@@ -1,0 +1,826 @@
+{
+  "description": "change-streams-pre_and_post_images",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "collMod",
+          "insert",
+          "update",
+          "getMore",
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams-pre_and_post_images.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/unified/change-streams-pre_and_post_images.yml
@@ -1,0 +1,350 @@
+description: "change-streams-pre_and_post_images"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "6.0.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+      ignoreCommandMonitoringEvents: [ collMod, insert, update, getMore, killCursors ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name change-stream-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &enablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: true }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &disablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: false }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateChangeStreamOnCollectionOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateChangeStreamOnCollectionOperation.cs
@@ -96,6 +96,14 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                         options ??= new ChangeStreamOptions();
                         options.Comment = argument.Value;
                         break;
+                    case "fullDocument":
+                        options ??= new ChangeStreamOptions();
+                        options.FullDocument = (ChangeStreamFullDocumentOption)Enum.Parse(typeof(ChangeStreamFullDocumentOption), argument.Value.AsString, true);
+                        break;
+                    case "fullDocumentBeforeChange":
+                        options ??= new ChangeStreamOptions();
+                        options.FullDocumentBeforeChange = (ChangeStreamFullDocumentBeforeChangeOption)Enum.Parse(typeof(ChangeStreamFullDocumentBeforeChangeOption), argument.Value.AsString, true);
+                        break;
                     case "pipeline":
                         var stages = argument.Value.AsBsonArray.Cast<BsonDocument>();
                         pipeline = new BsonDocumentStagePipelineDefinition<ChangeStreamDocument<BsonDocument>, ChangeStreamDocument<BsonDocument>>(stages);


### PR DESCRIPTION
[EG](https://spruce.mongodb.com/version/625db17e7742ae58d2d83865)