### PR TITLE
CSHARP-4406: Unite logging "Cluster" and "Sdam" categories

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
@@ -71,7 +71,7 @@ namespace MongoDB.Driver.Core.Clusters
         private TaskCompletionSource<bool> _descriptionChangedTaskCompletionSource;
         private readonly object _descriptionLock = new object();
         private readonly LatencyLimitingServerSelector _latencyLimitingServerSelector;
-        protected readonly EventLogger<LogCategories.Cluster> _clusterEventLogger;
+        protected readonly EventLogger<LogCategories.SDAM> _clusterEventLogger;
         protected readonly EventLogger<LogCategories.ServerSelection> _serverSelectionEventLogger;
         private Timer _rapidHeartbeatTimer;
         private readonly object _serverSelectionWaitQueueLock = new object();
@@ -101,7 +101,7 @@ namespace MongoDB.Driver.Core.Clusters
 
             _serverSessionPool = new CoreServerSessionPool(this);
 
-            _clusterEventLogger = loggerFactory.CreateEventLogger<LogCategories.Cluster>(eventSubscriber);
+            _clusterEventLogger = loggerFactory.CreateEventLogger<LogCategories.SDAM>(eventSubscriber);
             _serverSelectionEventLogger = loggerFactory.CreateEventLogger<LogCategories.ServerSelection>(eventSubscriber);
 
             ClusterDescription CreateInitialDescription()

--- a/src/MongoDB.Driver.Core/Core/Clusters/LoadBalancedCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/LoadBalancedCluster.cs
@@ -51,7 +51,7 @@ namespace MongoDB.Driver.Core.Clusters
         private readonly ICoreServerSessionPool _serverSessionPool;
         private readonly ClusterSettings _settings;
         private readonly InterlockedInt32 _state;
-        private readonly EventLogger<LogCategories.Cluster> _eventLogger;
+        private readonly EventLogger<LogCategories.SDAM> _eventLogger;
 
         public LoadBalancedCluster(
             ClusterSettings settings,
@@ -109,7 +109,7 @@ namespace MongoDB.Driver.Core.Clusters
 #pragma warning restore CS0618 // Type or member is obsolete
                 null);
 
-            _eventLogger = loggerFactory.CreateEventLogger<LogCategories.Cluster>(eventSubscriber);
+            _eventLogger = loggerFactory.CreateEventLogger<LogCategories.SDAM>(eventSubscriber);
         }
 
         public ClusterId ClusterId => _clusterId;

--- a/src/MongoDB.Driver.Core/Core/Logging/LogCategories.cs
+++ b/src/MongoDB.Driver.Core/Core/Logging/LogCategories.cs
@@ -19,8 +19,6 @@ namespace MongoDB.Driver.Core.Logging
     {
         public abstract class EventCategory { }
 
-        public sealed class Cluster : EventCategory { }
-
         public sealed class Command : EventCategory { }
 
         public sealed class Connection : EventCategory { }

--- a/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/DefaultServer.cs
@@ -173,9 +173,12 @@ namespace MongoDB.Driver.Core.Servers
                     lastUpdateTimestamp: DateTime.UtcNow,
                     topologyVersion: topologyVersion);
 
