### PR TITLE
TryRegisterClassMap implementation

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -382,7 +382,8 @@ namespace MongoDB.Bson.Serialization
         /// Creates and attempts to register a class map.
         /// </summary>
         /// <typeparam name="TClass">The class.</typeparam>
-        /// <returns>The class map.</returns>
+        /// <param name="classMap">The registered class map.</param>
+        /// <returns>false if already registered</returns>
         public static bool TryRegisterClassMap<TClass>(out BsonClassMap<TClass> classMap)
         {
             return TryRegisterClassMap(cm => { cm.AutoMap(); }, out classMap);
@@ -442,6 +443,7 @@ namespace MongoDB.Bson.Serialization
         /// Attempts to register a class map.
         /// </summary>
         /// <param name="classMap">The class map.</param>
+        /// <returns>false if already registered</returns>
         public static bool TryRegisterClassMap(BsonClassMap classMap)
         {
             var registered = false;

--- a/src/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -446,7 +446,7 @@ namespace MongoDB.Bson.Serialization
         /// <returns>false if already registered</returns>
         public static bool TryRegisterClassMap(BsonClassMap classMap)
         {
-            var registered = false;
+            var isRegistered = false;
 
             if (classMap == null)
             {
@@ -461,7 +461,7 @@ namespace MongoDB.Bson.Serialization
                 {
                     __classMaps.Add(classMap.ClassType, classMap);
                     BsonSerializer.RegisterDiscriminator(classMap.ClassType, classMap.Discriminator);
-                    registered = true;
+                    isRegistered = true;
                 }
             }
             finally
@@ -469,7 +469,7 @@ namespace MongoDB.Bson.Serialization
                 BsonSerializer.ConfigLock.ExitWriteLock();
             }
 
-            return registered;
+            return isRegistered;
         }
 
         // public methods


### PR DESCRIPTION
I've implemented the TryRegisterClassMap method which is an atomic version of the existing RegisterClassMap method.
This method is useful in highly concurrent scenarios as it avoids creating external locks before registering a class map.

Current workaround:

```c#
lock (_lock)
{
    if (!BsonClassMap.IsClassMapRegistered(typeof(T)))
        BsonClassMap.RegisterClassMap<T>(Map);
}
```