### PR TITLE
CSHARP-4605 Clean up Azure resources on task failure

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1825,6 +1825,10 @@ task_groups:
         params:
           file: testazurekms-expansions.yml
     teardown_group:
+      # Load expansions again. The setup task may have failed before running `expansions.update`.
+      - command: expansions.update
+        params:
+          file: testazurekms-expansions.yml
       - command: shell.exec
         params:
           shell: "bash"


### PR DESCRIPTION
# Summary
- Reload expansions before deleting Azure resources

Verified with this patch: https://spruce.mongodb.com/version/64345699d1fe076755db75cc/

# Background & Motivation

This is an improvement to the `testazurekms_task_group` added as part of DRIVERS-2411. https://github.com/mongodb/mongo-c-driver/pull/1234 explains this improvement.
