### PR TITLE
Update Release Notes v2.19.0.md

### DIFF
--- a/Release Notes/Release Notes v2.19.0.md
+++ b/Release Notes/Release Notes v2.19.0.md
@@ -45,3 +45,13 @@ An online version of these release notes is available [here](https://github.com/
 The full list of issues resolved in this release is available at [CSHARP JIRA project](https://jira.mongodb.org/issues/?jql=project%20%3D%20CSHARP%20AND%20fixVersion%20%3D%202.19.0%20ORDER%20BY%20key%20ASC).
 
 Documentation on the .NET driver can be found [here](https://www.mongodb.com/docs/drivers/csharp/v2.19/).
+
+## Upgrading
+
+If you upgrating from v2.18 and use `new BsonDateTime(date)` in filters you need to remove it and keep just the date. Example:
+
+```
+var filter = Builders<SomeClass>.Filter.Eq(x => x.CreatedAt, new BsonDateTime(DateTime.Now));
+// Change to
+var filter = Builders<SomeClass>.Filter.Eq(x => x.CreatedAt, DateTime.Now);
+```


### PR DESCRIPTION
Added an upgrade tip to fix error with BsonDateTime.

When upgrading from v2.18 an error occurs if a filter is using `new BsonDateTime()` with a date as parameter. Example:
```
    class Program
    {
        static void Main(string[] args)
        {
            var mongo = new MongoClient("mongodb://localhost:27017/test");
            var db = mongo.GetDatabase("test");

            db.DropCollection("employee");
            db.CreateCollection("employee");

            var collection = db.GetCollection<Employee>("employee");

            var today = DateTime.Now;
            
            collection.InsertOne(new Employee { CreatedAt = today });
            
            var filter = Builders<Employee>.Filter.Eq(x => x.CreatedAt, new BsonDateTime(today));            

            collection.Find(filter).ToList();
        }
    }

    public class Employee
    {
        [BsonId]
        [BsonRepresentation(BsonType.ObjectId)]
        public string Id { get; set; }
        
        public DateTime CreatedAt { get; set; }        
    }
```

In the last version this throws `MongoDB.Driver.Linq.ExpressionNotSupportedException`. To use version v2.19 filter have to be changed to:
`var filter = Builders<Employee>.Filter.Eq(x => x.CreatedAt, today);`
