### PR TITLE
CSHARP-4273: Cache AWS Credentials Where Possible.

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -514,6 +514,7 @@ functions:
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             MONGODB_URI="mongodb://localhost"
           EOF
+          export AWS_EC2_ENABLED=true
           PROJECT_DIRECTORY=${PROJECT_DIRECTORY} evergreen/run-mongodb-aws-test.sh
 
   run-aws-auth-test-with-aws-credentials-as-environment-variables:
@@ -987,7 +988,7 @@ tasks:
         - func: run-aws-auth-test-with-aws-credentials-as-environment-variables
         - func: run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
         - func: run-aws-auth-test-with-aws-EC2-credentials
-        # ECS test is skipped untill testing on Linux becomes possible
+        # ECS test is skipped until testing on Linux becomes possible
 
     - name: stable-api-tests-net472
       commands:

--- a/src/MongoDB.Driver.Core/Core/Authentication/External/AwsAuthenticationCredentialsProvider.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/External/AwsAuthenticationCredentialsProvider.cs
@@ -25,20 +25,27 @@ namespace MongoDB.Driver.Core.Authentication.External
 {
     internal class AwsCredentials : IExternalCredentials
     {
+        // credentials are considered expired when: Expiration - now > 5 mins
+        private static readonly TimeSpan __overlapWhenExpired = TimeSpan.FromMinutes(5);
+
         private readonly string _accessKeyId;
+        private readonly DateTime? _expiration;
         private readonly SecureString _secretAccessKey;
         private readonly string _sessionToken;
 
-        public AwsCredentials(string accessKeyId, SecureString secretAccessKey, string sessionToken)
+        public AwsCredentials(string accessKeyId, SecureString secretAccessKey, string sessionToken, string expiration)
         {
             _accessKeyId = Ensure.IsNotNull(accessKeyId, nameof(accessKeyId));
+            _expiration = expiration != null ? DateTime.Parse(expiration) : null;
             _secretAccessKey = Ensure.IsNotNull(secretAccessKey, nameof(secretAccessKey));
             _sessionToken = sessionToken; // can be null
         }
 
         public string AccessKeyId => _accessKeyId;
+        public DateTime? Expiration => _expiration;
         public SecureString SecretAccessKey => _secretAccessKey;
         public string SessionToken => _sessionToken;
+        public bool IsExpired => _expiration.HasValue ? (_expiration.Value - DateTime.UtcNow) < __overlapWhenExpired : false;
 
         public BsonDocument GetKmsCredentials()
             => new BsonDocument
@@ -93,7 +100,7 @@ namespace MongoDB.Driver.Core.Authentication.External
                 throw new InvalidOperationException($"When using AWS authentication if a session token is provided via environment variables then an access key ID and a secret access key must be provided also.");
             }
 
-            return new AwsCredentials(accessKeyId, SecureStringHelper.ToSecureString(secretAccessKey), sessionToken);
+            return new AwsCredentials(accessKeyId, SecureStringHelper.ToSecureString(secretAccessKey), sessionToken, expiration: null);
         }
 
         private async Task<AwsCredentials> CreateAwsCredentialsFromEcsResponseAsync(CancellationToken cancellationToken)
@@ -116,12 +123,23 @@ namespace MongoDB.Driver.Core.Authentication.External
 
         private AwsCredentials CreateAwsCreadentialsFromAwsResponse(string awsResponse)
         {
+            // Response template:
+            //{
+            //    "Code": "Success",
+            //    "LastUpdated": "..",
+            //    "Type": "AWS-HMAC",
+            //    "AccessKeyId": "..",
+            //    "SecretAccessKey": "..",
+            //    "Token": "",
+            //    "Expiration": "YYYY-mm-ddThh:mm:ssZ"
+            //}
             var parsedResponse = BsonDocument.Parse(awsResponse);
             var accessKeyId = parsedResponse.GetValue("AccessKeyId", null)?.AsString;
             var secretAccessKey = parsedResponse.GetValue("SecretAccessKey", null)?.AsString;
             var sessionToken = parsedResponse.GetValue("Token", null)?.AsString;
+            var expiration = parsedResponse.GetValue("Expiration", null)?.AsString;
 
-            return new AwsCredentials(accessKeyId, SecureStringHelper.ToSecureString(secretAccessKey), sessionToken);
+            return new AwsCredentials(accessKeyId, SecureStringHelper.ToSecureString(secretAccessKey), sessionToken, expiration);
         }
 
         // nested types

