### PR TITLE
CSHARP-4595: Support GridFS with Stable API.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -118,6 +118,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __snapshotReads = new Feature("SnapshotReads", WireVersion.Server50, notSupportedMessage: "Snapshot reads require MongoDB 5.0 or later");
         private static readonly Feature __sortArrayOperator = new Feature("SortArrayOperator", WireVersion.Server52);
         private static readonly Feature __speculativeAuthentication = new Feature("SpeculativeAuthentication", WireVersion.Server44);
+        private static readonly Feature __stableApi = new Feature("StableAPI", WireVersion.Server50);
         private static readonly Feature __streamingHello = new Feature("StreamingHello", WireVersion.Server44);
         private static readonly Feature __tailableCursor = new Feature("TailableCursor", WireVersion.Server32);
         private static readonly Feature __toConversionOperators = new Feature("ToConversionOperators", WireVersion.Server40);
@@ -655,6 +656,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the speculative authentication feature.
         /// </summary>
         public static Feature SpeculativeAuthentication => __speculativeAuthentication;
+
+        /// <summary>
+        /// Gets the speculative authentication feature.
+        /// </summary>
+        public static Feature StableApi => __stableApi;
 
         /// <summary>
         /// Gets the streaming hello feature.

--- a/src/MongoDB.Driver.GridFS/GridFSBucket.cs
+++ b/src/MongoDB.Driver.GridFS/GridFSBucket.cs
@@ -17,11 +17,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
-using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Bindings;
@@ -643,7 +641,7 @@ namespace MongoDB.Driver.GridFS
                 Filter = renderedFilter,
                 Limit = options.Limit,
                 MaxTime = options.MaxTime,
-                NoCursorTimeout = options.NoCursorTimeout ?? false,
+                NoCursorTimeout = options.NoCursorTimeout,
                 ReadConcern = GetReadConcern(),
                 RetryRequested = _database.Client.Settings.RetryReads,
                 Skip = options.Skip,


### PR DESCRIPTION
`GridFSBucket.Find` was failing because we always included `noCursorTimeout` even when not specified. `noCursorTimeout` is not supported with Stable API. That change was simple (removing the defaulting to false), but we had no integration tests around GridFS. Additionally while we test Stable API, we don't test it in strict mode nor do we have a mechanism to do so. I added `Feature.StableApi` so that I could write a strict mode Stable API test. Feedback appreciated especially if you can think of a better way to test it.