### PR TITLE
CSHARP-4417: ConnectionId should use longs for LocalValue and ServerValue

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionId.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionId.cs
@@ -28,8 +28,8 @@ namespace MongoDB.Driver.Core.Connections
     {
         // fields
         private readonly ServerId _serverId;
-        private readonly int _localValue;
-        private readonly int? _serverValue;
+        private readonly long _localValue;
+        private readonly long? _serverValue;
         private readonly int _hashCode;
 
         // constructors
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Core.Connections
         /// </summary>
         /// <param name="serverId">The server identifier.</param>
         public ConnectionId(ServerId serverId)
-            : this(serverId, IdGenerator<ConnectionId>.GetNextId())
+            : this(serverId, LongIdGenerator<ConnectionId>.GetNextId())
         {
         }
 
@@ -47,7 +47,7 @@ namespace MongoDB.Driver.Core.Connections
         /// </summary>
         /// <param name="serverId">The server identifier.</param>
         /// <param name="localValue">The local value.</param>
-        public ConnectionId(ServerId serverId, int localValue)
+        public ConnectionId(ServerId serverId, long localValue)
         {
             _serverId = Ensure.IsNotNull(serverId, nameof(serverId));
             _localValue = Ensure.IsGreaterThanOrEqualToZero(localValue, nameof(localValue));
@@ -57,7 +57,7 @@ namespace MongoDB.Driver.Core.Connections
                 .GetHashCode();
         }
 
-        private ConnectionId(ServerId serverId, int localValue, int serverValue)
+        private ConnectionId(ServerId serverId, long localValue, long serverValue)
             : this(serverId, localValue)
         {
             _serverValue = Ensure.IsGreaterThanOrEqualToZero(serverValue, nameof(serverValue));
@@ -81,7 +81,7 @@ namespace MongoDB.Driver.Core.Connections
         /// <value>
         /// The local value.
         /// </value>
-        public int LocalValue
+        public long LocalValue
         {
             get { return _localValue; }
         }
@@ -92,7 +92,7 @@ namespace MongoDB.Driver.Core.Connections
         /// <value>
         /// The server value.
         /// </value>
-        public int? ServerValue
+        public long? ServerValue
         {
             get { return _serverValue; }
         }
@@ -159,7 +159,7 @@ namespace MongoDB.Driver.Core.Connections
         /// </summary>
         /// <param name="serverValue">The server value.</param>
         /// <returns>A ConnectionId.</returns>
-        public ConnectionId WithServerValue(int serverValue)
+        public ConnectionId WithServerValue(long serverValue)
         {
             return new ConnectionId(_serverId, _localValue, serverValue);
         }

--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionId.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionId.cs
@@ -81,7 +81,19 @@ namespace MongoDB.Driver.Core.Connections
         /// <value>
         /// The local value.
         /// </value>
-        public long LocalValue
+        [Obsolete("Use LongLocalValue instead.")]
+        public int LocalValue
+        {
+            get { return (int)_localValue; }
+        }
+
+        /// <summary>
+        /// Gets the local value.
+        /// </summary>
+        /// <value>
+        /// The local value.
+        /// </value>
+        public long LongLocalValue
         {
             get { return _localValue; }
         }
@@ -92,7 +104,19 @@ namespace MongoDB.Driver.Core.Connections
         /// <value>
         /// The server value.
         /// </value>
-        public long? ServerValue
+        [Obsolete("Use LongServerValue instead.")]
+        public int? ServerValue
+        {
+            get { return (int)_serverValue; }
+        }
+
+        /// <summary>
+        /// Gets the server value.
+        /// </summary>
+        /// <value>
+        /// The server value.
+        /// </value>
+        public long? LongServerValue
         {
             get { return _serverValue; }
         }

--- a/src/MongoDB.Driver.Core/Core/Events/Diagnostics/TraceSourceEventHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Events/Diagnostics/TraceSourceEventHelper.cs
@@ -50,11 +50,11 @@ namespace MongoDB.Driver.Core.Events.Diagnostics
 
         public static string Format(ConnectionId id)
         {
-            if (id.ServerValue.HasValue)
+            if (id.LongServerValue.HasValue)
             {
-                return id.LocalValue.ToString() + "-" + id.ServerValue.Value.ToString();
+                return id.LongLocalValue.ToString() + "-" + id.LongServerValue.Value.ToString();
             }
-            return id.LocalValue.ToString();
+            return id.LongLocalValue.ToString();
         }
 
         public static string Format(ServerId serverId)

--- a/src/MongoDB.Driver.Core/Core/Logging/StructuredLogTemplateProviders.cs
+++ b/src/MongoDB.Driver.Core/Core/Logging/StructuredLogTemplateProviders.cs
@@ -131,14 +131,14 @@ namespace MongoDB.Driver.Core.Logging
         {
             var (host, port) = connectionId.ServerId.EndPoint.GetHostAndPort();
 
-            return new object[] { connectionId.ServerId.ClusterId.Value, connectionId.LocalValue, host, port, arg1};
+            return new object[] { connectionId.ServerId.ClusterId.Value, connectionId.LongLocalValue, host, port, arg1};
         }
 
         public static object[] GetParams(ConnectionId connectionId, object arg1, object arg2)
         {
             var (host, port) = connectionId.ServerId.EndPoint.GetHostAndPort();
 
-            return new object[] { connectionId.ServerId.ClusterId.Value, connectionId.LocalValue, host, port, arg1, arg2 };
+            return new object[] { connectionId.ServerId.ClusterId.Value, connectionId.LongLocalValue, host, port, arg1, arg2 };
         }
 
         public static object[] GetParamsOmitNull(ConnectionId connectionId, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object ommitableParam)
@@ -146,9 +146,9 @@ namespace MongoDB.Driver.Core.Logging
             var (host, port) = connectionId.ServerId.EndPoint.GetHostAndPort();
 
             if (ommitableParam == null)
-                return new object[] { connectionId.ServerId.ClusterId.Value, connectionId.LocalValue, host, port, arg1, arg2, arg3, arg4, arg5, arg6, arg7, };
+                return new object[] { connectionId.ServerId.ClusterId.Value, connectionId.LongLocalValue, host, port, arg1, arg2, arg3, arg4, arg5, arg6, arg7, };
             else
-                return new object[] { connectionId.ServerId.ClusterId.Value, connectionId.LocalValue, host, port, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ommitableParam };
+                return new object[] { connectionId.ServerId.ClusterId.Value, connectionId.LongLocalValue, host, port, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ommitableParam };
         }
 
         private static void AddTemplateProvider<TEvent>(LogLevel logLevel, string template, Func<TEvent, EventLogFormattingOptions, object[]> extractor) where TEvent : struct, IEvent =>

--- a/src/MongoDB.Driver.Core/Core/Logging/StructuredLogTemplateProvidersCommand.cs
+++ b/src/MongoDB.Driver.Core/Core/Logging/StructuredLogTemplateProvidersCommand.cs
@@ -49,7 +49,7 @@ namespace MongoDB.Driver.Core.Logging
                 CommandCommonParams(DatabaseName, Command),
                 (e, o) => GetParamsOmitNull(
                     e.ConnectionId,
-                    e.ConnectionId.ServerValue,
+                    e.ConnectionId.LongServerValue,
                     e.RequestId,
                     e.OperationId,
                     "Command started",
@@ -64,7 +64,7 @@ namespace MongoDB.Driver.Core.Logging
                 CommandCommonParams(DurationMS, Reply),
                 (e, o) => GetParamsOmitNull(
                     e.ConnectionId,
-                    e.ConnectionId.ServerValue,
+                    e.ConnectionId.LongServerValue,
                     e.RequestId,
                     e.OperationId,
                     "Command succeeded",
@@ -79,7 +79,7 @@ namespace MongoDB.Driver.Core.Logging
                 CommandCommonParams(DurationMS, Failure),
                 (e, o) => GetParamsOmitNull(
                     e.ConnectionId,
-                    e.ConnectionId.ServerValue,
+                    e.ConnectionId.LongServerValue,
                     e.RequestId,
                     e.OperationId,
                     "Command failed",

--- a/src/MongoDB.Driver.Core/Core/Servers/RoundTripTimeMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/RoundTripTimeMonitor.cs
@@ -150,7 +150,7 @@ namespace MongoDB.Driver.Core.Servers
                     var connectionId = toDispose?.ConnectionId;
                     toDispose?.Dispose();
 
-                    _logger?.LogDebug(ex, StructuredLogTemplateProviders.DriverConnectionId_Message, connectionId?.LocalValue, "Monitoring exception");
+                    _logger?.LogDebug(ex, StructuredLogTemplateProviders.DriverConnectionId_Message, connectionId?.LongLocalValue, "Monitoring exception");
                 }
                 ThreadHelper.Sleep(_heartbeatInterval, _cancellationToken);
             }

--- a/src/MongoDB.Driver.Core/MongoCursorNotFoundException.cs
+++ b/src/MongoDB.Driver.Core/MongoCursorNotFoundException.cs
@@ -35,7 +35,7 @@ namespace MongoDB.Driver
                 "Cursor {0} not found on server {1} using connection {2}.",
                 cursorId,
                 EndPointHelper.ToString(connectionId.ServerId.EndPoint),
-                connectionId.ServerValue);
+                connectionId.LongServerValue);
         }
         #endregion
 

