### PR TITLE
CSHARP-4141: Clustered Indexes for all Collections.

### DIFF
--- a/Docs/reference/content/reference/driver/admin.md
+++ b/Docs/reference/content/reference/driver/admin.md
@@ -64,7 +64,7 @@ using (var cursor = await client.ListDatabaseAsync())
 
 ## Collections
 
-These operations exists on the [`IMongoDatabase`]({{< apiref "T_MongoDB_Driver_IMongoDatabase" >}}) interface.
+These operations exist on the [`IMongoDatabase`]({{< apiref "T_MongoDB_Driver_IMongoDatabase" >}}) interface.
 
 ### Getting a collection
 
@@ -88,7 +88,7 @@ var options = new CreateCollectionOptions
 {
     Capped = true,
     MaxSize = 10000
-});
+};
 ```
 ```csharp
 // creates a capped collection named "foo" with a maximum size of 10,000 bytes
@@ -97,6 +97,19 @@ db.CreateCollection("foo", options);
 ```csharp
 // creates a capped collection named "foo" with a maximum size of 10,000 bytes
 await db.CreateCollectionAsync("foo", options); 
+```
+
+### Creating a clustered collection
+
+*New in MongoDB 5.3.* [Clustered collections](https://www.mongodb.com/docs/upcoming/core/clustered-collections/) are collections created
+with a clustered index. Documents in a clustered collection are ordered by the clustered index key value. To create a clustered collection:
+
+```csharp
+var options = new CreateCollectionOptions<Product>
+{
+    ClusteredIndex = new ClusteredIndexOptions<Product>()
+};
+db.CreateCollection("product", options);
 ```
 
 ### Dropping a collection

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -1,4 +1,4 @@
-/* Copyright 2016-present MongoDB Inc.
+﻿/* Copyright 2016-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __changeStreamPostBatchResumeToken = new Feature("ChangeStreamPostBatchResumeToken", WireVersion.Server40);
         private static readonly Feature __changeStreamPrePostImages = new Feature("ChangeStreamPrePostImages", WireVersion.Server60);
         private static readonly Feature __clientSideEncryption = new Feature("ClientSideEncryption", WireVersion.Server42);
+        private static readonly Feature __clusteredIndexes = new Feature("ClusteredIndexes", WireVersion.Server53);
         private static readonly Feature __collation = new Feature("Collation", WireVersion.Server34);
         private static readonly Feature __commandMessage = new Feature("CommandMessage", WireVersion.Server36);
         private static readonly Feature __commandsThatWriteAcceptWriteConcern = new Feature("CommandsThatWriteAcceptWriteConcern", WireVersion.Server34);
@@ -265,6 +266,12 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the client side encryption feature.
         /// </summary>
         public static Feature ClientSideEncryption => __clientSideEncryption;
+
+
+        /// <summary>
+        /// Gets the clustered indexes feature.
+        /// </summary>
+        public static Feature ClusteredIndexes => __clusteredIndexes;
 
         /// <summary>
         /// Gets the collation feature.

--- a/src/MongoDB.Driver.Core/Core/Operations/CreateCollectionOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CreateCollectionOperation.cs
@@ -69,6 +69,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private bool? _autoIndexId;
         private bool? _capped;
+        private BsonDocument _clusteredIndex;
         private Collation _collation;
         private readonly CollectionNamespace _collectionNamespace;
         private BsonValue _comment;
@@ -324,6 +325,18 @@ namespace MongoDB.Driver.Core.Operations
             set { _writeConcern = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the clustered index definition.
+        /// </summary>
+        /// <value>
+        /// The clustered index definition.
+        /// </value>
+        public BsonDocument ClusteredIndex
+        {
+            get => _clusteredIndex;
+            set => _clusteredIndex = value;
+        }
+
         // methods
         internal BsonDocument CreateCommand(ICoreSessionHandle session)
         {
@@ -332,6 +345,7 @@ namespace MongoDB.Driver.Core.Operations
             return new BsonDocument
             {
                 { "create", _collectionNamespace.CollectionName },
+                { "clusteredIndex", _clusteredIndex, _clusteredIndex != null },
                 { "capped", () => _capped.Value, _capped.HasValue },
                 { "autoIndexId", () => _autoIndexId.Value, _autoIndexId.HasValue },
                 { "size", () => _maxSize.Value, _maxSize.HasValue },

--- a/src/MongoDB.Driver/ClusteredIndexOptions.cs
+++ b/src/MongoDB.Driver/ClusteredIndexOptions.cs
@@ -14,6 +14,7 @@
 */
 
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 
 namespace MongoDB.Driver
 {
@@ -60,6 +61,15 @@ namespace MongoDB.Driver
         {
             get => _unique;
             set => _unique = value;
+        }
+
+        internal BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
+        {
+            return new BsonDocument {
+                { "key", _key.Render(documentSerializer, serializerRegistry) },
+                { "unique", _unique },
+                { "name", _name, _name != null }
+            };
         }
     }
 }