--- a/src/MongoDB.Driver.Core/Core/Authentication/External/CacheableCredentialsProvider.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/External/CacheableCredentialsProvider.cs
@@ -1,0 +1,93 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver.Core.Misc;
+
+namespace MongoDB.Driver.Core.Authentication.External
+{
+    internal interface ICredentialsCache<TCredentials> where TCredentials : IExternalCredentials
+    {
+        TCredentials Credentials { get; }
+        void Clear();
+    }
+
+    internal class CacheableCredentialsProvider<TCredentials> : IExternalAuthenticationCredentialsProvider<TCredentials>, ICredentialsCache<TCredentials>
+        where TCredentials : IExternalCredentials
+    {
+        private TCredentials _cachedCredentials;
+        private readonly IExternalAuthenticationCredentialsProvider<TCredentials> _provider;
+
+        public CacheableCredentialsProvider(IExternalAuthenticationCredentialsProvider<TCredentials> provider)
+        {
+            _provider = Ensure.IsNotNull(provider, nameof(provider));
+        }
+
+        public TCredentials Credentials => _cachedCredentials;
+
+        public TCredentials CreateCredentialsFromExternalSource(CancellationToken cancellationToken = default)
+        {
+            var cachedCredentials = _cachedCredentials;
+            if (IsValidCache(cachedCredentials))
+            {
+                return cachedCredentials;
+            }
+            else
+            {
+                Clear();
+                try
+                {
+                    cachedCredentials = _provider.CreateCredentialsFromExternalSource(cancellationToken);
+                    _cachedCredentials = cachedCredentials;
+                    return cachedCredentials;
+                }
+                catch
+                {
+                    Clear();
+                    throw;
+                }
+            }
+        }
+
+        public async Task<TCredentials> CreateCredentialsFromExternalSourceAsync(CancellationToken cancellationToken = default)
+        {
+            var cachedCredentials = _cachedCredentials;
+            if (IsValidCache(cachedCredentials))
+            {
+                return cachedCredentials;
+            }
+            else
+            {
+                Clear();
+                try
+                {
+                    cachedCredentials = await _provider.CreateCredentialsFromExternalSourceAsync(cancellationToken).ConfigureAwait(false);
+                    _cachedCredentials = cachedCredentials;
+                    return cachedCredentials;
+                }
+                catch
+                {
+                    Clear();
+                    throw;
+                }
+            }
+        }
+
+        // private methods
+        private bool IsValidCache(TCredentials credentials) => credentials != null && !credentials.IsExpired;
+        public void Clear() => _cachedCredentials = default;
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Authentication/External/ExternalCredentialsAuthenticators.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/External/ExternalCredentialsAuthenticators.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using System.Net.Http;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Core.Authentication.External
@@ -38,7 +37,7 @@ namespace MongoDB.Driver.Core.Authentication.External
         internal ExternalCredentialsAuthenticators(HttpClientHelper httpClientHelper)
         {
             _httpClientHelper = Ensure.IsNotNull(httpClientHelper, nameof(httpClientHelper));
-            _awsExternalAuthenticationCredentialsProvider = new Lazy<IExternalAuthenticationCredentialsProvider<AwsCredentials>>(() => new AwsAuthenticationCredentialsProvider(_httpClientHelper), isThreadSafe: true);
+            _awsExternalAuthenticationCredentialsProvider = new Lazy<IExternalAuthenticationCredentialsProvider<AwsCredentials>>(() => new CacheableCredentialsProvider<AwsCredentials>(new AwsAuthenticationCredentialsProvider(_httpClientHelper)), isThreadSafe: true);
             _gcpExternalAuthenticationCredentialsProvider = new Lazy<IExternalAuthenticationCredentialsProvider<GcpCredentials>>(() => new GcpAuthenticationCredentialsProvider(_httpClientHelper), isThreadSafe: true);
         }
 

--- a/src/MongoDB.Driver.Core/Core/Authentication/External/GcpAuthenticationCredentialsProvider.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/External/GcpAuthenticationCredentialsProvider.cs
@@ -30,6 +30,10 @@ namespace MongoDB.Driver.Core.Authentication.External
 
         public string AccessToken => _accessToken;
 
+        public DateTime? Expiration => null;
+
+        public bool IsExpired => false;
+
         public BsonDocument GetKmsCredentials() => new BsonDocument("accessToken", _accessToken);
     }
 

--- a/src/MongoDB.Driver.Core/Core/Authentication/External/IExternalCredentials.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/External/IExternalCredentials.cs
@@ -13,12 +13,15 @@
 * limitations under the License.
 */
 
+using System;
 using MongoDB.Bson;
 
 namespace MongoDB.Driver.Core.Authentication.External
 {
     internal interface IExternalCredentials
     {
+        DateTime? Expiration { get; }
+        bool IsExpired { get; }
         BsonDocument GetKmsCredentials();
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Authentication/SaslAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/SaslAuthenticator.cs
@@ -75,7 +75,7 @@ namespace MongoDB.Driver.Core.Authentication
 
         // methods
         /// <inheritdoc/>
-        public void Authenticate(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken)
+        public virtual void Authenticate(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken)
         {
             Ensure.IsNotNull(connection, nameof(connection));
             Ensure.IsNotNull(description, nameof(description));
@@ -114,7 +114,7 @@ namespace MongoDB.Driver.Core.Authentication
         }
 
         /// <inheritdoc/>
-        public async Task AuthenticateAsync(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken)
+        public virtual async Task AuthenticateAsync(IConnection connection, ConnectionDescription description, CancellationToken cancellationToken)
         {
             Ensure.IsNotNull(connection, nameof(connection));
             Ensure.IsNotNull(description, nameof(description));

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/CacheableCredentialsProviderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/CacheableCredentialsProviderTests.cs
@@ -1,0 +1,91 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core.Authentication.External;
+using MongoDB.Driver.Core.Misc;
+using Moq;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Tests.Core.Authentication
+{
+    public class CacheableCredentialsProviderTests
+    {
+        [Theory]
+        [ParameterAttributeData]
+        public async Task CreateCredentialsFromExternalSource_should_return_the_same_result_until_cache_valid([Values(false, true)] bool async)
+        {
+            bool isExpired = false;
+            Func<bool> isExpiredFunc = () => isExpired;
+            var subject = CreateSubject(isExpiredFunc);
+
+            var creds1 = await CreateCredentials();
+            var creds2 = await CreateCredentials();
+            creds1.Should().BeSameAs(creds2);
+
+            isExpired = true;
+            var creds3 = await CreateCredentials();
+            creds2.Should().NotBeSameAs(creds3);
+            var creds4 = await CreateCredentials();
+            creds3.Should().NotBeSameAs(creds4);
+
+            isExpired = false;
+            var creds5 = await CreateCredentials();
+            creds4.Should().BeSameAs(creds5);
+            var creds6 = await CreateCredentials();
+            creds5.Should().BeSameAs(creds6);
+
+            async Task<DummyCredentials> CreateCredentials() => async ? (await subject.CreateCredentialsFromExternalSourceAsync()) : subject.CreateCredentialsFromExternalSource();
+        }
+
+        private CacheableCredentialsProvider<DummyCredentials> CreateSubject(Func<bool> isExpiredFunc)
+        {
+            var externalCredentialsProviderMock = new Mock<IExternalAuthenticationCredentialsProvider<DummyCredentials>>();
+            var setupSequence = externalCredentialsProviderMock
+                .Setup(c => c.CreateCredentialsFromExternalSource(It.IsAny<CancellationToken>()))
+                .Returns(() => new DummyCredentials(isExpiredFunc));
+            var setupSequenceAsync = externalCredentialsProviderMock
+                .Setup(c => c.CreateCredentialsFromExternalSourceAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new DummyCredentials(isExpiredFunc));
+
+            return new CacheableCredentialsProvider<DummyCredentials>(externalCredentialsProviderMock.Object);
+        }
+    }
+
+    public class DummyCredentials : IExternalCredentials
+    {
+        private readonly Guid _id;
+        private readonly Func<bool> _isExpiredFunc;
+
+        public DummyCredentials(Func<bool> isExpiredFunc)
+        {
+            _id = Guid.NewGuid();
+            _isExpiredFunc = Ensure.IsNotNull(isExpiredFunc, nameof(isExpiredFunc));
+        }
+
+        public DateTime? Expiration { get; }
+
+        public bool IsExpired => _isExpiredFunc();
+
+        public Guid Id => _id;
+
+        public BsonDocument GetKmsCredentials() => new BsonDocument("dummy", 1);
+    }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoAWSAuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/MongoAWSAuthenticatorTests.cs
@@ -21,6 +21,7 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Authentication;
+using MongoDB.Driver.Core.Authentication.External;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Helpers;
@@ -102,7 +103,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication
             var saslContinueCommandResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(
                 "{ conversationId : 1, done : true, payload : BinData(0,\"\"), ok : 1}"));
 
-            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, mockClock.Object, serverApi: null);
+            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, Mock.Of<IExternalAuthenticationCredentialsProvider<AwsCredentials>>(), mockClock.Object, serverApi: null);
 
             var connection = new MockConnection(__serverId);
             connection.EnqueueCommandResponseMessage(saslStartCommandResponse);
@@ -181,7 +182,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication
             var saslStartCommandResponseString = $"{{ conversationId : 1, done : false, payload : BinData(0,\"{ToBase64(serverFirstMessage.ToBson())}\"), ok : 1 }}";
             var saslContinueCommandResponseString = "{ conversationId : 1, done : true, payload : BinData(0,\"\"), ok : 1}";
 
-            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, mockClock.Object, serverApi);
+            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, Mock.Of<IExternalAuthenticationCredentialsProvider<AwsCredentials>>(), mockClock.Object, serverApi);
 
             var connection = new MockConnection(__serverId);
             var saslStartResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(saslStartCommandResponseString));
