### PR TITLE
CSHARP-4496: Add decimal support to ObjectSerializer.

### DIFF
--- a/src/MongoDB.Bson/IO/JsonReader.cs
+++ b/src/MongoDB.Bson/IO/JsonReader.cs
@@ -804,6 +804,9 @@ namespace MongoDB.Bson.IO
                 case BsonType.DateTime:
                     ReadDateTime();
                     break;
+                case BsonType.Decimal128:
+                    ReadDecimal128();
+                    break;
                 case BsonType.Document:
                     ReadStartDocument();
                     while (ReadBsonType() != BsonType.EndOfDocument)

--- a/src/MongoDB.Bson/Serialization/Serializers/ObjectSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ObjectSerializer.cs
@@ -272,6 +272,10 @@ namespace MongoDB.Bson.Serialization.Serializers
                                 bsonWriter.WriteDateTime(bsonDateTime.MillisecondsSinceEpoch);
                                 return;
 
+                            case TypeCode.Decimal:
+                                bsonWriter.WriteDecimal128((decimal)value);
+                                return;
+
                             case TypeCode.Double:
                                 bsonWriter.WriteDouble((double)value);
                                 return;

--- a/tests/MongoDB.Bson.Tests/Jira/CSharp4496.cs
+++ b/tests/MongoDB.Bson.Tests/Jira/CSharp4496.cs
@@ -1,0 +1,34 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using FluentAssertions;
+using MongoDB.Bson.Serialization;
+using Xunit;
+
+namespace MongoDB.Bson.Tests.Jira
+{
+
+    public class CSharp4496
+    {
+        [Fact]
+        public void ObjectSerializer_should_deserialize_decimals_successfully()
+        {
+            const string json = "{ 'Object' : NumberDecimal('1.5') }";
+
+            dynamic rehydrated = BsonSerializer.Deserialize<object>(json);
+            ((decimal)rehydrated.Object).Should().Be(1.5m);
+        }
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/ObjectSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/ObjectSerializerTests.cs
@@ -112,6 +112,19 @@ namespace MongoDB.Bson.Tests.Serialization
         }
 
         [Fact]
+        public void TestDecimal()
+        {
+            var c = new C { Obj = 1.5M };
+            var json = c.ToJson();
+            var expected = "{ 'Obj' : NumberDecimal('1.5') }".Replace("'", "\"");
+            Assert.Equal(expected, json);
+
+            var bson = c.ToBson();
+            var rehydrated = BsonSerializer.Deserialize<C>(bson);
+            Assert.True(bson.SequenceEqual(rehydrated.ToBson()));
+        }
+
+        [Fact]
         public void TestDecimal128()
         {
             var c = new C { Obj = (Decimal128)1.5M };


### PR DESCRIPTION
Added support for `ObjectSerializer` to both read and write `Decimal128` data type.