### PR TITLE
CSHARP-4021: Add section to troubleshooting FAQ per driver with top SEO results.

### DIFF
--- a/Docs/reference/content/common_issues.md
+++ b/Docs/reference/content/common_issues.md
@@ -1,0 +1,75 @@
++++
+date = "2022-07-11T16:56:14Z"
+draft = false
+title = "Common issues"
+[menu.main]
+  weight = 1000
+  identifier = "Common issues"
+  pre = "<i class='fa fa-life-ring'></i>"
++++
+
+# Frequency Encountered Issues
+
+## Timeout during server selecting
+
+Each driver operation requires selecting a healthy server to be run on. In case if such server has not been found during server selection [timeout]({{< apiref "T_MongoDB_Driver_ServerSelectionTimeout" >}}), the driver will throw server selecting timeout exception. The exception will look similar to:
+
+```csharp
+A timeout occurred after 30000ms selecting a server using CompositeServerSelector{ Selectors = MongoDB.Driver.MongoClient+AreSessionsSupportedServerSelector, LatencyLimitingServerSelector{ AllowedLatencyRange = 00:00:00.0150000 }, OperationsCountServerSelector }. 
+Client view of cluster state is 
+{ 
+    ClusterId : "1", 
+    Type : "Unknown", 
+    State : "Disconnected", 
+    Servers : 
+    [{
+        ServerId: "{ ClusterId : 1, EndPoint : "Unspecified/localhost:27017" }",
+        EndPoint: "Unspecified/localhost:27017",
+        ReasonChanged: "Heartbeat",
+        State: "Disconnected",
+        ServerVersion: ,
+        TopologyVersion: ,
+        Type: "Unknown",
+        HeartbeatException: "<exception details>"
+    }] 
+}.
+```
+The error message consist of few parts:
+
+1. Used server selection timeout and a description of server selector used for. 
+2. The current cluster description. The main part of it is a list of servers that the driver is aware of. Each server description contains exhaustive description of its current state including information about an endpoint, a server version, a server type and its current health state. If the server is not heathy, most-likely it has happened because the latest heartbeat attempts were failed. The server description tracks such failures in HeartbeatException. This is the main area that should be analyzed for issue resolving. Most of heartbeat exception messages are self explanatory. Below there are few well-known frequent heartbeat exceptions:
+
+    * `No connection could be made because the target machine actively refused it` - a driver doesn't see a server endpoint. In most cases this means that a server is not visible in network or has not been launched.
+    
+    * `Attempted to read past the end of the stream.` - this error happens when driver can't connect to a server due to network error. Make sure that a configured server is accessible. One typical example of when this error happens is when client's machine IP is not configured in the Atlas IPs white list.
+
+## MongoWaitQueueFullException. The wait queue for acquiring a connection to server is full
+
+In the vast majority of cases this is expected behavior related to provided a mongo client configuration or the way how a driver is used. This exception indicates that too many consumers are trying to use MongoDB at once. As soon as a number of acquiring connections at the same time has reached WaitQueueSize value, all next connection acquiring attempts will be postponed until any previous acquiring process will be finished. If it won't happen during WaitQueueTimeout, the driver will throw this exception.
+
+## Unsupported LINQ or builder expressions
+
+Each LINQ expression or builder configuration must be translated into an appropriate mongo query to be executed by a server. Unfortunately it's not always possible to do with a typed approach due 2 reasons:
+
+1. A server doesn't have equvalent operators, methods or .dotnet types that have been configured in a LINQ expression.
+2. A driver doesn't support a particular tranformation from LINQ expression or builder configuration into a server query. It may happen because the provided query is too complicated or because some feature has not been implemented yet by a driver.
+
+In case if you see `Unsupported filter ..` or `Expression not supported ..` exception message, we recommend trying the following steps:
+
+1. If you use a default LINQ2 provider, configure LINQ3 [provider]({{< relref "reference\driver\crud\linq3.md" >}}). This is the most modern LINQ provider that supports much more various cases that may be not implemented in LINQ2.
+2. Try simplify your query as more as possible.
+3. If the above steps don't resolve your issue, it's always possible to provide a query in a raw BsonDocument or string form. All mongo query definitions like FilterDefinition, ProjectionDefinition, PipelineDefinition and etc support implicit conversions from a raw form. That allows specyfying any query that is supported by a server. For example, the below filters are equvalent from a server point of view:
+
+```csharp
+    FilterDefinition<Entity> typedFilter = Builders<Entity>.Filter.Eq(e => e.A, 1);
+    BsonDocument rawMQLfilter = BsonDocument.Parse("{ a : 1 }");
+```
+
+{{% note %}}
+Pay attention that if you use a raw mongo query form, you also avoid using all applied configuration via bson attributes like `BsonElement` or static serialization with [BsonClassMap]({{< relref "reference\bson\mapping\index.md" >}}). So, the provided field naming should be represented in the same way as it's stored on the server.
+{{% /note %}}
+It's also possible to combine a raw and typed forms in the same query:
+
+```csharp
+FilterDefinition<Entity> filter = Builders<Entity>.Filter.And(Builders<Entity>.Filter.Eq(e => e.A, 1), BsonDocument.Parse("{ b : 2 }"));
+```

