### PR TITLE
CSHARP-4127: Language specific examples for AWS Lambda.

### DIFF
--- a/tests/MongoDB.Driver.Examples/AwsLambda/AwsLambdaExamples.cs
+++ b/tests/MongoDB.Driver.Examples/AwsLambda/AwsLambdaExamples.cs
@@ -15,6 +15,7 @@
 
 #if NETCOREAPP3_1_OR_GREATER
 using Amazon.Lambda.Core;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using System;
 
@@ -41,8 +42,10 @@ namespace LambdaTest
 
         public string HandleRequest(ILambdaContext context)
         {
-            var databases = MongoClient.ListDatabaseNames();
-            return string.Join(",", databases);
+            var database = MongoClient.GetDatabase("db");
+            var collection = database.GetCollection<BsonDocument>("coll");
+            var result = collection.Find(FilterDefinition<BsonDocument>.Empty).First();
+            return result.ToString();
         }
         // End AWS Lambda Example 1
     }
@@ -78,8 +81,10 @@ namespace LambdaTest
 
         public string HandleRequest(ILambdaContext context)
         {
-            var databases = MongoClient.ListDatabaseNames();
-            return string.Join(",", databases);
+            var database = MongoClient.GetDatabase("db");
+            var collection = database.GetCollection<BsonDocument>("coll");
+            var result = collection.Find(FilterDefinition<BsonDocument>.Empty).First();
+            return result.ToString();
         }
     }
 }

