### PR TITLE
CSHARP-4465: Include correct type in exception in BsonTypeMapper.MapToDotNetValue.

### DIFF
--- a/src/MongoDB.Bson/ObjectModel/BsonTypeMapper.cs
+++ b/src/MongoDB.Bson/ObjectModel/BsonTypeMapper.cs
@@ -407,7 +407,7 @@ namespace MongoDB.Bson
                     }
                     else
                     {
-                        var message = string.Format("A BsonDocument can't be mapped to a {0}.", BsonUtils.GetFriendlyTypeName(options.MapBsonArrayTo));
+                        var message = string.Format("A BsonDocument can't be mapped to a {0}.", BsonUtils.GetFriendlyTypeName(options.MapBsonDocumentTo));
                         throw new NotSupportedException(message);
                     }
                 case BsonType.Double:


### PR DESCRIPTION
The error message to display when a BsonDocument is being mapped to an invalid type showed the target type name for BsonArray.