### PR TITLE
CSHARP-4331: Make LINQ3 the default LinqProvider.

### DIFF
--- a/Docs/reference/content/reference/driver/crud/linq3.md
+++ b/Docs/reference/content/reference/driver/crud/linq3.md
@@ -11,19 +11,21 @@ title = "LINQ3"
 
 ## LINQ3
 
-We have implemented a new LINQ provider, which is known as LINQ3. The current LINQ provider is known as LINQ2 (and LINQ1 is the now-obsolete LINQ provider in the v1.x releases of the driver).
+We have implemented a new LINQ provider, which is known as LINQ3. The previous LINQ provider is known as LINQ2 (and LINQ1 is the now-obsolete LINQ provider in the v1.x releases of the driver).
 
-While we fully transition to the new LINQ provider the two LINQ providers will exist side by side. LINQ2 will continue to be the default LINQ provider for the time being.
+While we fully transition to the new LINQ provider the two LINQ providers will exist side by side. Starting with 2.18.0, LINQ3 is the default LINQ provider.
 
-LINQ3 is production-ready. It fixes many LINQ2 bugs and offers support for a variety of new aggregation pipeline features present in newer server versions. We encourage all users to switch to LINQ3 and report any issues encountered. The [MongoDB Analyzer](https://www.mongodb.com/docs/mongodb-analyzer/current/) will provide tooltips indicating whether a particular query is supported in LINQ2, LINQ3, or both.
+LINQ3 is production-ready. It fixes many LINQ2 bugs and offers support for a variety of new aggregation pipeline features present in newer server versions. The [MongoDB Analyzer](https://www.mongodb.com/docs/mongodb-analyzer/current/) will provide tooltips indicating whether a particular query is supported in LINQ2, LINQ3, or both.
 
-You can opt into the new LINQ3 provider by configuring your `MongoClient` to use the new LINQ provider as follows:
+If you encounter a problem with LINQ3, you can switch back the LINQ2 provider by configuring your `MongoClient` to use the previous LINQ provider as follows:
 
 ```csharp
 var connectionString = "mongodb://localhost";
 var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
-clientSettings.LinqProvider = LinqProvider.V3;
+clientSettings.LinqProvider = LinqProvider.V2;
 var client = new MongoClient(clientSettings);
 ```
 
 The LINQ provider is only configurable at the `MongoClient` level. All LINQ queries run with a particular `MongoClient` use the same LINQ provider.
+
+If you do encounter a query that works in LINQ2 but fails in LINQ3, please file a [CSHARP ticket](https://jira.mongodb.org/browse/CSHARP) with a self-contained reproduction of the problem so that we can investigate and fix the issue.

--- a/src/MongoDB.Driver/ChangeStreamHelper.cs
+++ b/src/MongoDB.Driver/ChangeStreamHelper.cs
@@ -32,7 +32,7 @@ namespace MongoDB.Driver
             MessageEncoderSettings messageEncoderSettings,
             bool retryRequested)
         {
-            return CreateChangeStreamOperation(pipeline, LinqProvider.V2, options, readConcern, messageEncoderSettings, retryRequested);
+            return CreateChangeStreamOperation(pipeline, LinqProvider.V3, options, readConcern, messageEncoderSettings, retryRequested);
         }
 
         public static ChangeStreamOperation<TResult> CreateChangeStreamOperation<TResult>(
@@ -65,7 +65,7 @@ namespace MongoDB.Driver
             MessageEncoderSettings messageEncoderSettings,
             bool retryRequested)
         {
-            return CreateChangeStreamOperation(database, pipeline, LinqProvider.V2, options, readConcern, messageEncoderSettings, retryRequested);
+            return CreateChangeStreamOperation(database, pipeline, LinqProvider.V3, options, readConcern, messageEncoderSettings, retryRequested);
         }
 
         public static ChangeStreamOperation<TResult> CreateChangeStreamOperation<TResult>(
@@ -101,7 +101,7 @@ namespace MongoDB.Driver
             MessageEncoderSettings messageEncoderSettings,
             bool retryRequested)
         {
-            return CreateChangeStreamOperation(collection, pipeline, documentSerializer, LinqProvider.V2, options, readConcern, messageEncoderSettings, retryRequested);
+            return CreateChangeStreamOperation(collection, pipeline, documentSerializer, LinqProvider.V3, options, readConcern, messageEncoderSettings, retryRequested);
         }
 
         public static ChangeStreamOperation<TResult> CreateChangeStreamOperation<TResult, TDocument>(

--- a/src/MongoDB.Driver/FieldDefinition.cs
+++ b/src/MongoDB.Driver/FieldDefinition.cs
@@ -143,7 +143,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="String"/>.</returns>
         public virtual RenderedFieldDefinition Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(documentSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(documentSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="RenderedFieldDefinition{TField}"/>.</returns>
         public virtual RenderedFieldDefinition<TField> Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(documentSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(documentSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace MongoDB.Driver
             IBsonSerializerRegistry serializerRegistry,
             bool allowScalarValueForArrayField)
         {
-            return Render(documentSerializer, serializerRegistry, LinqProvider.V2, allowScalarValueForArrayField);
+            return Render(documentSerializer, serializerRegistry, LinqProvider.V3, allowScalarValueForArrayField);
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/FilterDefinition.cs
+++ b/src/MongoDB.Driver/FilterDefinition.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="BsonDocument"/>.</returns>
         public virtual BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(documentSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(documentSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/IndexKeysDefinition.cs
+++ b/src/MongoDB.Driver/IndexKeysDefinition.cs
@@ -35,7 +35,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="BsonDocument"/>.</returns>
         public virtual BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(documentSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(documentSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -112,7 +112,7 @@ namespace MongoDB.Driver
             _heartbeatInterval = ServerSettings.DefaultHeartbeatInterval;
             _heartbeatTimeout = ServerSettings.DefaultHeartbeatTimeout;
             _ipv6 = false;
-            _linqProvider = LinqProvider.V2;
+            _linqProvider = LinqProvider.V3;
             _loadBalanced = false;
             _localThreshold = MongoDefaults.LocalThreshold;
             _maxConnecting = MongoInternalDefaults.ConnectionPool.MaxConnecting;
@@ -961,7 +961,7 @@ namespace MongoDB.Driver
             clientSettings.HeartbeatInterval = url.HeartbeatInterval;
             clientSettings.HeartbeatTimeout = url.HeartbeatTimeout;
             clientSettings.IPv6 = url.IPv6;
-            clientSettings.LinqProvider = LinqProvider.V2;
+            clientSettings.LinqProvider = LinqProvider.V3;
             clientSettings.LoadBalanced = url.LoadBalanced;
             clientSettings.LocalThreshold = url.LocalThreshold;
             clientSettings.MaxConnecting = url.MaxConnecting;

--- a/src/MongoDB.Driver/PipelineDefinition.cs
+++ b/src/MongoDB.Driver/PipelineDefinition.cs
@@ -86,7 +86,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="RenderedPipelineDefinition{TOutput}"/></returns>
         public virtual RenderedPipelineDefinition<TOutput> Render(IBsonSerializer<TInput> inputSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(inputSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(inputSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace MongoDB.Driver
         /// <inheritdoc/>
         public override string ToString()
         {
-            return ToString(LinqProvider.V2);
+            return ToString(LinqProvider.V3);
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace MongoDB.Driver
         /// </returns>
         public string ToString(IBsonSerializer<TInput> inputSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return ToString(inputSerializer, serializerRegistry, LinqProvider.V2);
+            return ToString(inputSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/PipelineStageDefinition.cs
+++ b/src/MongoDB.Driver/PipelineStageDefinition.cs
@@ -188,7 +188,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="RenderedPipelineStageDefinition{TOutput}" /></returns>
         public virtual RenderedPipelineStageDefinition<TOutput> Render(IBsonSerializer<TInput> inputSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(inputSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(inputSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace MongoDB.Driver
         /// </returns>
         public string ToString(IBsonSerializer<TInput> inputSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return ToString(inputSerializer, serializerRegistry, LinqProvider.V2);
+            return ToString(inputSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>
@@ -283,7 +283,7 @@ namespace MongoDB.Driver
         /// <inheritdoc />
         IRenderedPipelineStageDefinition IPipelineStageDefinition.Render(IBsonSerializer inputSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render((IBsonSerializer<TInput>)inputSerializer, serializerRegistry, LinqProvider.V2);
+            return Render((IBsonSerializer<TInput>)inputSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <inheritdoc />

--- a/src/MongoDB.Driver/ProjectionDefinition.cs
+++ b/src/MongoDB.Driver/ProjectionDefinition.cs
@@ -73,7 +73,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="BsonDocument"/>.</returns>
         public virtual BsonDocument Render(IBsonSerializer<TSource> sourceSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(sourceSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(sourceSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="RenderedProjectionDefinition{TProjection}"/>.</returns>
         public virtual RenderedProjectionDefinition<TProjection> Render(IBsonSerializer<TSource> sourceSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(sourceSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(sourceSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/SortDefinition.cs
+++ b/src/MongoDB.Driver/SortDefinition.cs
@@ -51,7 +51,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="BsonDocument"/>.</returns>
         public virtual BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(documentSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(documentSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/UpdateDefinition.cs
+++ b/src/MongoDB.Driver/UpdateDefinition.cs
@@ -36,7 +36,7 @@ namespace MongoDB.Driver
         /// <returns>A <see cref="BsonValue"/>.</returns>
         public virtual BsonValue Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return Render(documentSerializer, serializerRegistry, LinqProvider.V2);
+            return Render(documentSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace MongoDB.Driver
         /// </returns>
         public string ToString(IBsonSerializer<TDocument> inputSerializer, IBsonSerializerRegistry serializerRegistry)
         {
-            return ToString(inputSerializer, serializerRegistry, LinqProvider.V2);
+            return ToString(inputSerializer, serializerRegistry, LinqProvider.V3);
         }
 
         /// <summary>


### PR DESCRIPTION
We will also need to update the release notes to highlight that LINQ3 is now the default and link to the LINQ3 page on how to revert back to LINQ2 if necessary.