--- a/tests/MongoDB.Driver.Examples/AwsLambda/AwsLambdaExamples.cs
+++ b/tests/MongoDB.Driver.Examples/AwsLambda/AwsLambdaExamples.cs
@@ -27,15 +27,15 @@ namespace LambdaTest
     public class ShareMongoClientLambdaHandler
     {
         // Start AWS Lambda Example 1
-        private MongoClient MongoClient { get; set; }
-        private MongoClient CreateMongoClient()
+        private static MongoClient MongoClient { get; set; }
+        private static MongoClient CreateMongoClient()
         {
             var mongoClientSettings = MongoClientSettings.FromConnectionString($"<MONGODB_URI>");
             mongoClientSettings.ServerApi = new ServerApi(ServerApiVersion.V1, strict: true);
             return new MongoClient(mongoClientSettings);
         }
 
-        public ShareMongoClientLambdaHandler()
+        static ShareMongoClientLambdaHandler()
         {
             MongoClient = CreateMongoClient();
         }
@@ -52,8 +52,8 @@ namespace LambdaTest
 
     public class ConnectUsingAwsIamAuthenticatorLambdaHandler
     {
-        private MongoClient MongoClient { get; set; }
-        private MongoClient CreateMongoClient()
+        private static MongoClient MongoClient { get; set; }
+        private static MongoClient CreateMongoClient()
         {
             // Start AWS Lambda Example 2
             string username = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID");
@@ -74,7 +74,7 @@ namespace LambdaTest
             // End AWS Lambda Example 2
         }
 
-        public ConnectUsingAwsIamAuthenticatorLambdaHandler()
+        static ConnectUsingAwsIamAuthenticatorLambdaHandler()
         {
             MongoClient = CreateMongoClient();
         }

--- a/tests/MongoDB.Driver.Examples/AwsLambda/AwsLambdaExamples.cs
+++ b/tests/MongoDB.Driver.Examples/AwsLambda/AwsLambdaExamples.cs
@@ -27,8 +27,8 @@ namespace LambdaTest
     public class ShareMongoClientLambdaHandler
     {
         // Start AWS Lambda Example 1
-        private static MongoClient MongoClient { get; set; }
-        private static MongoClient CreateMongoClient()
+        private MongoClient MongoClient { get; set; }
+        private MongoClient CreateMongoClient()
         {
             var mongoClientSettings = MongoClientSettings.FromConnectionString($"<MONGODB_URI>");
             mongoClientSettings.ServerApi = new ServerApi(ServerApiVersion.V1, strict: true);
@@ -52,8 +52,8 @@ namespace LambdaTest
 
     public class ConnectUsingAwsIamAuthenticatorLambdaHandler
     {
-        private static MongoClient MongoClient { get; set; }
-        private static MongoClient CreateMongoClient()
+        private MongoClient MongoClient { get; set; }
+        private MongoClient CreateMongoClient()
         {
             // Start AWS Lambda Example 2
             string username = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID");

--- a/tests/MongoDB.Driver.Examples/AwsLambda/AwsLambdaExamples.cs
+++ b/tests/MongoDB.Driver.Examples/AwsLambda/AwsLambdaExamples.cs
@@ -1,0 +1,86 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#if NETCOREAPP3_1_OR_GREATER
+using Amazon.Lambda.Core;
+using MongoDB.Driver;
+using System;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace LambdaTest
+{
+    public class ShareMongoClientLambdaHandler
+    {
+        // Start AWS Lambda Example 1
+        private static MongoClient MongoClient { get; set; }
+        private static MongoClient CreateMongoClient()
+        {
+            var mongoClientSettings = MongoClientSettings.FromConnectionString($"<MONGODB_URI>");
+            mongoClientSettings.ServerApi = new ServerApi(ServerApiVersion.V1, strict: true);
+            return new MongoClient(mongoClientSettings);
+        }
+
+        public ShareMongoClientLambdaHandler()
+        {
+            MongoClient = CreateMongoClient();
+        }
+
+        public string HandleRequest(ILambdaContext context)
+        {
+            var databases = MongoClient.ListDatabaseNames();
+            return string.Join(",", databases);
+        }
+        // End AWS Lambda Example 1
+    }
+
+    public class ConnectUsingAwsIamAuthenticatorLambdaHandler
+    {
+        private static MongoClient MongoClient { get; set; }
+        private static MongoClient CreateMongoClient()
+        {
+            // Start AWS Lambda Example 2
+            string username = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID");
+            string password = Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY");
+            string awsSessionToken = Environment.GetEnvironmentVariable("AWS_SESSION_TOKEN");
+
+            var awsCredentials =
+                new MongoCredential("MONGODB-AWS", new MongoExternalIdentity(username), new PasswordEvidence(password))
+                .WithMechanismProperty("AWS_SESSION_TOKEN", awsSessionToken);
+
+            var mongoUrl = MongoUrl.Create($"<MONGODB_URI>");
+
+            var mongoClientSettings = MongoClientSettings.FromUrl(mongoUrl);
+            mongoClientSettings.Credential = awsCredentials;
+            mongoClientSettings.ServerApi = new ServerApi(ServerApiVersion.V1, strict: true);
+
+            return new MongoClient(mongoClientSettings);
+            // End AWS Lambda Example 2
+        }
+
+        public ConnectUsingAwsIamAuthenticatorLambdaHandler()
+        {
+            MongoClient = CreateMongoClient();
+        }
+
+        public string HandleRequest(ILambdaContext context)
+        {
+            var databases = MongoClient.ListDatabaseNames();
+            return string.Join(",", databases);
+        }
+    }
+}
+#endif

--- a/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
+++ b/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
@@ -42,6 +42,11 @@
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\MongoDB.Bson\MongoDB.Bson.csproj" />
     <ProjectReference Include="..\..\src\MongoDB.Driver\MongoDB.Driver.csproj" />


### PR DESCRIPTION
How to configure AWS auth for atlas cluster:
1. Get your AWS_* (aws_access_key_id, aws_secret_access_key, aws_session_token) credentials in Single Sign-on page:
![image](https://user-images.githubusercontent.com/44870738/170119324-b9f00690-8e97-47cb-bd9d-a5d8eb40ca30.png)

Pay attention that values should be regenerated from time to time.
2. Configure credentials folder here: `c:\Users\{user_name}\.aws\`
3. Get your arn via `get-caller-identity`:
   
       $ ./aws sts get-caller-identity
        {
            "UserId": "blablabla:[dmitry.lukyanov@mongodb.com](mailto:dmitry.lukyanov@mongodb.com)",
            "Account": "%ID_VALUE%",
            "Arn": "arn:aws:sts::%ID_VALUE%:assumed-role/%ROLE_NAME%/[dmitry.lukyanov@mongodb.com](mailto:dmitry.lukyanov@mongodb.com)"
         }
pay attention on %ROLE_NAME%
4. list all roles via:

         $ ./aws iam list-roles
         {
           "Roles": [
           {
                 "Path": "..",
                 "RoleName": "%ROLE_NAME%",
                 "Arn": "arn:aws...:
            ...

in the provided roles, search for a record with a RoleName equal to %ROLE_NAME% and record his `arn`.
5. In your atlas cluster, create a new user with AWS authentication and set AWS IAM Role ARN from #4.
6. Then configure a mongoClient in the same way as it's done in this PR with `MONGODB-AWS` auth credentials
