### PR TITLE
35% performance improvement for class deserialization

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonMemberMap.cs
@@ -82,7 +82,6 @@ namespace MongoDB.Bson.Serialization
 
             //serializerVar.Deserialize<MyMemberClass>(context)
             var methos = serializerType.GetMethod("Deserialize", BindingFlags.Public | BindingFlags.Instance);
-            //var deserializeMethod = Expression.Call(serializerVar, nameof(IBsonSerializer<int>.Deserialize), new[] { serializer.ValueType }, contextParameter);
             var deserializeMethod = Expression.Call(convertSerializer, methos, contextParameter, argsVar);
 
             //check need cast document to base class if this property was overrided by new
@@ -99,20 +98,16 @@ namespace MongoDB.Bson.Serialization
             var assignProperty = Expression.Assign(property, deserializeMethod);
 
             //build func body by join pieces of code
-            //последний элемент блока автоматом считается возвращаемым значением ф-ии
             var funcBody = Expression.Block(
-                variables: new[] { /*entityVar, serializerVar,*/ argsVar },
+                variables: new[] { argsVar },
                 expressions: new[]
                 {
-                    //assignEntityVar,
-                    //assignSerializerVar,
                     setArgsNominalType,
                     assignProperty
                 });
 
             var lambda = Expression.Lambda<Action<BsonDeserializationContext, IBsonSerializer, TClass>>(funcBody, contextParameter, serializerParameter, documentParameter);
 
-            //компилируем лямду
             return lambda.Compile();
         }
 

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -207,7 +207,7 @@ namespace MongoDB.Bson.Serialization
             bsonReader.ReadEndDocument();
 
             if(_classMap.RequiredMembersExists)
-            CheckRequiredAndDefaultProperies(null, document, allMemberMaps, memberMapBitArray);
+                CheckRequiredAndDefaultProperies(null, document, allMemberMaps, memberMapBitArray);
 
             
             if (supportsInitialization != null)
@@ -281,14 +281,12 @@ namespace MongoDB.Bson.Serialization
             }
             bsonReader.ReadEndDocument();
             if (_classMap.RequiredMembersExists)
-            CheckRequiredAndDefaultProperies(values, null, allMemberMaps, memberMapBitArray);
+                CheckRequiredAndDefaultProperies(values, null, allMemberMaps, memberMapBitArray);
 
             return CreateInstanceUsingCreator(values);
         }
 
-        static bool NeedToCheckRequiredAndDefault(BsonClassMap<TClass> map)
-            => map.AllMemberMaps.Any(m => !m.IsReadOnly && (m.IsRequired || m.IsDefaultValueSpecified));
-
+    
     private void CheckRequiredAndDefaultProperies(Dictionary<string, object> values, TClass document, System.Collections.ObjectModel.ReadOnlyCollection<BsonMemberMap<TClass>> allMemberMaps, uint[] memberMapBitArray)
         {
             // check any members left over that we didn't have elements for (in blocks of 32 elements at a time)

--- a/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
@@ -79,7 +79,7 @@ namespace MongoDB.Bson.Tests
         public void ToDecimal_should_return_expected_result(string valueString, string expectedResultString)
         {
             var subject = Decimal128.Parse(valueString);
-            var expectedResult = decimal.Parse(expectedResultString);
+            var expectedResult = decimal.Parse(expectedResultString, CultureInfo.InvariantCulture);
 
             var result = Decimal128.ToDecimal(subject);
 


### PR DESCRIPTION
35% performance improvement for huge dto classes deserialization.
1) optimized create instance - without reflection
2) optimized set values to properties- without reflection, boxing, interface virtualization impact (for Deserialize Call)
3) optimized collection deserialization- in most cases we can just return prepared List, in some other cases - removed reflection
4) cache IsReadonly
5) dont call SetRequiredFields if required fields does not exists (flag of required fields exist was cached)
6) seporate deserialization of classes with default constructor and classes with creatorMap (to get rid of null checks)
7) add generic BsonMemberMap<TClass> for some optimizations above
8) fix one test , that used local culture in Parse method and failed
var expectedResult = decimal.Parse(expectedResultString, CultureInfo.InvariantCulture); -- pass culture here