### PR TITLE
CSHARP-4287: Only call Socket.IOControl on Windows

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/TcpStreamFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/TcpStreamFactory.cs
@@ -33,7 +33,6 @@ namespace MongoDB.Driver.Core.Connections
     {
         // fields
         private readonly TcpStreamSettings _settings;
-        private static readonly bool __supportsIOControl = OperatingSystemHelper.CurrentOperatingSystem == OperatingSystemPlatform.Windows;
 
         // constructors
         public TcpStreamFactory()
@@ -260,30 +259,29 @@ namespace MongoDB.Driver.Core.Connections
 
             var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-            if (__supportsIOControl)
+            try
             {
-                // Reviewing the .NET source, Socket.IOControl for IOControlCode.KeepAlivesValue will
-                // throw PlatformNotSupportedException on all platforms except for Windows.
-                // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs#L1346
-                var keepAliveValues = new KeepAliveValues
+                if (OperatingSystemHelper.CurrentOperatingSystem == OperatingSystemPlatform.Windows)
                 {
-                    OnOff = 1,
-                    KeepAliveTime = 120000, // 120 seconds in milliseconds
-                    KeepAliveInterval = 10000 // 10 seconds in milliseconds
-                };
-                socket.IOControl(IOControlCode.KeepAliveValues, keepAliveValues.ToBytes(), null);
-            }
-            else
-            {
-                // most platforms should support this call to SetSocketOption, but just in case call it in a try/catch also
-                try
+                    // Reviewing the .NET source, Socket.IOControl for IOControlCode.KeepAlivesValue will
+                    // throw PlatformNotSupportedException on all platforms except for Windows.
+                    // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs#L1346
+                    var keepAliveValues = new KeepAliveValues
+                    {
+                        OnOff = 1,
+                        KeepAliveTime = 120000, // 120 seconds in milliseconds
+                        KeepAliveInterval = 10000 // 10 seconds in milliseconds
+                    };
+                    socket.IOControl(IOControlCode.KeepAliveValues, keepAliveValues.ToBytes(), null);
+                }
+                else
                 {
                     socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 }
-                catch (PlatformNotSupportedException)
-                {
-                    // ignore PlatformNotSupportedException
-                }
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // ignore PlatformNotSupportedException
             }
 
             return socket;

--- a/src/MongoDB.Driver.Core/Core/Connections/TcpStreamFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/TcpStreamFactory.cs
@@ -33,6 +33,7 @@ namespace MongoDB.Driver.Core.Connections
     {
         // fields
         private readonly TcpStreamSettings _settings;
+        private static readonly bool __supportsIOControl = OperatingSystemHelper.CurrentOperatingSystem == OperatingSystemPlatform.Windows;
 
         // constructors
         public TcpStreamFactory()
@@ -259,7 +260,7 @@ namespace MongoDB.Driver.Core.Connections
 
             var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-            if (OperatingSystemHelper.CurrentOperatingSystem == OperatingSystemPlatform.Windows)
+            if (__supportsIOControl)
             {
                 // Reviewing the .NET source, Socket.IOControl for IOControlCode.KeepAlivesValue will
                 // throw PlatformNotSupportedException on all platforms except for Windows.

--- a/src/MongoDB.Driver.Core/Core/Misc/OperatingSystemHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/OperatingSystemHelper.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2020-present MongoDB Inc.
+﻿/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ namespace MongoDB.Driver.Core.Misc
 {
     internal enum OperatingSystemPlatform
     {
+        Unsupported = -1,
         Windows,
         Linux,
         MacOS
@@ -27,30 +28,36 @@ namespace MongoDB.Driver.Core.Misc
 
     internal static class OperatingSystemHelper
     {
-        public static OperatingSystemPlatform CurrentOperatingSystem
-        {
-            get
-            {
-#if NET472
-                return OperatingSystemPlatform.Windows;
-#else
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    return OperatingSystemPlatform.MacOS;
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    return OperatingSystemPlatform.Linux;
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    return OperatingSystemPlatform.Windows;
-                }
+        private static readonly OperatingSystemPlatform __currentOperatingSystem;
 
-                // should not be reached. If we're here, then there is a bug in the library
-                throw new PlatformNotSupportedException($"Unsupported platform '{RuntimeInformation.OSDescription}'.");
-#endif
+        static OperatingSystemHelper()
+        {
+#if NET472
+            __currentOperatingSystem = OperatingSystemPlatform.Windows;
+#else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                __currentOperatingSystem = OperatingSystemPlatform.Linux;
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                __currentOperatingSystem = OperatingSystemPlatform.MacOS;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                __currentOperatingSystem = OperatingSystemPlatform.Windows;
+            }
+            else
+            {
+                __currentOperatingSystem = OperatingSystemPlatform.Unsupported;
+            }
+#endif
         }
+
+        public static OperatingSystemPlatform CurrentOperatingSystem => __currentOperatingSystem switch
+        {
+            OperatingSystemPlatform.Unsupported => throw new PlatformNotSupportedException($"Unsupported platform '{RuntimeInformation.OSDescription}'."),
+            _ => __currentOperatingSystem
+        };
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/OperatingSystemHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/OperatingSystemHelper.cs
@@ -20,7 +20,6 @@ namespace MongoDB.Driver.Core.Misc
 {
     internal enum OperatingSystemPlatform
     {
-        Unsupported = -1,
         Windows,
         Linux,
         MacOS
@@ -28,36 +27,32 @@ namespace MongoDB.Driver.Core.Misc
 
     internal static class OperatingSystemHelper
     {
-        private static readonly OperatingSystemPlatform __currentOperatingSystem;
+        public static OperatingSystemPlatform CurrentOperatingSystem => __currentOperatingSystem.Value;
 
-        static OperatingSystemHelper()
+        private static readonly Lazy<OperatingSystemPlatform> __currentOperatingSystem = new Lazy<OperatingSystemPlatform>(DetermineOperatingSystemPlatform);
+
+        private static OperatingSystemPlatform DetermineOperatingSystemPlatform()
         {
 #if NET472
-            __currentOperatingSystem = OperatingSystemPlatform.Windows;
+            return OperatingSystemPlatform.Windows;
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                __currentOperatingSystem = OperatingSystemPlatform.Linux;
+                return OperatingSystemPlatform.Linux;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                __currentOperatingSystem = OperatingSystemPlatform.MacOS;
+                return OperatingSystemPlatform.MacOS;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                __currentOperatingSystem = OperatingSystemPlatform.Windows;
+                return OperatingSystemPlatform.Windows;
             }
             else
             {
-                __currentOperatingSystem = OperatingSystemPlatform.Unsupported;
+                throw new PlatformNotSupportedException($"Unsupported platform '{RuntimeInformation.OSDescription}'.");
             }
 #endif
         }
-
-        public static OperatingSystemPlatform CurrentOperatingSystem => __currentOperatingSystem switch
-        {
-            OperatingSystemPlatform.Unsupported => throw new PlatformNotSupportedException($"Unsupported platform '{RuntimeInformation.OSDescription}'."),
-            _ => __currentOperatingSystem
-        };
     }
 }


### PR DESCRIPTION
Only call Socket.IOControl with IOControlCode.KeepAliveValues on Windows as non-Windows platforms will always throw PlatformNotSupportedExceptions.