### PR TITLE
CSHARP-4677: Server selection logging tests fail on Load Balancer

### DIFF
--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedEventMatcher.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedEventMatcher.cs
@@ -116,8 +116,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
 
                 static ServerType MapServerType(string value) => value switch
                 {
-                    "Unknown" => ServerType.Unknown,
                     "LoadBalancer" => ServerType.LoadBalanced,
+                    "Unknown" => ServerType.Unknown,
                     _ => throw new Exception($"Unsupported event filter server type: {value}."),
                 };
             }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedEventMatcher.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedEventMatcher.cs
@@ -117,6 +117,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
                 static ServerType MapServerType(string value) => value switch
                 {
                     "Unknown" => ServerType.Unknown,
+                    "LoadBalancer" => ServerType.LoadBalanced,
                     _ => throw new Exception($"Unsupported event filter server type: {value}."),
                 };
             }


### PR DESCRIPTION
[Failure](https://evergreen.mongodb.com/task/dot_net_driver_load_balancer_tests__version~rapid_os~ubuntu_1804_topology~sharded_cluster_auth~noauth_ssl~nossl_test_load_balancer_netstandard21_32f1d3069af21a68de56f88fe43dc6c36f12dd28_23_06_15_15_18_44)