### PR TITLE
CSHARP-4184: Sync'd distinct-commnet tests from CRUD spec and updated unified runner.

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/distinct-comment.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/distinct-comment.json
@@ -1,0 +1,178 @@
+{
+  "description": "distinct-comment",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "distinct-comment-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "distinct-comment-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "distinct with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.14"
+        }
+      ],
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {},
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": [ 11, 22, 33 ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "coll0",
+                  "key": "x",
+                  "query": {},
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "distinct",
+                "databaseName": "distinct-comment-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "distinct with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {},
+            "comment": "comment"
+          },
+          "expectResult": [ 11, 22, 33 ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "coll0",
+                  "key": "x",
+                  "query": {},
+                  "comment": "comment"
+                },
+                "commandName": "distinct",
+                "databaseName": "distinct-comment-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "distinct with document comment - pre 4.4, server error",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.4.13"
+        }
+      ],
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {},
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "coll0",
+                  "key": "x",
+                  "query": {},
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "distinct",
+                "databaseName": "distinct-comment-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/distinct-comment.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/unified/distinct-comment.yml
@@ -1,0 +1,98 @@
+description: "distinct-comment"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name distinct-comment-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: "distinct with document comment"
+    runOnRequirements:
+      # https://jira.mongodb.org/browse/SERVER-44847
+      # Server supports distinct with comment of any type for comment starting from 4.4.14.
+      - minServerVersion: "4.4.14"
+    operations:
+      - name: distinct
+        object: *collection0
+        arguments:
+          fieldName: &fieldName x
+          filter: &filter {}
+          comment: &documentComment { key: "value"}
+        expectResult: [ 11, 22, 33 ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                distinct: *collection0Name
+                key: *fieldName
+                query: *filter
+                comment: *documentComment
+              commandName: distinct
+              databaseName: *database0Name
+
+  - description: "distinct with string comment"
+    runOnRequirements:
+      - minServerVersion: "4.4.0"
+    operations:
+      - name: distinct
+        object: *collection0
+        arguments:
+          fieldName: *fieldName
+          filter: *filter
+          comment: &stringComment "comment"
+        expectResult: [ 11, 22, 33 ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                distinct: *collection0Name
+                key: *fieldName
+                query: *filter
+                comment: *stringComment
+              commandName: distinct
+              databaseName: *database0Name
+
+  - description: "distinct with document comment - pre 4.4, server error"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.4.13"
+    operations:
+      - name: distinct
+        object: *collection0
+        arguments:
+          fieldName: *fieldName
+          filter: *filter
+          comment: *documentComment
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                distinct: *collection0Name
+                key: *fieldName
+                query: *filter
+                comment: *documentComment
+              commandName: distinct
+              databaseName: *database0Name

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDistinctOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDistinctOperation.cs
@@ -25,17 +25,20 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         private readonly IMongoCollection<BsonDocument> _collection;
         private readonly string _fieldName;
         private readonly FilterDefinition<BsonDocument> _filter;
+        private readonly DistinctOptions _options;
         private readonly IClientSessionHandle _session;
 
         public UnifiedDistinctOperation(
             IMongoCollection<BsonDocument> collection,
             string fieldName,
             FilterDefinition<BsonDocument> filter,
+            DistinctOptions options,
             IClientSessionHandle session)
         {
             _collection = collection;
             _fieldName = fieldName;
             _filter = filter;
+            _options = options;
             _session = session;
         }
 
@@ -44,8 +47,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             try
             {
                 using var cursor = _session == null
-                    ? _collection.Distinct<BsonValue>(_fieldName, _filter, cancellationToken: cancellationToken)
-                    : _collection.Distinct<BsonValue>(_session, _fieldName, _filter, cancellationToken: cancellationToken);
+                    ? _collection.Distinct<BsonValue>(_fieldName, _filter, _options, cancellationToken)
+                    : _collection.Distinct<BsonValue>(_session, _fieldName, _filter, _options, cancellationToken);
 
                 var result = cursor.ToList(cancellationToken);
 
@@ -62,8 +65,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             try
             {
                 using var cursor = _session == null
-                    ? await _collection.DistinctAsync<BsonValue>(_fieldName, _filter, cancellationToken: cancellationToken)
-                    : await _collection.DistinctAsync<BsonValue>(_session, _fieldName, _filter, cancellationToken: cancellationToken);
+                    ? await _collection.DistinctAsync<BsonValue>(_fieldName, _filter, _options, cancellationToken)
+                    : await _collection.DistinctAsync<BsonValue>(_session, _fieldName, _filter, _options, cancellationToken);
 
                 var result = await cursor.ToListAsync(cancellationToken);
 
@@ -91,12 +94,16 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 
             string fieldName = null;
             FilterDefinition<BsonDocument> filter = null;
+            DistinctOptions options = null;
             IClientSessionHandle session = null;
 
             foreach (var argument in arguments)
             {
                 switch (argument.Name)
                 {
+                    case "comment":
+                        options = new DistinctOptions { Comment = argument.Value };
+                        break;
                     case "fieldName":
                         fieldName = argument.Value.AsString;
                         break;
@@ -111,7 +118,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 }
             }
 
-            return new UnifiedDistinctOperation(collection, fieldName, filter, session);
+            return new UnifiedDistinctOperation(collection, fieldName, filter, options, session);
         }
     }
 }


### PR DESCRIPTION
Comment for distinct was implemented previously. This commit simply adds unified tests for the functionality.