--- a/tests/AstrolabeWorkloadExecutor/AstrolabeEventFormatter.cs
+++ b/tests/AstrolabeWorkloadExecutor/AstrolabeEventFormatter.cs
@@ -121,7 +121,7 @@ namespace AstrolabeWorkloadExecutor
 
         private BsonDocument CreateCmapEventDocument(string eventName, DateTime timestamp, ConnectionId connectionId) =>
             CreateCmapEventDocument(eventName, timestamp, connectionId.ServerId)
-            .Add("connectionId", connectionId.LocalValue);
+            .Add("connectionId", connectionId.LongLocalValue);
 
         private BsonDocument CreateCommandEventDocument(string eventName, DateTime timestamp, string commandName, int requestId) =>
             new BsonDocument

--- a/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
@@ -1347,14 +1347,14 @@ namespace MongoDB.Driver.Core.ConnectionPools
                 capturedEvents
                     .Events
                     .OfType<ConnectionPoolRemovedConnectionEvent>()
-                    .Select(c => c.ConnectionId.LocalValue));
+                    .Select(c => c.ConnectionId.LongLocalValue));
 
             foreach (var connection in allConnections)
             {
                 connection.IsExpired.Should().BeTrue();
 
                 removedConnections
-                    .Contains(connection.ConnectionId.LocalValue)
+                    .Contains(connection.ConnectionId.LongLocalValue)
                     .Should().Be(connection.Generation <= maxExpiredGeneration);
             }
 
