### PR TITLE
Skunkworks: Update .editorconfig to match coding convention for C# driver

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,17 +39,17 @@ csharp_indent_labels = one_less_than_current
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
 
 # avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_field = false:refactoring
+dotnet_style_qualification_for_property = false:refactoring
+dotnet_style_qualification_for_method = false:refactoring
 dotnet_style_qualification_for_event = false:suggestion
 
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
-csharp_style_var_for_built_in_types = false:suggestion
-csharp_style_var_when_type_is_apparent = false:none
-csharp_style_var_elsewhere = false:suggestion
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
+csharp_style_var_for_built_in_types = true:refactoring
+csharp_style_var_when_type_is_apparent = true:refactoring
+csharp_style_var_elsewhere = true:refactoring
+dotnet_style_predefined_type_for_locals_parameters_members = true:refactoring
+dotnet_style_predefined_type_for_member_access = true:refactoring
 
 # name all constant fields using PascalCase
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
@@ -59,22 +59,22 @@ dotnet_naming_symbols.constant_fields.applicable_kinds   = field
 dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-# static fields should have s_ prefix
+# static fields should have __ prefix
 dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
 dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
 dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = __
 dotnet_naming_style.static_prefix_style.capitalization = camel_case 
 
-# internal and private fields should be _camelCase
+# private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
 dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
 dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
 
@@ -84,27 +84,31 @@ dotnet_sort_system_directives_first = true
 csharp_prefer_braces = true:refactoring
 csharp_preserve_single_line_blocks = true:none
 csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_static_local_function = false:suggestion
 csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_switch_expression = false:suggestion
 
 # Code quality
-dotnet_style_readonly_field = true:suggestion
-dotnet_code_quality_unused_parameters = non_public:suggestion
+dotnet_style_readonly_field = true:silent
+dotnet_code_quality_unused_parameters = non_public:refactoring
 
 # Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
+dotnet_style_object_initializer = true:refactoring
+dotnet_style_collection_initializer = true:refactoring
 dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_null_propagation = true:refactoring
+dotnet_style_prefer_is_null_check_over_reference_equality_method = false:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+dotnet_style_prefer_auto_properties = false:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
 dotnet_style_prefer_conditional_expression_over_return = true:refactoring
-csharp_prefer_simple_default_expression = true:suggestion
+dotnet_style_prefer_compound_assignment = false:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:refactoring
+csharp_prefer_simple_default_expression = false:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = false:suggestion
+csharp_style_deconstructed_variable_declaration = false:suggestion
 
 # Expression-bodied members
 csharp_style_expression_bodied_methods = true:refactoring
@@ -117,13 +121,14 @@ csharp_style_expression_bodied_lambdas = true:refactoring
 csharp_style_expression_bodied_local_functions = true:refactoring
 
 # Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = false:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = false:suggestion
+csharp_style_inlined_variable_declaration = false:suggestion
+csharp_style_prefer_not_pattern = false:suggestion
 
 # Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_throw_expression = false:suggestion
+csharp_style_conditional_delegate_call = true:silent
 
 # Other features
 csharp_style_prefer_index_operator = false:none
@@ -155,7 +160,12 @@ csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
 # Analyzers
+csharp_style_unused_value_assignment_preference = discard_variable:refactoring
 dotnet_code_quality.ca1802.api_surface = private, internal
+dotnet_diagnostic.CA1065.severity = none
+dotnet_diagnostic.IDE0051.severity = none
+dotnet_diagnostic.IDE0052.severity = none
+dotnet_diagnostic.xUnit1004.severity = none
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/src/MongoDB.Bson/IO/IBsonReaderExtensions.cs
+++ b/src/MongoDB.Bson/IO/IBsonReaderExtensions.cs
@@ -96,7 +96,6 @@ namespace MongoDB.Bson.IO
         [Obsolete("In V3 mode use ReadBinaryData instead.")]
         public static BsonBinaryData ReadBinaryDataWithGuidRepresentationUnspecified(this IBsonReader reader)
         {
-#pragma warning disable 618
             if (BsonDefaults.GuidRepresentationMode == GuidRepresentationMode.V2)
             {
                 reader.PushSettings(s => s.GuidRepresentation = GuidRepresentation.Unspecified);
@@ -113,7 +112,6 @@ namespace MongoDB.Bson.IO
             {
                 return reader.ReadBinaryData();
             }
-#pragma warning restore 618
         }
 
         /// <summary>

--- a/src/MongoDB.Bson/ObjectModel/BsonArray.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonArray.cs
@@ -248,7 +248,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">A value to be mapped to a BsonArray.</param>
         /// <returns>A BsonArray or null.</returns>
-        public new static BsonArray Create(object value)
+        public static new BsonArray Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonBinaryData.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonBinaryData.cs
@@ -123,7 +123,6 @@ namespace MongoDB.Bson
         /// Initializes a new instance of the BsonBinaryData class.
         /// </summary>
         /// <param name="guid">A Guid.</param>
-#pragma warning disable 618
         [Obsolete("Use the constructor that also takes a GuidRepresentation instead.")]
         public BsonBinaryData(Guid guid)
             : this(
@@ -133,7 +132,6 @@ namespace MongoDB.Bson
                     : throw new InvalidOperationException("This constructor can only be used when BsonDefaults.GuidRepresentationMode is V2."))
         {
         }
-#pragma warning restore 618
 
         /// <summary>
         /// Initializes a new instance of the BsonBinaryData class.
@@ -188,7 +186,6 @@ namespace MongoDB.Bson
         /// <summary>
         /// Gets the BsonBinaryData as a Guid if the subtype is UuidStandard or UuidLegacy, otherwise null.
         /// </summary>
-#pragma warning disable 618 // about obsolete BsonBinarySubType.OldBinary
         [Obsolete("Use Value instead.")]
         public override object RawValue
         {
@@ -208,7 +205,6 @@ namespace MongoDB.Bson
                 }
             }
         }
-#pragma warning restore 618
 
         /// <summary>
         /// Gets the binary data subtype.
@@ -273,7 +269,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonBinaryData.</param>
         /// <returns>A BsonBinaryData or null.</returns>
-        public new static BsonBinaryData Create(object value)
+        public static new BsonBinaryData Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonBoolean.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonBoolean.cs
@@ -124,7 +124,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonBoolean.</param>
         /// <returns>A BsonBoolean or null.</returns>
-        public new static BsonBoolean Create(object value)
+        public static new BsonBoolean Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonDateTime.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDateTime.cs
@@ -137,7 +137,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonDateTime.</param>
         /// <returns>A BsonDateTime or null.</returns>
-        public new static BsonDateTime Create(object value)
+        public static new BsonDateTime Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonDecimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDecimal128.cs
@@ -99,7 +99,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonDecimal128.</param>
         /// <returns>A BsonDecimal128.</returns>