--- a/src/MongoDB.Driver/ClusteredIndexOptions.cs
+++ b/src/MongoDB.Driver/ClusteredIndexOptions.cs
@@ -1,0 +1,65 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Bson;
+
+namespace MongoDB.Driver
+{
+    /// <summary>
+    /// Options for creating a clustered index.
+    /// </summary>
+    public class ClusteredIndexOptions<TDocument>
+    {
+        private IndexKeysDefinition<TDocument> _key;
+        private string _name;
+        private bool _unique;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClusteredIndexOptions{TDocument}"/> class.
+        /// </summary>
+        public ClusteredIndexOptions()
+        {
+            _key = new BsonDocument { { "_id", 1 } };
+            _unique = true;
+        }
+
+        /// <summary>
+        /// Gets or sets the index key, which must currently be {_id: 1}.
+        /// </summary>
+        public IndexKeysDefinition<TDocument> Key
+        {
+            get => _key;
+            set => _key = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the index name.
+        /// </summary>
+        public string Name
+        {
+            get => _name;
+            set => _name = value;
+        }
+
+        /// <summary>
+        /// Gets or sets whether the index entries must be unique, which currently must be true.
+        /// </summary>
+        public bool Unique
+        {
+            get => _unique;
+            set => _unique = value;
+        }
+    }
+}

--- a/src/MongoDB.Driver/CreateCollectionOptions.cs
+++ b/src/MongoDB.Driver/CreateCollectionOptions.cs
@@ -237,10 +237,20 @@ namespace MongoDB.Driver
         #endregion
 
         // private fields
+        private ClusteredIndexOptions<TDocument> _clusteredIndex;
         private IBsonSerializer<TDocument> _documentSerializer;
         private FilterDefinition<TDocument> _validator;
 
         // public properties
+        /// <summary>
+        /// Gets or sets the <see cref="ClusteredIndexOptions{TDocument}"/>.
+        /// </summary>
+        public ClusteredIndexOptions<TDocument> ClusteredIndex
+        {
+            get { return _clusteredIndex; }
+            set { _clusteredIndex = value; }
+        }
+
         /// <summary>
         /// Gets or sets the document serializer.
         /// </summary>

--- a/src/MongoDB.Driver/CreateIndexModel.cs
+++ b/src/MongoDB.Driver/CreateIndexModel.cs
@@ -13,13 +13,7 @@
 * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MongoDB.Driver.Core.Misc;
-using MongoDB.Driver.Core.Operations;
 
 namespace MongoDB.Driver
 {

--- a/src/MongoDB.Driver/MongoDatabaseImpl.cs
+++ b/src/MongoDB.Driver/MongoDatabaseImpl.cs
@@ -647,15 +647,7 @@ namespace MongoDB.Driver
             var serializerRegistry = options.SerializerRegistry ?? BsonSerializer.SerializerRegistry;
             var documentSerializer = options.DocumentSerializer ?? serializerRegistry.GetSerializer<TDocument>();
 
-            BsonDocument clusteredIndex = null;
-            if (options.ClusteredIndex != null)
-            {
-                clusteredIndex = new BsonDocument {
-                    { "key", options.ClusteredIndex.Key.Render(documentSerializer, serializerRegistry) },
-                    { "unique", options.ClusteredIndex.Unique },
-                    { "name", options.ClusteredIndex.Name, options.ClusteredIndex.Name != null }
-                };
-            }
+            var clusteredIndex = options.ClusteredIndex?.Render(documentSerializer, serializerRegistry);
             var validator = options.Validator?.Render(documentSerializer, serializerRegistry, _linqProvider);
 
             var collectionNamespace = new CollectionNamespace(_databaseNamespace, name);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateCollectionOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateCollectionOperationTests.cs
@@ -87,6 +87,7 @@ namespace MongoDB.Driver.Core.Operations
             subject.AutoIndexId.Should().NotHaveValue();
 #pragma warning restore
             subject.Capped.Should().NotHaveValue();
+            subject.ClusteredIndex.Should().BeNull();
             subject.Collation.Should().BeNull();
             subject.EncryptedFields.Should().BeNull();
             subject.IndexOptionDefaults.Should().BeNull();
@@ -167,6 +168,28 @@ namespace MongoDB.Driver.Core.Operations
             {
                 { "create", _collectionNamespace.CollectionName },
                 { "capped", () => capped.Value, capped != null }
+            };
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void CreateCommand_should_return_expected_result_when_ClusteredIndex_is_set(
+            [Values(null, "{ key : { _id : 1 }, unique : true }", "{ key : { _id : 1 }, unique : true, name: 'clustered index name' }")]
+            string clusteredIndex)
+        {
+            var subject = new CreateCollectionOperation(_collectionNamespace, _messageEncoderSettings)
+            {
+                ClusteredIndex = clusteredIndex != null ? BsonDocument.Parse(clusteredIndex) : null
+            };
+            var session = OperationTestHelper.CreateSession();
+
+            var result = subject.CreateCommand(session);
+
+            var expectedResult = new BsonDocument
+            {
+                { "create", _collectionNamespace.CollectionName },
+                { "clusteredIndex", () => BsonDocument.Parse(clusteredIndex), clusteredIndex != null }
             };
             result.Should().Be(expectedResult);
         }

--- a/tests/MongoDB.Driver.TestConsoleApplication/Program.cs
+++ b/tests/MongoDB.Driver.TestConsoleApplication/Program.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.IO;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events.Diagnostics;
 

--- a/tests/MongoDB.Driver.Tests/Specifications/collection-management/tests/clustered-indexes.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/collection-management/tests/clustered-indexes.json
@@ -1,0 +1,176 @@
+{
+  "description": "clustered-indexes",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.3"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "ts-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "ts-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "createCollection with clusteredIndex",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        }
+      ]
+    },
+    {
+      "description": "listCollections includes clusteredIndex",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "filter": {
+              "name": {
+                "$eq": "test"
+              }
+            }
+          },
+          "expectResult": [
+            {
+              "name": "test",
+              "options": {
+                "clusteredIndex": {
+                  "key": {
+                    "_id": 1
+                  },
+                  "unique": true,
+                  "name": "test index",
+                  "v": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listIndexes returns the index",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "listIndexes",
+          "object": "collection0",
+          "expectResult": [
+            {
+              "key": {
+                "_id": 1
+              },
+              "name": "test index",
+              "clustered": true,
+              "unique": true,
+              "v": {
+                "$$type": [
+                  "int",
+                  "long"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/collection-management/tests/clustered-indexes.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/collection-management/tests/clustered-indexes.yml
@@ -1,0 +1,94 @@
+description: "clustered-indexes"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "5.3"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name ts-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "createCollection with clusteredIndex"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          clusteredIndex:
+            key: { _id: 1 }
+            unique: true
+            name: &index0Name "test index"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+
+  - description: "listCollections includes clusteredIndex"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          clusteredIndex:
+            key: { _id: 1 }
+            unique: true
+            name: &index0Name "test index"
+      - name: listCollections
+        object: *database0
+        arguments:
+          filter: { name: { $eq: *collection0Name } }
+        expectResult:
+          - name: *collection0Name
+            options:
+              clusteredIndex:
+                key: { _id: 1 }
+                unique: true
+                name: *index0Name
+                v: { $$type: [ int, long ] }
+
+  - description: "listIndexes returns the index"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          clusteredIndex:
+            key: { _id: 1 }
+            unique: true
+            name: *index0Name
+      - name: listIndexes
+        object: *collection0
+        expectResult:
+          - key: { _id: 1 }
+            name: *index0Name
+            clustered: true
+            unique: true
+            v: { $$type: [ int, long ] }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateCollectionOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateCollectionOperation.cs
@@ -170,11 +170,21 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             IClientSessionHandle session = null;
             TimeSpan? expireAfter = null;
             TimeSeriesOptions timeSeriesOptions = null;
+            ClusteredIndexOptions<BsonDocument> clusteredIndex = null;
 
             foreach (var argument in arguments)
             {
                 switch (argument.Name)
                 {
+                    case "clusteredIndex":
+                        var clusteredIndexSpecification = argument.Value.AsBsonDocument;
+                        clusteredIndex = new ClusteredIndexOptions<BsonDocument>
+                        {
+                            Key = clusteredIndexSpecification["key"].AsBsonDocument,
+                            Unique = clusteredIndexSpecification["unique"].AsBoolean,
+                            Name = clusteredIndexSpecification["name"].AsString
+                        };
+                        break;
                     case "collection":
                         name = argument.Value.AsString;
                         break;
@@ -213,10 +223,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 
             if (viewOn == null && pipeline == null)
             {
-                var options = new CreateCollectionOptions { ExpireAfter = expireAfter, TimeSeriesOptions = timeSeriesOptions };
+                var options = new CreateCollectionOptions<BsonDocument> { ExpireAfter = expireAfter, TimeSeriesOptions = timeSeriesOptions, ClusteredIndex = clusteredIndex };
                 return new UnifiedCreateCollectionOperation(session, database, name, options);
             }
-            if (viewOn != null && expireAfter == null && timeSeriesOptions == null)
+            if (viewOn != null && expireAfter == null && timeSeriesOptions == null && clusteredIndex == null)
             {
                 var options = new CreateViewOptions<BsonDocument>();
                 return new UnifiedCreateViewOperation(session, database, name, viewOn, pipeline, options);

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedListCollectionsOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedListCollectionsOperation.cs
@@ -45,9 +45,9 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     ? _database.ListCollections(_options, cancellationToken)
                     : _database.ListCollections(_session, _options, cancellationToken);
 
-                _ = cursor.ToList(cancellationToken);
+                var collections = cursor.ToList(cancellationToken);
 
-                return OperationResult.Empty();
+                return OperationResult.FromResult(new BsonArray(collections));
             }
             catch (Exception ex)
             {
@@ -63,9 +63,9 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     ? await _database.ListCollectionsAsync(_options, cancellationToken)
                     : await _database.ListCollectionsAsync(_session, _options, cancellationToken);
 
-                _ = await cursor.ToListAsync(cancellationToken);
+                var collections = await cursor.ToListAsync(cancellationToken);
 
-                return OperationResult.Empty();
+                return OperationResult.FromResult(new BsonArray(collections));
             }
             catch (Exception ex)
             {

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedListIndexesOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedListIndexesOperation.cs
@@ -45,9 +45,9 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     ? _collection.Indexes.List(_listIndexesOptions, cancellationToken)
                     : _collection.Indexes.List(_session, _listIndexesOptions, cancellationToken);
 
-                _ = cursor.ToList(cancellationToken);
+                var indexes = cursor.ToList(cancellationToken);
 
-                return OperationResult.Empty();
+                return OperationResult.FromResult(new BsonArray(indexes));
             }
             catch (Exception ex)
             {
@@ -63,9 +63,9 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     ? await _collection.Indexes.ListAsync(_listIndexesOptions, cancellationToken)
                     : await _collection.Indexes.ListAsync(_session, _listIndexesOptions, cancellationToken);
 
-                _ = await cursor.ToListAsync(cancellationToken);
+                var indexes = await cursor.ToListAsync(cancellationToken);
 
-                return OperationResult.Empty();
+                return OperationResult.FromResult(new BsonArray(indexes));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The API to create a clustered index is:

```
var options = new CreateCollectionOptions<Product>
{
    ClusteredIndex = new ClusteredIndexOptions<Product>
    {
        Key = Builders<Product>.IndexKeys.Ascending(x => x.Id),
        Unique = true,
        Name = "custom clustered index key name"
    }
};
db.CreateCollection("products", options);
```

The `Key` must be `{ _id: 1 }` and `Unique` must be `true` at the moment, but the spec was written in such a way that the server can remove these requirements in the future and not require additional work by drivers. If you create a `new ClusteredIndexOptions<T>()`, these options will be defaulted automatically.

Ideally I wanted to support non-generic `CreateCollectionsOptions.ClusteredIndex`, but `CreateCollectionOptions<TDocument>` derives from `CreateCollectionOptions`. I couldn't think of a way to define a `CreateIndexOptions.ClusteredIndex` property with type `ClusteredIndexOptions<BsonDocument>` but then change the type of the property on the derived type to `CreateCollectionOptions<TDocument>.ClusteredIndex` to `ClusteredIndexOptions<TDocument>`. I opted to only support the `ClusteredIndex` property on `CreateCollectionOptions<TDocument>`. If anyone has ideas, I'm all ears.