@@ -1446,14 +1446,14 @@ namespace MongoDB.Driver.Core.ConnectionPools
             _capturedEvents.Events
                 .Take(connectionsCount * 2)
                 .OfType<ConnectionPoolRemovingConnectionEvent>()
-                .Select(e => e.ConnectionId.LocalValue)
-                .ShouldBeEquivalentTo(connectionsExpired.Select(c => c.LocalValue));
+                .Select(e => e.ConnectionId.LongLocalValue)
+                .ShouldBeEquivalentTo(connectionsExpired.Select(c => c.LongLocalValue));
 
             _capturedEvents.Events
                 .Take(connectionsCount * 2)
                 .OfType<ConnectionPoolRemovedConnectionEvent>()
-                .Select(e => e.ConnectionId.LocalValue)
-                .ShouldAllBeEquivalentTo(connectionsExpired.Select(c => c.LocalValue));
+                .Select(e => e.ConnectionId.LongLocalValue)
+                .ShouldAllBeEquivalentTo(connectionsExpired.Select(c => c.LongLocalValue));
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
@@ -1343,7 +1343,7 @@ namespace MongoDB.Driver.Core.ConnectionPools
             subject.Clear(true);
 
             capturedEvents.WaitForOrThrowIfTimeout(events => events.Count() >= connectionsToBeRemovedCount, TimeSpan.FromSeconds(5));