-        public new static BsonDecimal128 Create(object value)
+        public static new BsonDecimal128 Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDocument.cs
@@ -31,7 +31,7 @@ namespace MongoDB.Bson
     public class BsonDocument : BsonValue, IComparable<BsonDocument>, IConvertibleToBsonDocument, IEnumerable<BsonElement>, IEquatable<BsonDocument>
     {
         // constants
-        private const int __indexesThreshold = 8; // the _indexes dictionary will not be created until the document grows to contain 8 elements
+        private const int IndexesThreshold = 8; // the _indexes dictionary will not be created until the document grows to contain 8 elements
 
         // private fields
         // use a list and a dictionary because we want to preserve the order in which the elements were added
@@ -354,7 +354,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">The object to be mapped to a BsonDocument.</param>
         /// <returns>A BsonDocument.</returns>
-        public new static BsonDocument Create(object value)
+        public static new BsonDocument Create(object value)
         {
             if (value == null)
             {
@@ -1272,7 +1272,7 @@ namespace MongoDB.Bson
         // private methods
         private void RebuildIndexes()
         {
-            if (_elements.Count < __indexesThreshold)
+            if (_elements.Count < IndexesThreshold)
             {
                 _indexes = null;
                 return;

--- a/src/MongoDB.Bson/ObjectModel/BsonDouble.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonDouble.cs
@@ -26,16 +26,16 @@ namespace MongoDB.Bson
     public class BsonDouble : BsonValue, IComparable<BsonDouble>, IEquatable<BsonDouble>
     {
         #region static
-        const int __minPrecreatedValue = -100;
-        const int __maxPrecreatedValue = 100;
-        private static readonly BsonDouble[] __precreatedInstances = new BsonDouble[__maxPrecreatedValue - __minPrecreatedValue + 1];
+        const int MinPrecreatedValue = -100;
+        const int MaxPrecreatedValue = 100;
+        private static readonly BsonDouble[] __precreatedInstances = new BsonDouble[MaxPrecreatedValue - MinPrecreatedValue + 1];
 
         static BsonDouble()
         {
-            for (var i = __minPrecreatedValue; i <= __maxPrecreatedValue; i++)
+            for (var i = MinPrecreatedValue; i <= MaxPrecreatedValue; i++)
             {
                 var precreatedInstance = new BsonDouble(i);
-                var index = i - __minPrecreatedValue;
+                var index = i - MinPrecreatedValue;
                 __precreatedInstances[index] = precreatedInstance;
             }
         }
@@ -85,9 +85,9 @@ namespace MongoDB.Bson
         public static implicit operator BsonDouble(double value)
         {
             var intValue = (int)value;
-            if (intValue == value && intValue >= __minPrecreatedValue && intValue <= __maxPrecreatedValue)
+            if (intValue == value && intValue >= MinPrecreatedValue && intValue <= MaxPrecreatedValue)
             {
-                var index = intValue - __minPrecreatedValue;
+                var index = intValue - MinPrecreatedValue;
                 return __precreatedInstances[index];
             }
             return new BsonDouble(value);
@@ -122,7 +122,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonDouble.</param>
         /// <returns>A BsonDouble.</returns>
-        public new static BsonDouble Create(object value)
+        public static new BsonDouble Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonInt32.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonInt32.cs
@@ -25,16 +25,16 @@ namespace MongoDB.Bson
     public class BsonInt32 : BsonValue, IComparable<BsonInt32>, IEquatable<BsonInt32>
     {
         #region static
-        const int __minPrecreatedValue = -100;
-        const int __maxPrecreatedValue = 100;
-        private static readonly BsonInt32[] __precreatedInstances = new BsonInt32[__maxPrecreatedValue - __minPrecreatedValue + 1];
+        const int MinPrecreatedValue = -100;
+        const int MaxPrecreatedValue = 100;
+        private static readonly BsonInt32[] __precreatedInstances = new BsonInt32[MaxPrecreatedValue - MinPrecreatedValue + 1];
 
         static BsonInt32()
         {
-            for (var i = __minPrecreatedValue; i <= __maxPrecreatedValue; i++)
+            for (var i = MinPrecreatedValue; i <= MaxPrecreatedValue; i++)
             {
                 var precreatedInstance = new BsonInt32(i);
-                var index = i - __minPrecreatedValue;
+                var index = i - MinPrecreatedValue;
                 __precreatedInstances[index] = precreatedInstance;
             }
         }
@@ -133,9 +133,9 @@ namespace MongoDB.Bson
         /// <returns>A BsonInt32.</returns>
         public static implicit operator BsonInt32(int value)
         {
-            if (value >= __minPrecreatedValue && value <= __maxPrecreatedValue)
+            if (value >= MinPrecreatedValue && value <= MaxPrecreatedValue)
             {
-                var index = value - __minPrecreatedValue;
+                var index = value - MinPrecreatedValue;
                 return __precreatedInstances[index];
             }
             return new BsonInt32(value);
@@ -170,7 +170,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonInt32.</param>
         /// <returns>A BsonInt32 or null.</returns>
-        public new static BsonInt32 Create(object value)
+        public static new BsonInt32 Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonInt64.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonInt64.cs
@@ -25,16 +25,16 @@ namespace MongoDB.Bson
     public class BsonInt64 : BsonValue, IComparable<BsonInt64>, IEquatable<BsonInt64>
     {
         #region static
-        const long __minPrecreatedValue = -100L;
-        const long __maxPrecreatedValue = 100L;
-        private static readonly BsonInt64[] __precreatedInstances = new BsonInt64[__maxPrecreatedValue - __minPrecreatedValue + 1];
+        const long MinPrecreatedValue = -100L;
+        const long MaxPrecreatedValue = 100L;
+        private static readonly BsonInt64[] __precreatedInstances = new BsonInt64[MaxPrecreatedValue - MinPrecreatedValue + 1];
 
         static BsonInt64()
         {
-            for (var i = __minPrecreatedValue; i <= __maxPrecreatedValue; i++)
+            for (var i = MinPrecreatedValue; i <= MaxPrecreatedValue; i++)
             {
                 var precreatedInstance = new BsonInt64(i);
-                var index = i - __minPrecreatedValue;
+                var index = i - MinPrecreatedValue;
                 __precreatedInstances[index] = precreatedInstance;
             }
         }
@@ -87,9 +87,9 @@ namespace MongoDB.Bson
         /// <returns>A BsonInt64.</returns>
         public static implicit operator BsonInt64(long value)
         {
-            if (value >= __minPrecreatedValue && value <= __maxPrecreatedValue)
+            if (value >= MinPrecreatedValue && value <= MaxPrecreatedValue)
             {
-                var index = value - __minPrecreatedValue;
+                var index = value - MinPrecreatedValue;
                 return __precreatedInstances[index];
             }
             return new BsonInt64(value);
@@ -124,7 +124,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonInt64.</param>
         /// <returns>A BsonInt64 or null.</returns>
-        public new static BsonInt64 Create(object value)
+        public static new BsonInt64 Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonJavaScript.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonJavaScript.cs
@@ -96,7 +96,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonJavaScript.</param>
         /// <returns>A BsonJavaScript or null.</returns>
-        public new static BsonJavaScript Create(object value)
+        public static new BsonJavaScript Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonJavaScriptWithScope.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonJavaScriptWithScope.cs
@@ -89,7 +89,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonJavaScriptWithScope.</param>
         /// <returns>A BsonJavaScriptWithScope or null.</returns>
-        public new static BsonJavaScriptWithScope Create(object value)
+        public static new BsonJavaScriptWithScope Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonObjectId.cs
@@ -205,7 +205,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonObjectId.</param>
         /// <returns>A BsonObjectId or null.</returns>
-        public new static BsonObjectId Create(object value)
+        public static new BsonObjectId Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonRegularExpression.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonRegularExpression.cs
@@ -174,7 +174,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonRegularExpression.</param>
         /// <returns>A BsonRegularExpression or null.</returns>
-        public new static BsonRegularExpression Create(object value)
+        public static new BsonRegularExpression Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonString.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonString.cs
@@ -123,7 +123,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonString.</param>
         /// <returns>A BsonString or null.</returns>
-        public new static BsonString Create(object value)
+        public static new BsonString Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonSymbol.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonSymbol.cs
@@ -94,7 +94,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonSymbol.</param>
         /// <returns>A BsonSymbol or null.</returns>
-        public new static BsonSymbol Create(object value)
+        public static new BsonSymbol Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/BsonTimestamp.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonTimestamp.cs
@@ -110,7 +110,7 @@ namespace MongoDB.Bson
         /// </summary>
         /// <param name="value">An object to be mapped to a BsonTimestamp.</param>
         /// <returns>A BsonTimestamp or null.</returns>
-        public new static BsonTimestamp Create(object value)
+        public static new BsonTimestamp Create(object value)
         {
             if (value == null)
             {

--- a/src/MongoDB.Bson/ObjectModel/Decimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/Decimal128.cs
@@ -29,10 +29,10 @@ namespace MongoDB.Bson
     {
         #region static
         // private constants
-        private const short __exponentMax = 6111;
-        private const short __exponentMin = -6176;
-        private const short __exponentBias = 6176;
-        private const short __maxSignificandDigits = 34;
+        private const short ExponentMax = 6111;
+        private const short ExponentMin = -6176;
+        private const short ExponentBias = 6176;
+        private const short MaxSignificandDigits = 34;
 
         // private static fields
         private static readonly UInt128 __maxSignificand = UInt128.Parse("9999999999999999999999999999999999"); // must be initialized before Decimal128.Parse is called
@@ -1128,7 +1128,7 @@ namespace MongoDB.Bson
             significandString = RemoveLeadingZeroes(significandString);
             significandString = ClampOrRound(ref exponent, significandString);
 
-            if (exponent > __exponentMax || exponent < __exponentMin)
+            if (exponent > ExponentMax || exponent < ExponentMin)
             {
                 result = default(Decimal128);
                 return false;
@@ -1148,42 +1148,42 @@ namespace MongoDB.Bson
         // private static methods
         private static string ClampOrRound(ref int exponent, string significandString)
         {
-            if (exponent > __exponentMax)
+            if (exponent > ExponentMax)
             {
                 if (significandString == "0")
                 {
                     // since significand is zero simply use the largest possible exponent
-                    exponent = __exponentMax;
+                    exponent = ExponentMax;
                 }
                 else
                 {
                     // use clamping to bring the exponent into range
-                    var numberOfTrailingZeroesToAdd = exponent - __exponentMax;
+                    var numberOfTrailingZeroesToAdd = exponent - ExponentMax;
                     var digitsAvailable = 34 - significandString.Length;
                     if (numberOfTrailingZeroesToAdd <= digitsAvailable)
                     {
-                        exponent = __exponentMax;
+                        exponent = ExponentMax;
                         significandString = significandString + new string('0', numberOfTrailingZeroesToAdd);
                     }
                 }
             }
-            else if (exponent < __exponentMin)
+            else if (exponent < ExponentMin)
             {
                 if (significandString == "0")
                 {
                     // since significand is zero simply use the smallest possible exponent
-                    exponent = __exponentMin;
+                    exponent = ExponentMin;
                 }
                 else
                 {
                     // use exact rounding to bring the exponent into range
-                    var numberOfTrailingZeroesToRemove = __exponentMin - exponent;
+                    var numberOfTrailingZeroesToRemove = ExponentMin - exponent;
                     if (numberOfTrailingZeroesToRemove < significandString.Length)
                     {
                         var trailingDigits = significandString.Substring(significandString.Length - numberOfTrailingZeroesToRemove);
                         if (Regex.IsMatch(trailingDigits, "^0+$"))
                         {
-                            exponent = __exponentMin;
+                            exponent = ExponentMin;
                             significandString = significandString.Substring(0, significandString.Length - numberOfTrailingZeroesToRemove);
                         }
                     }
@@ -1193,7 +1193,7 @@ namespace MongoDB.Bson
             {
                 // use exact rounding to reduce significand to 34 digits
                 var numberOfTrailingZeroesToRemove = significandString.Length - 34;
-                if (exponent + numberOfTrailingZeroesToRemove <= __exponentMax)
+                if (exponent + numberOfTrailingZeroesToRemove <= ExponentMax)
                 {
                     var trailingDigits = significandString.Substring(significandString.Length - numberOfTrailingZeroesToRemove);
                     if (Regex.IsMatch(trailingDigits, "^0+$"))
@@ -1229,7 +1229,7 @@ namespace MongoDB.Bson
 
         private static Decimal128 FromComponents(bool isNegative, short exponent, UInt128 significand)
         {
-            if (exponent < __exponentMin || exponent > __exponentMax)
+            if (exponent < ExponentMin || exponent > ExponentMax)
             {
                 throw new ArgumentOutOfRangeException(nameof(exponent));
             }

--- a/src/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -32,8 +32,8 @@ namespace MongoDB.Bson.Serialization
     public class BsonClassMap
     {
         // private static fields
-        private readonly static Dictionary<Type, BsonClassMap> __classMaps = new Dictionary<Type, BsonClassMap>();
-        private readonly static Queue<Type> __knownTypesQueue = new Queue<Type>();
+        private static readonly Dictionary<Type, BsonClassMap> __classMaps = new Dictionary<Type, BsonClassMap>();
+        private static readonly Queue<Type> __knownTypesQueue = new Queue<Type>();
         private static int __freezeNestingLevel = 0;
 
         // private fields

--- a/src/MongoDB.Bson/Serialization/Conventions/ConventionRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/ConventionRegistry.cs
@@ -24,8 +24,8 @@ namespace MongoDB.Bson.Serialization.Conventions
     public static class ConventionRegistry
     {
         // private static fields
-        private readonly static List<ConventionPackContainer> __conventionPacks = new List<ConventionPackContainer>();
-        private readonly static object __lock = new object();
+        private static readonly List<ConventionPackContainer> __conventionPacks = new List<ConventionPackContainer>();
+        private static readonly object __lock = new object();
 
         // static constructors
         static ConventionRegistry()

--- a/src/MongoDB.Bson/Serialization/Serializers/BitArraySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BitArraySerializer.cs
@@ -85,7 +85,6 @@ namespace MongoDB.Bson.Serialization.Serializers
         }
 
         // public methods
-#pragma warning disable 618 // about obsolete BsonBinarySubType.OldBinary
         /// <summary>
         /// Deserializes a value.
         /// </summary>
@@ -141,7 +140,6 @@ namespace MongoDB.Bson.Serialization.Serializers
                     throw CreateCannotDeserializeFromBsonTypeException(bsonType);
             }
         }
-#pragma warning restore 618
 
         /// <summary>
         /// Serializes a value.

--- a/src/MongoDB.Bson/Serialization/Serializers/ByteArraySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ByteArraySerializer.cs
@@ -78,7 +78,6 @@ namespace MongoDB.Bson.Serialization.Serializers
         }
 
         // public methods
-#pragma warning disable 618 // about obsolete BsonBinarySubType.OldBinary
         /// <summary>
         /// Deserializes a value.
         /// </summary>
@@ -114,7 +113,6 @@ namespace MongoDB.Bson.Serialization.Serializers
                     throw CreateCannotDeserializeFromBsonTypeException(bsonType);
             }
         }
-#pragma warning restore 618
 
         /// <summary>
         /// Serializes a value.

--- a/src/MongoDB.Bson/Serialization/Serializers/DynamicDocumentBaseSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DynamicDocumentBaseSerializer.cs
@@ -27,7 +27,7 @@ namespace MongoDB.Bson.Serialization.Serializers
     public abstract class DynamicDocumentBaseSerializer<T> : SerializerBase<T> where T : class, IDynamicMetaObjectProvider
     {
         // private static fields
-        private static readonly IBsonSerializer<object> _objectSerializer = BsonSerializer.LookupSerializer<object>();
+        private static readonly IBsonSerializer<object> __objectSerializer = BsonSerializer.LookupSerializer<object>();
 
         // constructors
         /// <summary>
@@ -58,7 +58,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                     while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
                     {
                         var name = bsonReader.ReadName();
-                        var value = _objectSerializer.Deserialize(dynamicContext);
+                        var value = __objectSerializer.Deserialize(dynamicContext);
                         SetValueForMember(document, name, value);
                     }
                     bsonReader.ReadEndDocument();
@@ -101,7 +101,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 if (TryGetValueForMember(value, memberName, out memberValue))
                 {
                     bsonWriter.WriteName(memberName);
-                    _objectSerializer.Serialize(dynamicContext, memberValue);
+                    __objectSerializer.Serialize(dynamicContext, memberValue);
                 }
             }
             bsonWriter.WriteEndDocument();

--- a/src/MongoDB.Driver.Core/ChangeStreamDocument.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamDocument.cs
@@ -44,7 +44,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the backing document.
         /// </summary>
-        new public BsonDocument BackingDocument => base.BackingDocument;
+        public new BsonDocument BackingDocument => base.BackingDocument;
 
         /// <summary>
         /// Gets the cluster time.

--- a/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
@@ -29,10 +29,10 @@ namespace MongoDB.Driver.Core.Authentication
     public sealed class GssapiAuthenticator : SaslAuthenticator
     {
         // constants
-        private const string __canonicalizeHostNamePropertyName = "CANONICALIZE_HOST_NAME";
-        private const string __realmPropertyName = "REALM";
-        private const string __serviceNamePropertyName = "SERVICE_NAME";
-        private const string __serviceRealmPropertyName = "SERVICE_REALM";
+        private const string CanonicalizeHostNamePropertyNameValue = "CANONICALIZE_HOST_NAME";
+        private const string RealmPropertyNameValue = "REALM";
+        private const string ServiceNamePropertyNameValue = "SERVICE_NAME";
+        private const string ServiceRealmPropertyNameValue = "SERVICE_REALM";
 
         // static properties
         /// <summary>
@@ -43,7 +43,7 @@ namespace MongoDB.Driver.Core.Authentication
         /// </value>
         public static string CanonicalizeHostNamePropertyName
         {
-            get { return __canonicalizeHostNamePropertyName; }
+            get { return CanonicalizeHostNamePropertyNameValue; }
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace MongoDB.Driver.Core.Authentication
         [Obsolete("Use ServiceRealmPropertyName")]
         public static string RealmPropertyName
         {
-            get { return __realmPropertyName; }
+            get { return RealmPropertyNameValue; }
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace MongoDB.Driver.Core.Authentication
         /// </value>
         public static string ServiceNamePropertyName
         {
-            get { return __serviceNamePropertyName; }
+            get { return ServiceNamePropertyNameValue; }
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace MongoDB.Driver.Core.Authentication
         /// </value>
         public static string ServiceRealmPropertyName
         {
-            get { return __serviceRealmPropertyName; }
+            get { return ServiceRealmPropertyNameValue; }
         }
 
         // constructors
@@ -180,14 +180,14 @@ namespace MongoDB.Driver.Core.Authentication
                 {
                     switch (pair.Key.ToUpperInvariant())
                     {
-                        case __serviceNamePropertyName:
+                        case ServiceNamePropertyNameValue:
                             serviceName = (string)pair.Value;
                             break;
-                        case __serviceRealmPropertyName:
-                        case __realmPropertyName:
+                        case ServiceRealmPropertyNameValue:
+                        case RealmPropertyNameValue:
                             realm = (string)pair.Value;
                             break;
-                        case __canonicalizeHostNamePropertyName:
+                        case CanonicalizeHostNamePropertyNameValue:
                             canonicalizeHostName = bool.Parse(pair.Value);
                             break;
                         default:

--- a/src/MongoDB.Driver.Core/Core/Authentication/Libgssapi/Oid.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Libgssapi/Oid.cs
@@ -31,11 +31,11 @@ namespace MongoDB.Driver.Core.Authentication.Libgssapi
             int numBytes = oidBytes.Length;
             var unmanagedArray = Marshal.AllocHGlobal(numBytes);
             Marshal.Copy(oidBytes, 0, unmanagedArray, numBytes);
-            return new Oid { elements = unmanagedArray, length = (uint)numBytes };
+            return new Oid { _elements = unmanagedArray, _length = (uint)numBytes };
         }
         #endregion
 
-        private uint length;
-        private IntPtr elements;
+        private uint _length;
+        private IntPtr _elements;
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Authentication/Sspi/SecurityBuffer.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Sspi/SecurityBuffer.cs
@@ -25,7 +25,6 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
     /// <remarks>
     /// http://msdn.microsoft.com/en-us/library/windows/desktop/aa379814(v=vs.85).aspx
     /// </remarks>
-    [SuppressMessage("Microsoft.Design", "CA1049:TypesThatOwnNativeResourcesShouldBeDisposable", Justification = "Implementing IDisposable on a struct leads to memory leaks.")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct SecurityBuffer
     {

--- a/src/MongoDB.Driver.Core/Core/Authentication/Sspi/SecurityBufferDescriptor.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Sspi/SecurityBufferDescriptor.cs
@@ -25,7 +25,6 @@ namespace MongoDB.Driver.Core.Authentication.Sspi
     /// <remarks>
     /// http://msdn.microsoft.com/en-us/library/windows/desktop/aa379815(v=vs.85).aspx
     /// </remarks>
-    [SuppressMessage("Microsoft.Design", "CA1049:TypesThatOwnNativeResourcesShouldBeDisposable", Justification = "Implementing IDisposable on a struct leads to memory leaks.")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct SecurityBufferDescriptor
     {

--- a/src/MongoDB.Driver.Core/Core/Authentication/Vendored/CryptographyHelpers.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Vendored/CryptographyHelpers.cs
@@ -50,7 +50,7 @@ namespace MongoDB.Driver.Core.Authentication.Vendored
     internal static class CryptographyHelpers
     {
 
-        private static readonly string Cryptography_MissingIV
+        private const string Cryptography_MissingIV
             = "The cipher mode specified requires that an initialization vector (IV) be used.";
 
         public static byte[] CloneByteArray(this byte[] src)

--- a/src/MongoDB.Driver.Core/Core/Authentication/Vendored/Rfc2898DeriveBytes.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Vendored/Rfc2898DeriveBytes.cs
@@ -50,18 +50,18 @@ namespace MongoDB.Driver.Core.Authentication.Vendored
 {
     internal class Rfc2898DeriveBytes : DeriveBytes
     {
-        private static readonly string Cryptography_PasswordDerivedBytes_FewBytesSalt
+        private const string Cryptography_PasswordDerivedBytes_FewBytesSalt
             = "Salt is not at least eight bytes.";
-        private static readonly string ArgumentOutOfRange_NeedPosNum
+        private const string ArgumentOutOfRange_NeedPosNum
             = "Positive number required.";
 
-        private static readonly string Cryptography_HashAlgorithmNameNullOrEmpty
+        private const string Cryptography_HashAlgorithmNameNullOrEmpty
             = "The hash algorithm name cannot be null or empty.";
 
-        private static readonly string ArgumentOutOfRange_NeedNonNegNum
+        private const string ArgumentOutOfRange_NeedNonNegNum
             = "Non-negative number required.";
 
-        private static readonly string Cryptography_UnknownHashAlgorithm
+        private const string Cryptography_UnknownHashAlgorithm
             = "'{0}' is not a known hash algorithm.";
 
         private const int MinimumSaltSize = 8;
@@ -275,7 +275,6 @@ namespace MongoDB.Driver.Core.Authentication.Vendored
             return args != null ? string.Format(resourceFormat, args) : resourceFormat;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "HMACSHA1 is needed for compat. (https://github.com/dotnet/corefx/issues/9438)")]
         private HMAC OpenHmac()
         {
             Debug.Assert(_password != null);

--- a/src/MongoDB.Driver.Core/Core/Clusters/ClusterDescription.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/ClusterDescription.cs
@@ -210,9 +210,7 @@ namespace MongoDB.Driver.Core.Clusters
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }
@@ -350,13 +348,11 @@ namespace MongoDB.Driver.Core.Clusters
 
             string FormatConnectionMode()
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseDirectConnection)
                 {
                     return _directConnection.HasValue ? $"DirectConnection : \"{_directConnection}\", " : "";
                 }
                 else if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     return $"ConnectionMode : \"{_connectionMode}\", ";
                 }

--- a/src/MongoDB.Driver.Core/Core/Clusters/ServerSelectors/WritableServerSelector.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/ServerSelectors/WritableServerSelector.cs
@@ -27,7 +27,7 @@ namespace MongoDB.Driver.Core.Clusters.ServerSelectors
     {
         #region static
         // static fields
-        private readonly static WritableServerSelector __instance = new WritableServerSelector();
+        private static readonly WritableServerSelector __instance = new WritableServerSelector();
 
         // static properties
         /// <summary>

--- a/src/MongoDB.Driver.Core/Core/Compression/Zstandard/Zstandard64NativeMethods.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/Zstandard/Zstandard64NativeMethods.cs
@@ -52,6 +52,7 @@ namespace MongoDB.Driver.Core.Compression.Zstandard
 {
     internal class Zstandard64NativeMethods
     {
+#pragma warning disable IDE1006
         // private static fields
         private static readonly Lazy<LibraryLoader> __libraryLoader;
         private static readonly Lazy<Delegates64.ZSTD_CStreamInSize> __ZSTD_CStreamInSize;
@@ -77,7 +78,7 @@ namespace MongoDB.Driver.Core.Compression.Zstandard
 
         private static readonly Lazy<Delegates64.ZSTD_isError> __ZSTD_isError;
         private static readonly Lazy<Delegates64.ZSTD_getErrorName> __ZSTD_getErrorName;
-
+#pragma warning restore
 
         // static constructor
         static Zstandard64NativeMethods()

--- a/src/MongoDB.Driver.Core/Core/Compression/Zstandard/ZstandardStream.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/Zstandard/ZstandardStream.cs
@@ -56,7 +56,7 @@ namespace MongoDB.Driver.Core.Compression.Zstandard
         public static int MaxCompressionLevel => ZstandardNativeWrapper.MaxCompressionLevel; // maximum compression level available
         #endregion
 
-        private const int _defaultCompressionLevel = 6;
+        private const int DefaultCompressionLevel = 6;
 
         private readonly ArrayPool<byte> _arrayPool = ArrayPool<byte>.Shared;
         private readonly Stream _compressedStream; // input for decompress and output for compress
@@ -241,7 +241,7 @@ namespace MongoDB.Driver.Core.Compression.Zstandard
                 throw new ArgumentOutOfRangeException(nameof(compressionLevel));
             }
 
-            return compressionLevel.WithDefault(_defaultCompressionLevel);
+            return compressionLevel.WithDefault(DefaultCompressionLevel);
         }
 
         private CompressionMode EnsureCompressionModeIsValid(CompressionMode compressionMode)

--- a/src/MongoDB.Driver.Core/Core/Compression/ZstandardCompressor.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/ZstandardCompressor.cs
@@ -23,14 +23,14 @@ namespace MongoDB.Driver.Core.Compression
     internal class ZstandardCompressor : ICompressor
     {
         // private constants
-        private const int _defaultCompressionLevel = 6;
+        private const int DefaultCompressionLevel = 6;
 
         // private fields
         private readonly int _compressionLevel;
 
         public ZstandardCompressor(Optional<int> compressionLevel = default)
         {
-            _compressionLevel = compressionLevel.WithDefault(_defaultCompressionLevel);
+            _compressionLevel = compressionLevel.WithDefault(DefaultCompressionLevel);
         }
 
         public CompressorType Type => CompressorType.ZStandard;

--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilder.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilder.cs
@@ -34,7 +34,7 @@ namespace MongoDB.Driver.Core.Configuration
     public class ClusterBuilder
     {
         // constants
-        private const string __traceSourceName = "MongoDB-SDAM";
+        private const string TraceSourceName = "MongoDB-SDAM";
 
         // fields
         private EventAggregator _eventAggregator;
@@ -125,7 +125,7 @@ namespace MongoDB.Driver.Core.Configuration
             {
                 return this;
             }
-            var traceSource = new TraceSource(__traceSourceName, SourceLevels.All);
+            var traceSource = new TraceSource(TraceSourceName, SourceLevels.All);
             traceSource.Listeners.Clear(); // remove the default listener
             var listener = _sdamLoggingSettings.ShouldLogToStdout
                 ? new TextWriterTraceListener(Console.Out)

--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterSettings.cs
@@ -156,9 +156,7 @@ namespace MongoDB.Driver.Core.Configuration
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }
@@ -345,9 +343,7 @@ namespace MongoDB.Driver.Core.Configuration
                 return ClusterType.LoadBalanced;
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
             if (_connectionModeSwitch == ConnectionModeSwitch.UseDirectConnection)
-#pragma warning restore CS0618 // Type or member is obsolete
             {
                 if (_directConnection.GetValueOrDefault())
                 {

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -50,9 +50,9 @@ namespace MongoDB.Driver.Core.Configuration
     public sealed class ConnectionString
     {
         // constants
-        private const string srvPrefix = "_mongodb._tcp.";
-        private const int defaultMongoDBPort = 27017;
-        private const int defaultSrvPort = 53;
+        private const string SrvPrefix = "_mongodb._tcp.";
+        private const int DefaultMongoDBPort = 27017;
+        private const int DefaultSrvPort = 53;
 
         // private fields
         private readonly string _originalConnectionString;
@@ -606,7 +606,7 @@ namespace MongoDB.Driver.Core.Configuration
             if (resolveHosts)
             {
                 resolvedScheme = ConnectionStringScheme.MongoDB;
-                var srvRecords = _dnsResolver.ResolveSrvRecords(srvPrefix + host, cancellationToken);
+                var srvRecords = _dnsResolver.ResolveSrvRecords(SrvPrefix + host, cancellationToken);
                 hosts = GetHostsFromSrvRecords(srvRecords);
                 ValidateResolvedHosts(host, hosts);
             }
@@ -654,7 +654,7 @@ namespace MongoDB.Driver.Core.Configuration
             if (resolveHosts)
             {
                 resolvedScheme = ConnectionStringScheme.MongoDB;
-                var srvRecords = await _dnsResolver.ResolveSrvRecordsAsync(srvPrefix + host, cancellationToken).ConfigureAwait(false);
+                var srvRecords = await _dnsResolver.ResolveSrvRecordsAsync(SrvPrefix + host, cancellationToken).ConfigureAwait(false);
                 hosts = GetHostsFromSrvRecords(srvRecords);
                 ValidateResolvedHosts(host, hosts);
             }
@@ -752,10 +752,10 @@ namespace MongoDB.Driver.Core.Configuration
 
         private void ExtractHosts(Match match)
         {
-            int defaultPort = defaultMongoDBPort;
+            int defaultPort = DefaultMongoDBPort;
             if (_scheme == ConnectionStringScheme.MongoDBPlusSrv)
             {
-                defaultPort = defaultSrvPort;
+                defaultPort = DefaultSrvPort;
             }
             List<EndPoint> endPoints = new List<EndPoint>();
             foreach (Capture host in match.Groups["host"].Captures)

--- a/src/MongoDB.Driver.Core/Core/Operations/ChangeStreamCursor.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ChangeStreamCursor.cs
@@ -159,7 +159,6 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         // private methods
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         private TDocument DeserializeDocument(RawBsonDocument rawDocument)
         {
             using (var stream = new ByteBufferStream(rawDocument.Slice, ownsBuffer: false))

--- a/src/MongoDB.Driver.Core/Core/Operations/CursorBatchDeserializationHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CursorBatchDeserializationHelper.cs
@@ -35,7 +35,6 @@ namespace MongoDB.Driver.Core.Operations
         /// <param name="documentSerializer">The document serializer.</param>
         /// <param name="messageEncoderSettings">The message encoder settings.</param>
         /// <returns>The documents.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         public static List<TDocument> DeserializeBatch<TDocument>(RawBsonArray batch, IBsonSerializer<TDocument> documentSerializer, MessageEncoderSettings messageEncoderSettings)
         {
             var documents = new List<TDocument>();

--- a/src/MongoDB.Driver.Core/Core/Operations/FindAndModifyOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindAndModifyOperationBase.cs
@@ -209,7 +209,6 @@ namespace MongoDB.Driver.Core.Operations
         /// <returns>An element name validator for the command.</returns>
         protected abstract IElementNameValidator GetCommandValidator();
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         private TResult ProcessCommandResult(ConnectionId connectionId, RawBsonDocument rawBsonDocument)
         {
             var binaryReaderSettings = new BsonBinaryReaderSettings

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
@@ -267,7 +267,7 @@ namespace MongoDB.Driver.Core.Operations
 
         private class Validator : IElementNameValidator
         {
-            public readonly static Validator Instance = new Validator();
+            public static readonly Validator Instance = new Validator();
 
             public IElementNameValidator GetValidatorForChildContent(string elementName)
             {

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableWriteOperationExecutor.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableWriteOperationExecutor.cs
@@ -76,7 +76,7 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
-        public async static Task<TResult> ExecuteAsync<TResult>(IRetryableWriteOperation<TResult> operation, IWriteBinding binding, bool retryRequested, CancellationToken cancellationToken)
+        public static async Task<TResult> ExecuteAsync<TResult>(IRetryableWriteOperation<TResult> operation, IWriteBinding binding, bool retryRequested, CancellationToken cancellationToken)
         {
             using (var context = await RetryableWriteContext.CreateAsync(binding, retryRequested, cancellationToken).ConfigureAwait(false))
             {

--- a/src/MongoDB.Driver.Core/Core/Servers/Server.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/Server.cs
@@ -486,7 +486,6 @@ namespace MongoDB.Driver.Core.Servers
                 CancellationToken cancellationToken)
             {
                 secondaryOk = GetEffectiveSecondaryOk(secondaryOk);
-#pragma warning disable 618
                 var protocol = new QueryWireProtocol<TDocument>(
                     collectionNamespace,
                     query,
@@ -502,7 +501,6 @@ namespace MongoDB.Driver.Core.Servers
                     awaitData,
                     serializer,
                     messageEncoderSettings);
-#pragma warning restore 618
 
                 return ExecuteProtocol(protocol, cancellationToken);
             }
@@ -562,7 +560,6 @@ namespace MongoDB.Driver.Core.Servers
                 CancellationToken cancellationToken)
             {
                 secondaryOk = GetEffectiveSecondaryOk(secondaryOk);
-#pragma warning disable 618
                 var protocol = new QueryWireProtocol<TDocument>(
                     collectionNamespace,
                     query,
@@ -578,7 +575,6 @@ namespace MongoDB.Driver.Core.Servers
                     awaitData,
                     serializer,
                     messageEncoderSettings);
-#pragma warning restore 618
 
                 return ExecuteProtocolAsync(protocol, cancellationToken);
             }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -447,7 +447,6 @@ namespace MongoDB.Driver.Core.WireProtocol
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         private TCommandResult ProcessResponse(ConnectionId connectionId, CommandMessage responseMessage)
         {
             using (new CommandMessageDisposer(responseMessage))

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingQueryMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingQueryMessageWireProtocol.cs
@@ -231,7 +231,6 @@ namespace MongoDB.Driver.Core.WireProtocol
             connection.ReceiveMessageAsync(message.RequestId, encoderSelector, _messageEncoderSettings, cancellationToken).IgnoreExceptions();
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         private TCommandResult ProcessReply(ConnectionId connectionId, ReplyMessage<RawBsonDocument> reply)
         {
             if (reply.NumberReturned == 0)

--- a/src/MongoDB.Driver.GridFS/GridFSFileInfo.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSFileInfo.cs
@@ -61,7 +61,7 @@ namespace MongoDB.Driver.GridFS
         /// <value>
         /// The backing document.
         /// </value>
-        new public BsonDocument BackingDocument
+        public new BsonDocument BackingDocument
         {
             get { return base.BackingDocument; }
         }

--- a/src/MongoDB.Driver.GridFS/GridFSFileInfoCompat.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSFileInfoCompat.cs
@@ -59,7 +59,7 @@ namespace MongoDB.Driver.GridFS
         /// <value>
         /// The backing document.
         /// </value>
-        new public BsonDocument BackingDocument
+        public new BsonDocument BackingDocument
         {
             get { return base.BackingDocument; }
         }

--- a/src/MongoDB.Driver.GridFS/GridFSForwardOnlyDownloadStream.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSForwardOnlyDownloadStream.cs
@@ -159,9 +159,7 @@ namespace MongoDB.Driver.GridFS
                 var md5 = BsonUtils.ToHexString(_md5.GetHashAndReset());
                 if (!md5.Equals(FileInfo.MD5, StringComparison.OrdinalIgnoreCase))
                 {
-#pragma warning disable 618
                     throw new GridFSMD5Exception(_idAsBsonValue);
-#pragma warning restore
                 }
             }
         }
@@ -204,9 +202,7 @@ namespace MongoDB.Driver.GridFS
         {
             var chunksCollectionNamespace = Bucket.GetChunksCollectionNamespace();
             var messageEncoderSettings = Bucket.GetMessageEncoderSettings();
-#pragma warning disable 618
             var filter = new BsonDocument("files_id", _idAsBsonValue);
-#pragma warning restore
             var sort = new BsonDocument("n", 1);
 
             return new FindOperation<BsonDocument>(
@@ -264,9 +260,7 @@ namespace MongoDB.Driver.GridFS
         {
             if (batch == null)
             {
-#pragma warning disable 618
                 throw new GridFSChunkException(_idAsBsonValue, _nextChunkNumber, "missing");
-#pragma warning restore
             }
 
             var previousBatch = _batch;
@@ -290,18 +284,14 @@ namespace MongoDB.Driver.GridFS
 
                 if (n != _nextChunkNumber)
                 {
-#pragma warning disable 618
                     throw new GridFSChunkException(_idAsBsonValue, _nextChunkNumber, "missing");
-#pragma warning restore
                 }
                 _nextChunkNumber++;
 
                 var expectedChunkSize = n == _lastChunkNumber ? _lastChunkSize : FileInfo.ChunkSizeBytes;
                 if (bytes.Length != expectedChunkSize)
                 {
-#pragma warning disable 618
                     throw new GridFSChunkException(_idAsBsonValue, _nextChunkNumber, "the wrong size");
-#pragma warning restore
                 }
 
                 if (_checkMD5)

--- a/src/MongoDB.Driver.GridFS/GridFSSeekableDownloadStream.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSSeekableDownloadStream.cs
@@ -151,13 +151,11 @@ namespace MongoDB.Driver.GridFS
         {
             var chunksCollectionNamespace = Bucket.GetChunksCollectionNamespace();
             var messageEncoderSettings = Bucket.GetMessageEncoderSettings();
-#pragma warning disable 618
             var filter = new BsonDocument
             {
                 { "files_id", _idAsBsonValue },
                 { "n", n }
             };
-#pragma warning restore
 
             return new FindOperation<BsonDocument>(
                 chunksCollectionNamespace,
@@ -197,9 +195,7 @@ namespace MongoDB.Driver.GridFS
         {
             if (documents.Count == 0)
             {
-#pragma warning disable 618
                 throw new GridFSChunkException(_idAsBsonValue, n, "missing");
-#pragma warning restore
             }
 
             var document = documents[0];
@@ -210,9 +206,7 @@ namespace MongoDB.Driver.GridFS
             var expectedChunkSize = n == lastChunk ? FileInfo.Length % chunkSizeBytes : chunkSizeBytes;
             if (data.Length != expectedChunkSize)
             {
-#pragma warning disable 618
                 throw new GridFSChunkException(_idAsBsonValue, n, "the wrong size");
-#pragma warning restore
             }
 
             return data;

--- a/src/MongoDB.Driver.Legacy/Builders/CollectionOptionsBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/CollectionOptionsBuilder.cs
@@ -278,7 +278,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<CollectionOptionsBuilder>
+        internal new class Serializer : SerializerBase<CollectionOptionsBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, CollectionOptionsBuilder value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/CreateViewOptionsBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/CreateViewOptionsBuilder.cs
@@ -78,7 +78,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<CreateViewOptionsBuilder>
+        internal new class Serializer : SerializerBase<CreateViewOptionsBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, CreateViewOptionsBuilder value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/FieldsBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/FieldsBuilder.cs
@@ -212,7 +212,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<FieldsBuilder>
+        internal new class Serializer : SerializerBase<FieldsBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, FieldsBuilder value)
             {
@@ -429,7 +429,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<FieldsBuilder<TDocument>>
+        internal new class Serializer : SerializerBase<FieldsBuilder<TDocument>>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, FieldsBuilder<TDocument> value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/GeoHaystackSearchOptionsBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/GeoHaystackSearchOptionsBuilder.cs
@@ -136,7 +136,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<GeoHaystackSearchOptionsBuilder>
+        internal new class Serializer : SerializerBase<GeoHaystackSearchOptionsBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, GeoHaystackSearchOptionsBuilder value)
             {
@@ -266,7 +266,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<GeoHaystackSearchOptionsBuilder<TDocument>>
+        internal new class Serializer : SerializerBase<GeoHaystackSearchOptionsBuilder<TDocument>>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, GeoHaystackSearchOptionsBuilder<TDocument> value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/GeoNearOptionsBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/GeoNearOptionsBuilder.cs
@@ -139,7 +139,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<GeoNearOptionsBuilder>
+        internal new class Serializer : SerializerBase<GeoNearOptionsBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, GeoNearOptionsBuilder value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/GroupByBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/GroupByBuilder.cs
@@ -106,7 +106,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<GroupByBuilder>
+        internal new class Serializer : SerializerBase<GroupByBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, GroupByBuilder value)
             {
@@ -180,7 +180,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<GroupByBuilder<TDocument>>
+        internal new class Serializer : SerializerBase<GroupByBuilder<TDocument>>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, GroupByBuilder<TDocument> value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/IndexKeysBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/IndexKeysBuilder.cs
@@ -296,7 +296,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested class
-        new internal class Serializer : SerializerBase<IndexKeysBuilder>
+        internal new class Serializer : SerializerBase<IndexKeysBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IndexKeysBuilder value)
             {
@@ -639,7 +639,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<IndexKeysBuilder<TDocument>>
+        internal new class Serializer : SerializerBase<IndexKeysBuilder<TDocument>>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IndexKeysBuilder<TDocument> value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/IndexOptionsBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/IndexOptionsBuilder.cs
@@ -434,7 +434,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<IndexOptionsBuilder>
+        internal new class Serializer : SerializerBase<IndexOptionsBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IndexOptionsBuilder value)
             {
@@ -858,7 +858,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<IndexOptionsBuilder<TDocument>>
+        internal new class Serializer : SerializerBase<IndexOptionsBuilder<TDocument>>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IndexOptionsBuilder<TDocument> value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/SortByBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/SortByBuilder.cs
@@ -142,7 +142,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<SortByBuilder>
+        internal new class Serializer : SerializerBase<SortByBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, SortByBuilder value)
             {
@@ -285,7 +285,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<SortByBuilder<TDocument>>
+        internal new class Serializer : SerializerBase<SortByBuilder<TDocument>>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, SortByBuilder<TDocument> value)
             {

--- a/src/MongoDB.Driver.Legacy/Builders/UpdateBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/UpdateBuilder.cs
@@ -1778,7 +1778,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<UpdateBuilder>
+        internal new class Serializer : SerializerBase<UpdateBuilder>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, UpdateBuilder value)
             {
@@ -3100,7 +3100,7 @@ namespace MongoDB.Driver.Builders
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<UpdateBuilder<TDocument>>
+        internal new class Serializer : SerializerBase<UpdateBuilder<TDocument>>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, UpdateBuilder<TDocument> value)
             {

--- a/src/MongoDB.Driver.Legacy/MongoCollection.cs
+++ b/src/MongoDB.Driver.Legacy/MongoCollection.cs
@@ -1110,9 +1110,7 @@ namespace MongoDB.Driver
             double y,
             int limit)
         {
-#pragma warning disable 618
             return GeoNearAs<TDocument>(query, x, y, limit, GeoNearOptions.Null);
-#pragma warning restore
         }
 
         /// <summary>
@@ -1703,9 +1701,7 @@ namespace MongoDB.Driver
                     Collation = args.Collation,
                     Filter = query,
                     FinalizeFunction = args.FinalizeFunction,
-#pragma warning disable 618
                     JavaScriptMode = args.JsMode,
-#pragma warning restore 618
                     Limit = args.Limit,
                     MaxTime = args.MaxTime,
                     ReadConcern = _settings.ReadConcern,
@@ -1733,19 +1729,13 @@ namespace MongoDB.Driver
                     Collation = args.Collation,
                     Filter = query,
                     FinalizeFunction = args.FinalizeFunction,
-#pragma warning disable 618
                     JavaScriptMode = args.JsMode,
-#pragma warning restore 618
                     Limit = args.Limit,
                     MaxTime = args.MaxTime,
-#pragma warning disable 618
                     NonAtomicOutput = args.OutputIsNonAtomic,
-#pragma warning restore 618
                     OutputMode = outputMode,
                     Scope = scope,
-#pragma warning disable 618
                     ShardedOutput = args.OutputIsSharded,
-#pragma warning restore 618
                     Sort = sort,
                     Verbose = args.Verbose,
                     WriteConcern = _settings.WriteConcern
@@ -2491,7 +2481,6 @@ namespace MongoDB.Driver
         /// </summary>
         /// <param name="document">The document to insert.</param>
         /// <returns>A WriteConcernResult (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual WriteConcernResult Insert(TDefaultDocument document)
         {
             return Insert<TDefaultDocument>(document);
@@ -2503,7 +2492,6 @@ namespace MongoDB.Driver
         /// <param name="document">The document to insert.</param>
         /// <param name="options">The options to use for this Insert.</param>
         /// <returns>A WriteConcernResult (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual WriteConcernResult Insert(TDefaultDocument document, MongoInsertOptions options)
         {
             return Insert<TDefaultDocument>(document, options);
@@ -2515,7 +2503,6 @@ namespace MongoDB.Driver
         /// <param name="document">The document to insert.</param>
         /// <param name="writeConcern">The write concern to use for this Insert.</param>
         /// <returns>A WriteConcernResult (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual WriteConcernResult Insert(TDefaultDocument document, WriteConcern writeConcern)
         {
             return Insert<TDefaultDocument>(document, writeConcern);
@@ -2526,7 +2513,6 @@ namespace MongoDB.Driver
         /// </summary>
         /// <param name="documents">The documents to insert.</param>
         /// <returns>A list of WriteConcernResults (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual IEnumerable<WriteConcernResult> InsertBatch(IEnumerable<TDefaultDocument> documents)
         {
             return InsertBatch<TDefaultDocument>(documents);
@@ -2538,7 +2524,6 @@ namespace MongoDB.Driver
         /// <param name="documents">The documents to insert.</param>
         /// <param name="options">The options to use for this Insert.</param>
         /// <returns>A list of WriteConcernResults (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual IEnumerable<WriteConcernResult> InsertBatch(
             IEnumerable<TDefaultDocument> documents,
             MongoInsertOptions options)
@@ -2552,7 +2537,6 @@ namespace MongoDB.Driver
         /// <param name="documents">The documents to insert.</param>
         /// <param name="writeConcern">The write concern to use for this Insert.</param>
         /// <returns>A list of WriteConcernResults (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual IEnumerable<WriteConcernResult> InsertBatch(
             IEnumerable<TDefaultDocument> documents,
             WriteConcern writeConcern)
@@ -2577,7 +2561,6 @@ namespace MongoDB.Driver
         /// </summary>
         /// <param name="document">The document to save.</param>
         /// <returns>A WriteConcernResult (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual WriteConcernResult Save(TDefaultDocument document)
         {
             return Save<TDefaultDocument>(document);
@@ -2590,7 +2573,6 @@ namespace MongoDB.Driver
         /// <param name="document">The document to save.</param>
         /// <param name="options">The options to use for this Save.</param>
         /// <returns>A WriteConcernResult (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual WriteConcernResult Save(TDefaultDocument document, MongoInsertOptions options)
         {
             return Save<TDefaultDocument>(document, options);
@@ -2603,7 +2585,6 @@ namespace MongoDB.Driver
         /// <param name="document">The document to save.</param>
         /// <param name="writeConcern">The write concern to use for this Insert.</param>
         /// <returns>A WriteConcernResult (or null if WriteConcern is disabled).</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public virtual WriteConcernResult Save(TDefaultDocument document, WriteConcern writeConcern)
         {
             return Save<TDefaultDocument>(document, writeConcern);

--- a/src/MongoDB.Driver.Legacy/MongoServer.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServer.cs
@@ -59,8 +59,8 @@ namespace MongoDB.Driver
     public class MongoServer
     {
         // private static fields
-        private readonly static object __staticLock = new object();
-        private readonly static Dictionary<MongoServerSettings, MongoServer> __servers = new Dictionary<MongoServerSettings, MongoServer>();
+        private static readonly object __staticLock = new object();
+        private static readonly Dictionary<MongoServerSettings, MongoServer> __servers = new Dictionary<MongoServerSettings, MongoServer>();
         private static int __nextSequentialId;
         private static int __maxServerCount = 100;
         private static HashSet<char> __invalidDatabaseNameChars;
@@ -397,7 +397,6 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the current state of this server (as of the last operation, not updated until another operation is performed).
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations")]
         public virtual MongoServerState State
         {
             get

--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -86,10 +86,8 @@ namespace MongoDB.Driver
             _allowInsecureTls = false;
             _applicationName = null;
             _compressors = new CompressorConfiguration[0];
-#pragma warning disable CS0618 // Type or member is obsolete
             _connectionMode = ConnectionMode.Automatic;
             _connectionModeSwitch = ConnectionModeSwitch.NotSet;
-#pragma warning restore CS0618 // Type or member is obsolete
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _credentials = new MongoCredentialStore(new MongoCredential[0]);
             _directConnection = null;
@@ -291,9 +289,7 @@ namespace MongoDB.Driver
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }
@@ -302,9 +298,7 @@ namespace MongoDB.Driver
             set
             {
                 if (_isFrozen) { throw new InvalidOperationException("MongoServerSettings is frozen."); }
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }
@@ -891,7 +885,7 @@ namespace MongoDB.Driver
             serverSettings.MinConnectionPoolSize = url.MinConnectionPoolSize;
             serverSettings.ReadConcern = new ReadConcern(url.ReadConcernLevel);
             serverSettings.ReadEncoding = null; // ReadEncoding must be provided in code
-            serverSettings.ReadPreference = (url.ReadPreference == null) ? ReadPreference.Primary : url.ReadPreference;
+            serverSettings.ReadPreference = url.ReadPreference ?? ReadPreference.Primary;
             serverSettings.ReplicaSetName = url.ReplicaSetName;
             serverSettings.RetryReads = url.RetryReads ?? true;
             serverSettings.RetryWrites = url.RetryWrites ?? true;

--- a/src/MongoDB.Driver.Legacy/Operations/FindUsersUsingUserManagementCommandsOperation.cs
+++ b/src/MongoDB.Driver.Legacy/Operations/FindUsersUsingUserManagementCommandsOperation.cs
@@ -47,7 +47,7 @@ namespace MongoDB.Driver.Operations
         // methods
         public IEnumerable<BsonDocument> Execute(IReadBinding binding, CancellationToken cancellationToken)
         {
-            var filter = _username == null ? (BsonValue)1 : _username;
+            var filter = _username ?? (BsonValue)1;
             var command = new BsonDocument("usersInfo", filter);
             var operation = new ReadCommandOperation<BsonDocument>(_databaseNamespace, command, BsonDocumentSerializer.Instance, _messageEncoderSettings)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/CollectionOptionsWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/CollectionOptionsWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<CollectionOptionsWrapper>
+        internal new class Serializer : SerializerBase<CollectionOptionsWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, CollectionOptionsWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/CommandDocument.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/CommandDocument.cs
@@ -146,7 +146,7 @@ namespace MongoDB.Driver
         }
 
         // nested classes
-        new internal class Serializer : SerializeAsNominalTypeSerializer<CommandDocument, BsonDocument>
+        internal new class Serializer : SerializeAsNominalTypeSerializer<CommandDocument, BsonDocument>
         {
         }
     }

--- a/src/MongoDB.Driver.Legacy/Wrappers/CommandWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/CommandWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<CommandWrapper>
+        internal new class Serializer : SerializerBase<CommandWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, CommandWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/CreateViewOptionsWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/CreateViewOptionsWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<CreateViewOptionsWrapper>
+        internal new class Serializer : SerializerBase<CreateViewOptionsWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, CreateViewOptionsWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/FieldsWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/FieldsWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<FieldsWrapper>
+        internal new class Serializer : SerializerBase<FieldsWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, FieldsWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/GeoHaystackSearchOptionsWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/GeoHaystackSearchOptionsWrapper.cs
@@ -56,7 +56,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<GeoHaystackSearchOptionsWrapper>
+        internal new class Serializer : SerializerBase<GeoHaystackSearchOptionsWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, GeoHaystackSearchOptionsWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/GeoNearOptionsWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/GeoNearOptionsWrapper.cs
@@ -56,7 +56,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<GeoNearOptionsWrapper>
+        internal new class Serializer : SerializerBase<GeoNearOptionsWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, GeoNearOptionsWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/GroupByWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/GroupByWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<GroupByWrapper>
+        internal new class Serializer : SerializerBase<GroupByWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, GroupByWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/IndexKeysWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/IndexKeysWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<IndexKeysWrapper>
+        internal new class Serializer : SerializerBase<IndexKeysWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IndexKeysWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/IndexOptionsWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/IndexOptionsWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<IndexOptionsWrapper>
+        internal new class Serializer : SerializerBase<IndexOptionsWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IndexOptionsWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/QueryWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/QueryWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<QueryWrapper>
+        internal new class Serializer : SerializerBase<QueryWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, QueryWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/ScopeWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/ScopeWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<ScopeWrapper>
+        internal new class Serializer : SerializerBase<ScopeWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, ScopeWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/SortByWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/SortByWrapper.cs
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<SortByWrapper>
+        internal new class Serializer : SerializerBase<SortByWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, SortByWrapper value)
             {

--- a/src/MongoDB.Driver.Legacy/Wrappers/UpdateWrapper.cs
+++ b/src/MongoDB.Driver.Legacy/Wrappers/UpdateWrapper.cs
@@ -76,7 +76,7 @@ namespace MongoDB.Driver.Wrappers
         }
 
         // nested classes
-        new internal class Serializer : SerializerBase<UpdateWrapper>
+        internal new class Serializer : SerializerBase<UpdateWrapper>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, UpdateWrapper value)
             {

--- a/src/MongoDB.Driver/AggregateFluentBase.cs
+++ b/src/MongoDB.Driver/AggregateFluentBase.cs
@@ -29,7 +29,6 @@ namespace MongoDB.Driver
     public abstract class AggregateFluentBase<TResult> : IOrderedAggregateFluent<TResult>
     {
         /// <inheritdoc />
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations")]
         public virtual IMongoDatabase Database
         {
             get { throw new NotImplementedException(); }

--- a/src/MongoDB.Driver/AsyncCursorHelper.cs
+++ b/src/MongoDB.Driver/AsyncCursorHelper.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Driver
 {
     internal static class AsyncCursorHelper
     {
-        public async static Task<bool> AnyAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
+        public static async Task<bool> AnyAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
         {
             using (var cursor = await cursorTask.ConfigureAwait(false))
             {
@@ -39,7 +39,7 @@ namespace MongoDB.Driver
             }
         }
 
-        public async static Task<T> FirstAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
+        public static async Task<T> FirstAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
         {
             using (var cursor = await cursorTask.ConfigureAwait(false))
             {
@@ -56,7 +56,7 @@ namespace MongoDB.Driver
             }
         }
 
-        public async static Task<T> FirstOrDefaultAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
+        public static async Task<T> FirstOrDefaultAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
         {
             using (var cursor = await cursorTask.ConfigureAwait(false))
             {
@@ -73,7 +73,7 @@ namespace MongoDB.Driver
             }
         }
 
-        public async static Task<T> SingleAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
+        public static async Task<T> SingleAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
         {
             using (var cursor = await cursorTask.ConfigureAwait(false))
             {
@@ -90,7 +90,7 @@ namespace MongoDB.Driver
             }
         }
 
-        public async static Task<T> SingleOrDefaultAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
+        public static async Task<T> SingleOrDefaultAsync<T>(Task<IAsyncCursor<T>> cursorTask, CancellationToken cancellationToken)
         {
             using (var cursor = await cursorTask.ConfigureAwait(false))
             {

--- a/src/MongoDB.Driver/ChangeStreamPreAndPostImagesOptions.cs
+++ b/src/MongoDB.Driver/ChangeStreamPreAndPostImagesOptions.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the backing document.
         /// </summary>
-        new public BsonDocument BackingDocument => base.BackingDocument;
+        public new BsonDocument BackingDocument => base.BackingDocument;
 
         /// <summary>
         /// Gets or sets a value indicating whether ChangeStreamPreAndPostImages is enabled.

--- a/src/MongoDB.Driver/ClusterKey.cs
+++ b/src/MongoDB.Driver/ClusterKey.cs
@@ -168,9 +168,7 @@ namespace MongoDB.Driver
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }

--- a/src/MongoDB.Driver/ConnectionModeHelper.cs
+++ b/src/MongoDB.Driver/ConnectionModeHelper.cs
@@ -51,6 +51,6 @@ namespace MongoDB.Driver
                     throw new ArgumentException($"Invalid connectionModeSwitch: {connectionModeSwitch}.", nameof(connectionModeSwitch));
             }
         }
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/MongoDB.Driver/DensifyRange.cs
+++ b/src/MongoDB.Driver/DensifyRange.cs
@@ -235,8 +235,8 @@ namespace MongoDB.Driver
     public sealed class DensifyKeywordNumericBounds<TNumber> : DensifyNumericBounds<TNumber>
     {
         #region static
-        private readonly static DensifyKeywordNumericBounds<TNumber> __full = new DensifyKeywordNumericBounds<TNumber>("full");
-        private readonly static DensifyKeywordNumericBounds<TNumber> __partition = new DensifyKeywordNumericBounds<TNumber>("partition");
+        private static readonly DensifyKeywordNumericBounds<TNumber> __full = new DensifyKeywordNumericBounds<TNumber>("full");
+        private static readonly DensifyKeywordNumericBounds<TNumber> __partition = new DensifyKeywordNumericBounds<TNumber>("partition");
 
         internal static DensifyKeywordNumericBounds<TNumber> Full => __full;
         internal static DensifyKeywordNumericBounds<TNumber> Partition => __partition;
@@ -378,8 +378,8 @@ namespace MongoDB.Driver
     public sealed class DensifyKeywordDateTimeBounds : DensifyDateTimeBounds
     {
         #region static
-        private readonly static DensifyKeywordDateTimeBounds __full = new DensifyKeywordDateTimeBounds("full");
-        private readonly static DensifyKeywordDateTimeBounds __partition = new DensifyKeywordDateTimeBounds("partition");
+        private static readonly DensifyKeywordDateTimeBounds __full = new DensifyKeywordDateTimeBounds("full");
+        private static readonly DensifyKeywordDateTimeBounds __partition = new DensifyKeywordDateTimeBounds("partition");
 
         internal static DensifyKeywordDateTimeBounds Full => __full;
         internal static DensifyKeywordDateTimeBounds Partition => __partition;

--- a/src/MongoDB.Driver/IMongoCollectionExtensions.cs
+++ b/src/MongoDB.Driver/IMongoCollectionExtensions.cs
@@ -1909,9 +1909,7 @@ namespace MongoDB.Driver
             Ensure.IsNotNull(collection, nameof(collection));
             Ensure.IsNotNull(filter, nameof(filter));
 
-#pragma warning disable 618
             return collection.ReplaceOne(new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
-#pragma warning restore 618
         }
 
         /// <summary>
@@ -1956,9 +1954,7 @@ namespace MongoDB.Driver
             Ensure.IsNotNull(session, nameof(session));
             Ensure.IsNotNull(filter, nameof(filter));
 
-#pragma warning disable 618
             return collection.ReplaceOne(session, new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
-#pragma warning restore 618
         }
 
         /// <summary>
@@ -1999,9 +1995,7 @@ namespace MongoDB.Driver
             Ensure.IsNotNull(collection, nameof(collection));
             Ensure.IsNotNull(filter, nameof(filter));
 
-#pragma warning disable 618
             return collection.ReplaceOneAsync(new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
-#pragma warning restore 618
         }
 
         /// <summary>
@@ -2046,9 +2040,7 @@ namespace MongoDB.Driver
             Ensure.IsNotNull(session, nameof(session));
             Ensure.IsNotNull(filter, nameof(filter));
 
-#pragma warning disable 618
             return collection.ReplaceOneAsync(session, new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
-#pragma warning restore 618
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/Linq/Linq2Implementation/Expressions/SerializedValueExpression.cs
+++ b/src/MongoDB.Driver/Linq/Linq2Implementation/Expressions/SerializedValueExpression.cs
@@ -53,7 +53,7 @@ namespace MongoDB.Driver.Linq.Linq2Implementation.Expressions
 
         public override string ToString()
         {
-            return $"Constant({_value.ToString()})";
+            return $"Constant({_value})";
         }
 
         protected internal override Expression Accept(ExtensionExpressionVisitor visitor)

--- a/src/MongoDB.Driver/Linq/Linq2Implementation/Processors/EmbeddedPipeline/EmbeddedPipelineBinder.cs
+++ b/src/MongoDB.Driver/Linq/Linq2Implementation/Processors/EmbeddedPipeline/EmbeddedPipelineBinder.cs
@@ -24,7 +24,7 @@ namespace MongoDB.Driver.Linq.Linq2Implementation.Processors.EmbeddedPipeline
 {
     internal sealed class EmbeddedPipelineBinder : PipelineBinderBase<EmbeddedPipelineBindingContext>
     {
-        private readonly static CompositeMethodCallBinder<EmbeddedPipelineBindingContext> __methodCallBinder;
+        private static readonly CompositeMethodCallBinder<EmbeddedPipelineBindingContext> __methodCallBinder;
 
         static EmbeddedPipelineBinder()
         {

--- a/src/MongoDB.Driver/Linq/Linq2Implementation/Processors/Pipeline/PipelineBinder.cs
+++ b/src/MongoDB.Driver/Linq/Linq2Implementation/Processors/Pipeline/PipelineBinder.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Driver.Linq.Linq2Implementation.Processors.Pipeline
 {
     internal sealed class PipelineBinder : PipelineBinderBase<PipelineBindingContext>
     {
-        private readonly static MethodInfoMethodCallBinder<PipelineBindingContext> __methodCallBinder;
+        private static readonly MethodInfoMethodCallBinder<PipelineBindingContext> __methodCallBinder;
 
         static PipelineBinder()
         {

--- a/src/MongoDB.Driver/Linq/Linq2Implementation/Translators/QueryableTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq2Implementation/Translators/QueryableTranslator.cs
@@ -391,7 +391,7 @@ namespace MongoDB.Driver.Linq.Linq2Implementation.Translators
             }
             else
             {
-                throw new NotSupportedException($"The expression {selector.ToString()} is not supported.");
+                throw new NotSupportedException($"The expression {selector} is not supported.");
             }
 
             if (!projectValue.Contains("_id"))

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/AstSortField.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Ast/AstSortField.cs
@@ -50,9 +50,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Ast
 
     internal abstract class AstSortOrder
     {
-        private readonly static AstSortOrder __ascending = new AstAscendingSortOrder();
-        private readonly static AstSortOrder __descending = new AstDescendingSortOrder();
-        private readonly static AstSortOrder __metaTextScore = new AstMetaTextScoreSortOrder();
+        private static readonly AstSortOrder __ascending = new AstAscendingSortOrder();
+        private static readonly AstSortOrder __descending = new AstDescendingSortOrder();
+        private static readonly AstSortOrder __metaTextScore = new AstMetaTextScoreSortOrder();
 
         public static AstSortOrder Ascending => __ascending;
         public static AstSortOrder Descending => __descending;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Misc/ConvertHelper.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Misc/ConvertHelper.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
 {
     internal static class ConvertHelper
     {
-        private readonly static (Type SourceType, Type TargetType)[] __wideningConverts = new[]
+        private static readonly (Type SourceType, Type TargetType)[] __wideningConverts = new[]
         {
             (typeof(byte), typeof(short)),
             (typeof(byte), typeof(ushort)),

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/StringProperty.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/StringProperty.cs
@@ -20,15 +20,15 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Reflection
     internal static class StringProperty
     {
         // private static fields
-        private static readonly PropertyInfo __Length;
+        private static readonly PropertyInfo __length;
 
         // static constructor
         static StringProperty()
         {
-            __Length = ReflectionInfo.Property((string s) => s.Length);
+            __length = ReflectionInfo.Property((string s) => s.Length);
         }
 
         // public properties
-        public static PropertyInfo Length => __Length;
+        public static PropertyInfo Length => __length;
     }
 }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/DateTimeSubtractWithDateTimeMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/DateTimeSubtractWithDateTimeMethodToAggregationExpressionTranslator.cs
@@ -29,7 +29,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 {
     internal static class DateTimeSubtractWithDateTimeMethodToAggregationExpressionTranslator
     {
-        private readonly static MethodInfo[] __dateTimeSubtractWithDateTimeMethods =
+        private static readonly MethodInfo[] __dateTimeSubtractWithDateTimeMethods =
         {
             DateTimeMethod.SubtractWithDateTime,
             DateTimeMethod.SubtractWithDateTimeAndTimezone,
@@ -37,13 +37,13 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             DateTimeMethod.SubtractWithDateTimeAndUnitAndTimezone
         };
 
-        private readonly static MethodInfo[] __dateTimeSubtractWithTimezoneMethods =
+        private static readonly MethodInfo[] __dateTimeSubtractWithTimezoneMethods =
         {
             DateTimeMethod.SubtractWithDateTimeAndTimezone,
             DateTimeMethod.SubtractWithDateTimeAndUnitAndTimezone
         };
 
-        private readonly static MethodInfo[] __dateTimeSubtractWithUnitMethods =
+        private static readonly MethodInfo[] __dateTimeSubtractWithUnitMethods =
         {
             DateTimeMethod.SubtractWithDateTimeAndUnit,
             DateTimeMethod.SubtractWithDateTimeAndUnitAndTimezone

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToExecutableQueryTranslators/CountMethodToExecutableQueryTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToExecutableQueryTranslators/CountMethodToExecutableQueryTranslator.cs
@@ -32,7 +32,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecut
         // private static fields
         private static readonly MethodInfo[] __countMethods;
         private static readonly MethodInfo[] __countWithPredicateMethods;
-        private static readonly IExecutableQueryFinalizer<int, int> _finalizer = new SingleOrDefaultFinalizer<int>();
+        private static readonly IExecutableQueryFinalizer<int, int> __finalizer = new SingleOrDefaultFinalizer<int>();
         private static readonly IBsonSerializer<int> __wrappedInt32Serializer = new WrappedValueSerializer<int>("_v", new Int32Serializer());
 
         // static constructor
@@ -82,7 +82,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecut
                     provider.Collection,
                     provider.Options,
                     pipeline,
-                    _finalizer);
+                    __finalizer);
             }
 
             throw new ExpressionNotSupportedException(expression);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToExecutableQueryTranslators/LongCountMethodToExecutableQueryTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToExecutableQueryTranslators/LongCountMethodToExecutableQueryTranslator.cs
@@ -32,7 +32,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecut
         // private static fields
         private static readonly MethodInfo[] __longCountMethods;
         private static readonly MethodInfo[] __longCountWithPredicateMethods;
-        private static readonly IExecutableQueryFinalizer<long, long> _finalizer = new SingleOrDefaultFinalizer<long>();
+        private static readonly IExecutableQueryFinalizer<long, long> __finalizer = new SingleOrDefaultFinalizer<long>();
         private static readonly IBsonSerializer<long> __wrappedInt64Serializer = new WrappedValueSerializer<long>("_v", new Int64Serializer());
 
         // static constructor
@@ -82,7 +82,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecut
                     provider.Collection,
                     provider.Options,
                     pipeline,
-                    _finalizer);
+                    __finalizer);
             }
 
             throw new ExpressionNotSupportedException(expression);

--- a/src/MongoDB.Driver/ListCollectionNamesOptions.cs
+++ b/src/MongoDB.Driver/ListCollectionNamesOptions.cs
@@ -23,7 +23,7 @@ namespace MongoDB.Driver
     public sealed class ListCollectionNamesOptions
     {
         // fields
-        private bool? authorizedCollections;
+        private bool? _authorizedCollections;
         private BsonValue _comment;
         private FilterDefinition<BsonDocument> _filter;
 
@@ -33,8 +33,8 @@ namespace MongoDB.Driver
         /// </summary>
         public bool? AuthorizedCollections
         {
-            get { return authorizedCollections; }
-            set { authorizedCollections = value; }
+            get { return _authorizedCollections; }
+            set { _authorizedCollections = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -93,10 +93,8 @@ namespace MongoDB.Driver
             _applicationName = null;
             _autoEncryptionOptions = null;
             _compressors = new CompressorConfiguration[0];
-#pragma warning disable CS0618 // Type or member is obsolete
             _connectionMode = ConnectionMode.Automatic;
             _connectionModeSwitch = ConnectionModeSwitch.NotSet;
-#pragma warning restore CS0618 // Type or member is obsolete
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _credentials = new MongoCredentialStore(new MongoCredential[0]);
             _directConnection = null;
@@ -313,9 +311,7 @@ namespace MongoDB.Driver
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }
@@ -325,7 +321,6 @@ namespace MongoDB.Driver
             set
             {
                 if (_isFrozen) { throw new InvalidOperationException("MongoClientSettings is frozen."); }
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
@@ -333,7 +328,6 @@ namespace MongoDB.Driver
 
                 _directConnection = value;
                 _connectionModeSwitch = ConnectionModeSwitch.UseDirectConnection; // _connectionMode is always Automatic here
-#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 
@@ -953,7 +947,7 @@ namespace MongoDB.Driver
             clientSettings.MinConnectionPoolSize = url.MinConnectionPoolSize;
             clientSettings.ReadConcern = new ReadConcern(url.ReadConcernLevel);
             clientSettings.ReadEncoding = null; // ReadEncoding must be provided in code
-            clientSettings.ReadPreference = (url.ReadPreference == null) ? ReadPreference.Primary : url.ReadPreference;
+            clientSettings.ReadPreference = url.ReadPreference ?? ReadPreference.Primary;
             clientSettings.ReplicaSetName = url.ReplicaSetName;
             clientSettings.RetryReads = url.RetryReads.GetValueOrDefault(true);
             clientSettings.RetryWrites = url.RetryWrites.GetValueOrDefault(true);

--- a/src/MongoDB.Driver/MongoDefaults.cs
+++ b/src/MongoDB.Driver/MongoDefaults.cs
@@ -102,10 +102,8 @@ namespace MongoDB.Driver
         [Obsolete("Configure serializers instead.")]
         public static GuidRepresentation GuidRepresentation
         {
-#pragma warning disable 618
             get { return BsonDefaults.GuidRepresentation; }
             set { BsonDefaults.GuidRepresentation = value; }
-#pragma warning restore 618
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -275,9 +275,7 @@ namespace MongoDB.Driver
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -94,9 +94,7 @@ namespace MongoDB.Driver
             _authenticationSource = null;
             _compressors = new CompressorConfiguration[0];
             _connectionMode = ConnectionMode.Automatic;
-#pragma warning disable CS0618 // Type or member is obsolete
             _connectionModeSwitch = ConnectionModeSwitch.NotSet;
-#pragma warning restore CS0618 // Type or member is obsolete
             _connectTimeout = MongoDefaults.ConnectTimeout;
             _databaseName = null;
             _directConnection = null;
@@ -305,9 +303,7 @@ namespace MongoDB.Driver
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
-#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }
@@ -315,14 +311,12 @@ namespace MongoDB.Driver
             }
             set
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
                 {
                     throw new InvalidOperationException("DirectConnection cannot be used when ConnectionModeSwitch is set to UseConnectionMode.");
                 }
                 _directConnection = value;
                 _connectionModeSwitch = ConnectionModeSwitch.UseDirectConnection; // _connectionMode is always Automatic here
-#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 
@@ -929,7 +923,6 @@ namespace MongoDB.Driver
                     ParseAndAppendCompressorOptions(query, compressor);
                 }
             }
-#pragma warning disable CS0618
             if (_connectionModeSwitch == ConnectionModeSwitch.UseConnectionMode)
             {
                 if (_connectionMode != ConnectionMode.Automatic)
@@ -938,7 +931,6 @@ namespace MongoDB.Driver
                 }
             }
             else if (_connectionModeSwitch == ConnectionModeSwitch.UseDirectConnection)
-#pragma warning restore CS0618
             {
                 if (_directConnection.HasValue)
                 {

--- a/tests/MongoDB.Bson.Tests/Jira/CSharp104Tests.cs
+++ b/tests/MongoDB.Bson.Tests/Jira/CSharp104Tests.cs
@@ -34,7 +34,7 @@ namespace MongoDB.Bson.Tests.Jira
             {
             }
 
-            private const string _literal = "constant";
+            private const string Literal = "constant";
             private readonly string _readOnly;
             private string _getOnly;
             private string _setOnly;

--- a/tests/MongoDB.Bson.Tests/Jira/CSharp460Tests.cs
+++ b/tests/MongoDB.Bson.Tests/Jira/CSharp460Tests.cs
@@ -33,18 +33,18 @@ namespace MongoDB.Bson.Tests.Jira
 
         public sealed class DummyCollection<T> : IFooBarList<T>
         {
-            private T[] items;
+            private T[] _items;
 
             public DummyCollection()
             {
-                this.items = new T[0];
+                _items = new T[0];
             }
 
             // ICollection<T> Members
 
             public int Count
             {
-                get { return this.items.Length; }
+                get { return _items.Length; }
             }
 
             bool ICollection<T>.IsReadOnly
@@ -54,9 +54,9 @@ namespace MongoDB.Bson.Tests.Jira
 
             public void Add(T item)
             {
-                var index = this.items.Length;
-                Array.Resize(ref this.items, index + 1);
-                this.items[index] = item;
+                var index = _items.Length;
+                Array.Resize(ref _items, index + 1);
+                _items[index] = item;
             }
 
             public void Clear()
@@ -83,7 +83,7 @@ namespace MongoDB.Bson.Tests.Jira
 
             public IEnumerator<T> GetEnumerator()
             {
-                return ((IEnumerable<T>)this.items).GetEnumerator();
+                return ((IEnumerable<T>)_items).GetEnumerator();
             }
 
             // IEnumerable Members

--- a/tests/MongoDB.Bson.Tests/ObjectModel/BsonDocumentTests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/BsonDocumentTests.cs
@@ -597,10 +597,8 @@ namespace MongoDB.Bson.Tests
             Assert.Equal(null, document["x", (bool?)null].AsNullableBoolean);
             Assert.Equal(null, document["x", BsonNull.Value].AsNullableBoolean);
 #pragma warning restore
-#pragma warning disable 219
             Assert.Throws<InvalidCastException>(() => { var v = (bool?)document["s"]; });
             Assert.Throws<InvalidCastException>(() => { var v = document["s"].AsNullableBoolean; });
-#pragma warning restore
         }
 
         [Fact]
@@ -646,10 +644,8 @@ namespace MongoDB.Bson.Tests
             Assert.Equal(null, document["x", (double?)null].AsNullableDouble);
             Assert.Equal(null, document["x", BsonNull.Value].AsNullableDouble);
 #pragma warning restore
-#pragma warning disable 219
             Assert.Throws<InvalidCastException>(() => { var v = (double?)document["s"]; });
             Assert.Throws<InvalidCastException>(() => { var v = document["s"].AsNullableDouble; });
-#pragma warning restore
         }
 
         [Theory]
@@ -702,10 +698,8 @@ namespace MongoDB.Bson.Tests
             Assert.Equal(null, document["x", (int?)null].AsNullableInt32);
             Assert.Equal(null, document["x", BsonNull.Value].AsNullableInt32);
 #pragma warning restore
-#pragma warning disable 219
             Assert.Throws<InvalidCastException>(() => { var v = (int?)document["s"]; });
             Assert.Throws<InvalidCastException>(() => { var v = document["s"].AsNullableInt32; });
-#pragma warning restore
         }
 
         [Fact]
@@ -725,10 +719,8 @@ namespace MongoDB.Bson.Tests
             Assert.Equal(null, document["x", (long?)null].AsNullableInt64);
             Assert.Equal(null, document["x", BsonNull.Value].AsNullableInt64);
 #pragma warning restore
-#pragma warning disable 219
             Assert.Throws<InvalidCastException>(() => { var v = (long?)document["s"]; });
             Assert.Throws<InvalidCastException>(() => { var v = document["s"].AsNullableInt64; });
-#pragma warning restore
         }
 
         [Fact]
@@ -749,10 +741,8 @@ namespace MongoDB.Bson.Tests
             Assert.Equal(null, document["x", (ObjectId?)null].AsNullableObjectId);
             Assert.Equal(null, document["x", BsonNull.Value].AsNullableObjectId);
 #pragma warning restore
-#pragma warning disable 219
             Assert.Throws<InvalidCastException>(() => { var v = (ObjectId?)document["s"]; });
             Assert.Throws<InvalidCastException>(() => { var v = document["s"].AsNullableObjectId; });
-#pragma warning restore
         }
 
         [Fact]

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonClassMapTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonClassMapTests.cs
@@ -30,14 +30,14 @@ namespace MongoDB.Bson.Tests.Serialization
 #pragma warning disable 649 // never assigned to
         private class A
         {
-            private int fieldNotMapped;
+            private int _fieldNotMapped;
             public readonly int FieldNotMapped2;
             public int FieldMapped;
             [BsonElement("FieldMappedByAttribute")]
-            private int fieldMappedByAttribute;
+            private int _fieldMappedByAttribute;
 #pragma warning disable 414 // fieldMappedByAttribute2 is assigned but its value is never used
             [BsonElement]
-            private readonly int fieldMappedByAttribute2;
+            private readonly int _fieldMappedByAttribute2;
 #pragma warning restore
 
             public int PropertyMapped { get; set; }
@@ -57,7 +57,7 @@ namespace MongoDB.Bson.Tests.Serialization
 
             public A()
             {
-                fieldMappedByAttribute2 = 10;
+                _fieldMappedByAttribute2 = 10;
             }
         }
 
@@ -97,7 +97,7 @@ namespace MongoDB.Bson.Tests.Serialization
 
     public class BsonClassMapMapByNameTests
     {
-#pragma warning disable 169 // never used
+#pragma warning disable 169, IDE1006 // never used
         private class C
         {
             private string f;

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/BsonValueSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/BsonValueSerializerTests.cs
@@ -154,7 +154,7 @@ namespace MongoDB.Bson.Tests.Serialization
                 var exception = Record.Exception(() => new TestClass(Guid.Empty));
                 exception.Should().BeOfType<InvalidOperationException>();
             }
-#pragma warning disable 618
+#pragma warning restore
         }
 
         [Theory]
@@ -175,10 +175,10 @@ namespace MongoDB.Bson.Tests.Serialization
                 var guidRepresentation = BsonDefaults.GuidRepresentationMode == GuidRepresentationMode.V2 ? BsonDefaults.GuidRepresentation : GuidRepresentation.Unspecified;
                 switch (guidRepresentation)
                 {
-                    case GuidRepresentation.CSharpLegacy: expectedGuidJson = $"CSUUID('{guid.ToString()}')"; break;
-                    case GuidRepresentation.JavaLegacy: expectedGuidJson = $"JUUID('{guid.ToString()}')"; break;
-                    case GuidRepresentation.PythonLegacy: expectedGuidJson = $"PYUUID('{guid.ToString()}')"; break;
-                    case GuidRepresentation.Standard: expectedGuidJson = $"UUID('{guid.ToString()}')"; break;
+                    case GuidRepresentation.CSharpLegacy: expectedGuidJson = $"CSUUID('{guid}')"; break;
+                    case GuidRepresentation.JavaLegacy: expectedGuidJson = $"JUUID('{guid}')"; break;
+                    case GuidRepresentation.PythonLegacy: expectedGuidJson = $"PYUUID('{guid}')"; break;
+                    case GuidRepresentation.Standard: expectedGuidJson = $"UUID('{guid}')"; break;
                     default: throw new Exception("Unexpected GuidRepresentation.");
                 }
 
@@ -195,7 +195,7 @@ namespace MongoDB.Bson.Tests.Serialization
                 var exception = Record.Exception(() => new TestClass(guid));
                 exception.Should().BeOfType<InvalidOperationException>();
             }
-#pragma warning disable 618
+#pragma warning restore
         }
     }
 

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/CollectionSerializerGenericTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/CollectionSerializerGenericTests.cs
@@ -492,8 +492,8 @@ namespace MongoDB.Bson.Tests.Serialization.CollectionSerializersGeneric
             public LinkedList<string> LL { get; set; }
         }
 
-        private static string id1 = "123456789012345678901234";
-        private static string id2 = "432109876543210987654321";
+        private const string Id1 = "123456789012345678901234";
+        private const string Id2 = "432109876543210987654321";
 
         [Fact]
         public void TestNull()
@@ -539,7 +539,7 @@ namespace MongoDB.Bson.Tests.Serialization.CollectionSerializersGeneric
         [Fact]
         public void TestOneString()
         {
-            var list = new List<string>(new[] { id1 });
+            var list = new List<string>(new[] { Id1 });
             var obj = new T { L = list, IC = list, IE = list, IL = list, Q = new Queue<string>(list), S = new Stack<string>(list), H = new HashSet<string>(list), LL = new LinkedList<string>(list) };
             var json = obj.ToJson();
             var rep = "[ObjectId(\"123456789012345678901234\")]";
@@ -560,7 +560,7 @@ namespace MongoDB.Bson.Tests.Serialization.CollectionSerializersGeneric
         [Fact]
         public void TestTwoStrings()
         {
-            var list = new List<string>(new[] { id1, id2 });
+            var list = new List<string>(new[] { Id1, Id2 });
             var obj = new T { L = list, IC = list, IE = list, IL = list, Q = new Queue<string>(list), S = new Stack<string>(list), H = new HashSet<string>(list), LL = new LinkedList<string>(list) };
             var json = obj.ToJson();
             var rep = "[ObjectId(\"123456789012345678901234\"), ObjectId(\"432109876543210987654321\")]";

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DictionaryGenericSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DictionaryGenericSerializerTests.cs
@@ -622,8 +622,8 @@ namespace MongoDB.Bson.Tests.Serialization.DictionaryGenericSerializers
             public Dictionary<string, string> Dictionary;
         }
 
-        private static string id1 = "123456789012345678901234";
-        private static string id2 = "432109876543210987654321";
+        private const string Id1 = "123456789012345678901234";
+        private const string Id2 = "432109876543210987654321";
 
         [Fact]
         public void TestSerializeNull()
@@ -654,7 +654,7 @@ namespace MongoDB.Bson.Tests.Serialization.DictionaryGenericSerializers
         [Fact]
         public void TestSerialize1()
         {
-            C c = new C { Dictionary = new Dictionary<string, string> { { "a", id1 } } };
+            C c = new C { Dictionary = new Dictionary<string, string> { { "a", Id1 } } };
             var json = c.ToJson();
             var expected = ("{ 'Dictionary' : { \"a\" : ObjectId(\"123456789012345678901234\") } }").Replace("'", "\"");
             Assert.Equal(expected, json);
@@ -667,7 +667,7 @@ namespace MongoDB.Bson.Tests.Serialization.DictionaryGenericSerializers
         [Fact]
         public void TestSerialize2()
         {
-            C c = new C { Dictionary = new Dictionary<string, string> { { "a", id1 }, { "b", id2 } } };
+            C c = new C { Dictionary = new Dictionary<string, string> { { "a", Id1 }, { "b", Id2 } } };
             var json = c.ToJson();
             var expected1 = ("{ 'Dictionary' : { \"a\" : ObjectId(\"123456789012345678901234\"), \"b\" : ObjectId(\"432109876543210987654321\") } }").Replace("'", "\"");
             var expected2 = ("{ 'Dictionary' : { \"b\" : ObjectId(\"432109876543210987654321\"), \"a\" : ObjectId(\"123456789012345678901234\") } }").Replace("'", "\"");

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/ExtraElementsWithImmutableClassTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/ExtraElementsWithImmutableClassTests.cs
@@ -301,7 +301,7 @@ namespace MongoDB.Bson.Tests.Serialization
             Assert.Same(BsonSymbolTable.Lookup("abc"), c.X["XSymbol"]);
             Assert.Equal(new BsonTimestamp(1234), c.X["XTimestamp"]);
             Assert.Same(BsonUndefined.Value, c.X["XUndefined"]);
-#pragma warning disable 618
+#pragma warning restore 618
         }
     }
 }

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/GenericEnumerableSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/GenericEnumerableSerializerTests.cs
@@ -217,15 +217,15 @@ namespace MongoDB.Bson.Tests.Serialization.GenericEnumerable
 
         public class AddressCollection : IAddressCollection
         {
-            private readonly List<Address> data = new();
-            public int Count => data.Count;
+            private readonly List<Address> _data = new();
+            public int Count => _data.Count;
             public bool IsReadOnly => false;
-            public void Add(Address item) => data.Add(item);
-            public void Clear() => data.Clear();
-            public bool Contains(Address item) => data.Contains(item);
-            public void CopyTo(Address[] array, int arrayIndex) => data.CopyTo(array, arrayIndex);
-            public IEnumerator<Address> GetEnumerator() => data.GetEnumerator();
-            public bool Remove(Address item) => data.Remove(item);
+            public void Add(Address item) => _data.Add(item);
+            public void Clear() => _data.Clear();
+            public bool Contains(Address item) => _data.Contains(item);
+            public void CopyTo(Address[] array, int arrayIndex) => _data.CopyTo(array, arrayIndex);
+            public IEnumerator<Address> GetEnumerator() => _data.GetEnumerator();
+            public bool Remove(Address item) => _data.Remove(item);
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
 

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/GuidSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/GuidSerializerTests.cs
@@ -317,12 +317,10 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
                         foreach (var readerGuidRepresentation in EnumHelper.GetValuesAndNull<GuidRepresentation>())
                         {
                             var effectiveGuidRepresentation = serializerGuidRepresentation;
-#pragma warning disable 618
                             if (defaultGuidRepresentationMode == GuidRepresentationMode.V2 && serializerGuidRepresentation == GuidRepresentation.Unspecified)
                             {
                                 effectiveGuidRepresentation = readerGuidRepresentation ?? defaultGuidRepresentation;
                             }
-#pragma warning restore 618
                             if (effectiveGuidRepresentation == GuidRepresentation.Unspecified)
                             {
                                 continue;

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/NullableTypeSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/NullableTypeSerializerTests.cs
@@ -48,7 +48,7 @@ namespace MongoDB.Bson.Tests.Serialization
         //    public string StructP { get; set; }
         //}
 
-        private const string _template =
+        private const string Template =
             "{ " +
             "'Boolean' : null, " +
             "'DateTime' : null, " +
@@ -67,7 +67,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             C c = new C();
             var json = c.ToJson();
-            var expected = _template.Replace("'", "\"");
+            var expected = Template.Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();
@@ -80,7 +80,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             C c = new C { Boolean = true };
             var json = c.ToJson();
-            var expected = _template.Replace("'Boolean' : null", "'Boolean' : true").Replace("'", "\"");
+            var expected = Template.Replace("'Boolean' : null", "'Boolean' : true").Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();
@@ -93,7 +93,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             C c = new C { DateTime = BsonConstants.UnixEpoch };
             var json = c.ToJson();
-            var expected = _template.Replace("'DateTime' : null", "'DateTime' : ISODate('1970-01-01T00:00:00Z')").Replace("'", "\"");
+            var expected = Template.Replace("'DateTime' : null", "'DateTime' : ISODate('1970-01-01T00:00:00Z')").Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();
@@ -106,7 +106,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             C c = new C { DateOnly = BsonConstants.UnixEpoch };
             var json = c.ToJson();
-            var expected = _template.Replace("'DateOnly' : null", "'DateOnly' : ISODate('1970-01-01T00:00:00Z')").Replace("'", "\"");
+            var expected = Template.Replace("'DateOnly' : null", "'DateOnly' : ISODate('1970-01-01T00:00:00Z')").Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();
@@ -119,7 +119,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             C c = new C { Double = 1.5 };
             var json = c.ToJson();
-            var expected = _template.Replace("'Double' : null", "'Double' : 1.5").Replace("'", "\"");
+            var expected = Template.Replace("'Double' : null", "'Double' : 1.5").Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();
@@ -132,7 +132,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             var c = new C { Enum = ConsoleColor.Red };
             var json = c.ToJson();
-            var expected = _template.Replace("'Enum' : null", "'Enum' : 'Red'").Replace("'", "\"");
+            var expected = Template.Replace("'Enum' : null", "'Enum' : 'Red'").Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();
@@ -163,7 +163,7 @@ namespace MongoDB.Bson.Tests.Serialization
                     case GuidRepresentation.Standard: expectedGuidJson = "UUID('00000000-0000-0000-0000-000000000000')"; break;
                     default: throw new Exception("Unexpected GuidRepresentation.");
                 }
-                var expected = _template.Replace("'Guid' : null", $"'Guid' : {expectedGuidJson}").Replace("'", "\"");
+                var expected = Template.Replace("'Guid' : null", $"'Guid' : {expectedGuidJson}").Replace("'", "\"");
                 Assert.Equal(expected, json);
 
                 var bson = c.ToBson(writerSettings: new BsonBinaryWriterSettings());
@@ -183,7 +183,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             C c = new C { Int32 = 1 };
             var json = c.ToJson();
-            var expected = _template.Replace("'Int32' : null", "'Int32' : 1").Replace("'", "\"");
+            var expected = Template.Replace("'Int32' : null", "'Int32' : 1").Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();
@@ -196,7 +196,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             C c = new C { Int64 = 2 };
             var json = c.ToJson();
-            var expected = _template.Replace("'Int64' : null", "'Int64' : NumberLong(2)").Replace("'", "\"");
+            var expected = Template.Replace("'Int64' : null", "'Int64' : NumberLong(2)").Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();
@@ -209,7 +209,7 @@ namespace MongoDB.Bson.Tests.Serialization
         {
             C c = new C { ObjectId = ObjectId.Empty };
             var json = c.ToJson();
-            var expected = _template.Replace("'ObjectId' : null", "'ObjectId' : ObjectId('000000000000000000000000')").Replace("'", "\"");
+            var expected = Template.Replace("'ObjectId' : null", "'ObjectId' : ObjectId('000000000000000000000000')").Replace("'", "\"");
             Assert.Equal(expected, json);
 
             var bson = c.ToBson();

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/TimeSpanSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/TimeSpanSerializerTests.cs
@@ -191,7 +191,7 @@ namespace MongoDB.Bson.Tests.Serialization
 
     public class TimeSpanSerializerDoubleNanosecondsTests
     {
-        private const long __nanosecondsPerTick = 100;
+        private const long NanosecondsPerTick = 100;
 
         public class C : IC
         {
@@ -210,7 +210,7 @@ namespace MongoDB.Bson.Tests.Serialization
         [InlineData(-92233720368547700.0, "-92233720368547696.0")] // almost Int64.MinValue
         public void TestNanoseconds(double nanoseconds, string jsonValue)
         {
-            var ticks = (long)(nanoseconds / __nanosecondsPerTick);
+            var ticks = (long)(nanoseconds / NanosecondsPerTick);
             TimeSpanSerializerTestsHelper<C>.TestValue(ticks, jsonValue);
         }
     }
@@ -422,7 +422,7 @@ namespace MongoDB.Bson.Tests.Serialization
 
     public class TimeSpanSerializerInt32NanosecondsTests
     {
-        private const long __nanosecondsPerTick = 100;
+        private const long NanosecondsPerTick = 100;
 
         public class C : IC
         {
@@ -441,7 +441,7 @@ namespace MongoDB.Bson.Tests.Serialization
         [InlineData(-2147483600)] // almost Int32.MinValue
         public void TestNanoseconds(int nanoseconds)
         {
-            var ticks = nanoseconds / __nanosecondsPerTick;
+            var ticks = nanoseconds / NanosecondsPerTick;
             TimeSpanSerializerTestsHelper<C>.TestValue(ticks, nanoseconds.ToString());
         }
     }
@@ -659,7 +659,7 @@ namespace MongoDB.Bson.Tests.Serialization
 
     public class TimeSpanSerializerInt64NanosecondsTests
     {
-        private const long __nanosecondsPerTick = 100;
+        private const long NanosecondsPerTick = 100;
 
         public class C : IC
         {
@@ -678,7 +678,7 @@ namespace MongoDB.Bson.Tests.Serialization
         [InlineData(-9223372036854775800, "NumberLong(\"-9223372036854775800\")")] // almost Int64.MinValue
         public void TestNanoseconds(long nanoseconds, string jsonValue)
         {
-            var ticks = nanoseconds / __nanosecondsPerTick;
+            var ticks = nanoseconds / NanosecondsPerTick;
             TimeSpanSerializerTestsHelper<C>.TestValue(ticks, jsonValue);
         }
     }

--- a/tests/MongoDB.Bson.Tests/Specifications/uuid/prose-tests/ExplicitEncodingTests.cs
+++ b/tests/MongoDB.Bson.Tests/Specifications/uuid/prose-tests/ExplicitEncodingTests.cs
@@ -32,7 +32,7 @@ namespace MongoDB.Bson.Tests.Specifications.uuid.prose_tests
 
 #pragma warning disable 618
             var exception = Record.Exception(() => new BsonBinaryData(guid));
-#pragma warning disable 618
+#pragma warning restore 618
 
             exception.Should().BeOfType<InvalidOperationException>();
         }
@@ -63,9 +63,7 @@ namespace MongoDB.Bson.Tests.Specifications.uuid.prose_tests
 
             var guid = new Guid("00112233445566778899aabbccddeeff");
 
-#pragma warning disable 618
             var exception = Record.Exception(() => new BsonBinaryData(guid, GuidRepresentation.Unspecified));
-#pragma warning disable 618
 
             exception.Should().BeOfType<InvalidOperationException>();
         }

--- a/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/CoreTestConfiguration.cs
@@ -213,7 +213,7 @@ namespace MongoDB.Driver
                 {
                     __traceSource.TraceEvent(TraceEventType.Information, 0, $"CreateCluster: DescriptionChanged event handler called.");
                     __traceSource.TraceEvent(TraceEventType.Information, 0, $"CreateCluster: any{expectedServerKey}Server = {anyExpectedServer}.");
-                    __traceSource.TraceEvent(TraceEventType.Information, 0, $"CreateCluster: new description: {e.NewClusterDescription.ToString()}.");
+                    __traceSource.TraceEvent(TraceEventType.Information, 0, $"CreateCluster: new description: {e.NewClusterDescription}.");
                 }
                 Volatile.Write(ref hasExpectedServer, anyExpectedServer);
             };

--- a/tests/MongoDB.Driver.Core.TestHelpers/Logging/XunitLogger.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/Logging/XunitLogger.cs
@@ -56,7 +56,7 @@ namespace MongoDB.Driver.Core.TestHelpers.Logging
             {
                 if (logLevel >= minLogLevelActual)
                 {
-                    _output.WriteLine($"{dateTime.ToString("hh:mm:ss.FFF")}_{logLevel}<{decorator}> {format}", arguments);
+                    _output.WriteLine($"{dateTime:hh:mm:ss.FFF)}_{logLevel}<{decorator}> {format}", arguments);
                 }
             }
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/SaslPrepHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/SaslPrepHelperTests.cs
@@ -29,7 +29,7 @@ namespace MongoDB.Driver.Core.Authentication
         [Fact]
         public void SaslPrepQuery_accepts_undefined_codepoint()
         {     
-            var strWithUnassignedCodepoint = $"abc{char.ConvertFromUtf32(_unassignedCodePoint.Value)}";
+            var strWithUnassignedCodepoint = $"abc{char.ConvertFromUtf32(__unassignedCodePoint.Value)}";
             
             SaslPrepHelper.SaslPrepQuery(strWithUnassignedCodepoint).Should().Be(strWithUnassignedCodepoint);
         }
@@ -107,7 +107,7 @@ namespace MongoDB.Driver.Core.Authentication
         [Fact]
         public void SaslPrepStored_throws_exception_when_passed_an_undefined_codepoint()
         { 
-            var strWithUnassignedCodepoint = $"abc{char.ConvertFromUtf32(_unassignedCodePoint.Value)}";
+            var strWithUnassignedCodepoint = $"abc{char.ConvertFromUtf32(__unassignedCodePoint.Value)}";
             
             var exception = Record.Exception(()=>SaslPrepHelper.SaslPrepStored(strWithUnassignedCodepoint));
             
@@ -115,7 +115,7 @@ namespace MongoDB.Driver.Core.Authentication
             exception.Message.Should().Be("Character at position 3 is unassigned");
         }
 
-        private static readonly Lazy<int> _unassignedCodePoint = new Lazy<int>(FindUnassignedCodePoint);
+        private static readonly Lazy<int> __unassignedCodePoint = new Lazy<int>(FindUnassignedCodePoint);
 
         private static int FindUnassignedCodePoint()
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha256AuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha256AuthenticatorTests.cs
@@ -36,10 +36,10 @@ namespace MongoDB.Driver.Core.Authentication
     public class ScramSha256AuthenticatorTests
     {
         // private constants
-        private const string _clientNonce = "rOprNGfwEbeRWgbNEkqO";
-        private const int _iterationCount = 4096;
-        private const string _serverNonce = "%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0";
-        private const string _serverSalt = "W22ZaJ0SNY7soEsUEjb6gQ==";
+        private const string ClientNonce = "rOprNGfwEbeRWgbNEkqO";
+        private const int IterationCount = 4096;
+        private const string ServerNonce = "%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0";
+        private const string ServerSalt = "W22ZaJ0SNY7soEsUEjb6gQ==";
 
         // private static
         private static readonly UsernamePasswordCredential __credential = new UsernamePasswordCredential("source", "user", "pencil");
@@ -61,11 +61,11 @@ namespace MongoDB.Driver.Core.Authentication
          * S: v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=
         */
 
-        private static readonly string __clientRequest1 = $"n,,n=user,r={_clientNonce}";
+        private static readonly string __clientRequest1 = $"n,,n=user,r={ClientNonce}";
         private static readonly string __serverResponse1 =
-            $"r={_clientNonce}{_serverNonce},s={_serverSalt},i={_iterationCount}";
+            $"r={ClientNonce}{ServerNonce},s={ServerSalt},i={IterationCount}";
         private static readonly string __clientRequest2 =
-            $"c=biws,r={_clientNonce}{_serverNonce},p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ=";
+            $"c=biws,r={ClientNonce}{ServerNonce},p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ=";
         private static readonly string __serverResponse2 = "v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=";
         private static readonly string __clientOptionalFinalRequest = "";
         private static readonly string __serverOptionalFinalResponse = "";
@@ -127,7 +127,7 @@ namespace MongoDB.Driver.Core.Authentication
             [Values(false, true)] bool async)
         {
             var serverApi = useServerApi ? new ServerApi(ServerApiVersion.V1, true, true) : null;
-            var randomStringGenerator = new ConstantRandomStringGenerator(_clientNonce);
+            var randomStringGenerator = new ConstantRandomStringGenerator(ClientNonce);
 
             var subject = new ScramSha256Authenticator(__credential, randomStringGenerator, serverApi);
 
@@ -190,10 +190,10 @@ namespace MongoDB.Driver.Core.Authentication
         public void Authenticate_should_throw_when_server_provides_invalid_r_value(
             [Values(false, true)] bool async)
         {
-            var randomStringGenerator = new ConstantRandomStringGenerator(_clientNonce);
+            var randomStringGenerator = new ConstantRandomStringGenerator(ClientNonce);
             var subject = new ScramSha256Authenticator(__credential, randomStringGenerator, serverApi: null);
             var poisonedSaslStart = PoisonSaslMessage(message: __clientRequest1, poison: "bluePill");
-            var poisonedSaslStartResponse = CreateSaslStartReply(poisonedSaslStart, _serverNonce, _serverSalt, _iterationCount);
+            var poisonedSaslStartResponse = CreateSaslStartReply(poisonedSaslStart, ServerNonce, ServerSalt, IterationCount);
             var poisonedSaslStartResponseMessage = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(
                 @"{conversationId: 1, " +
                 $" payload: BinData(0,\"{ToUtf8Base64(poisonedSaslStartResponse)}\")," +
@@ -224,10 +224,10 @@ namespace MongoDB.Driver.Core.Authentication
         public void Authenticate_should_throw_when_server_provides_invalid_serverSignature(
             [Values(false, true)] bool async)
         {
-            var randomStringGenerator = new ConstantRandomStringGenerator(_clientNonce);
+            var randomStringGenerator = new ConstantRandomStringGenerator(ClientNonce);
             var subject = new ScramSha256Authenticator(__credential, randomStringGenerator, serverApi: null);
 
-            var saslStartReply = CreateSaslStartReply(__clientRequest1, _serverNonce, _serverSalt, _iterationCount);
+            var saslStartReply = CreateSaslStartReply(__clientRequest1, ServerNonce, ServerSalt, IterationCount);
             var poisonedSaslContinueReply = PoisonSaslMessage(message: __serverResponse2, poison: "redApple");
             var saslStartResponseMessage = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(
                 @"{conversationId: 1, " +
@@ -267,7 +267,7 @@ namespace MongoDB.Driver.Core.Authentication
             [Values(false, true)] bool useLongAuthentication,
             [Values(false, true)] bool async)
         {
-            var randomStringGenerator = new ConstantRandomStringGenerator(_clientNonce);
+            var randomStringGenerator = new ConstantRandomStringGenerator(ClientNonce);
             var subject = new ScramSha256Authenticator(__credential, randomStringGenerator, serverApi: null);
 
             var saslStartResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(
@@ -429,7 +429,7 @@ namespace MongoDB.Driver.Core.Authentication
         public void Authenticate_should_use_cache(
             [Values(false, true)] bool async)
         {
-            var randomStringGenerator = new ConstantRandomStringGenerator(_clientNonce);
+            var randomStringGenerator = new ConstantRandomStringGenerator(ClientNonce);
             var subject = new ScramSha256Authenticator(__credential, randomStringGenerator, serverApi: null);
 
             var saslStartResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(
@@ -482,7 +482,7 @@ namespace MongoDB.Driver.Core.Authentication
                 var subject = new ScramSha256Authenticator(__credential, randomStringGenerator, serverApi: null);
                 var mockConnection = new MockConnection();
 
-                var payload1 = $"r=aa,s={_serverSalt},i=1";
+                var payload1 = $"r=aa,s={ServerSalt},i=1";
                 var serverResponse1 = $"{{ ok : 1, payload : BinData(0,\"{ToUtf8Base64(payload1)}\"), done : true, conversationId : 1 }}";
                 var serverResponseRawDocument1 = RawBsonDocumentHelper.FromJson(serverResponse1);
                 var serverResponseMessage1 = MessageHelper.BuildCommandResponse(serverResponseRawDocument1);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterDescriptionTests.cs
@@ -328,7 +328,7 @@ namespace MongoDB.Driver.Core.Clusters
         public void ToString_with_directConnection_should_return_string_representation([Values(null, false)] bool? directConnection)
         {
             var subject = new ClusterDescription(new ClusterId(1), directConnection, dnsMonitorException: null, ClusterType.Standalone, new[] { __serverDescription1 });
-            var directConnectionString = directConnection.HasValue ? $", DirectConnection : \"{directConnection.Value.ToString()}\"" : string.Empty;
+            var directConnectionString = directConnection.HasValue ? $", DirectConnection : \"{directConnection.Value}\"" : string.Empty;
             var expected = string.Format("{{ ClusterId : \"1\"{1}, Type : \"Standalone\", State : \"Disconnected\", Servers : [{0}] }}",
                 __serverDescription1.ToString(),
                 directConnectionString);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ReplicaSetConfigTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ReplicaSetConfigTests.cs
@@ -29,15 +29,15 @@ namespace MongoDB.Driver.Core.Clusters
 {
     public class ReplicaSetConfigTests
     {
-        private static readonly EndPoint[] _endPoints =
+        private static readonly EndPoint[] __endPoints =
             new[] { new DnsEndPoint("localhost", 27017), new DnsEndPoint("localhost", 27018) };
-        private static readonly string _name = "rs1";
-        private static readonly int _version = 10;
+        private static readonly string __name = "rs1";
+        private static readonly int __version = 10;
 
         [Fact]
         public void Constructor_should_throw_if_endpoints_is_null()
         {
-            Action act = () => new ReplicaSetConfig(null, _name, _endPoints[0], _version);
+            Action act = () => new ReplicaSetConfig(null, __name, __endPoints[0], __version);
 
             act.ShouldThrow<ArgumentNullException>();
         }
@@ -45,19 +45,19 @@ namespace MongoDB.Driver.Core.Clusters
         [Fact]
         public void Constructor_should_assign_properties_correctly()
         {
-            var subject = new ReplicaSetConfig(_endPoints, _name, _endPoints[0], _version);
+            var subject = new ReplicaSetConfig(__endPoints, __name, __endPoints[0], __version);
 
-            subject.Members.Should().BeEquivalentTo(_endPoints);
-            subject.Name.Should().Be(_name);
-            subject.Primary.Should().Be(_endPoints[0]);
-            subject.Version.Should().Be(_version);
+            subject.Members.Should().BeEquivalentTo(__endPoints);
+            subject.Name.Should().Be(__name);
+            subject.Primary.Should().Be(__endPoints[0]);
+            subject.Version.Should().Be(__version);
         }
 
         [Fact]
         public void Equals_should_ignore_revision()
         {
-            var subject1 = new ReplicaSetConfig(_endPoints, _name, _endPoints[0], _version);
-            var subject2 = new ReplicaSetConfig(_endPoints, _name, _endPoints[0], _version);
+            var subject1 = new ReplicaSetConfig(__endPoints, __name, __endPoints[0], __version);
+            var subject2 = new ReplicaSetConfig(__endPoints, __name, __endPoints[0], __version);
             subject1.Equals(subject2).Should().BeTrue();
             subject1.Equals((object)subject2).Should().BeTrue();
             subject1.GetHashCode().Should().Be(subject2.GetHashCode());
@@ -66,14 +66,14 @@ namespace MongoDB.Driver.Core.Clusters
         [Fact]
         public void Equals_should_not_be_the_same_when_a_field_is_different()
         {
-            var subject1 = new ReplicaSetConfig(_endPoints, _name, _endPoints[0], _version);
+            var subject1 = new ReplicaSetConfig(__endPoints, __name, __endPoints[0], __version);
 
-            var subject2 = new ReplicaSetConfig(new[] { _endPoints[0] }, _name, _endPoints[0], _version);
-            var subject3 = new ReplicaSetConfig(_endPoints, null, _endPoints[0], _version);
-            var subject4 = new ReplicaSetConfig(_endPoints, _name, _endPoints[1], _version);
-            var subject5 = new ReplicaSetConfig(_endPoints, _name, null, _version);
-            var subject6 = new ReplicaSetConfig(_endPoints, _name, _endPoints[0], _version + 1);
-            var subject7 = new ReplicaSetConfig(_endPoints, _name, _endPoints[0], null);
+            var subject2 = new ReplicaSetConfig(new[] { __endPoints[0] }, __name, __endPoints[0], __version);
+            var subject3 = new ReplicaSetConfig(__endPoints, null, __endPoints[0], __version);
+            var subject4 = new ReplicaSetConfig(__endPoints, __name, __endPoints[1], __version);
+            var subject5 = new ReplicaSetConfig(__endPoints, __name, null, __version);
+            var subject6 = new ReplicaSetConfig(__endPoints, __name, __endPoints[0], __version + 1);
+            var subject7 = new ReplicaSetConfig(__endPoints, __name, __endPoints[0], null);
 
             subject1.Should().NotBe(subject2);
             subject1.Should().NotBe(subject3);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Compression/ZstandardNativeTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Compression/ZstandardNativeTests.cs
@@ -30,7 +30,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Compression
     {
         #region static
         // private constants
-        private const string __testMessagePortion = @"Two households, both alike in dignity,
+        private const string TestMessagePortion = @"Two households, both alike in dignity,
         In fair Verona, where we lay our scene,
         From ancient grudge break to new mutiny,
         Where civil blood makes civil hands unclean.
@@ -52,7 +52,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Compression
         private static byte[] GenerateBigMessage(int size)
         {
             var resultBytes = new List<byte>();
-            var messagePortionBytes = Encoding.ASCII.GetBytes(__testMessagePortion);
+            var messagePortionBytes = Encoding.ASCII.GetBytes(TestMessagePortion);
             while (resultBytes.Count < size)
             {
                 resultBytes.AddRange(messagePortionBytes);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateIndexRequestTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateIndexRequestTests.cs
@@ -435,7 +435,7 @@ namespace MongoDB.Driver.Core.Operations
             var expectedResult = new BsonDocument
             {
                 { "key", keys },
-                { "name", name != null ? name : additionalOptions != null ? additionalOptions["name"].AsString : "x_1" },
+                { "name", name ?? (additionalOptions != null ? additionalOptions["name"].AsString : "x_1") },
             };
             result.Should().Be(expectedResult);
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ReIndexOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ReIndexOperationTests.cs
@@ -146,5 +146,4 @@ namespace MongoDB.Driver.Core.Operations
             ExecuteOperation(operation);
         }
     }
-#pragma warning restore 618
 }

--- a/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3173Tests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3173Tests.cs
@@ -42,16 +42,16 @@ namespace MongoDB.Driver.Core.Tests.Jira
     public class CSharp3173Tests
     {
 #pragma warning disable CS0618 // Type or member is obsolete
-        private readonly static ClusterConnectionMode __clusterConnectionMode = ClusterConnectionMode.Sharded;
-        private readonly static ConnectionModeSwitch __connectionModeSwitch = ConnectionModeSwitch.UseConnectionMode;
+        private static readonly ClusterConnectionMode __clusterConnectionMode = ClusterConnectionMode.Sharded;
+        private static readonly ConnectionModeSwitch __connectionModeSwitch = ConnectionModeSwitch.UseConnectionMode;
 #pragma warning restore CS0618 // Type or member is obsolete
-        private readonly static ClusterId __clusterId = new ClusterId();
-        private readonly static bool? __directConnection = null;
-        private readonly static EndPoint __endPoint1 = new DnsEndPoint("localhost", 27017);
-        private readonly static EndPoint __endPoint2 = new DnsEndPoint("localhost", 27018);
-        private readonly static TimeSpan __heartbeatInterval = TimeSpan.FromMilliseconds(200);
-        private readonly static ServerId __serverId1 = new ServerId(__clusterId, __endPoint1);
-        private readonly static ServerId __serverId2 = new ServerId(__clusterId, __endPoint2);
+        private static readonly ClusterId __clusterId = new ClusterId();
+        private static readonly bool? __directConnection = null;
+        private static readonly EndPoint __endPoint1 = new DnsEndPoint("localhost", 27017);
+        private static readonly EndPoint __endPoint2 = new DnsEndPoint("localhost", 27018);
+        private static readonly TimeSpan __heartbeatInterval = TimeSpan.FromMilliseconds(200);
+        private static readonly ServerId __serverId1 = new ServerId(__clusterId, __endPoint1);
+        private static readonly ServerId __serverId2 = new ServerId(__clusterId, __endPoint2);
 
         [Theory]
         [ParameterAttributeData]

--- a/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3302Tests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Jira/CSharp3302Tests.cs
@@ -40,16 +40,16 @@ namespace MongoDB.Driver.Core.Tests.Jira
     public class CSharp3302Tests
     {
 #pragma warning disable CS0618 // Type or member is obsolete
-        private readonly static ClusterConnectionMode __clusterConnectionMode = ClusterConnectionMode.ReplicaSet;
-        private readonly static ConnectionModeSwitch __connectionModeSwitch = ConnectionModeSwitch.UseConnectionMode;
+        private static readonly ClusterConnectionMode __clusterConnectionMode = ClusterConnectionMode.ReplicaSet;
+        private static readonly ConnectionModeSwitch __connectionModeSwitch = ConnectionModeSwitch.UseConnectionMode;
 #pragma warning restore CS0618 // Type or member is obsolete
-        private readonly static ClusterId __clusterId = new ClusterId();
-        private readonly static bool? __directConnection = null;
-        private readonly static EndPoint __endPoint1 = new DnsEndPoint("localhost", 27017);
-        private readonly static EndPoint __endPoint2 = new DnsEndPoint("localhost", 27018);
-        private readonly static TimeSpan __heartbeatInterval = TimeSpan.FromMilliseconds(200);
-        private readonly static ServerId __serverId1 = new ServerId(__clusterId, __endPoint1);
-        private readonly static ServerId __serverId2 = new ServerId(__clusterId, __endPoint2);
+        private static readonly ClusterId __clusterId = new ClusterId();
+        private static readonly bool? __directConnection = null;
+        private static readonly EndPoint __endPoint1 = new DnsEndPoint("localhost", 27017);
+        private static readonly EndPoint __endPoint2 = new DnsEndPoint("localhost", 27018);
+        private static readonly TimeSpan __heartbeatInterval = TimeSpan.FromMilliseconds(200);
+        private static readonly ServerId __serverId1 = new ServerId(__clusterId, __endPoint1);
+        private static readonly ServerId __serverId2 = new ServerId(__clusterId, __endPoint2);
 
         [Fact]
         public async Task RapidHeartbeatTimerCallback_should_ignore_reentrant_calls()

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
@@ -71,42 +71,44 @@ namespace MongoDB.Driver.Specifications.connection_monitoring_and_pooling
 
         private static class Schema
         {
-            public readonly static string _path = nameof(_path);
-            public readonly static string version = nameof(version);
-            public readonly static string style = nameof(style);
-            public readonly static string description = nameof(description);
-            public readonly static string poolOptions = nameof(poolOptions);
-            public readonly static string operations = nameof(operations);
-            public readonly static string error = nameof(error);
-            public readonly static string events = nameof(events);
-            public readonly static string ignore = nameof(ignore);
-            public readonly static string async = nameof(async);
+            public static readonly string _path = nameof(_path);
+            public static readonly string version = nameof(version);
+            public static readonly string style = nameof(style);
+            public static readonly string description = nameof(description);
+            public static readonly string poolOptions = nameof(poolOptions);
+            public static readonly string operations = nameof(operations);
+            public static readonly string error = nameof(error);
+            public static readonly string events = nameof(events);
+            public static readonly string ignore = nameof(ignore);
+            public static readonly string async = nameof(async);
 
             public static class Operations
             {
+#pragma warning disable IDE1006
                 public const string runOn = nameof(runOn);
-                public readonly static string failPoint = nameof(failPoint);
+#pragma warning restore
+                public static readonly string failPoint = nameof(failPoint);
             }
 
             public static class Intergration
             {
-                public readonly static string runOn = nameof(runOn);
-                public readonly static string failPoint = nameof(failPoint);
+                public static readonly string runOn = nameof(runOn);
+                public static readonly string failPoint = nameof(failPoint);
             }
 
             public static class Styles
             {
-                public readonly static string unit = nameof(unit);
-                public readonly static string integration = nameof(integration);
+                public static readonly string unit = nameof(unit);
+                public static readonly string integration = nameof(integration);
             }
 
             public sealed class FailPoint
             {
-                public readonly static string appName = nameof(appName);
-                public readonly static string data = nameof(data);
+                public static readonly string appName = nameof(appName);
+                public static readonly string data = nameof(data);
             }
 
-            public readonly static string[] AllFields = new[]
+            public static readonly string[] AllFields = new[]
             {
                 _path,
                 version,

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringTestRunner.cs
@@ -594,7 +594,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
         private class TestCaseFactory : JsonDrivenTestCaseFactory
         {
             // private constants
-            private readonly string[] MonitoringPrefixes =
+            private static readonly string[] __monitoringPrefixes =
             {
                 "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.",
                 "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.legacy_hello.monitoring."
@@ -612,7 +612,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
             {
                 var loadBalancerTestDirectory = $"{Path.PathSeparator}load-balanced{Path.PathSeparator}";
                 return base.ShouldReadJsonDocument(path) &&
-                       !MonitoringPrefixes.Any(prefix => path.StartsWith(prefix)) &&
+                       !__monitoringPrefixes.Any(prefix => path.StartsWith(prefix)) &&
                        !path.Contains(loadBalancerTestDirectory);  // load balancer support not yet implemented
             }
         }

--- a/tests/MongoDB.Driver.Examples/ClientSideEncryption2Examples.cs
+++ b/tests/MongoDB.Driver.Examples/ClientSideEncryption2Examples.cs
@@ -30,8 +30,8 @@ namespace MongoDB.Driver.Examples
     public class ClientSideEncryption2Examples
     {
         private const string LocalMasterKey = "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk";
-        private readonly static CollectionNamespace CollectionNamespace = CollectionNamespace.FromFullName("docsExamples.encrypted");
-        private readonly static CollectionNamespace KeyVaultNamespace = CollectionNamespace.FromFullName("keyvault.datakeys");
+        private static readonly CollectionNamespace __collectionNamespace = CollectionNamespace.FromFullName("docsExamples.encrypted");
+        private static readonly CollectionNamespace __keyVaultNamespace = CollectionNamespace.FromFullName("keyvault.datakeys");
 
         [SkippableFact]
         public void FLE2AutomaticEncryption()
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Examples
             var keyVaultClient = new MongoClient();
 
             // Create two data keys.
-            var clientEncryptionOptions = new ClientEncryptionOptions(keyVaultClient, KeyVaultNamespace, kmsProviders);
+            var clientEncryptionOptions = new ClientEncryptionOptions(keyVaultClient, __keyVaultNamespace, kmsProviders);
             using var clientEncryption = new ClientEncryption(clientEncryptionOptions);
             var dataKeyOptions = new DataKeyOptions();
             var dataKey1 = clientEncryption.CreateDataKey("local", dataKeyOptions, CancellationToken.None);
@@ -64,7 +64,7 @@ namespace MongoDB.Driver.Examples
             var encryptedFieldsMap = new Dictionary<string, BsonDocument>()
             {
                 {
-                    CollectionNamespace.ToString(),
+                    __collectionNamespace.ToString(),
                     new BsonDocument
                     {
                         {
@@ -89,13 +89,13 @@ namespace MongoDB.Driver.Examples
                     }
                 }
             };
-            var autoEncryptionOptions = new AutoEncryptionOptions(KeyVaultNamespace, kmsProviders, encryptedFieldsMap: encryptedFieldsMap);
+            var autoEncryptionOptions = new AutoEncryptionOptions(__keyVaultNamespace, kmsProviders, encryptedFieldsMap: encryptedFieldsMap);
             var encryptedClient = new MongoClient(new MongoClientSettings { AutoEncryptionOptions = autoEncryptionOptions });
 
             // Create an FLE 2 collection.
-            var database = encryptedClient.GetDatabase(CollectionNamespace.DatabaseNamespace.DatabaseName);
-            database.CreateCollection(CollectionNamespace.CollectionName);
-            var encryptedCollection = database.GetCollection<BsonDocument>(CollectionNamespace.CollectionName);
+            var database = encryptedClient.GetDatabase(__collectionNamespace.DatabaseNamespace.DatabaseName);
+            database.CreateCollection(__collectionNamespace.CollectionName);
+            var encryptedCollection = database.GetCollection<BsonDocument>(__collectionNamespace.CollectionName);
 
             // Auto encrypt an insert and find with "Indexed" and "Unindexed" encrypted fields.
             string indexedValue = "indexedValue";
@@ -108,8 +108,8 @@ namespace MongoDB.Driver.Examples
             findResult["encryptedUnindexed"].Should().Be(new BsonString(unindexedValue));
 
             // Find documents without decryption.
-            var unencryptedDatabase = unencryptedClient.GetDatabase(CollectionNamespace.DatabaseNamespace.DatabaseName);
-            var unencryptedCollection = unencryptedDatabase.GetCollection<BsonDocument>(CollectionNamespace.CollectionName);
+            var unencryptedDatabase = unencryptedClient.GetDatabase(__collectionNamespace.DatabaseNamespace.DatabaseName);
+            var unencryptedCollection = unencryptedDatabase.GetCollection<BsonDocument>(__collectionNamespace.CollectionName);
             findResult = unencryptedCollection.Find(new BsonDocument("_id", 1)).Single().AsBsonDocument;
             findResult["encryptedIndexed"].Should().BeOfType<BsonBinaryData>();
             findResult["encryptedUnindexed"].Should().BeOfType<BsonBinaryData>();
@@ -117,21 +117,21 @@ namespace MongoDB.Driver.Examples
 
         private void DropCollections(IMongoClient client)
         {
-            var database = client.GetDatabase(CollectionNamespace.DatabaseNamespace.DatabaseName);
+            var database = client.GetDatabase(__collectionNamespace.DatabaseNamespace.DatabaseName);
             database.DropCollection(
-                CollectionNamespace.CollectionName,
+                __collectionNamespace.CollectionName,
                 new DropCollectionOptions
                 {
                     EncryptedFields = new BsonDocument
                     {
-                        {  "escCollection", $"enxcol_.{CollectionNamespace.CollectionName}.esc" },
-                        {  "eccCollection", $"enxcol_.{CollectionNamespace.CollectionName}.ecc" },
-                        {  "ecocCollection", $"enxcol_.{CollectionNamespace.CollectionName}.ecoc" },
+                        {  "escCollection", $"enxcol_.{__collectionNamespace.CollectionName}.esc" },
+                        {  "eccCollection", $"enxcol_.{__collectionNamespace.CollectionName}.ecc" },
+                        {  "ecocCollection", $"enxcol_.{__collectionNamespace.CollectionName}.ecoc" },
                     }
                 });
 
-            database = client.GetDatabase(KeyVaultNamespace.DatabaseNamespace.DatabaseName);
-            database.DropCollection(KeyVaultNamespace.CollectionName);
+            database = client.GetDatabase(__keyVaultNamespace.DatabaseNamespace.DatabaseName);
+            database.DropCollection(__keyVaultNamespace.CollectionName);
         }
     }
 }

--- a/tests/MongoDB.Driver.Examples/DocumentationExamples.cs
+++ b/tests/MongoDB.Driver.Examples/DocumentationExamples.cs
@@ -26,17 +26,17 @@ namespace MongoDB.Driver.Examples
 {
     public class DocumentationExamples
     {
-        private readonly IMongoClient client;
-        private readonly IMongoCollection<BsonDocument> collection;
-        private readonly IMongoDatabase database;
+        private readonly IMongoClient _client;
+        private readonly IMongoCollection<BsonDocument> _collection;
+        private readonly IMongoDatabase _database;
 
         public DocumentationExamples()
         {
             var connectionString = CoreTestConfiguration.ConnectionString.ToString();
-            client = new MongoClient(connectionString);
-            database = client.GetDatabase("test");
-            collection = database.GetCollection<BsonDocument>("inventory");
-            database.DropCollection("inventory");
+            _client = new MongoClient(connectionString);
+            _database = _client.GetDatabase("test");
+            _collection = _database.GetCollection<BsonDocument>("inventory");
+            _database.DropCollection("inventory");
         }
 
         [Fact]
@@ -52,10 +52,10 @@ namespace MongoDB.Driver.Examples
                 { "tags", new BsonArray { "cotton" } },
                 { "size", new BsonDocument { { "h", 28 }, { "w", 35.5 }, { "uom", "cm" } } }
             };
-            collection.InsertOne(document);
+            _collection.InsertOne(document);
             // End Example 1
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                 "{ item: \"canvas\", qty: 100, tags: [\"cotton\"], size: { h: 28, w: 35.5, uom: \"cm\" } }"));
@@ -68,7 +68,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 2
             var filter = Builders<BsonDocument>.Filter.Eq("item", "canvas");
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 2
 
             Render(filter).Should().Be("{ item: \"canvas\" }");
@@ -107,10 +107,10 @@ namespace MongoDB.Driver.Examples
                     { "size", new BsonDocument { { "h", 19 }, { "w", 22.85 }, {  "uom", "cm"} } }
                 },
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 3
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                "{ item: \"journal\", qty: 25, tags: [\"blank\", \"red\"], size: { h: 14, w: 21, uom: \"cm\" } }",
@@ -167,10 +167,10 @@ namespace MongoDB.Driver.Examples
                     { "status", "A" }
                 },
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 6
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                "{ item: \"journal\", qty: 25, size: { h: 14, w: 21, uom: \"cm\" }, status: \"A\" }",
@@ -187,7 +187,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 7
             var filter = Builders<BsonDocument>.Filter.Empty;
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 7
 
             Render(filter).Should().Be("{}");
@@ -200,7 +200,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 9
             var filter = Builders<BsonDocument>.Filter.Eq("status", "D");
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 9
 
             Render(filter).Should().Be("{ status : \"D\" }");
@@ -213,7 +213,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 10
             var filter = Builders<BsonDocument>.Filter.In("status", new[] { "A", "D" });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 10
 
             Render(filter).Should().Be("{ status: { $in: [ \"A\", \"D\" ] } }");
@@ -227,7 +227,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 11
             var builder = Builders<BsonDocument>.Filter;
             var filter = builder.And(builder.Eq("status", "A"), builder.Lt("qty", 30));
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 11
 
             Render(filter).Should().Be("{ status: \"A\", qty: { $lt: 30 } }");
@@ -241,7 +241,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 12
             var builder = Builders<BsonDocument>.Filter;
             var filter = builder.Or(builder.Eq("status", "A"), builder.Lt("qty", 30));
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 12
 
             Render(filter).Should().Be("{ $or: [ { status: \"A\" }, { qty: { $lt: 30 } } ] }");
@@ -257,7 +257,7 @@ namespace MongoDB.Driver.Examples
             var filter = builder.And(
                 builder.Eq("status", "A"),
                 builder.Or(builder.Lt("qty", 30), builder.Regex("item", new BsonRegularExpression("^p"))));
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 13
 
             Render(filter).Should().Be("{ status: \"A\", $or: [ { qty: { $lt: 30 } }, { item: /^p/ } ] }");
@@ -311,10 +311,10 @@ namespace MongoDB.Driver.Examples
                     { "size", new BsonDocument { { "h", 10 }, { "w", 15.25 }, { "uom", "cm" } } },
                     { "status", "A" } },
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 14
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                 "{ item: \"journal\", qty: 25, size: { h: 14, w: 21, uom: \"cm\" }, status: \"A\" }",
@@ -331,7 +331,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 15
             var filter = Builders<BsonDocument>.Filter.Eq("size", new BsonDocument { { "h", 14 }, { "w", 21 }, { "uom", "cm" } });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 15
 
             Render(filter).Should().Be("{ size: { h: 14, w: 21, uom: \"cm\" } }");
@@ -344,7 +344,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 16
             var filter = Builders<BsonDocument>.Filter.Eq("size", new BsonDocument { { "w", 21 }, { "h", 14 }, { "uom", "cm" } });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 16
 
             Render(filter).Should().Be("{ size: { w: 21, h: 14, uom: \"cm\" } }");
@@ -357,7 +357,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 17
             var filter = Builders<BsonDocument>.Filter.Eq("size.uom", "in");
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 17
 
             Render(filter).Should().Be("{ \"size.uom\": \"in\" }");
@@ -370,7 +370,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 18
             var filter = Builders<BsonDocument>.Filter.Lt("size.h", 15);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 18
 
             Render(filter).Should().Be("{ \"size.h\": { $lt: 15 } }");
@@ -384,7 +384,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 19
             var builder = Builders<BsonDocument>.Filter;
             var filter = builder.And(builder.Lt("size.h", 15), builder.Eq("size.uom", "in"), builder.Eq("status", "D"));
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 19
 
             Render(filter).Should().Be("{ \"size.h\": { $lt: 15 }, \"size.uom\": \"in\", status: \"D\" }");
@@ -439,10 +439,10 @@ namespace MongoDB.Driver.Examples
                     { "dim_cm", new BsonArray { 10, 15.25 } }
                 }
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 20
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                 "{ item: \"journal\", qty: 25, tags: [\"blank\", \"red\"], dim_cm: [ 14, 21 ] }",
@@ -459,7 +459,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 21
             var filter = Builders<BsonDocument>.Filter.Eq("tags", new[] { "red", "blank" });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 21
 
             Render(filter).Should().Be("{ tags: [\"red\", \"blank\"] }");
@@ -472,7 +472,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 22
             var filter = Builders<BsonDocument>.Filter.All("tags", new[] { "red", "blank" });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 22
 
             Render(filter).Should().Be("{ tags: { $all: [\"red\", \"blank\"] } }");
@@ -485,7 +485,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 23
             var filter = Builders<BsonDocument>.Filter.Eq("tags", "red");
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 23
 
             Render(filter).Should().Be("{ tags: \"red\" }");
@@ -498,7 +498,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 24
             var filter = Builders<BsonDocument>.Filter.Gt("dim_cm", 25);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 24
 
             Render(filter).Should().Be("{ dim_cm: { $gt: 25 } }");
@@ -512,7 +512,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 25
             var builder = Builders<BsonDocument>.Filter;
             var filter = builder.And(builder.Gt("dim_cm", 15), builder.Lt("dim_cm", 20));
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 25
 
             Render(filter).Should().Be("{ dim_cm: { $gt: 15, $lt: 20 } }");
@@ -525,7 +525,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 26
             var filter = Builders<BsonDocument>.Filter.ElemMatch<BsonValue>("dim_cm", new BsonDocument { { "$gt", 22 }, { "$lt", 30 } });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 26
 
             Render(filter).Should().Be("{ dim_cm: { $elemMatch: { $gt: 22, $lt: 30 } } }");
@@ -538,7 +538,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 27
             var filter = Builders<BsonDocument>.Filter.Gt("dim_cm.1", 25);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 27
 
             Render(filter).Should().Be("{ \"dim_cm.1\": { $gt: 25 } }");
@@ -551,7 +551,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 28
             var filter = Builders<BsonDocument>.Filter.Size("tags", 3);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 28
 
             Render(filter).Should().Be("{ tags: { $size: 3 } }");
@@ -615,10 +615,10 @@ namespace MongoDB.Driver.Examples
                         }
                 }
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 29
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                 "{ item: \"journal\", instock: [ { warehouse: \"A\", qty: 5 }, { warehouse: \"C\", qty: 15 } ] }",
@@ -635,7 +635,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 30
             var filter = Builders<BsonDocument>.Filter.AnyEq("instock", new BsonDocument { { "warehouse", "A" }, { "qty", 5 } });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 30
 
             Render(filter).Should().Be("{ instock: { warehouse: \"A\", qty: 5 } }");
@@ -648,7 +648,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 31
             var filter = Builders<BsonDocument>.Filter.AnyEq("instock", new BsonDocument { { "qty", 5 }, { "warehouse", "A" } });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 31
 
             Render(filter).Should().Be("{ instock: { qty: 5, warehouse: \"A\" } }");
@@ -661,7 +661,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 32
             var filter = Builders<BsonDocument>.Filter.Lte("instock.0.qty", 20);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 32
 
             Render(filter).Should().Be("{ \"instock.0.qty\": { $lte: 20 } }");
@@ -674,7 +674,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 33
             var filter = Builders<BsonDocument>.Filter.Lte("instock.qty", 20);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 33
 
             Render(filter).Should().Be("{ \"instock.qty\": { $lte: 20 } }");
@@ -687,7 +687,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 34
             var filter = Builders<BsonDocument>.Filter.ElemMatch<BsonValue>("instock", new BsonDocument { { "qty", 5 }, { "warehouse", "A" } });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 34
 
             Render(filter).Should().Be("{ instock: { $elemMatch: { qty: 5, warehouse: \"A\" } } }");
@@ -700,7 +700,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 35
             var filter = Builders<BsonDocument>.Filter.ElemMatch<BsonValue>("instock", new BsonDocument { { "qty", new BsonDocument { { "$gt", 10 }, { "$lte", 20 } } } });
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 35
 
             Render(filter).Should().Be("{ instock: { $elemMatch: { qty: { $gt: 10, $lte: 20 } } } }");
@@ -714,7 +714,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 36
             var builder = Builders<BsonDocument>.Filter;
             var filter = builder.And(builder.Gt("instock.qty", 10), builder.Lte("instock.qty", 20));
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 36
 
             Render(filter).Should().Be("{ \"instock.qty\": { $gt: 10, $lte: 20 } }");
@@ -728,7 +728,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 37
             var builder = Builders<BsonDocument>.Filter;
             var filter = builder.And(builder.Eq("instock.qty", 5), builder.Eq("instock.warehouse", "A"));
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 37
 
             Render(filter).Should().Be("{ \"instock.qty\": 5, \"instock.warehouse\": \"A\" }");
@@ -745,10 +745,10 @@ namespace MongoDB.Driver.Examples
                 new BsonDocument { { "_id", 1 }, { "item", BsonNull.Value } },
                 new BsonDocument { { "_id", 2 } }
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 38
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             result.Should().Equal(ParseMultiple(
                 "{ _id: 1, item: null }",
                 "{ _id: 2 }"));
@@ -761,7 +761,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 39
             var filter = Builders<BsonDocument>.Filter.Eq("item", BsonNull.Value);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 39
 
             Render(filter).Should().Be("{ item: null }");
@@ -774,7 +774,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 40
             var filter = Builders<BsonDocument>.Filter.Type("item", BsonType.Null);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 40
 
             Render(filter).Should().Be("{ item : { $type: 10 } }");
@@ -787,7 +787,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 41
             var filter = Builders<BsonDocument>.Filter.Exists("item", false);
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 41
 
             Render(filter).Should().Be("{ item : { $exists: false } }");
@@ -858,10 +858,10 @@ namespace MongoDB.Driver.Examples
                         }
                 }
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 42
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                 "{ item: \"journal\", status: \"A\", size: { h: 14, w: 21, uom: \"cm\" }, instock: [ { warehouse: \"A\", qty: 5 } ] }",
@@ -879,7 +879,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 43
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
-            var result = collection.Find(filter).ToList();
+            var result = _collection.Find(filter).ToList();
             // End Example 43
 
             Render(filter).Should().Be("{ status: \"A\" }");
@@ -893,7 +893,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 44
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
             var projection = Builders<BsonDocument>.Projection.Include("item").Include("status");
-            var result = collection.Find<BsonDocument>(filter).Project(projection).ToList();
+            var result = _collection.Find<BsonDocument>(filter).Project(projection).ToList();
             // End Example 44
 
             Render(filter).Should().Be("{ status: \"A\" }");
@@ -908,7 +908,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 45
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
             var projection = Builders<BsonDocument>.Projection.Include("item").Include("status").Exclude("_id");
-            var result = collection.Find<BsonDocument>(filter).Project(projection).ToList();
+            var result = _collection.Find<BsonDocument>(filter).Project(projection).ToList();
             // End Example 45
 
             Render(filter).Should().Be("{ status: \"A\" }");
@@ -923,7 +923,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 46
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
             var projection = Builders<BsonDocument>.Projection.Exclude("status").Exclude("instock");
-            var result = collection.Find<BsonDocument>(filter).Project(projection).ToList();
+            var result = _collection.Find<BsonDocument>(filter).Project(projection).ToList();
             // End Example 46
 
             Render(filter).Should().Be("{ status: \"A\" }");
@@ -938,7 +938,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 47
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
             var projection = Builders<BsonDocument>.Projection.Include("item").Include("status").Include("size.uom");
-            var result = collection.Find<BsonDocument>(filter).Project(projection).ToList();
+            var result = _collection.Find<BsonDocument>(filter).Project(projection).ToList();
             // End Example 47
 
             Render(filter).Should().Be("{ status: \"A\" }");
@@ -953,7 +953,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 48
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
             var projection = Builders<BsonDocument>.Projection.Exclude("size.uom");
-            var result = collection.Find<BsonDocument>(filter).Project(projection).ToList();
+            var result = _collection.Find<BsonDocument>(filter).Project(projection).ToList();
             // End Example 48
 
             Render(filter).Should().Be("{ status: \"A\" }");
@@ -968,7 +968,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 49
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
             var projection = Builders<BsonDocument>.Projection.Include("item").Include("status").Include("instock.qty");
-            var result = collection.Find<BsonDocument>(filter).Project(projection).ToList();
+            var result = _collection.Find<BsonDocument>(filter).Project(projection).ToList();
             // End Example 49
 
             Render(filter).Should().Be("{ status: \"A\" }");
@@ -983,7 +983,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 50
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
             var projection = Builders<BsonDocument>.Projection.Include("item").Include("status").Slice("instock", -1);
-            var result = collection.Find<BsonDocument>(filter).Project(projection).ToList();
+            var result = _collection.Find<BsonDocument>(filter).Project(projection).ToList();
             // End Example 50
 
             Render(filter).Should().Be("{ status: \"A\" }");
@@ -1076,10 +1076,10 @@ namespace MongoDB.Driver.Examples
                     { "qty", 95 },
                     { "size", new BsonDocument { { "h", 22.85 }, { "w", 30.5 }, { "uom", "cm" } } }, { "status", "A" } },
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 51
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                 "{ item: \"canvas\", qty: 100, size: { h: 28, w: 35.5, uom: \"cm\" }, status: \"A\" }",
@@ -1102,7 +1102,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 52
             var filter = Builders<BsonDocument>.Filter.Eq("item", "paper");
             var update = Builders<BsonDocument>.Update.Set("size.uom", "cm").Set("status", "P").CurrentDate("lastModified");
-            var result = collection.UpdateOne(filter, update);
+            var result = _collection.UpdateOne(filter, update);
             // End Example 52
 
             Render(filter).Should().Be("{ item: \"paper\" }");
@@ -1117,7 +1117,7 @@ namespace MongoDB.Driver.Examples
             // Start Example 53
             var filter = Builders<BsonDocument>.Filter.Lt("qty", 50);
             var update = Builders<BsonDocument>.Update.Set("size.uom", "in").Set("status", "P").CurrentDate("lastModified");
-            var result = collection.UpdateMany(filter, update);
+            var result = _collection.UpdateMany(filter, update);
             // End Example 53
 
             Render(filter).Should().Be("{ qty: { $lt: 50 } }");
@@ -1140,7 +1140,7 @@ namespace MongoDB.Driver.Examples
                         new BsonDocument { { "warehouse", "B" }, { "qty", 40 } } }
                     }
             };
-            var result = collection.ReplaceOne(filter, replacement);
+            var result = _collection.ReplaceOne(filter, replacement);
             // End Example 54
 
             Render(filter).Should().Be("{ item: \"paper\" }");
@@ -1196,10 +1196,10 @@ namespace MongoDB.Driver.Examples
                     { "status", "A" }
                 }
             };
-            collection.InsertMany(documents);
+            _collection.InsertMany(documents);
             // End Example 55
 
-            var result = collection.Find("{}").ToList();
+            var result = _collection.Find("{}").ToList();
             RemoveIds(result);
             result.Should().Equal(ParseMultiple(
                 "{ item: \"journal\", qty: 25, size: { h: 14, w: 21, uom: \"cm\" }, status: \"A\" }",
@@ -1216,7 +1216,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 56
             var filter = Builders<BsonDocument>.Filter.Empty;
-            var result = collection.DeleteMany(filter);
+            var result = _collection.DeleteMany(filter);
             // End Example 56
 
             Render(filter).Should().Be("{}");
@@ -1229,7 +1229,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 57
             var filter = Builders<BsonDocument>.Filter.Eq("status", "A");
-            var result = collection.DeleteMany(filter);
+            var result = _collection.DeleteMany(filter);
             // End Example 57
 
             Render(filter).Should().Be("{ status : \"A\" }");
@@ -1242,7 +1242,7 @@ namespace MongoDB.Driver.Examples
 
             // Start Example 58
             var filter = Builders<BsonDocument>.Filter.Eq("status", "D");
-            var result = collection.DeleteOne(filter);
+            var result = _collection.DeleteOne(filter);
             // End Example 58
 
             Render(filter).Should().Be("{ status : \"D\" }");
@@ -1263,7 +1263,7 @@ namespace MongoDB.Driver.Examples
                 .Match(Builders<BsonDocument>.Filter.Eq("items.fruit", "banana"))
                 .Sort(Builders<BsonDocument>.Sort.Ascending("date"));
 
-            var cursor = collection.Aggregate(pipeline);
+            var cursor = _collection.Aggregate(pipeline);
             // End Aggregation Example 1
 
             Render(pipeline).Should().Be("[{ $match : { \"items.fruit\" : \"banana\" } },   { $sort : { \"date\" : 1 } }]");
@@ -1307,7 +1307,7 @@ namespace MongoDB.Driver.Examples
                 })
                 .Sort(Builders<BsonDocument>.Sort.Ascending("numberSold"));
 
-            var cursor = collection.Aggregate(pipeline);
+            var cursor = _collection.Aggregate(pipeline);
             // End Aggregation Example 2
 
             Render(pipeline).Should().Be(@"
@@ -1375,7 +1375,7 @@ namespace MongoDB.Driver.Examples
                     })}
                 });
 
-            var cursor = collection.Aggregate(pipeline);
+            var cursor = _collection.Aggregate(pipeline);
             // End Aggregation Example 3
 
             Render(pipeline).Should().Be(@"
@@ -1466,7 +1466,7 @@ namespace MongoDB.Driver.Examples
                     }
                 });
 
-            var cursor = collection.Aggregate(pipeline);
+            var cursor = _collection.Aggregate(pipeline);
             // End Aggregation Example 4
 
             Render(pipeline).Should().Be(@"
@@ -1500,7 +1500,7 @@ namespace MongoDB.Driver.Examples
 
             // Start runCommand Example 1
             var command = new JsonCommand<BsonDocument>("{ buildInfo : 1 }");
-            var result = database.RunCommand(command);
+            var result = _database.RunCommand(command);
             // End runCommand Example 1
 
             result["ok"].ToBoolean().Should().BeTrue();
@@ -1512,18 +1512,18 @@ namespace MongoDB.Driver.Examples
             //db.runCommand({collStats:"restaurants"})
 
             const string collectionName = "restaurants";
-            if (database.ListCollectionNames().ToList().Any(c => c == collectionName))
+            if (_database.ListCollectionNames().ToList().Any(c => c == collectionName))
             {
-                database.DropCollection(collectionName);
+                _database.DropCollection(collectionName);
             }
-            database.CreateCollection(collectionName);
+            _database.CreateCollection(collectionName);
 
             // Start runCommand Example 2
             var command = new JsonCommand<BsonDocument>("{ collStats : 'restaurants' }");
-            var result = database.RunCommand(command);
+            var result = _database.RunCommand(command);
             // End runCommand Example 2
 
-            database.DropCollection(collectionName);
+            _database.DropCollection(collectionName);
 
             result["ok"].ToBoolean().Should().BeTrue();
         }
@@ -1537,7 +1537,7 @@ namespace MongoDB.Driver.Examples
             // Start Index Example 1
             var keys = Builders<BsonDocument>.IndexKeys.Ascending("score");
             var indexModel = new CreateIndexModel<BsonDocument>(keys);
-            var result = collection.Indexes.CreateOne(indexModel);
+            var result = _collection.Indexes.CreateOne(indexModel);
             // End Index Example 1
 
             result.Should().Be("score_1");
@@ -1560,7 +1560,7 @@ namespace MongoDB.Driver.Examples
                 PartialFilterExpression = Builders<BsonDocument>.Filter.Gt(document => document["rating"], 5)
             };
             var indexModel = new CreateIndexModel<BsonDocument>(keys, indexOptions);
-            var result = collection.Indexes.CreateOne(indexModel);
+            var result = _collection.Indexes.CreateOne(indexModel);
             // End Index Example 2
 
             Render(indexModel.Options.PartialFilterExpression).Should().Be("{ \"rating\" : { \"$gt\" : 5 } }");
@@ -1579,13 +1579,13 @@ namespace MongoDB.Driver.Examples
             };
 
             var arrayUpdatesTestCollectionName = "arrayUpdatesTest";
-            var testDatabase = client.GetDatabase("test");
+            var testDatabase = _client.GetDatabase("test");
             testDatabase.DropCollection(arrayUpdatesTestCollectionName);
             var arrayUpdatesTestCollection = testDatabase.GetCollection<BsonDocument>(arrayUpdatesTestCollectionName);
             arrayUpdatesTestCollection.InsertOne(document);
 
             // Start Exploiting The Power Of Arrays Example
-            var collection = client
+            var collection = _client
                 .GetDatabase("test")
                 .GetCollection<BsonDocument>("arrayUpdatesTest");
 

--- a/tests/MongoDB.Driver.GridFS.Tests/GridFSBucketTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/GridFSBucketTests.cs
@@ -161,7 +161,6 @@ namespace MongoDB.Driver.GridFS.Tests
         {
             var subject = CreateSubject();
 
-#pragma warning disable 618
             Action action;
             if (async)
             {
@@ -171,7 +170,6 @@ namespace MongoDB.Driver.GridFS.Tests
             {
                 action = () => subject.Delete(null);
             }
-#pragma warning restore
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("id");
         }
@@ -183,7 +181,6 @@ namespace MongoDB.Driver.GridFS.Tests
         {
             var subject = CreateSubject();
 
-#pragma warning disable 618
             Action action;
             if (async)
             {
@@ -193,7 +190,6 @@ namespace MongoDB.Driver.GridFS.Tests
             {
                 action = () => subject.DownloadAsBytes(null);
             }
-#pragma warning restore
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("id");
         }
@@ -226,7 +222,6 @@ namespace MongoDB.Driver.GridFS.Tests
             var subject = CreateSubject();
             var destination = new Mock<Stream>().Object;
 
-#pragma warning disable 618
             Action action;
             if (async)
             {
@@ -236,7 +231,6 @@ namespace MongoDB.Driver.GridFS.Tests
             {
                 action = () => subject.DownloadToStream(null, destination);
             }
-#pragma warning restore
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("id");
         }
@@ -249,7 +243,6 @@ namespace MongoDB.Driver.GridFS.Tests
             var subject = CreateSubject();
             var id = (BsonValue)123;
 
-#pragma warning disable 618
             Action action;
             if (async)
             {
@@ -259,7 +252,6 @@ namespace MongoDB.Driver.GridFS.Tests
             {
                 action = () => subject.DownloadToStream(id, null);
             }
-#pragma warning restore
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("destination");
         }
@@ -407,7 +399,6 @@ namespace MongoDB.Driver.GridFS.Tests
         {
             var subject = CreateSubject();
 
-#pragma warning disable 618
             Action action;
             if (async)
             {
@@ -417,7 +408,6 @@ namespace MongoDB.Driver.GridFS.Tests
             {
                 action = () => subject.OpenDownloadStream(null);
             }
-#pragma warning restore
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("id");
         }
@@ -487,7 +477,6 @@ namespace MongoDB.Driver.GridFS.Tests
             var subject = CreateSubject();
             var newFilename = "filename";
 
-#pragma warning disable 618
             Action action;
             if (async)
             {
@@ -497,7 +486,6 @@ namespace MongoDB.Driver.GridFS.Tests
             {
                 action = () => subject.Rename(null, newFilename);
             }
-#pragma warning restore
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("id");
         }
@@ -510,7 +498,6 @@ namespace MongoDB.Driver.GridFS.Tests
             var subject = CreateSubject();
             var id = (BsonValue)123;
 
-#pragma warning disable 618
             Action action;
             if (async)
             {
@@ -520,7 +507,6 @@ namespace MongoDB.Driver.GridFS.Tests
             {
                 action = () => subject.Rename(id, null);
             }
-#pragma warning restore
 
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("newFilename");
         }

--- a/tests/MongoDB.Driver.Legacy.TestHelpers/ExpectedErrorMessage.cs
+++ b/tests/MongoDB.Driver.Legacy.TestHelpers/ExpectedErrorMessage.cs
@@ -25,10 +25,10 @@ namespace MongoDB.Driver.Tests
     public static class ExpectedErrorMessage
     {
         // private static fields
-        private static string _firstEmptySequence;
-        private static string _lastEmptySequence;
-        private static string _singleEmptySequence;
-        private static string _singleLongSequence;
+        private static string __firstEmptySequence;
+        private static string __lastEmptySequence;
+        private static string __singleEmptySequence;
+        private static string __singleLongSequence;
 
         // static constructor
         static ExpectedErrorMessage()
@@ -42,7 +42,7 @@ namespace MongoDB.Driver.Tests
             }
             catch (Exception ex)
             {
-                _firstEmptySequence = ex.Message;
+                __firstEmptySequence = ex.Message;
             }
 
             try
@@ -51,7 +51,7 @@ namespace MongoDB.Driver.Tests
             }
             catch (Exception ex)
             {
-                _lastEmptySequence = ex.Message;
+                __lastEmptySequence = ex.Message;
             }
 
             try
@@ -60,7 +60,7 @@ namespace MongoDB.Driver.Tests
             }
             catch (Exception ex)
             {
-                _singleEmptySequence = ex.Message;
+                __singleEmptySequence = ex.Message;
             }
 
             try
@@ -69,29 +69,29 @@ namespace MongoDB.Driver.Tests
             }
             catch (Exception ex)
             {
-                _singleLongSequence = ex.Message;
+                __singleLongSequence = ex.Message;
             }
         }
 
         // public static properties
         public static string FirstEmptySequence
         {
-            get { return _firstEmptySequence; }
+            get { return __firstEmptySequence; }
         }
 
         public static string LastEmptySequence
         {
-            get { return _lastEmptySequence; }
+            get { return __lastEmptySequence; }
         }
 
         public static string SingleEmptySequence
         {
-            get { return _singleEmptySequence; }
+            get { return __singleEmptySequence; }
         }
 
         public static string SingleLongSequence
         {
-            get { return _singleLongSequence; }
+            get { return __singleLongSequence; }
         }
     }
 }

--- a/tests/MongoDB.Driver.Legacy.Tests/GridFS/MongoGridFSSettingsTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/GridFS/MongoGridFSSettingsTests.cs
@@ -37,13 +37,11 @@ namespace MongoDB.Driver.Tests.GridFS
         [Fact]
         public void TestDefaultsObsolete()
         {
-#pragma warning disable 618
             var settings = new MongoGridFSSettings();
             Assert.False(settings.IsFrozen);
             Assert.Equal(0, settings.ChunkSize);
             Assert.Equal(null, settings.Root);
             Assert.Equal(null, settings.WriteConcern);
-#pragma warning restore
         }
 
         public void TestCreation()

--- a/tests/MongoDB.Driver.Legacy.Tests/Jira/CSharp801Tests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/Jira/CSharp801Tests.cs
@@ -59,9 +59,7 @@ namespace MongoDB.Driver.Tests.Jira
         {
             public object GenerateId(object container, object document)
             {
-#pragma warning disable 219
                 var collection = (MongoCollection<C>)container; // should not throw an InvalidCastException
-#pragma warning restore
                 return 1;
             }
 

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoCollectionTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoCollectionTests.cs
@@ -122,7 +122,7 @@ namespace MongoDB.Driver.Tests
                 },
 #pragma warning disable 618
                 OutputMode = AggregateOutputMode.Cursor,
-#pragma warning disable 618
+#pragma warning restore
                 BatchSize = 1
             });
             var results = query.ToList();

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoServerTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoServerTests.cs
@@ -72,10 +72,8 @@ namespace MongoDB.Driver.Tests
                 Server = new MongoServerAddress("localhost"),
             };
             var operationExecutor = new DefaultLegacyOperationExecutor();
-#pragma warning disable 618
             var server1 = MongoServer.Create(settings, operationExecutor);
             var server2 = MongoServer.Create(settings, operationExecutor);
-#pragma warning restore 618
             Assert.Same(server1, server2);
             Assert.Equal(settings, server1.Settings);
         }
@@ -137,9 +135,7 @@ namespace MongoDB.Driver.Tests
         public void TestGetAllServers()
         {
             var snapshot1 = MongoServer.GetAllServers();
-#pragma warning disable 618
             var server = MongoServer.Create("mongodb://newhostnamethathasnotbeenusedbefore", new DefaultLegacyOperationExecutor());
-#pragma warning restore
             var snapshot2 = MongoServer.GetAllServers();
             Assert.Equal(snapshot1.Length + 1, snapshot2.Length);
             Assert.False(snapshot1.Contains(server));

--- a/tests/MongoDB.Driver.TestHelpers/DisposableMongoClient.cs
+++ b/tests/MongoDB.Driver.TestHelpers/DisposableMongoClient.cs
@@ -27,66 +27,66 @@ namespace MongoDB.Driver.TestHelpers
     /// </summary>
     public class DisposableMongoClient : IMongoClient, IDisposable
     {
-        private readonly IMongoClient wrapped;
+        private readonly IMongoClient _wrapped;
         private readonly ILogger<DisposableMongoClient> _logger;
 
         public DisposableMongoClient(IMongoClient wrapped, ILogger<DisposableMongoClient> logger)
         {
-            this.wrapped = wrapped;
+            _wrapped = wrapped;
 
             _logger = logger.Decorate($"_cluster:{wrapped.Cluster.ClusterId}");
             _logger.Debug("Created");
         }
 
-        public ICluster Cluster => wrapped.Cluster;
+        public ICluster Cluster => _wrapped.Cluster;
 
-        public MongoClientSettings Settings => wrapped.Settings;
+        public MongoClientSettings Settings => _wrapped.Settings;
 
-        public IMongoClient Wrapped => wrapped;
+        public IMongoClient Wrapped => _wrapped;
 
         public void DropDatabase(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
-            wrapped.DropDatabase(name, cancellationToken);
+            _wrapped.DropDatabase(name, cancellationToken);
         }
 
         public void DropDatabase(IClientSessionHandle session, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
-            wrapped.DropDatabase(session, name, cancellationToken);
+            _wrapped.DropDatabase(session, name, cancellationToken);
         }
 
         public Task DropDatabaseAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.DropDatabaseAsync(name, cancellationToken);
+            return _wrapped.DropDatabaseAsync(name, cancellationToken);
         }
 
         public Task DropDatabaseAsync(IClientSessionHandle session, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.DropDatabaseAsync(session, name, cancellationToken);
+            return _wrapped.DropDatabaseAsync(session, name, cancellationToken);
         }
 
         public IMongoDatabase GetDatabase(string name, MongoDatabaseSettings settings = null)
         {
-            return wrapped.GetDatabase(name, settings);
+            return _wrapped.GetDatabase(name, settings);
         }
 
         public IAsyncCursor<string> ListDatabaseNames(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabaseNames(cancellationToken);
+            return _wrapped.ListDatabaseNames(cancellationToken);
         }
 
         public IAsyncCursor<string> ListDatabaseNames(
             ListDatabaseNamesOptions options,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabaseNames(options, cancellationToken);
+            return _wrapped.ListDatabaseNames(options, cancellationToken);
         }
 
         public IAsyncCursor<string> ListDatabaseNames(
             IClientSessionHandle session,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabaseNames(session, cancellationToken);
+            return _wrapped.ListDatabaseNames(session, cancellationToken);
         }
 
         public IAsyncCursor<string> ListDatabaseNames(
@@ -94,27 +94,27 @@ namespace MongoDB.Driver.TestHelpers
             ListDatabaseNamesOptions options,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabaseNames(session, options, cancellationToken);
+            return _wrapped.ListDatabaseNames(session, options, cancellationToken);
         }
 
         public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabaseNamesAsync(cancellationToken);
+            return _wrapped.ListDatabaseNamesAsync(cancellationToken);
         }
 
         public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
             ListDatabaseNamesOptions options,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabaseNamesAsync(options, cancellationToken);
+            return _wrapped.ListDatabaseNamesAsync(options, cancellationToken);
         }
 
         public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
             IClientSessionHandle session,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabaseNamesAsync(session, cancellationToken);
+            return _wrapped.ListDatabaseNamesAsync(session, cancellationToken);
         }
 
         public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
@@ -122,27 +122,27 @@ namespace MongoDB.Driver.TestHelpers
             ListDatabaseNamesOptions options,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabaseNamesAsync(session, options, cancellationToken);
+            return _wrapped.ListDatabaseNamesAsync(session, options, cancellationToken);
         }
 
         public IAsyncCursor<BsonDocument> ListDatabases(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabases(cancellationToken);
+            return _wrapped.ListDatabases(cancellationToken);
         }
 
         public IAsyncCursor<BsonDocument> ListDatabases(
             ListDatabasesOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabases(options, cancellationToken);
+            return _wrapped.ListDatabases(options, cancellationToken);
         }
 
         public IAsyncCursor<BsonDocument> ListDatabases(
             IClientSessionHandle session,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabases(session, cancellationToken);
+            return _wrapped.ListDatabases(session, cancellationToken);
         }
 
         public IAsyncCursor<BsonDocument> ListDatabases(
@@ -150,24 +150,24 @@ namespace MongoDB.Driver.TestHelpers
             ListDatabasesOptions options,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabases(session, options, cancellationToken);
+            return _wrapped.ListDatabases(session, options, cancellationToken);
         }
 
         public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabasesAsync(cancellationToken);
+            return _wrapped.ListDatabasesAsync(cancellationToken);
         }
 
         public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
             ListDatabasesOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabasesAsync(options, cancellationToken);
+            return _wrapped.ListDatabasesAsync(options, cancellationToken);
         }
 
         public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(IClientSessionHandle session, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabasesAsync(session, cancellationToken);
+            return _wrapped.ListDatabasesAsync(session, cancellationToken);
         }
 
         public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
@@ -175,17 +175,17 @@ namespace MongoDB.Driver.TestHelpers
             ListDatabasesOptions options,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.ListDatabasesAsync(session, options, cancellationToken);
+            return _wrapped.ListDatabasesAsync(session, options, cancellationToken);
         }
 
         public IClientSessionHandle StartSession(ClientSessionOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.StartSession(options, cancellationToken);
+            return _wrapped.StartSession(options, cancellationToken);
         }
 
         public Task<IClientSessionHandle> StartSessionAsync(ClientSessionOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.StartSessionAsync(options, cancellationToken);
+            return _wrapped.StartSessionAsync(options, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -194,7 +194,7 @@ namespace MongoDB.Driver.TestHelpers
             ChangeStreamOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.Watch(pipeline, options, cancellationToken);
+            return _wrapped.Watch(pipeline, options, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -204,7 +204,7 @@ namespace MongoDB.Driver.TestHelpers
             ChangeStreamOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.Watch(session, pipeline, options, cancellationToken);
+            return _wrapped.Watch(session, pipeline, options, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -213,7 +213,7 @@ namespace MongoDB.Driver.TestHelpers
             ChangeStreamOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.WatchAsync(pipeline, options, cancellationToken);
+            return _wrapped.WatchAsync(pipeline, options, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -223,33 +223,33 @@ namespace MongoDB.Driver.TestHelpers
             ChangeStreamOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return wrapped.WatchAsync(session, pipeline, options, cancellationToken);
+            return _wrapped.WatchAsync(session, pipeline, options, cancellationToken);
         }
 
         public IMongoClient WithReadConcern(ReadConcern readConcern)
         {
-            return wrapped.WithReadConcern(readConcern);
+            return _wrapped.WithReadConcern(readConcern);
         }
 
         public IMongoClient WithReadPreference(ReadPreference readPreference)
         {
-            return wrapped.WithReadPreference(readPreference);
+            return _wrapped.WithReadPreference(readPreference);
         }
 
         public IMongoClient WithWriteConcern(WriteConcern writeConcern)
         {
-            return wrapped.WithWriteConcern(writeConcern);
+            return _wrapped.WithWriteConcern(writeConcern);
         }
 
         public void Dispose()
         {
             _logger.Debug("Disposing");
 
-            ClusterRegistry.Instance.UnregisterAndDisposeCluster(wrapped.Cluster);
+            ClusterRegistry.Instance.UnregisterAndDisposeCluster(_wrapped.Cluster);
 
             _logger.Debug("Cluster unregistered and disposed");
 
-            if (wrapped is MongoClient mongoClient)
+            if (_wrapped is MongoClient mongoClient)
             {
                 var controller = mongoClient.LibMongoCryptController;
                 foreach (var clientToDispose in new[] { controller?.InternalClient, controller?.MongoCryptdClient })

--- a/tests/MongoDB.Driver.Tests/ClusterTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterTests.cs
@@ -49,8 +49,8 @@ namespace MongoDB.Driver.Tests
             "getnonce"
         };
 
-        private const string _collectionName = "test";
-        private const string _databaseName = "test";
+        private const string CollectionName = "test";
+        private const string DatabaseName = "test";
 
         /// <summary>
         /// Test that starting a new transaction on a pinned ClientSession unpins the
@@ -86,9 +86,9 @@ namespace MongoDB.Driver.Tests
 
                 using var failPoint = FailPoint.Configure(slowServer, NoCoreSession.NewHandle(), failCommand);
 
-                var database = client.GetDatabase(_databaseName);
+                var database = client.GetDatabase(DatabaseName);
                 CreateCollection();
-                var collection = database.GetCollection<BsonDocument>(_collectionName);
+                var collection = database.GetCollection<BsonDocument>(CollectionName);
 
                 // warm up connections
                 var channels = new ConcurrentBag<IChannelHandle>();
@@ -154,9 +154,9 @@ namespace MongoDB.Driver.Tests
         private void CreateCollection()
         {
             var client = DriverTestConfiguration.Client;
-            var database = client.GetDatabase(_databaseName).WithWriteConcern(WriteConcern.WMajority);
+            var database = client.GetDatabase(DatabaseName).WithWriteConcern(WriteConcern.WMajority);
 
-            var collection = database.GetCollection<BsonDocument>(_collectionName);
+            var collection = database.GetCollection<BsonDocument>(CollectionName);
             collection.InsertOne(new BsonDocument());
         }
 
@@ -181,8 +181,8 @@ namespace MongoDB.Driver.Tests
         private void DropCollection()
         {
             var client = DriverTestConfiguration.Client;
-            var database = client.GetDatabase(_databaseName).WithWriteConcern(WriteConcern.WMajority);
-            database.DropCollection(_collectionName);
+            var database = client.GetDatabase(DatabaseName).WithWriteConcern(WriteConcern.WMajority);
+            database.DropCollection(CollectionName);
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenConfigureFailPointTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenConfigureFailPointTest.cs
@@ -55,7 +55,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return cluster.SelectServer(WritableServerSelector.Instance, CancellationToken.None);
         }
 
-        protected async virtual Task<IServer> GetFailPointServerAsync()
+        protected virtual async Task<IServer> GetFailPointServerAsync()
         {
             if (TestRunner.FailPointServer != null)
             {

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenCountDocumentsTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenCountDocumentsTest.cs
@@ -53,15 +53,11 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         {
             if (_session == null)
             {
-#pragma warning disable 618
                 _result = _collection.CountDocuments(_filter, _options, cancellationToken);
-#pragma warning restore
             }
             else
             {
-#pragma warning disable 618
                 _result = _collection.CountDocuments(_session, _filter, _options, cancellationToken);
-#pragma warning restore
             }
         }
 
@@ -69,15 +65,11 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         {
             if (_session == null)
             {
-#pragma warning disable 618
                 _result = await _collection.CountDocumentsAsync(_filter, _options, cancellationToken).ConfigureAwait(false);
-#pragma warning restore
             }
             else
             {
-#pragma warning disable 618
                 _result = await _collection.CountDocumentsAsync(_session, _filter, _options, cancellationToken).ConfigureAwait(false);
-#pragma warning restore
             }
         }
 

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenTargetedFailPointTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenTargetedFailPointTest.cs
@@ -37,7 +37,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return TestRunner.FailPointCluster.SelectServer(pinnedServerSelector, CancellationToken.None);
         }
 
-        protected async override Task<IServer> GetFailPointServerAsync()
+        protected override async Task<IServer> GetFailPointServerAsync()
         {
             var pinnedServerEndpoint = GetPinnedServerEndpointAndAssertNotNull();
             var pinnedServerSelector = CreateServerSelector(pinnedServerEndpoint);

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/Translators/AggregateProjectTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTests/Translators/AggregateProjectTranslatorTests.cs
@@ -30,7 +30,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTests.Translators
 {
     public class AggregateProjectTranslatorTests : IntegrationTestBase
     {
-        private readonly static ExpressionTranslationOptions __codePointTranslationOptions = new ExpressionTranslationOptions
+        private static readonly ExpressionTranslationOptions __codePointTranslationOptions = new ExpressionTranslationOptions
         {
             StringTranslationMode = AggregateStringTranslationMode.CodePoints
         };

--- a/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTestsOnLinq3/Translators/AggregateProjectTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq2ImplementationTestsOnLinq3/Translators/AggregateProjectTranslatorTests.cs
@@ -31,7 +31,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq2ImplementationTestsOnLinq3.Translators
 {
     public class AggregateProjectTranslatorTests : IntegrationTestBase
     {
-        private readonly static ExpressionTranslationOptions __codePointTranslationOptions = new ExpressionTranslationOptions
+        private static readonly ExpressionTranslationOptions __codePointTranslationOptions = new ExpressionTranslationOptions
         {
             StringTranslationMode = AggregateStringTranslationMode.CodePoints
         };

--- a/tests/MongoDB.Driver.Tests/OcspIntegrationTests.cs
+++ b/tests/MongoDB.Driver.Tests/OcspIntegrationTests.cs
@@ -26,7 +26,7 @@ namespace MongoDB.Driver.Tests
 {
     public class OcspIntegrationTests : LoggableTestClass
     {
-        private static readonly string _shouldSucceedEnvironmentVariableName = "OCSP_TLS_SHOULD_SUCCEED";
+        private static readonly string __shouldSucceedEnvironmentVariableName = "OCSP_TLS_SHOULD_SUCCEED";
 
         // public constructors
         public OcspIntegrationTests(ITestOutputHelper testOutputHelper)
@@ -52,7 +52,7 @@ namespace MongoDB.Driver.Tests
             /* We cannot call RequireServer.Check() because this would result in a connection being made to the mongod
              * and that connection will not succeed if we're testing the revoked certificate case. */
 
-            RequireEnvironment.Check().EnvironmentVariable(_shouldSucceedEnvironmentVariableName);
+            RequireEnvironment.Check().EnvironmentVariable(__shouldSucceedEnvironmentVariableName);
 
             var shouldSucceed = GetShouldSucceed();
             /* To prevent OCSP caching from polluting the test results, we MUST run the "secure" version before
@@ -111,11 +111,11 @@ namespace MongoDB.Driver.Tests
         private bool GetShouldSucceed()
         {
             var ocspOutcomeEnvironmentVariableValue
-                = Environment.GetEnvironmentVariable(_shouldSucceedEnvironmentVariableName);
+                = Environment.GetEnvironmentVariable(__shouldSucceedEnvironmentVariableName);
             if (!Boolean.TryParse(ocspOutcomeEnvironmentVariableValue, out var successExpected))
             {
                 throw new Exception(
-                    $"Invalid value of {ocspOutcomeEnvironmentVariableValue} in {_shouldSucceedEnvironmentVariableName}."
+                    $"Invalid value of {ocspOutcomeEnvironmentVariableValue} in {__shouldSucceedEnvironmentVariableName}."
                     + $" Expected true/false.");
             }
             return successExpected;

--- a/tests/MongoDB.Driver.Tests/Packaging/PackagingTests.cs
+++ b/tests/MongoDB.Driver.Tests/Packaging/PackagingTests.cs
@@ -95,7 +95,6 @@ namespace MongoDB.Driver.Tests.Packaging
             }
         }
 
-#pragma warning disable IDE0051 // Remove unused private members
         private static void RunAllTests()
         {
             // Left it outside Main method to protect us from losing sync between xunit and console modes
@@ -105,7 +104,6 @@ namespace MongoDB.Driver.Tests.Packaging
 
             Zstandard_compression_should_provide_MaxCompressionLevel();
         }
-#pragma warning restore IDE0051 // Remove unused private members
 
 #if CONSOLE_TEST
         static void Main(string[] args)

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/CountDocumentsTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/CountDocumentsTest.cs
@@ -32,15 +32,11 @@ namespace MongoDB.Driver.Tests.Specifications.crud
         {
             if (async)
             {
-#pragma warning disable 618
                 return collection.CountDocumentsAsync(_filter, _options).GetAwaiter().GetResult();
-#pragma warning restore
             }
             else
             {
-#pragma warning disable 618
                 return collection.CountDocuments(_filter, _options);
-#pragma warning restore
             }
         }
 

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/EstimatedDocumentCountTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/EstimatedDocumentCountTest.cs
@@ -32,15 +32,11 @@ namespace MongoDB.Driver.Tests.Specifications.crud
         {
             if (async)
             {
-#pragma warning disable 618
                 return collection.EstimatedDocumentCountAsync(_options).GetAwaiter().GetResult();
-#pragma warning restore
             }
             else
             {
-#pragma warning disable 618
                 return collection.EstimatedDocumentCount(_options);
-#pragma warning restore
             }
         }
 


### PR DESCRIPTION
This PR updates the .editorconfig file to match the coding conventions used in the C# driver.  The changes eliminated something like 95% of the 10,000+ errors from running code analysis on this project.  Tweaks were made to the source code to address the remaining errors.  These changes consisted of fixing portions of the code that were inconsistent with the conventions used elsewhere and removing suppressions of warnings that didn't exist in the first place.  (Perhaps some of these were genuine warnings in earlier C# versions, but more recent compiler versions may be smart enough to recognize that these warnings were superfluous.)  With the entirety of this PR in place, code analysis passes on the project with no errors.

I've set the severity for a number of the analysis rules to `refactoring`, which means that no error is produced for violating them, but IntelliSense offers you the option to change them in the code editor.  At least some of these might make sense to consider enabling in the future, given that they would represent code quality improvements and modernizations to take full advantage of some of the features added in more recent C# versions.  However, given that this PR is already not tiny and Skunkworks is of limited duration, I'm leaving them disabled for now.