### PR TITLE
CSHARP-4171: Support for Deploying MongoDB behind a L4 Load Balancer 5.0 Backports.

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1600,14 +1600,14 @@ buildvariants:
     - name: plain-auth-tests
 
 - matrix_name: load-balancer-tests
-  matrix_spec: { version: ["latest"], auth: "noauth", ssl: "nossl", topology: "sharded-cluster", os: "ubuntu-1804" }
+  matrix_spec: { version: ["5.0", "6.0", "latest"], auth: "noauth", ssl: "nossl", topology: "sharded-cluster", os: "ubuntu-1804" }
   display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
   tasks:
     - name: "test-load-balancer-netstandard20"
     - name: "test-load-balancer-netstandard21"
 
 - matrix_name: load-balancer-tests-secure
-  matrix_spec: { version: ["latest"], auth: "auth", ssl: "ssl", topology: "sharded-cluster", os: "ubuntu-1804" }
+  matrix_spec: { version: ["5.0", "6.0", "latest"], auth: "auth", ssl: "ssl", topology: "sharded-cluster", os: "ubuntu-1804" }
   display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
   tasks:
     - name: "test-load-balancer-netstandard20"

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1600,14 +1600,14 @@ buildvariants:
     - name: plain-auth-tests
 
 - matrix_name: load-balancer-tests
-  matrix_spec: { version: ["5.0", "6.0", "latest"], auth: "noauth", ssl: "nossl", topology: "sharded-cluster", os: "ubuntu-1804" }
+  matrix_spec: { version: ["5.0", "6.0", "rapid", "latest"], auth: "noauth", ssl: "nossl", topology: "sharded-cluster", os: "ubuntu-1804" }
   display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
   tasks:
     - name: "test-load-balancer-netstandard20"
     - name: "test-load-balancer-netstandard21"
 
 - matrix_name: load-balancer-tests-secure
-  matrix_spec: { version: ["5.0", "6.0", "latest"], auth: "auth", ssl: "ssl", topology: "sharded-cluster", os: "ubuntu-1804" }
+  matrix_spec: { version: ["5.0", "6.0", "rapid", "latest"], auth: "auth", ssl: "ssl", topology: "sharded-cluster", os: "ubuntu-1804" }
   display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
   tasks:
     - name: "test-load-balancer-netstandard20"


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/6286ac582fbabe0be724d3b0