### PR TITLE
CSHARP-4728: Add implementation for Atlas Search Sort

### DIFF
--- a/src/MongoDB.Driver/AggregateFluent.cs
+++ b/src/MongoDB.Driver/AggregateFluent.cs
@@ -244,10 +244,11 @@ namespace MongoDB.Driver
             SearchHighlightOptions<TResult> highlight = null,
             string indexName = null,
             SearchCountOptions count = null,
+            SortDefinition<TResult> sort = null,
             bool returnStoredSource = false,
             bool scoreDetails = false)
         {
-            return WithPipeline(_pipeline.Search(searchDefinition, highlight, indexName, count, returnStoredSource, scoreDetails));
+            return WithPipeline(_pipeline.Search(searchDefinition, highlight, indexName, count, sort, returnStoredSource, scoreDetails));
         }
 
         public override IAggregateFluent<SearchMetaResult> SearchMeta(

--- a/src/MongoDB.Driver/AggregateFluentBase.cs
+++ b/src/MongoDB.Driver/AggregateFluentBase.cs
@@ -222,6 +222,7 @@ namespace MongoDB.Driver
             SearchHighlightOptions<TResult> highlight = null,
             string indexName = null,
             SearchCountOptions count = null,
+            SortDefinition<TResult> sort = null,
             bool returnStoredSource = false,
             bool scoreDetails = false)
         {

--- a/src/MongoDB.Driver/IAggregateFluent.cs
+++ b/src/MongoDB.Driver/IAggregateFluent.cs
@@ -361,6 +361,7 @@ namespace MongoDB.Driver
         /// <param name="highlight">The highlight options.</param>
         /// <param name="indexName">The index name.</param>
         /// <param name="count">The count options.</param>
+        /// <param name="sort">The sort specification.</param>
         /// <param name="returnStoredSource">
         /// Flag that specifies whether to perform a full document lookup on the backend database
         /// or return only stored source fields directly from Atlas Search.
@@ -375,6 +376,7 @@ namespace MongoDB.Driver
             SearchHighlightOptions<TResult> highlight = null,
             string indexName = null,
             SearchCountOptions count = null,
+            SortDefinition<TResult> sort = null,
             bool returnStoredSource = false,
             bool scoreDetails = false);
 

--- a/src/MongoDB.Driver/Linq/MongoQueryable.cs
+++ b/src/MongoDB.Driver/Linq/MongoQueryable.cs
@@ -1145,6 +1145,7 @@ namespace MongoDB.Driver.Linq
         /// <param name="highlight">The highlight options.</param>
         /// <param name="indexName">The index name.</param>
         /// <param name="count">The count options.</param>
+        /// <param name="sort">The sort specification.</param>
         /// <param name="returnStoredSource">
         /// Flag that specifies whether to perform a full document lookup on the backend database
         /// or return only stored source fields directly from Atlas Search.
@@ -1160,12 +1161,13 @@ namespace MongoDB.Driver.Linq
             SearchHighlightOptions<TSource> highlight = null,
             string indexName = null,
             SearchCountOptions count = null,
+            SortDefinition<TSource> sort = null,
             bool returnStoredSource = false,
             bool scoreDetails = false)
         {
             return AppendStage(
                 source,
-                PipelineStageDefinitionBuilder.Search(searchDefinition, highlight, indexName, count, returnStoredSource, scoreDetails));
+                PipelineStageDefinitionBuilder.Search(searchDefinition, highlight, indexName, count, sort, returnStoredSource, scoreDetails));
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/PipelineDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineDefinitionBuilder.cs
@@ -1175,6 +1175,7 @@ namespace MongoDB.Driver
         /// <param name="highlight">The highlight options.</param>
         /// <param name="indexName">The index name.</param>
         /// <param name="count">The count options.</param>
+        /// <param name="sort">The sort specification.</param>
         /// <param name="returnStoredSource">
         /// Flag that specifies whether to perform a full document lookup on the backend database
         /// or return only stored source fields directly from Atlas Search.
