### PR TITLE
CSHARP-4316: Ensure that LINQ3 only applies Nullable property translators to Nullables types and not properties with similar names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,5 +157,6 @@ Please see our [guidelines](CONTRIBUTING.md) for contributing to the driver.
 * Craig Wilson              https://github.com/craiggwilson
 * Ming Yau Lee              https://github.com/mingyaulee
 * Daniel Hegener            daniel.hegener@fisglobal.com
+* Vladimir Setyaev          setyaev_v@pgstudio.io
 
 If you have contributed and we have neglected to add you to this list please contact one of the maintainers to be added to the list (with apologies).

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MemberExpressionToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MemberExpressionToAggregationExpressionTranslator.cs
@@ -26,6 +26,7 @@ using MongoDB.Driver.Linq.Linq3Implementation.Ast.Expressions;
 using MongoDB.Driver.Linq.Linq3Implementation.Misc;
 using MongoDB.Driver.Linq.Linq3Implementation.Serializers;
 using MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators.PropertyTranslators;
+using MongoDB.Driver.Support;
 
 namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators
 {
@@ -36,7 +37,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             var containerExpression = expression.Expression;
             var member = expression.Member;
 
-            if (member is PropertyInfo property)
+            if (member is PropertyInfo property && property.DeclaringType.IsNullable())
             {
                 switch (property.Name)
                 {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MemberExpressionToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MemberExpressionToAggregationExpressionTranslator.cs
@@ -21,7 +21,6 @@ using System.Reflection;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver.Linq.Linq3Implementation.Ast;
 using MongoDB.Driver.Linq.Linq3Implementation.Ast.Expressions;
 using MongoDB.Driver.Linq.Linq3Implementation.Misc;
 using MongoDB.Driver.Linq.Linq3Implementation.Serializers;

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp4316Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp4316Tests.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
+{
+    public class CSharp4316Tests : Linq3IntegrationTest
+    {
+        [Fact]
+        public void Nullable_type_translate_should_work()
+        {
+            var collection = GetCollection<ModelContainNullableType>();
+            var fluent = collection.Aggregate()
+                .Group(x => new { Some = x.Some.Value, x.AnotherKeyGroup, x.Some.HasValue }, x => x.Select(t => t));
+
+            var stages = Translate(collection, fluent);
+            var expected = new []
+            {
+                "{ $group : {'_id' : { Some : '$Some', AnotherKeyGroup : '$AnotherKeyGroup', HasValue : { $ne : ['$Some', null] }}, __agg0 : { '$push' : '$$ROOT'}}}",
+                "{ $project : { '_v' : '$__agg0', _id : 0 } }"
+            };
+
+            AssertStages(stages, expected);
+        }
+
+        [Fact]
+        public void Type_contains_property_value_translate_should_work()
+        {
+            var collection = GetCollection<ModelWithoutNullable>();
+            var fluent = collection.Aggregate()
+                .Group(x => new { Key1 = x.Property.Value, Key2 = x.SomeData, Key3 = x.Property.HasValue}, x => x.Select(t => t));
+
+            var stages = Translate(collection, fluent);
+            var expected = new []
+            {
+                "{ $group : {'_id' : { Key1 : '$Property.Value', Key2 : '$SomeData', Key3 : '$Property.HasValue' }, __agg0 : { '$push' : '$$ROOT'}}}",
+                "{ $project : { '_v' : '$__agg0', _id : 0 } }"
+            };
+            AssertStages(stages, expected);
+        }
+
+        public class ModelContainNullableType
+        {
+            public int? Some { get; set; }
+            public float AnotherKeyGroup { get; set; }
+
+        }
+
+        public class ModelWithoutNullable
+        {
+            public CustomTypeLikeNullable Property { get; set; }
+            public int SomeData { get; set; }
+        }
+
+        public class CustomTypeLikeNullable
+        {
+            public string Value { get; set; }
+            public bool HasValue { get; set; }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp4316Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationTests/Jira/CSharp4316Tests.cs
@@ -1,4 +1,21 @@
-﻿using System.Linq;
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Driver.Linq;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
@@ -6,52 +23,62 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
     public class CSharp4316Tests : Linq3IntegrationTest
     {
         [Fact]
-        public void Nullable_type_translate_should_work()
+        public void Value_and_HasValue_should_work_when_properties_on_Nullable_type()
         {
-            var collection = GetCollection<ModelContainNullableType>();
-            var fluent = collection.Aggregate()
-                .Group(x => new { Some = x.Some.Value, x.AnotherKeyGroup, x.Some.HasValue }, x => x.Select(t => t));
+            var collection = CreateCollection();
+            var matchStage = "{ $match : { 'ActualNullable' : { $ne : null } } }";
+            var projectStage = "{ $project : { Id : '$_id', Value : '$ActualNullable', HasValue : { $ne : ['$ActualNullable', null] }, _id : 0 } }";
 
-            var stages = Translate(collection, fluent);
-            var expected = new []
-            {
-                "{ $group : {'_id' : { Some : '$Some', AnotherKeyGroup : '$AnotherKeyGroup', HasValue : { $ne : ['$Some', null] }}, __agg0 : { '$push' : '$$ROOT'}}}",
-                "{ $project : { '_v' : '$__agg0', _id : 0 } }"
-            };
+            var queryable = collection.AsQueryable()
+                .Where(x => x.ActualNullable.HasValue)
+                .Select(x => new { x.Id, x.ActualNullable.Value, x.ActualNullable.HasValue });
 
-            AssertStages(stages, expected);
+            var stages = Translate(collection, queryable);
+            AssertStages(stages, matchStage, projectStage);
+
+            var results = queryable.ToList();
+            results.Select(r => r.Id).Should().Equal(2);
         }
 
         [Fact]
-        public void Type_contains_property_value_translate_should_work()
+        public void Value_and_HasValue_should_work_when_properties_not_on_Nullable_type()
         {
-            var collection = GetCollection<ModelWithoutNullable>();
-            var fluent = collection.Aggregate()
-                .Group(x => new { Key1 = x.Property.Value, Key2 = x.SomeData, Key3 = x.Property.HasValue}, x => x.Select(t => t));
+            var collection = CreateCollection();
+            var matchStage = "{ $match : { 'OnlyLooksLikeNullable.HasValue' : true } }";
+            var projectStage = "{ $project : { Id : '$_id', Value : '$OnlyLooksLikeNullable.Value', HasValue : '$OnlyLooksLikeNullable.HasValue', _id : 0 } }";
 
-            var stages = Translate(collection, fluent);
-            var expected = new []
-            {
-                "{ $group : {'_id' : { Key1 : '$Property.Value', Key2 : '$SomeData', Key3 : '$Property.HasValue' }, __agg0 : { '$push' : '$$ROOT'}}}",
-                "{ $project : { '_v' : '$__agg0', _id : 0 } }"
-            };
-            AssertStages(stages, expected);
+            var queryable = collection
+                .AsQueryable()
+                .Where(x => x.OnlyLooksLikeNullable.HasValue)
+                .Select(x => new { x.Id, Value = x.OnlyLooksLikeNullable.Value, HasValue = x.OnlyLooksLikeNullable.HasValue });
+
+            var stages = Translate(collection, queryable);
+            AssertStages(stages, matchStage, projectStage);
+
+            var results = queryable.ToList();
+            results.Select(r => r.Id).Should().Equal(1);
         }
 
-        public class ModelContainNullableType
+        private IMongoCollection<C> CreateCollection()
         {
-            public int? Some { get; set; }
-            public float AnotherKeyGroup { get; set; }
+            var collection = GetCollection<C>("C");
 
+            CreateCollection(
+                collection,
+                new C { Id = 1, OnlyLooksLikeNullable = new OnlyLooksLikeNullable { Value = "SomeValue", HasValue = true }, ActualNullable = null },
+                new C { Id = 2, OnlyLooksLikeNullable = new OnlyLooksLikeNullable { Value = null, HasValue = false }, ActualNullable = true });
+
+            return collection;
         }
 
-        public class ModelWithoutNullable
+        private class C
         {
-            public CustomTypeLikeNullable Property { get; set; }
-            public int SomeData { get; set; }
+            public int Id { get; set; }
+            public OnlyLooksLikeNullable OnlyLooksLikeNullable { get; set; }
+            public bool? ActualNullable { get; set; }
         }
 
-        public class CustomTypeLikeNullable
+        private class OnlyLooksLikeNullable
         {
             public string Value { get; set; }
             public bool HasValue { get; set; }


### PR DESCRIPTION
We were accidentally matching all properties named `Value` or `HasValue` even if they weren't on `Nullable<T>` types.