### PR TITLE
CSHARP-4442: Hide aws sdk in release package.

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.14" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.14" PrivateAssets="All" />
     <PackageReference Include="DnsClient" Version="1.6.1" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.14" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Without applied fix, a consumer will see:
![image](https://user-images.githubusercontent.com/44870738/205463806-d5f43350-2bde-407e-bd80-1b6da7596485.png)
and therefore will be able to use aws sdk public classes.
The applied change hides this internal (for the driver) classes from consumers. 
![image](https://user-images.githubusercontent.com/44870738/205463835-17b73f89-9f43-40a0-b51c-5d2fba50e082.png)
As a result, aws.sdk public classes will be unavailable for driver's consumers