@@ -1192,11 +1193,12 @@ namespace MongoDB.Driver
             SearchHighlightOptions<TOutput> highlight = null,
             string indexName = null,
             SearchCountOptions count = null,
+            SortDefinition<TOutput> sort = null,
             bool returnStoredSource = false,
             bool scoreDetails = false)
         {
             Ensure.IsNotNull(pipeline, nameof(pipeline));
-            return pipeline.AppendStage(PipelineStageDefinitionBuilder.Search(searchDefinition, highlight, indexName, count, returnStoredSource, scoreDetails));
+            return pipeline.AppendStage(PipelineStageDefinitionBuilder.Search(searchDefinition, highlight, indexName, count, sort, returnStoredSource, scoreDetails));
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
@@ -1316,6 +1316,7 @@ namespace MongoDB.Driver
         /// <param name="highlight">The highlight options.</param>
         /// <param name="indexName">The index name.</param>
         /// <param name="count">The count options.</param>
+        /// <param name="sort">The sort specification.</param>
         /// <param name="returnStoredSource">
         /// Flag that specifies whether to perform a full document lookup on the backend database
         /// or return only stored source fields directly from Atlas Search.
@@ -1330,6 +1331,7 @@ namespace MongoDB.Driver
             SearchHighlightOptions<TInput> highlight = null,
             string indexName = null,
             SearchCountOptions count = null,
+            SortDefinition<TInput> sort = null,
             bool returnStoredSource = false,
             bool scoreDetails = false)
         {
@@ -1343,6 +1345,7 @@ namespace MongoDB.Driver
                     var renderedSearchDefinition = searchDefinition.Render(s, sr);
                     renderedSearchDefinition.Add("highlight", () => highlight.Render(s, sr), highlight != null);
                     renderedSearchDefinition.Add("count", () => count.Render(), count != null);
+                    renderedSearchDefinition.Add("sort", () => sort.Render(s, sr), sort != null);
                     renderedSearchDefinition.Add("index", indexName, indexName != null);
                     renderedSearchDefinition.Add("returnStoredSource", returnStoredSource, returnStoredSource);
                     renderedSearchDefinition.Add("scoreDetails", scoreDetails, scoreDetails);

--- a/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
@@ -195,6 +195,19 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void Search_should_add_expected_stage_with_sort()
+        {
+            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
+            var builder = new SearchDefinitionBuilder<BsonDocument>();
+            var sortBuilder = new SortDefinitionBuilder<BsonDocument>();
+
+            var result = pipeline.Search(builder.Text("bar", "foo"), sort: sortBuilder.Ascending("foo"));
+
+            var stages = RenderStages(result, BsonDocumentSerializer.Instance);
+            stages[0].Should().Be("{ $search: { text: { query: 'foo', path: 'bar' }, sort: { 'foo': 1 } } }");
+        }
+
+        [Fact]
         public void Search_should_throw_when_pipeline_is_null()
         {
             PipelineDefinition<BsonDocument, BsonDocument> pipeline = null;

--- a/tests/MongoDB.Driver.Tests/Search/AtlasSearchTests.cs
+++ b/tests/MongoDB.Driver.Tests/Search/AtlasSearchTests.cs
@@ -403,6 +403,17 @@ namespace MongoDB.Driver.Tests.Search
         }
 
         [Fact]
+        public void Should()
+        {
+            var result = SearchSingle(
+                Builders.Search.Compound().Should(
+                    Builders.Search.Phrase(x => x.Body, "life, liberty"),
+                    Builders.Search.Wildcard(x => x.Body, "happ*", true))
+                .MinimumShouldMatch(2));
+            result.Title.Should().Be("Declaration of Independence");
+        }
+
+        [Fact]
         public void Sort()
         {
             var results = GetTestCollection().Aggregate()
@@ -413,17 +424,6 @@ namespace MongoDB.Driver.Tests.Search
                 .Limit(1)
                 .ToList();
             results.Should().ContainSingle().Which.Title.Should().Be("US Constitution");
-        }
-
-        [Fact]
-        public void Should()
-        {
-            var result = SearchSingle(
-                Builders.Search.Compound().Should(
-                    Builders.Search.Phrase(x => x.Body, "life, liberty"),
-                    Builders.Search.Wildcard(x => x.Body, "happ*", true))
-                .MinimumShouldMatch(2));
-            result.Title.Should().Be("Declaration of Independence");
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Tests/Search/AtlasSearchTests.cs
+++ b/tests/MongoDB.Driver.Tests/Search/AtlasSearchTests.cs
@@ -113,19 +113,6 @@ namespace MongoDB.Driver.Tests.Search
         }
 
         [Fact]
-        public void Sort()
-        {
-            var results = GetTestCollection().Aggregate()
-                .Search(
-                    Builders.Search.Text(x => x.Body, "liberty"),
-                    sort: Builders.Sort.Descending(x => x.Title))
-                .Project<HistoricalDocument>(Builders.Projection.Include(x => x.Title))
-                .Limit(1)
-                .ToList();
-            results.Should().ContainSingle().Which.Title.Should().Be("Gettysburg Address");
-        }
-
-        [Fact]
         public void Exists()
         {
             var result = SearchSingle(
@@ -413,6 +400,19 @@ namespace MongoDB.Driver.Tests.Search
             bucket = result.Facet["date"].Buckets.Should().NotBeNull().And.ContainSingle().Subject;
             bucket.Id.Should().Be((BsonDateTime)DateTime.MinValue);
             bucket.Count.Should().Be(108);
+        }
+
+        [Fact]
+        public void Sort()
+        {
+            var results = GetTestCollection().Aggregate()
+                .Search(
+                    Builders.Search.Text(x => x.Body, "liberty"),
+                    sort: Builders.Sort.Descending(x => x.Title))
+                .Project<HistoricalDocument>(Builders.Projection.Include(x => x.Title))
+                .Limit(1)
+                .ToList();
+            results.Should().ContainSingle().Which.Title.Should().Be("US Constitution");
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/Search/AtlasSearchTests.cs
+++ b/tests/MongoDB.Driver.Tests/Search/AtlasSearchTests.cs
@@ -113,6 +113,19 @@ namespace MongoDB.Driver.Tests.Search
         }
 
         [Fact]
+        public void Sort()
+        {
+            var results = GetTestCollection().Aggregate()
+                .Search(
+                    Builders.Search.Text(x => x.Body, "liberty"),
+                    sort: Builders.Sort.Descending(x => x.Title))
+                .Project<HistoricalDocument>(Builders.Projection.Include(x => x.Title))
+                .Limit(1)
+                .ToList();
+            results.Should().ContainSingle().Which.Title.Should().Be("Gettysburg Address");
+        }
+
+        [Fact]
         public void Exists()
         {
             var result = SearchSingle(

--- a/tests/MongoDB.Driver.Tests/Search/AtlasSearchTests.cs
+++ b/tests/MongoDB.Driver.Tests/Search/AtlasSearchTests.cs
@@ -232,7 +232,7 @@ namespace MongoDB.Driver.Tests.Search
             var result = SearchSingle(
                 Builders.Search.Compound().MustNot(
                     Builders.Search.Phrase(x => x.Body, "life, liberty")));
-            result.Title.Should().Be("US Constitution");
+            result.Title.Should().Be("Gettysburg Address");
         }
 
         [Fact]


### PR DESCRIPTION
The 10 July 2023 release of MongoDB Atlas Search introduced the sort option.

[Atlas Search Changelog - 10 July 2023 Release](https://www.mongodb.com/docs/atlas/atlas-search/changelog/#10-july-2023-release)

[Sort Atlas Search Results](https://www.mongodb.com/docs/atlas/atlas-search/sort/#std-label-sort-ref)

It would be very nice to have access to the sort field from the C# driver