--- a/Docs/reference/content/frequently_encountered_issues.md
+++ b/Docs/reference/content/frequently_encountered_issues.md
@@ -1,10 +1,10 @@
 +++
 date = "2022-07-11T16:56:14Z"
 draft = false
-title = "Common issues"
+title = "Frequently Encountered Issues"
 [menu.main]
   weight = 1000
-  identifier = "Common issues"
+  identifier = "Frequently Encountered Issues"
   pre = "<i class='fa fa-life-ring'></i>"
 +++
 

--- a/Docs/reference/content/frequently_encountered_issues.md
+++ b/Docs/reference/content/frequently_encountered_issues.md
@@ -60,7 +60,7 @@ This exception usually indicates a threading or concurrency problem in your appl
 Each LINQ or Builder expression must be translated into MQL (MongoDB Query Language), which is executed by the server. Unfortunately this is not always possible for two main reasons:
 
 1. You are attempting to use a .NET feature that does not have an obvious or equivalent MongoDB representation. For example, .NET and MongoDB have different semantics around collations.
-2. The driver doesn't support a particular tranformation from LINQ or Builder expression into a server query. It may happen because the provided query is too complicated or because some feature has not been implemented yet by the driver.
+2. The driver doesn't support a particular transformation from LINQ or Builder expression into a server query. It may happen because the provided query is too complicated or because some feature has not been implemented yet by the driver.
 
 If you see an `Unsupported filter ...` or `Expression not supported ...` exception message, we recommend trying the following steps:
 

--- a/Docs/reference/content/frequently_encountered_issues.md
+++ b/Docs/reference/content/frequently_encountered_issues.md
@@ -42,7 +42,9 @@ The error message consists of few parts:
 
     * `No connection could be made because the target machine actively refused it`: The driver cannot see this cluster node. This can be because the cluster node has crashed, a firewall is preventing network traffic from reaching the cluster node or port, or some other network error is preventing traffic from being successfully routed to the cluster node.
     
-    * `Attempted to read past the end of the stream`: This error typically indicates a TLS/SSL-related problem such as an expired/invalid certificate or an untrusted root CA. You can use tools like `openssl s_client` to debug TLS/SSL-related certificate problems.
+    * `Attempted to read past the end of the stream`: This error happens when driver can't connect to a server due to network error. Make sure that a configured server is accessible. One typical example of when this error happens is when client's machine IP is not configured in the Atlas IPs white list.
+    
+    * `The remote certificate is invalid according to the validation procedure`: This error typically indicates a TLS/SSL-related problem such as an expired/invalid certificate or an untrusted root CA. You can use tools like `openssl s_client` to debug TLS/SSL-related certificate problems.
 
 ## MongoWaitQueueFullException. The wait queue for acquiring a connection to server is full.
 

