### PR TITLE
CSHARP-3191: driver tries to run getLastError on mongocryptd that does not exists.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
@@ -59,7 +59,7 @@ namespace MongoDB.Driver.Core.Connections
             {
                 description = UpdateConnectionIdWithServerValue(description, connectionIdServerValue.Value);
             }
-            else
+            else if (!description.HelloResult.IsMongocryptd) // mongocryptd doesn't provide ConnectionId
             {
                 try
                 {
@@ -90,7 +90,7 @@ namespace MongoDB.Driver.Core.Connections
             {
                 description = UpdateConnectionIdWithServerValue(description, connectionIdServerValue.Value);
             }
-            else
+            else if (!description.HelloResult.IsMongocryptd) // mongocryptd doesn't provide ConnectionId
             {
                 try
                 {

--- a/src/MongoDB.Driver.Core/Core/Connections/HelloResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/HelloResult.cs
@@ -125,6 +125,14 @@ namespace MongoDB.Driver.Core.Connections
         }
 
         /// <summary>
+        /// Gets a value indicating whether this instance is a mongocryptd.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is a mongocryptd; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsMongocryptd => _wrapped.TryGetValue("iscryptd", out var isCryptd) && isCryptd.IsBoolean ? isCryptd.ToBoolean() : false;
+
+        /// <summary>
         /// Gets a value indicating whether this instance is a replica set member.
         /// </summary>
         /// <value>

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloResultTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Net;
 using FluentAssertions;
 using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Misc;
@@ -317,6 +318,19 @@ namespace MongoDB.Driver.Core.Connections
 
             var subject = new HelloResult(doc);
             subject.HelloOk.Should().BeFalse();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void IsMongocryptd_should_return_expected_result([Values(false, true, null)] bool? isMongocryptd)
+        {
+            var helloResultDocument = new BsonDocument
+            {
+                { "iscryptd", () => isMongocryptd.Value, isMongocryptd.HasValue }
+            };
+
+            var subject = new HelloResult(helloResultDocument);
+            subject.IsMongocryptd.Should().Be(isMongocryptd.GetValueOrDefault(defaultValue: false));
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/HelloResultTests.cs
@@ -330,7 +330,8 @@ namespace MongoDB.Driver.Core.Connections
             };
 
             var subject = new HelloResult(helloResultDocument);
-            subject.IsMongocryptd.Should().Be(isMongocryptd.GetValueOrDefault(defaultValue: false));
+
+            subject.IsMongocryptd.Should().Be(isMongocryptd.GetValueOrDefault());
         }
     }
 }


### PR DESCRIPTION
The mongocryptd's `hello` response:

        MongoDB Enterprise > db.isMaster()
        {
                "ismaster" : true,
                "iscryptd" : true,
                "maxBsonObjectSize" : 16777216,
                "maxMessageSizeBytes" : 48000000,
                "localTime" : ISODate("2022-06-22T01:27:36.854Z"),
                "maxWireVersion" : 17,
                "minWireVersion" : 0,
                "ok" : 1
        }