@@ -262,7 +263,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication
             var saslContinueCommandResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(
                 "{ conversationId : 1, done : true, payload : BinData(0,\"\"), ok : 1}"));
 
-            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, SystemClock.Instance, serverApi: null);
+            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, Mock.Of<IExternalAuthenticationCredentialsProvider<AwsCredentials>>(), SystemClock.Instance, serverApi: null);
 
             var connection = new MockConnection(__serverId);
             connection.EnqueueCommandResponseMessage(saslStartCommandResponse);
@@ -305,7 +306,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication
             var saslStartCommandResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(
                 $"{{ conversationId : 1, done : false, payload : BinData(0,\"{ToBase64(serverFirstMessage.ToBson())}\"), ok : 1 }}"));
 
-            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, SystemClock.Instance, serverApi: null);
+            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, Mock.Of<IExternalAuthenticationCredentialsProvider<AwsCredentials>>(), SystemClock.Instance, serverApi: null);
 
             var connection = new MockConnection(__serverId);
             connection.EnqueueCommandResponseMessage(saslStartCommandResponse);
@@ -350,7 +351,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication
             var saslContinueCommandResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson(
                 "{ conversationId : 1, done : true, payload : BinData(0,\"\"), ok : 1}"));
 
-            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, SystemClock.Instance, serverApi: null);
+            var subject = new MongoAWSAuthenticator(credential, null, mockRandomByteGenerator.Object, Mock.Of<IExternalAuthenticationCredentialsProvider<AwsCredentials>>(), SystemClock.Instance, serverApi: null);
 
             var connection = new MockConnection(__serverId);
             connection.EnqueueCommandResponseMessage(saslStartCommandResponse);
