### PR TITLE
 [s390x] Add MongoDB.Driver support for big-endian clients

### DIFF
--- a/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
+++ b/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
@@ -307,7 +307,7 @@ namespace MongoDB.Bson.IO
         {
             ThrowIfDisposed();
             this.ReadBytes(_temp, 0, 8);
-            return BitConverter.ToDouble(_temp, 0);
+            return PacketBitConverter.ToDouble(_temp, 0);
         }
 
         /// <inheritdoc/>
@@ -323,7 +323,7 @@ namespace MongoDB.Bson.IO
         {
             ThrowIfDisposed();
             this.ReadBytes(_temp, 0, 8);
-            return BitConverter.ToInt64(_temp, 0);
+            return PacketBitConverter.ToInt64(_temp, 0);
         }
 
         /// <inheritdoc/>
@@ -494,7 +494,7 @@ namespace MongoDB.Bson.IO
         public override void WriteDouble(double value)
         {
             ThrowIfDisposed();
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = PacketBitConverter.GetBytes(value);
             _stream.Write(bytes, 0, 8);
         }
 
@@ -513,7 +513,7 @@ namespace MongoDB.Bson.IO
         public override void WriteInt64(long value)
         {
             ThrowIfDisposed();
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = PacketBitConverter.GetBytes(value);
             _stream.Write(bytes, 0, 8);
         }
 

--- a/src/MongoDB.Bson/IO/ByteBufferStream.cs
+++ b/src/MongoDB.Bson/IO/ByteBufferStream.cs
@@ -418,12 +418,12 @@ namespace MongoDB.Bson.IO
             if (segment.Count >= 8)
             {
                 _position += 8;
-                return BitConverter.ToDouble(segment.Array, segment.Offset);
+                return PacketBitConverter.ToDouble(segment.Array, segment.Offset);
             }
             else
             {
                 this.ReadBytes(_temp, 0, 8);
-                return BitConverter.ToDouble(_temp, 0);
+                return PacketBitConverter.ToDouble(_temp, 0);
             }
         }
 
@@ -458,12 +458,12 @@ namespace MongoDB.Bson.IO
             if (segment.Count >= 8)
             {
                 _position += 8;
-                return BitConverter.ToInt64(segment.Array, segment.Offset);
+                return PacketBitConverter.ToInt64(segment.Array, segment.Offset);
             }
             else
             {
                 this.ReadBytes(_temp, 0, 8);
-                return BitConverter.ToInt64(_temp, 0);
+                return PacketBitConverter.ToInt64(_temp, 0);
             }
         }
 
@@ -637,7 +637,7 @@ namespace MongoDB.Bson.IO
 
             PrepareToWrite(8);
 
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = PacketBitConverter.GetBytes(value);
             _buffer.SetBytes(_position, bytes, 0, 8);
 
             SetPositionAfterWrite(_position + 8);
@@ -677,7 +677,7 @@ namespace MongoDB.Bson.IO
 
             PrepareToWrite(8);
 
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = PacketBitConverter.GetBytes(value);
             _buffer.SetBytes(_position, bytes, 0, 8);
 
             SetPositionAfterWrite(_position + 8);
@@ -731,7 +731,7 @@ namespace MongoDB.Bson.IO
                 var bytes = rentedSegmentEncoded.Segment.Array;
                 actualLength = rentedSegmentEncoded.Segment.Count;
 
-                var lengthPlusOneBytes = BitConverter.GetBytes(actualLength + 1);
+                var lengthPlusOneBytes = PacketBitConverter.GetBytes(actualLength + 1);
 
                 _buffer.SetBytes(_position, lengthPlusOneBytes, 0, 4);
                 _buffer.SetBytes(_position + 4, bytes, 0, actualLength);

--- a/src/MongoDB.Bson/IO/ElementAppendingBsonWriter.cs
+++ b/src/MongoDB.Bson/IO/ElementAppendingBsonWriter.cs
@@ -83,7 +83,7 @@ namespace MongoDB.Bson.IO
                 // just copy the bytes (without the length and terminating null)
                 var lengthBytes = new byte[4];
                 slice.GetBytes(0, lengthBytes, 0, 4);
