### PR TITLE
Added a test that verifies CSHARP-4637

### DIFF
--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/ObjectSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/ObjectSerializerTests.cs
@@ -142,6 +142,34 @@ namespace MongoDB.Bson.Tests.Serialization
         }
 
         [Fact]
+        public void BsonTestDecimal128()
+        {
+            var c = new C { Obj = new Decimal128(1.5M) };
+            var json = c.ToJson();
+            var expected = "{ 'Obj' : NumberDecimal('1.5') }".Replace("'", "\"");
+            Assert.Equal(expected, json);
+
+            var bson = c.ToBson();
+            var rehydrated = BsonSerializer.Deserialize<C>(bson);
+            Assert.True(bson.SequenceEqual(rehydrated.ToBson()));
+            Assert.True(rehydrated.Obj is Decimal128);
+        }
+
+        [Fact]
+        public void PureTestDecimal128()
+        {
+            var c = new C { Obj = 1.5M };
+            var json = c.ToJson();
+            var expected = "{ 'Obj' : NumberDecimal('1.5') }".Replace("'", "\"");
+            Assert.Equal(expected, json);
+
+            var bson = c.ToBson();
+            var rehydrated = BsonSerializer.Deserialize<C>(bson);
+            Assert.True(bson.SequenceEqual(rehydrated.ToBson()));
+            Assert.True(rehydrated.Obj is Decimal);
+        }
+
+        [Fact]
         public void TestDouble()
         {
             var c = new C { Obj = 1.5 };


### PR DESCRIPTION
I've added a test that verifies bug I've opened in jira [CSHARP-4637](https://jira.mongodb.org/projects/CSHARP/issues/CSHARP-4637). Actually the bug was introduced in commit 9bbca930bc062c36f806a6d17dbf3a40d97ff831 when base serialization for decimal whas changed to Decimal128 actually breaking serialization as showed in the test.

Also I think that tests for serialization / deserialization are not entirely correct, you should verify that the rehydrated object in memory is the same of the original object.