+            var (host, port) = ServerId.EndPoint.GetHostAndPort();
             EventLogger.Logger?.LogDebug(
                 StructuredLogTemplateProviders.ServerId_Message_Description,
-                ServerId,
+                ServerId.ClusterId.Value,
+                host,
+                port,
                 newDescription,
                 "Invalidating description");
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Logging/EventLoggerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Logging/EventLoggerTests.cs
@@ -90,7 +90,6 @@ namespace MongoDB.Driver.Core.Logging
 
             var eventsData = new (object, object)[]
             {
-                (new LogCategories.Cluster(), new ClusterAddedServerEvent(serverId, TimeSpan.FromSeconds(1))),
                 (new LogCategories.Command(), new CommandStartedEvent("test", new Bson.BsonDocument(), new DatabaseNamespace("test"), 1, 1, connectionId)),
                 (new LogCategories.Connection(), new ConnectionCreatedEvent(connectionId, null, 1)),
                 (new LogCategories.SDAM(), new ServerHeartbeatStartedEvent(connectionId, true)),

--- a/tests/MongoDB.Driver.Tests/LoggingTests.cs
+++ b/tests/MongoDB.Driver.Tests/LoggingTests.cs
@@ -46,36 +46,35 @@ namespace MongoDB.Driver.Tests
 
             AssertLogs(new[]
             {
-                Cluster("Description changed"),
+                SDAM("Description changed"),
                 SDAM("Server opening"),
                 Connection("Connection pool opening"),
                 Connection("Connection pool created"),
                 SDAM("Server opened"),
-                Cluster("Cluster opened"),
+                SDAM("Cluster opened"),
                 Connection("Connection checkout started"),
                 Connection("Connection created"),
                 Connection("Connection added"),
                 Connection("Connection ready"),
                 Connection("Connection checked out"),
                 TestsDebug<DisposableMongoClient>("Disposing"),
-                Cluster("Cluster closing"),
-                Cluster("Removing server"),
+                SDAM("Cluster closing"),
+                SDAM("Removing server"),
                 SDAM("Server closing"),
                 Connection("Connection closing"),
                 Connection("Connection closed"),
                 Connection("Connection pool closed"),
                 SDAM("Server closed"),
-                Cluster("Removed server"),
-                Cluster("Disposing"),
-                Cluster("Description changed"),
-                Cluster("Disposed"),
-                Cluster("Cluster closed"),
+                SDAM("Removed server"),
+                SDAM("Disposing"),
+                SDAM("Description changed"),
+                SDAM("Disposed"),
+                SDAM("Cluster closed"),
                 TestsDebug<DisposableMongoClient>("Cluster unregistered and disposed"),
                 TestsDebug<DisposableMongoClient>("Disposed")
             },
             logs);
 
-            (LogLevel, string, string) Cluster(string message) => (LogLevel.Debug, LogCategoryHelper.GetCategoryName<LogCategories.Cluster>(), message);
             (LogLevel, string, string) Connection(string message) => (LogLevel.Debug, LogCategoryHelper.GetCategoryName<LogCategories.Connection>(), message);
             (LogLevel, string, string) SDAM(string message) => (LogLevel.Debug, LogCategoryHelper.GetCategoryName<LogCategories.SDAM>(), message);
             (LogLevel, string, string) TestsDebug<T>(string message) => (LogLevel.Debug, $"MongoDB.Tests.{typeof(T).Name}", message);

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/LoggingTests.cs
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/LoggingTests.cs
@@ -98,32 +98,31 @@ namespace MongoDB.Driver.SmokeTests.Sdk
         {
             return new[]
             {
-                Cluster("Description changed"),
+                SDAM("Description changed"),
                 SDAM("Server opening"),
                 Connection("Connection pool opening"),
                 Connection("Connection pool created"),
                 SDAM("Server opened"),
-                Cluster("Cluster opened"),
+                SDAM("Cluster opened"),
                 Connection("Connection checkout started"),
                 Connection("Connection created"),
                 Connection("Connection added"),
                 Connection("Connection ready"),
                 Connection("Connection checked out"),
-                Cluster("Cluster closing"),
-                Cluster("Removing server"),
+                SDAM("Cluster closing"),
+                SDAM("Removing server"),
                 SDAM("Server closing"),
                 Connection("Connection closing"),
                 Connection("Connection closed"),
                 Connection("Connection pool closed"),
                 SDAM("Server closed"),
-                Cluster("Removed server"),
-                Cluster("Disposing"),
-                Cluster("Description changed"),
-                Cluster("Disposed"),
-                Cluster("Cluster closed")
+                SDAM("Removed server"),
+                SDAM("Disposing"),
+                SDAM("Description changed"),
+                SDAM("Disposed"),
+                SDAM("Cluster closed")
             };
 
-            LogEntry Cluster(string message) => new LogEntry(LogLevel.Debug, "MongoDB.Cluster", message);
             LogEntry Connection(string message) => new LogEntry(LogLevel.Debug, "MongoDB.Connection", message);
             LogEntry SDAM(string message) => new LogEntry(LogLevel.Debug, "MongoDB.SDAM", message);
         }


### PR DESCRIPTION
- Fix "Invalidating description" log message in DefaultServer

SDAM category was mistakenly split to Cluster and SDAM categories. Spec specifies single category for both.