### PR TITLE
CSHARP-4626: Fix urlencode on MacOS variants.

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -459,7 +459,7 @@ functions:
         working_dir: mongo-csharp-driver
         script: |
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias urlencode='python -c "import sys, urllib as ul; sys.stdout.write(ul.quote_plus(sys.argv[1]))"'
+            alias urlencode='${python3_binary} -c "import sys, urllib.parse as ulp; sys.stdout.write(ulp.quote_plus(sys.argv[1]))"'
             USER=$(urlencode "${iam_auth_ecs_account}")
             PASS=$(urlencode "${iam_auth_ecs_secret_access_key}")
             MONGODB_URI="mongodb://$USER:$PASS@localhost"
@@ -486,8 +486,8 @@ functions:
         script: |
           # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias urlencode='python -c "import sys, urllib as ul; sys.stdout.write(ul.quote_plus(sys.argv[1]))"'
-            alias jsonkey='python -c "import json,sys;sys.stdout.write(json.load(sys.stdin)[sys.argv[1]])" < ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json'
+            alias urlencode='${python3_binary} -c "import sys, urllib.parse as ulp; sys.stdout.write(ulp.quote_plus(sys.argv[1]))"'
+            alias jsonkey='${python3_binary} -c "import json,sys;sys.stdout.write(json.load(sys.stdin)[sys.argv[1]])" < ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json'
             USER=$(jsonkey AccessKeyId)
             USER=$(urlencode $USER)
             PASS=$(jsonkey SecretAccessKey)
@@ -661,7 +661,7 @@ functions:
         script: |
           # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias jsonkey='python -c "import json,sys;sys.stdout.write(json.load(sys.stdin)[sys.argv[1]])" < ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json'
+            alias jsonkey='${python3_binary} -c "import json,sys;sys.stdout.write(json.load(sys.stdin)[sys.argv[1]])" < ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json'
             export AWS_ACCESS_KEY_ID=$(jsonkey AccessKeyId)
             export AWS_SECRET_ACCESS_KEY=$(jsonkey SecretAccessKey)
             export AWS_SESSION_TOKEN=$(jsonkey SessionToken)
@@ -1714,6 +1714,7 @@ axes:
         display_name: "Windows 64-bit"
         variables:
           OS: "windows-64"
+          python3_binary: "C:/python/Python38/python.exe"
           skip_ECS_auth_test: true
           skip_web_identity_auth_test: true
         run_on: windows-64-vs2017-test
@@ -1721,11 +1722,13 @@ axes:
         display_name: "Ubuntu 18.04"
         variables:
           OS: "ubuntu-1804"
+          python3_binary: "/opt/python/3.8/bin/python3"
         run_on: ubuntu1804-test
       - id: "macos-1100"
         display_name: "macOS 11.00"
         variables:
           OS: "macos-1100"
+          python3_binary: /Library/Frameworks/Python.framework/Versions/3.8/bin/python3
           skip_EC2_auth_test: true
           skip_ECS_auth_test: true
           skip_web_identity_auth_test: true
@@ -1734,6 +1737,7 @@ axes:
         display_name: "macOS 11.00 M1"
         variables:
           OS: "macos-1100-arm64"
+          python3_binary: /Library/Frameworks/Python.framework/Versions/3.8/bin/python3
           skip_EC2_auth_test: true
           skip_ECS_auth_test: true
           skip_web_identity_auth_test: true


### PR DESCRIPTION
Using `python` worked until some OS variants started to map `python` to `python2` but others `python3`. The standard way to work around this is to use `python3` where you require `python3`, but some variants (cough cough Windows) don't map `python3`.

I tried the alternate approach of doing `python3` detection as many of our OCSP and other tests do. Unfortunately these aliases are evaluated before `drivers-evergreen-tools` is sourced and thus our `python3` detection scripts aren't available yet.

I then tried switching to `jq -sRjr @uri` for `urlencode`, which worked great except some MacOS machines don't have `jq` installed and the EG user doesn't have sufficient privileges to run `brew install jq`.

This lead me to take the same approach as `mongo-python-driver` to ensure that `python3` is used for these build scripts - which is to include the `python3` path as an environment variable configured for each OS variant.

Complete run of all variants can be found here:
https://spruce.mongodb.com/version/64a759231e2d1741743513aa/tasks