### PR TITLE
CSHARP-4138: Added new allowDiskUse tests.

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate-allowdiskuse.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate-allowdiskuse.json
@@ -1,0 +1,155 @@
+{
+  "description": "aggregate-allowdiskuse",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate does not send allowDiskUse when value is not specified",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
+                  "allowDiskUse": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate sends allowDiskUse false when false is specified",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ],
+            "allowDiskUse": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
+                  "allowDiskUse": false
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate sends allowDiskUse true when true is specified",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ],
+            "allowDiskUse": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
+                  "allowDiskUse": true
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate-allowdiskuse.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/aggregate-allowdiskuse.yml
@@ -1,0 +1,75 @@
+description: aggregate-allowdiskuse
+
+schemaVersion: '1.0'
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: 'Aggregate does not send allowDiskUse when value is not specified'
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: &pipeline [ { $match: {} } ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline
+                allowDiskUse: { $$exists: false }
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: 'Aggregate sends allowDiskUse false when false is specified'
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: *pipeline
+          allowDiskUse: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline
+                allowDiskUse: false
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: 'Aggregate sends allowDiskUse true when true is specified'
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: *pipeline
+          allowDiskUse: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline
+                allowDiskUse: true
+              commandName: aggregate
+              databaseName: *database0Name


### PR DESCRIPTION
Sync'd new `aggregate-allowdiskuse.[json|yml]`. No production code changes necessary as we use `bool? AllowDiskUse` throughout the driver. If `AllowDiskUse` isn't set explicitly, we use the server's default, which is false on pre-6.0 and true on 6.0 or later.