### PR TITLE
Skunkworks: Tweak CSS for printing

### DIFF
--- a/Docs/reference/themes/mongodb/static/css/overrides.css
+++ b/Docs/reference/themes/mongodb/static/css/overrides.css
@@ -115,3 +115,26 @@ a code {
 .jsEnabled #search {
   visibility: visible;
 }
+
+@media print {
+  a[href]:after {
+    content: none !important;
+  }
+
+  .edit-link,
+  .sidebar,
+  .toggle-nav,
+  #header-db .nav-items {
+    display: none !important;
+  }
+
+  #header-db {
+    position: inherit !important;
+  }
+
+  .content .main-column {
+    margin-top: 0 !important;
+    margin-left: 0 !important;
+    width: 100% !important;
+  }
+}


### PR DESCRIPTION
This PR adds a printer-specific section (`@media print`) to the CSS for the reference documentation to fix a number of things that were causing the pages to not look right when printed.  The appearance when viewing on screen is unaffected.  I've tested by running locally with

```
hugo server --baseUrl=http://localhost --buildDrafts --watch
```

There is an issue where the CSS used in the browser reverts back to the original version when the page is refreshed or the user navigates to a different page.  I'm not sure exactly why.  Before merging, we would need to ensure that the issue does not occur when viewing the documentation for real or fix whatever is causing it.

Before:
![C# Print Before](https://user-images.githubusercontent.com/5299/180519003-98c0a3bf-1c61-46c4-bb78-eb24371d6ad3.png)

After:
![C# Print After](https://user-images.githubusercontent.com/5299/180519021-db2fadf5-9e49-428a-b290-3d910bd41733.png)

