### PR TITLE
Update ObjectSerializer.cs

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/ObjectSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ObjectSerializer.cs
@@ -256,6 +256,10 @@ namespace MongoDB.Bson.Serialization.Serializers
                             case TypeCode.String:
                                 bsonWriter.WriteString((string)value);
                                 return;
+
+                            case TypeCode.Decimal:
+                                bsonWriter.WriteDecimal128((decimal)value);
+                                return;
                         }
                     }
 


### PR DESCRIPTION
When object has value converted to decimal by system, the TypeCode assigned to it becomes TypeCode.Decimal and the switch case where TypeCode.Object is handled is ignored which is the only place where decimal is being added for object .Because of that, right now when the object is added to a collection instead of being added as "$numberDecimal" it gets processed as an non primitive object, the SerializeDiscriminatedValue method is called and the object gets serialized as "_t":"System.Decimal", "_v": value.