@@ -422,7 +423,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication
                 "{ conversationId : 1, done : true, payload : BinData(0,\"\"), ok : 1}"));
 
             var properties = new[] { new KeyValuePair<string, string>("AWS_SESSION_TOKEN", sessionToken) };
-            var subject = new MongoAWSAuthenticator(credential, properties, mockRandomByteGenerator.Object, mockClock.Object, serverApi: null);
+            var subject = new MongoAWSAuthenticator(credential, properties, mockRandomByteGenerator.Object, Mock.Of<IExternalAuthenticationCredentialsProvider<AwsCredentials>>(), mockClock.Object, serverApi: null);
 
             var connection = new MockConnection(__serverId);
             connection.EnqueueCommandResponseMessage(saslStartCommandResponse);

--- a/tests/MongoDB.Driver.Tests/Communication/Security/AwsAuthenticationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Communication/Security/AwsAuthenticationTests.cs
@@ -13,8 +13,13 @@
 * limitations under the License.
 */
 
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
 using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core.Authentication.External;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Communication.Security
@@ -41,5 +46,102 @@ namespace MongoDB.Driver.Tests.Communication.Security
                 var count = collection.CountDocuments(FilterDefinition<BsonDocument>.Empty);
             }
         }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public async Task Aws_external_credentials_caching_prose_test([Values(false, true)] bool async)