-            var removedConnections = new HashSet<int>(
+            var removedConnections = new HashSet<long>(
                 capturedEvents
                     .Events
                     .OfType<ConnectionPoolRemovedConnectionEvent>()

--- a/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/MaintenanceHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/MaintenanceHelperTests.cs
@@ -159,7 +159,7 @@ namespace MongoDB.Driver.Core.Tests.Core.ConnectionPools
 
                 var maitenanceInPlayTimeout = TimeSpan.FromMilliseconds(50);
                 eventCapturer.WaitForEventOrThrowIfTimeout<ConnectionPoolAddedConnectionEvent>(maitenanceInPlayTimeout);
-                eventCapturer.Next().Should().BeOfType<ConnectionPoolAddedConnectionEvent>().Which.ConnectionId.LocalValue.Should().Be(1);  // minPoolSize has been enrolled
+                eventCapturer.Next().Should().BeOfType<ConnectionPoolAddedConnectionEvent>().Which.ConnectionId.LongLocalValue.Should().Be(1);  // minPoolSize has been enrolled
                 eventCapturer.Any().Should().BeFalse();
 
                 SpinWait.SpinUntil(() => pool.ConnectionHolder._connections().Count > 0, TimeSpan.FromSeconds(1)).Should().BeTrue(); // wait until connection 1 has been returned to the pool after minPoolSize logic
@@ -168,7 +168,7 @@ namespace MongoDB.Driver.Core.Tests.Core.ConnectionPools
                 if (checkOutConnection)
                 {
                     acquiredConnection = pool.AcquireConnection(CancellationToken.None);
-                    acquiredConnection.ConnectionId.LocalValue.Should().Be(1);
+                    acquiredConnection.ConnectionId.LongLocalValue.Should().Be(1);
                 }
 
                 IncrementGeneration(pool);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionIdTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionIdTests.cs
@@ -17,7 +17,6 @@ using System;
 using System.Net;
 using FluentAssertions;
 using MongoDB.Driver.Core.Clusters;
-using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Servers;
 using Xunit;
 
@@ -74,7 +73,7 @@ namespace MongoDB.Driver.Core.Connections
         }
 
         [Fact]
-        public void LocalValues_of_2_ids_should_not_be_the_same_when_automically_constructed()
+        public void LocalValues_of_2_ids_should_not_be_the_same_when_automatically_constructed()
         {
             var subject = new ConnectionId(__serverId);
             var subject2 = new ConnectionId(__serverId);
@@ -82,22 +81,28 @@ namespace MongoDB.Driver.Core.Connections
             subject.LocalValue.Should().NotBe(subject2.LocalValue);
         }
 
-        [Fact]
-        public void LocalValue_should_be_what_was_specified_in_the_constructor()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(int.MaxValue)]
+        [InlineData((long)int.MaxValue+1)]
+        public void LocalValue_should_be_what_was_specified_in_the_constructor(long localValue)
         {
-            var subject = new ConnectionId(__serverId, 10);
+            var subject = new ConnectionId(__serverId, localValue);
 
-            subject.LocalValue.Should().Be(10);
+            subject.LocalValue.Should().Be(localValue);
         }
 