--- a/Docs/reference/content/frequently_encountered_issues.md
+++ b/Docs/reference/content/frequently_encountered_issues.md
@@ -3,9 +3,10 @@ date = "2022-07-11T16:56:14Z"
 draft = false
 title = "Frequently Encountered Issues"
 [menu.main]
-  weight = 1000
+  parent = "Issues & Help"
   identifier = "Frequently Encountered Issues"
-  pre = "<i class='fa fa-life-ring'></i>"
+  weight = 10
+  pre = "<i class='fa'></i>"
 +++
 
 # Frequently Encountered Issues

--- a/Docs/reference/content/frequently_encountered_issues.md
+++ b/Docs/reference/content/frequently_encountered_issues.md
@@ -42,7 +42,7 @@ The error message consists of few parts:
 
     * `No connection could be made because the target machine actively refused it`: The driver cannot see this cluster node. This can be because the cluster node has crashed, a firewall is preventing network traffic from reaching the cluster node or port, or some other network error is preventing traffic from being successfully routed to the cluster node.
     
-    * `Attempted to read past the end of the stream`: This error happens when driver can't connect to a server due to network error. Make sure that a configured server is accessible. One typical example of when this error happens is when client's machine IP is not configured in the Atlas IPs white list.
+    * `Attempted to read past the end of the stream`: This error happens when the driver can't connect to the cluster nodes due to a network error, misconfigured firewall, or other network issue. Ensure that all cluster nodes are reachable. One common cause of this error is when the client machine's IP address is not configured in the Atlas IPs Access List, which can be found under the Network Access tab for your Atlas Project.
     
     * `The remote certificate is invalid according to the validation procedure`: This error typically indicates a TLS/SSL-related problem such as an expired/invalid certificate or an untrusted root CA. You can use tools like `openssl s_client` to debug TLS/SSL-related certificate problems.
 

--- a/Docs/reference/content/issues_help.md
+++ b/Docs/reference/content/issues_help.md
@@ -10,7 +10,7 @@ title = "Issues & Help"
 
 ## Support
 
-Please check [frequently encountered issues]({{< relref "common_issues.md" >}}) before opening a support case or reporting a bug.
+Please check [frequently encountered issues]({{< relref "frequently_encountered_issues.md" >}}) before opening a support case or reporting a bug.
 
 If you require assistance with this driver, please see our paid support resources at [MongoDB Support Portal](https://support.mongodb.com/welcome)
 - Free support for customers without support subscriptions can be received through the [MongoDB Community Developer Forums](https://developer.mongodb.com/community/forums/)

--- a/Docs/reference/content/issues_help.md
+++ b/Docs/reference/content/issues_help.md
@@ -9,6 +9,9 @@ title = "Issues & Help"
 +++
 
 ## Support
+
+Please check that most frequent questions and their description [here]({{< relref "common_issues.md" >}}).
+
 If you require assistance with this driver, please see our paid support resources at [MongoDB Support Portal](https://support.mongodb.com/welcome)
 - Free support for customers without support subscriptions can be received through the [MongoDB Community Developer Forums](https://developer.mongodb.com/community/forums/)
 

--- a/Docs/reference/content/issues_help.md
+++ b/Docs/reference/content/issues_help.md
@@ -10,7 +10,7 @@ title = "Issues & Help"
 
 ## Support
 
-Please check that most frequent questions and their description [here]({{< relref "common_issues.md" >}}).
+Please check [frequently encountered issues]({{< relref "common_issues.md" >}}) before opening a support case or reporting a bug.
 
 If you require assistance with this driver, please see our paid support resources at [MongoDB Support Portal](https://support.mongodb.com/welcome)
 - Free support for customers without support subscriptions can be received through the [MongoDB Community Developer Forums](https://developer.mongodb.com/community/forums/)


### PR DESCRIPTION
I'm not sure what we can suggest for these tickets:
* https://jira.mongodb.org/browse/CSHARP-2489
* https://jira.mongodb.org/browse/CSHARP-1677

it looks like too easy and straightforward questions, thoughts?

NOTE: to deploy changes locally, use this hugo command:

      ..\mongo-csharp-driver\Docs\reference>hugo.exe server