### PR TITLE
CSHARP-4483: connectionId returned in heartbeats may be int32, double, or int64.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ConnectionInitializer.cs
@@ -176,7 +176,7 @@ namespace MongoDB.Driver.Core.Connections
             return description;
         }
 
-        private ConnectionDescription UpdateConnectionIdWithServerValue(ConnectionDescription description, int serverValue)
+        private ConnectionDescription UpdateConnectionIdWithServerValue(ConnectionDescription description, long serverValue)
         {
             var connectionId = description.ConnectionId.WithServerValue(serverValue);
             description = description.WithConnectionId(connectionId);

--- a/src/MongoDB.Driver.Core/Core/Connections/HelloResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/HelloResult.cs
@@ -72,13 +72,13 @@ namespace MongoDB.Driver.Core.Connections
         /// <summary>
         /// Gets the connection id server value.
         /// </summary>
-        public int? ConnectionIdServerValue
+        public long? ConnectionIdServerValue
         {
             get
             {
                 if (_wrapped.TryGetValue("connectionId", out var connectionIdBsonValue))
                 {
-                    return connectionIdBsonValue.ToInt32();
+                    return connectionIdBsonValue.ToInt64();
                 }
 
                 return null;

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionInitializerTests.cs
@@ -128,7 +128,9 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
-        public void InitializeConnection_should_acquire_connectionId_from_hello_response([Values(1, int.MaxValue, (long)int.MaxValue + 1, long.MaxValue, 1d, (double)int.MaxValue+1, (double)int.MaxValue*4)] object serverConnectionId, [Values(false, true)] bool async)
+        public void InitializeConnection_should_acquire_connectionId_from_hello_response(
+            [Values(1, int.MaxValue, (long)int.MaxValue + 1, long.MaxValue, 1d, (double)int.MaxValue+1, (double)int.MaxValue*4)] object serverConnectionId,
+            [Values(false, true)] bool async)
         {
             var formattedServerConnectionId = $"{serverConnectionId}" + (serverConnectionId is double ? ".0" : "");
             var helloResponse = MessageHelper.BuildCommandResponse(RawBsonDocumentHelper.FromJson($"{{ ok : 1, connectionId : {formattedServerConnectionId} }}"));
@@ -146,7 +148,9 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
-        public void InitializeConnection_should_acquire_connectionId_from_legacy_hello_response([Values(1, int.MaxValue, (long)int.MaxValue + 1, long.MaxValue, 1d, (double)int.MaxValue+1, (double)int.MaxValue*4)] object serverConnectionId, [Values(false, true)] bool async)
+        public void InitializeConnection_should_acquire_connectionId_from_legacy_hello_response(
+            [Values(1, int.MaxValue, (long)int.MaxValue + 1, long.MaxValue, 1d, (double)int.MaxValue+1, (double)int.MaxValue*4)] object serverConnectionId,
+            [Values(false, true)] bool async)
         {
             var formattedServerConnectionId = $"{serverConnectionId}" + (serverConnectionId is double ? ".0" : "");
             var legacyHelloReply = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson($"{{ ok : 1, connectionId : {formattedServerConnectionId} }}"));


### PR DESCRIPTION
Although CSHARP-4417 changes the client and server connectionIds to use `int64`, the server description update code path was not tested. The update code path is where the server response is used update the `ConnectionId.LongServerValue`. `HelloResult.ConnectionIdServerValue` still parsed `connectionId` in the response as an `int32`. This has been fixed and additional tests added.

Although `HelloResult` is public, it is in Core. We renamed this class during the offensive language removal initiative and no one complained. Thus changing the data type of `HelloResult.ConnectionIdServerValue` from `int?` to `long?` shouldn't be problematic.