+        {
+            RequireEnvironment
+                .Check()
+                .EnvironmentVariable("AWS_TESTS_ENABLED")
+                .EnvironmentVariable("AWS_EC2_ENABLED");
+
+            // 1. Clear the cache.
+            SetCache(date: null);
+            // 2. Create a new client.
+            using var client = DriverTestConfiguration.CreateDisposableClient();
+            var cache = GetCache();
+            cache.Should().BeNull();
+
+            await Find(client);
+            // 3. Ensure that a find operation adds credentials to the cache..
+            GetCache().Should().NotBeNull();
+
+            // 4. Override the cached credentials with an "Expiration" that is within thirty seconds of the current UTC time.
+            SetCache(date: DateTime.UtcNow.AddSeconds(30));
+
+            // 5. Create a new client.
+            using var client2 = DriverTestConfiguration.CreateDisposableClient();
+            GetCache().Should().NotBeNull();
+
+            await Find(client2);
+            // 6. Ensure that a find operation updates the credentials in the cache.
+            var cache2 = GetCache();
+            cache2.Should().NotBeNull().And.Should().NotBeSameAs(cache);
+            // 7. Poison the cache with garbage content.
+            SetCache(awsKeyId: "garbage");
+            GetCache().AccessKeyId.Should().Be("garbage");
+            // 8. Create a new client.
+            using var client3 = DriverTestConfiguration.CreateDisposableClient();
+            // 9. Ensure that a find operation results in an error.
+            var exception = await Record.ExceptionAsync(() => Find(client3));
+            exception.Should().NotBeNull();
+
+            // 10. Ensure that the cache has been cleared.
+            GetCache().Should().BeNull();
+            // 11. Ensure that a subsequent find operation succeeds.
+            await Find(client3);
+            // 12. Ensure that the cache has been set.
+            var cache3 = GetCache();
+            cache3.Should().NotBeNull();
+            // reset cache
+            SetCache(date: null);
+
+            void SetCache(DateTime? date = null, string awsKeyId = null)
+            {
+                var cachebleProvider = (CacheableCredentialsProvider<AwsCredentials>)ExternalCredentialsAuthenticators.Instance.Aws;
+
+                var currentCache = cachebleProvider._cachedCredentials();
+                if (date.HasValue)
+                {
+                    currentCache._expiration(date);
+                }
+                else
+                {
+                    if (awsKeyId == null)
+                    {
+                        cachebleProvider._cachedCredentials(null);
+                    }
+                }
+
+                if (awsKeyId != null)
+                {
+                    currentCache._accessKeyId(awsKeyId);
+                }
+            }
+
+            AwsCredentials GetCache() => ((CacheableCredentialsProvider<AwsCredentials>)ExternalCredentialsAuthenticators.Instance.Aws)._cachedCredentials();
+
+            async Task Find(IMongoClient client)
+            {
+                var collection = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName).GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName); ;
+                using var cursor = async
+                    ? await collection.FindAsync(FilterDefinition<BsonDocument>.Empty)
+                    : collection.FindSync(FilterDefinition<BsonDocument>.Empty);
+                cursor.ToList();
+            }
+        }
+    }
+
+    internal static class CacheableCredentialsProviderReflector
+    {
+        public static void _cachedCredentials(this CacheableCredentialsProvider<AwsCredentials> provider, AwsCredentials credentials) => Reflector.SetFieldValue(provider, nameof(_cachedCredentials), credentials);
+        public static AwsCredentials _cachedCredentials(this CacheableCredentialsProvider<AwsCredentials> provider) => (AwsCredentials)Reflector.GetFieldValue(provider, nameof(_cachedCredentials));
+    }
+
+    internal static class AwsCredentialsReflector
+    {
+        public static void _accessKeyId(this AwsCredentials awsCredentials, string value) => Reflector.SetFieldValue(awsCredentials, nameof(_accessKeyId), value);
+        public static void _expiration(this AwsCredentials awsCredentials, DateTime? value) => Reflector.SetFieldValue(awsCredentials, nameof(_expiration), value);
     }
 }

--- a/tests/MongoDB.Driver.Tests/Communication/Security/AwsAuthenticationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Communication/Security/AwsAuthenticationTests.cs
@@ -67,8 +67,8 @@ namespace MongoDB.Driver.Tests.Communication.Security
             // 3. Ensure that a find operation adds credentials to the cache..
             GetCache().Should().NotBeNull();
 
-            // 4. Override the cached credentials with an "Expiration" that is within thirty seconds of the current UTC time.
-            SetCache(date: DateTime.UtcNow.AddSeconds(30));
+            // 4. Override the cached credentials with an "Expiration" that is within one minute of the current UTC time.
+            SetCache(date: DateTime.UtcNow.AddMinutes(1));
 
             // 5. Create a new client.
             using var client2 = DriverTestConfiguration.CreateDisposableClient();


### PR DESCRIPTION
Some notes:
1. The spec requirement about dedicated thread is removed at this point. so we just save creds somewhere globally. Spec should be updated. cc: @blink1073 
2. There is an open question about clearing cache for CSFLE. (update: https://jira.mongodb.org/browse/DRIVERS-2464. It's about Azure, but I guess for Aws we can mimic their solution)