-        [Fact]
-        public void WithServerValue_should_set_the_server_value_and_leave_the_LocalValue_alone()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(int.MaxValue)]
+        [InlineData((long)int.MaxValue+1)]
+        public void WithServerValue_should_set_the_server_value_and_leave_the_LocalValue_alone(long serverValue)
         {
             var subject = new ConnectionId(__serverId, 10)
-                .WithServerValue(11);
+                .WithServerValue(serverValue);
 
             subject.LocalValue.Should().Be(10);
-            subject.ServerValue.Should().Be(11);
+            subject.ServerValue.Should().Be(serverValue);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionIdTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionIdTests.cs
@@ -73,23 +73,23 @@ namespace MongoDB.Driver.Core.Connections
         }
 
         [Fact]
-        public void LocalValues_of_2_ids_should_not_be_the_same_when_automatically_constructed()
+        public void LongLocalValues_of_2_ids_should_not_be_the_same_when_automatically_constructed()
         {
             var subject = new ConnectionId(__serverId);
             var subject2 = new ConnectionId(__serverId);
 
-            subject.LocalValue.Should().NotBe(subject2.LocalValue);
+            subject.LongLocalValue.Should().NotBe(subject2.LongLocalValue);
         }
 
         [Theory]
         [InlineData(0)]
         [InlineData(int.MaxValue)]
         [InlineData((long)int.MaxValue+1)]
-        public void LocalValue_should_be_what_was_specified_in_the_constructor(long localValue)
+        public void LongLocalValue_should_be_what_was_specified_in_the_constructor(long localValue)
         {
             var subject = new ConnectionId(__serverId, localValue);
 
-            subject.LocalValue.Should().Be(localValue);
+            subject.LongLocalValue.Should().Be(localValue);
         }
 
         [Theory]
@@ -101,8 +101,8 @@ namespace MongoDB.Driver.Core.Connections
             var subject = new ConnectionId(__serverId, 10)
                 .WithServerValue(serverValue);
 
-            subject.LocalValue.Should().Be(10);
-            subject.ServerValue.Should().Be(serverValue);
+            subject.LongLocalValue.Should().Be(10);
+            subject.LongServerValue.Should().Be(serverValue);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -130,7 +130,7 @@ namespace MongoDB.Driver.Core.Connections
 
             var sentMessages = connection.GetSentMessages();
             sentMessages.Should().HaveCount(1);
-            result.ConnectionId.ServerValue.Should().Be(1);
+            result.ConnectionId.LongServerValue.Should().Be(1);
         }
 
         [Theory]
@@ -148,7 +148,7 @@ namespace MongoDB.Driver.Core.Connections
 
             var sentMessages = connection.GetSentMessages();
             sentMessages.Should().HaveCount(1);
-            result.ConnectionId.ServerValue.Should().Be(1);
+            result.ConnectionId.LongServerValue.Should().Be(1);
         }
 
         [Theory]
@@ -204,7 +204,7 @@ namespace MongoDB.Driver.Core.Connections
 
             var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
-            result.ConnectionId.ServerValue.Should().Be(1);
+            result.ConnectionId.LongServerValue.Should().Be(1);
 
             SpinWait.SpinUntil(() => connection.GetSentMessages().Count >= 1, TimeSpan.FromSeconds(5)).Should().BeTrue();
 
@@ -231,7 +231,7 @@ namespace MongoDB.Driver.Core.Connections
 
             var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
-            result.ConnectionId.ServerValue.Should().Be(1);
+            result.ConnectionId.LongServerValue.Should().Be(1);
 
             SpinWait.SpinUntil(() => connection.GetSentMessages().Count >= 1, TimeSpan.FromSeconds(5)).Should().BeTrue();
 
@@ -264,7 +264,7 @@ namespace MongoDB.Driver.Core.Connections
             var result = InitializeConnection(subject, connection, async, CancellationToken.None);
 
             result.MaxWireVersion.Should().Be(6);