-                var length = BitConverter.ToInt32(lengthBytes, 0);
+                var length = PacketBitConverter.ToInt32(lengthBytes, 0);
                 using (var elements = slice.GetSlice(4, length - 5))
                 {
                     var stream = binaryWriter.BsonStream;

--- a/src/MongoDB.Bson/IO/PacketBitConverter.cs
+++ b/src/MongoDB.Bson/IO/PacketBitConverter.cs
@@ -1,0 +1,96 @@
+using System;
+
+namespace MongoDB.Bson.IO
+{
+    #pragma warning disable 1591
+
+    public static class PacketBitConverter
+    {
+        // Due to the lack of support of the C# BinaryPrimitives class
+        // on netstandard2.0 this class is necessary for back compatibility.
+        // All instances of use of methods of this class can be replaced with corresponding
+        // BinaryPrimitives methods for future versions.
+
+        // MongoDB sends packets in LittleEndian encoding
+        // The methods provided by the BitConverter class check for the
+        // endianness of the client system and do conversions accordingly
+        // which lead to incorrect conversions on BigEndian client systems
+
+        // Following function are analogous with BinaryPrimitives.Write*LittleEndian
+        public static byte[] GetBytes(int value)
+        {
+            return new byte[] {
+                (byte)value, (byte)(value >> 8), (byte)(value >> 16), (byte)(value >> 24)
+            };
+        }
+
+        public static byte[] GetBytes(long value)
+        {
+            return new byte[] {
+                (byte)value, (byte)(value >> 8), (byte)(value >> 16), (byte)(value >> 24),
+                (byte)(value >> 32), (byte)(value >> 40), (byte)(value >> 48), (byte)(value >> 56)
+            };
+        }
+
+        unsafe public static byte[] GetBytes(float value)
+        {
+            int val = *(int*)&value;
+            return GetBytes(val);
+        }
+
+        unsafe public static byte[] GetBytes(double value)
+        {
+            long val = *(long*)&value;
+            return GetBytes(val);
+        }
+
+        // Following functions are analogous to BinaryPrimitives.Read*LittleEndian
+        unsafe public static float ToSingle(byte[] byteArray, int startIndex)
+        {
+            int val = ToInt32(byteArray, startIndex);
+            return *(float*)&val;
+        }
+
+        unsafe public static double ToDouble(byte[] byteArray, int startIndex)
+        {
+            long val = ToInt64(byteArray, startIndex);
+            return *(double*)&val;
+        }
+
+        [CLSCompliant(false)]
+        public static ushort ToUInt16(byte[] byteArray, int startIndex)
+        {
+            return (ushort)(byteArray[startIndex++] | byteArray[startIndex] << 8);
+        }
+
+        [CLSCompliant(false)]
+        public static uint ToUInt32(byte[] byteArray, int startIndex)
+        {
+            return (uint)(byteArray[startIndex++] | byteArray[startIndex++] << 8
+                  | byteArray[startIndex++] << 16 | byteArray[startIndex] << 24);
+        }
+
+        [CLSCompliant(false)]
+        public static ulong ToUInt64(byte[] byteArray, int startIndex)
+        {
+            return (ulong)ToUInt32(byteArray, startIndex) + ((ulong)ToUInt32(byteArray, startIndex+4) << 32);
+        }
+
+        public static short ToInt16(byte[] byteArray, int startIndex)
+        {
+            return (short)ToUInt16(byteArray, startIndex);
+        }
+
+        public static int ToInt32(byte[] byteArray, int startIndex)
+        {
+            return (int)ToUInt32(byteArray, startIndex);
+        }
+
+        public static long ToInt64(byte[] byteArray, int startIndex)
+        {
+            return (long)ToUInt64(byteArray, startIndex);
+        }
+    }
+
+    #pragma warning restore 1591
+}

--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -10,6 +10,7 @@
     <Description>Official MongoDB supported BSON library. See https://www.mongodb.com/docs/drivers/csharp/ for more details.</Description>
     <PackageDescription>MongoDB's Official Bson Library.</PackageDescription>
     <PackageTags>$(PackageTags);bson</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MongoDB.Bson/ObjectModel/GuidConverter.cs
+++ b/src/MongoDB.Bson/ObjectModel/GuidConverter.cs
@@ -39,31 +39,19 @@ namespace MongoDB.Bson
             switch (representation)
             {
                 case GuidRepresentation.CSharpLegacy:
-                    if (!BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
                     break;
                 case GuidRepresentation.JavaLegacy:
                     Array.Reverse(bytes, 0, 8);
                     Array.Reverse(bytes, 8, 8);
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
+                    Array.Reverse(bytes, 0, 4);
+                    Array.Reverse(bytes, 4, 2);
+                    Array.Reverse(bytes, 6, 2);
                     break;
                 case GuidRepresentation.PythonLegacy:
                 case GuidRepresentation.Standard:
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
+                    Array.Reverse(bytes, 0, 4);
+                    Array.Reverse(bytes, 4, 2);
+                    Array.Reverse(bytes, 6, 2);
                     break;
                 case GuidRepresentation.Unspecified:
                     throw new InvalidOperationException("Unable to convert byte array to Guid because GuidRepresentation is Unspecified.");
@@ -107,31 +95,19 @@ namespace MongoDB.Bson
             switch (guidRepresentation)
             {
                 case GuidRepresentation.CSharpLegacy:
-                    if (!BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
                     break;
                 case GuidRepresentation.JavaLegacy:
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
+                    Array.Reverse(bytes, 0, 4);
+                    Array.Reverse(bytes, 4, 2);
+                    Array.Reverse(bytes, 6, 2);
                     Array.Reverse(bytes, 0, 8);
                     Array.Reverse(bytes, 8, 8);
                     break;
                 case GuidRepresentation.PythonLegacy:
                 case GuidRepresentation.Standard:
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
+                    Array.Reverse(bytes, 0, 4);
+                    Array.Reverse(bytes, 4, 2);
+                    Array.Reverse(bytes, 6, 2);
                     break;
                 case GuidRepresentation.Unspecified:
                     throw new InvalidOperationException("Unable to convert Guid to byte array because GuidRepresentation is Unspecified.");

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -315,7 +315,7 @@ namespace MongoDB.Driver.Core.Connections
             {
                 var messageSizeBytes = new byte[4];
                 _stream.ReadBytes(messageSizeBytes, 0, 4, cancellationToken);
-                var messageSize = BitConverter.ToInt32(messageSizeBytes, 0);
+                var messageSize = PacketBitConverter.ToInt32(messageSizeBytes, 0);
                 EnsureMessageSizeIsValid(messageSize);
                 var inputBufferChunkSource = new InputBufferChunkSource(BsonChunkPool.Default);
                 var buffer = ByteBufferFactory.Create(inputBufferChunkSource, messageSize);
@@ -385,7 +385,7 @@ namespace MongoDB.Driver.Core.Connections
                 var messageSizeBytes = new byte[4];
                 var readTimeout = _stream.CanTimeout ? TimeSpan.FromMilliseconds(_stream.ReadTimeout) : Timeout.InfiniteTimeSpan;
                 await _stream.ReadBytesAsync(messageSizeBytes, 0, 4, readTimeout, cancellationToken).ConfigureAwait(false);
-                var messageSize = BitConverter.ToInt32(messageSizeBytes, 0);
+                var messageSize = PacketBitConverter.ToInt32(messageSizeBytes, 0);
                 EnsureMessageSizeIsValid(messageSize);
                 var inputBufferChunkSource = new InputBufferChunkSource(BsonChunkPool.Default);
                 var buffer = ByteBufferFactory.Create(inputBufferChunkSource, messageSize);
@@ -797,7 +797,7 @@ namespace MongoDB.Driver.Core.Connections
             private int GetResponseTo(IByteBuffer message)
             {
                 var backingBytes = message.AccessBackingBytes(8);
-                return BitConverter.ToInt32(backingBytes.Array, backingBytes.Offset);
+                return PacketBitConverter.ToInt32(backingBytes.Array, backingBytes.Offset);
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/KeepAliveValues.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/KeepAliveValues.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using MongoDB.Bson.IO;
 
 namespace MongoDB.Driver.Core.Connections
 {
@@ -30,9 +31,9 @@ namespace MongoDB.Driver.Core.Connections
         public byte[] ToBytes()
         {
             var bytes = new byte[12];
-            Array.Copy(BitConverter.GetBytes(OnOff), 0, bytes, 0, 4);
-            Array.Copy(BitConverter.GetBytes(KeepAliveTime), 0, bytes, 4, 4);
-            Array.Copy(BitConverter.GetBytes(KeepAliveInterval), 0, bytes, 8, 4);
+            Array.Copy(PacketBitConverter.GetBytes(OnOff), 0, bytes, 0, 4);
+            Array.Copy(PacketBitConverter.GetBytes(KeepAliveTime), 0, bytes, 4, 4);
+            Array.Copy(PacketBitConverter.GetBytes(KeepAliveInterval), 0, bytes, 8, 4);
             return bytes;
         }
     }


### PR DESCRIPTION
The current MongoDB.Driver causes a crash when used on big-endian systems. This error stems from the use of BitConverter function used in method definitions across the code.

The BitConverter class does conversions according to the endianess of the system it is operating on which causes incorrect reads of little-endian packets sent by the server.

BitConverter can be replaced with BinaryPrimitives provided by C# but due to their lack of support for netstandard2.0 and to maintain backcompatibility implemented a PacketBitConverter under MongoDB.Bson.IO namespace.

With the changes the following error is fixed:
```
Unhandled Exception:
System.TimeoutException: A timeout occurred after 30000ms selecting a server using CompositeServerSelector{ Selectors = MongoDB.Driver.MongoClient+AreSessionsSupportedServerSelector, LatencyLimitingServerSelector{ AllowedLatencyRange = 00:00:00.0150000 }, OperationsCountServerSelector }. Client view of cluster state is { ClusterId : "1", Type : "Unknown", State : "Disconnected", Servers : [{ ServerId: "{ ClusterId : 1, EndPoint : "127.0.0.1:27017" }", EndPoint: "127.0.0.1:27017", ReasonChanged: "Heartbeat", State: "Disconnected", ServerVersion: , TopologyVersion: , Type: "Unknown", HeartbeatException: "MongoDB.Driver.MongoConnectionException: An exception occurred while opening a connection to the server.
 ---> MongoDB.Driver.MongoConnectionException: An exception occurred while receiving a message from the server.
 ---> System.FormatException: The size of the message is invalid.
   at MongoDB.Driver.Core.Connections.BinaryConnection.EnsureMessageSizeIsValid(Int32 messageSize)
   at MongoDB.Driver.Core.Connections.BinaryConnection.ReceiveBuffer(CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at MongoDB.Driver.Core.Connections.BinaryConnection.ReceiveBuffer(CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Connections.BinaryConnection.ReceiveBuffer(Int32 responseTo, CancellationToken cancellationToken)
--- End of stack trace from previous location ---
   at MongoDB.Driver.Core.Connections.BinaryConnection.Dropbox.RemoveMessage(Int32 responseTo)
   at MongoDB.Driver.Core.Connections.BinaryConnection.ReceiveBuffer(Int32 responseTo, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Connections.BinaryConnection.ReceiveMessage(Int32 responseTo, IMessageEncoderSelector encoderSelector, MessageEncoderSettings messageEncoderSettings, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.WireProtocol.CommandUsingQueryMessageWireProtocol`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.19.2.0, Culture=neutral, PublicKeyToken=null]].Execute(IConnection connection, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.WireProtocol.CommandWireProtocol`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.19.2.0, Culture=neutral, PublicKeyToken=null]].Execute(IConnection connection, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Connections.HelloHelper.GetResult(IConnection connection, CommandWireProtocol`1 helloProtocol, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Connections.ConnectionInitializer.SendHello(IConnection connection, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Connections.BinaryConnection.OpenHelper(CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at MongoDB.Driver.Core.Connections.BinaryConnection.OpenHelper(CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Connections.BinaryConnection.Open(CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Servers.ServerMonitor.InitializeConnection(CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Servers.ServerMonitor.Heartbeat(CancellationToken cancellationToken)", LastHeartbeatTimestamp: "2023-06-12T09:11:05.4264866Z", LastUpdateTimestamp: "2023-06-12T09:11:05.4264870Z" }] }.
   at MongoDB.Driver.Core.Clusters.Cluster.ThrowTimeoutException(IServerSelector selector, ClusterDescription description)
   at MongoDB.Driver.Core.Clusters.Cluster.WaitForDescriptionChangedHelper.HandleCompletedTask(Task completedTask)
   at MongoDB.Driver.Core.Clusters.Cluster.WaitForDescriptionChanged(IServerSelector selector, ClusterDescription description, Task descriptionChangedTask, TimeSpan timeout, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Clusters.Cluster.SelectServer(IServerSelector selector, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoClient.AreSessionsSupportedAfterServerSelection(CancellationToken cancellationToken)
   at MongoDB.Driver.MongoClient.AreSessionsSupported(CancellationToken cancellationToken)
   at MongoDB.Driver.MongoClient.StartImplicitSession(CancellationToken cancellationToken)
   at MongoDB.Driver.OperationExecutor.StartImplicitSession(CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.19.2.0, Culture=neutral, PublicKeyToken=null]].UsingImplicitSession[BulkWriteResult`1](Func`2 func, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.19.2.0, Culture=neutral, PublicKeyToken=null]].BulkWrite(IEnumerable`1 requests, BulkWriteOptions options, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionBase`1.<>c__DisplayClass75_0[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.19.2.0, Culture=neutral, PublicKeyToken=null]].<InsertMany>b__0(IEnumerable`1 requests, BulkWriteOptions bulkWriteOptions)
   at MongoDB.Driver.MongoCollectionBase`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.19.2.0, Culture=neutral, PublicKeyToken=null]].InsertMany(IEnumerable`1 documents, InsertManyOptions options, Action`2 bulkWrite)
   at MongoDB.Driver.MongoCollectionBase`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.19.2.0, Culture=neutral, PublicKeyToken=null]].InsertMany(IEnumerable`1 documents, InsertManyOptions options, CancellationToken cancellationToken)
```