### PR TITLE
[BsonClassMap] Default value of discriminator

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonClassMap.cs
+++ b/src/MongoDB.Bson/Serialization/BsonClassMap.cs
@@ -1026,7 +1026,7 @@ namespace MongoDB.Bson.Serialization
             _creatorMaps.Clear();
             _creator = null;
             _declaredMemberMaps = new List<BsonMemberMap>();
-            _discriminator = _classType.Name;
+            _discriminator = _classType.FullName;
             _discriminatorIsRequired = false;
             _extraElementsMemberMap = null;
             _idMemberMap = null;


### PR DESCRIPTION
### Problem
An error occurred while deserializing the Value property of class Locator: Unknown discriminator value 'CategoryData'.
 ---> MongoDB.Bson.BsonSerializationException: Unknown discriminator value 'CategoryData'.

### Example to reproduce
```
namespace UnManagementLibrary.Models
{
    public class WikiLocator
    {
        public string Method { get; set; } = "locator.wiki";
        
        public CategoryData Value { get; init; }
        public class CategoryData
        {
            public long CategoryId { get; set; }
            public string CategoryName { get; set; }
        }
    }
    
// ...
// and 20 classes like this
// ...

    public class LevelPriorityLocator
    {
        public string Method { get; set; } = "locator.priority";
        
        public LevelPriorityData Value { get; init; }
        public class LevelPriorityData
        {
            public long Level { get; set; }
            public long Priority { get; set; }
        }
    }
}
```

```
namespace Program
{
    public class Locator
    {
        [MongoDB.Bson.Serialization.Attributes.BsonId]
        public string Id { get; init; }
        public string Method { get; init; }
        public object Value { get; init; }
    }
}
```

When i trying to save `Localor` instances (set all props as is from UnManagementLibrary.Models) to db, i see:
```
{
    "_id" : "99b889d8-8b8e-4d2f-a4e3-e1a650bdd39c",
    "Method" : "locator.wiki",
    "Value" : {
        "_t" : "CategoryData",
        "CategoryId" : NumberLong(10),
        "CategoryName" : "Europe"
    },
    "UpdateDt" : ISODate("2023-07-18T05:20:30.877+0000")
}
```

but i want _classType.FullName in _t, like that (see _t):

```
{
    "_id" : "99b889d8-8b8e-4d2f-a4e3-e1a650bdd39c",
    "Method" : "locator.wiki",
    "Value" : {
        "_t" : "UnManagementLibrary.Models.WikiLocator+CategoryData",
        "CategoryId" : NumberLong(10),
        "CategoryName" : "Europe"
    },
    "UpdateDt" : ISODate("2023-07-18T05:20:30.877+0000")
}
```

to avoid problem (exeption).