-            result.ConnectionId.ServerValue.Should().Be(10);
+            result.ConnectionId.LongServerValue.Should().Be(10);
             result.AvailableCompressors.Count.Should().Be(1);
             result.AvailableCompressors.Should().Contain(ToCompressorTypeEnum(compressorType));
 

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
@@ -210,7 +210,7 @@ namespace MongoDB.Driver.Specifications.connection_monitoring_and_pooling
                 }
                 else
                 {
-                    actualEvent.ConnectionId().LocalValue.Should().Be(expectedConnectionId);
+                    actualEvent.ConnectionId().LongLocalValue.Should().Be(expectedConnectionId);
                 }
             }
 
@@ -693,7 +693,7 @@ namespace MongoDB.Driver.Specifications.connection_monitoring_and_pooling
 
                         var connectionIdsToIgnore = new HashSet<long>(eventCapturer.Events
                             .OfType<ConnectionCreatedEvent>()
-                            .Select(c => c.ConnectionId.LocalValue)
+                            .Select(c => c.ConnectionId.LongLocalValue)
                             .ToList());
 
                         eventsFilter = o =>
@@ -704,7 +704,7 @@ namespace MongoDB.Driver.Specifications.connection_monitoring_and_pooling
                                 or ConnectionFailedEvent)
                             {
                                 var connectionId = o.ConnectionId();
-                                return !connectionIdsToIgnore.Contains(connectionId.LocalValue) &&
+                                return !connectionIdsToIgnore.Contains(connectionId.LongLocalValue) &&
                                     EndPointHelper.Equals(connectionId.ServerId.EndPoint, server.EndPoint);
                             }
 

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
@@ -691,7 +691,7 @@ namespace MongoDB.Driver.Specifications.connection_monitoring_and_pooling
                     {
                         eventCapturer.WaitForOrThrowIfTimeout(events => events.Any(e => e is ConnectionCreatedEvent), TimeSpan.FromMilliseconds(500));
 
-                        var connectionIdsToIgnore = new HashSet<int>(eventCapturer.Events
+                        var connectionIdsToIgnore = new HashSet<long>(eventCapturer.Events
                             .OfType<ConnectionCreatedEvent>()
                             .Select(c => c.ConnectionId.LocalValue)
                             .ToList());

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
@@ -618,7 +618,7 @@ namespace MongoDB.Driver.Specifications.connection_monitoring_and_pooling
 
         private void ResetConnectionId()
         {
-            IdGeneratorReflector.__lastId(0);
+            LongIdGeneratorReflector.__lastId(0);
         }
 
         private (IConnectionPool, FailPoint, ICluster, Func<object, bool>) SetupConnectionData(BsonDocument test, EventCapturer eventCapturer, bool isUnit)
@@ -844,9 +844,9 @@ namespace MongoDB.Driver.Specifications.connection_monitoring_and_pooling
         }
     }
 
-    internal static class IdGeneratorReflector
+    internal static class LongIdGeneratorReflector
     {
-        public static void __lastId(int value) => Reflector.SetStaticFieldValue(typeof(IdGenerator<ConnectionId>), nameof(__lastId), value);
+        public static void __lastId(int value) => Reflector.SetStaticFieldValue(typeof(LongIdGenerator<ConnectionId>), nameof(__lastId), value);
     }
 
     internal static class IServerReflector

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedEventMatcher.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedEventMatcher.cs
@@ -248,7 +248,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
                 // So even though servers less than 4.2 don't provide connectionId, we still have this value through getLastError, so don't assert hasServerConnectionId=false.
                 if (value)
                 {
-                    connectionId.ServerValue.Should().HaveValue();
+                    connectionId.LongServerValue.Should().HaveValue();
                 }
             }
         }


### PR DESCRIPTION
ConnectionId should use longs for LocalValue and ServerValue to match 64-bit integer connectionId returned from the server.