### PR TITLE
CSHARP-4214: Fixed Build target.

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.targets
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.targets
@@ -7,7 +7,7 @@
       <CompressionOsxRuntimesPath>runtimes/osx/native</CompressionOsxRuntimesPath>
     </PropertyGroup>
 
-    <!--snappy-->
+    <!--snappy/zstd-->
     <!--win-->
     <ItemGroup>
       <!--x32/x64-->
@@ -28,29 +28,6 @@
     <ItemGroup>
       <!--x32/x64-->
       <Content Include="$(MSBuildThisFileDirectory)../$(CompressionOsxRuntimesPath)/**/*.dylib">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>%(FileName)%(Extension)</Link>
-      </Content>
-    </ItemGroup>
-
-    <!--zstd-->
-    <!--win -->
-    <ItemGroup>
-      <Content Include="$(MSBuildThisFileDirectory)../$(CompressionWinRuntimesPath)/*.dll">
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <Link>%(FileName)%(Extension)</Link>
-      </Content>
-    </ItemGroup>
-    <!--linux-->
-    <ItemGroup>
-      <Content Include="$(MSBuildThisFileDirectory)../$(CompressionLinuxRuntimesPath)/*.so">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>%(FileName)%(Extension)</Link>
-      </Content>
-    </ItemGroup>
-    <!--osx-->
-    <ItemGroup>
-      <Content Include="$(MSBuildThisFileDirectory)../$(CompressionOsxRuntimesPath)/*.dylib">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>%(FileName)%(Extension)</Link>
       </Content>


### PR DESCRIPTION
We found a problem in target build for msbuild that seems
to break web project publishing in MsBuild. The modification
done at the target includes multiple times the same file
making publishing from MsBuild commandline to fail.

Details are in jira https://jira.mongodb.org/browse/CSHARP-4214

I'm not entirely sure of the fix, previous version of the file was really simpler, it includes explicitly the dll that should be included, this version uses overlapping wildcard that generates issue.