### PR TITLE
Enable PerformanceCounters on net6.0-windows

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounterEventSubscriber.cs
+++ b/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounterEventSubscriber.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-#if NET472
+#if NET472 || WINDOWS
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounters/ConnectionPerformanceRecorder.cs
+++ b/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounters/ConnectionPerformanceRecorder.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-#if NET472
+#if NET472 || WINDOWS
 using System.Diagnostics;
 
 namespace MongoDB.Driver.Core.Events.Diagnostics.PerformanceCounters

--- a/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounters/ConnectionPoolPerformanceRecorder.cs
+++ b/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounters/ConnectionPoolPerformanceRecorder.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-#if NET472
+#if NET472 || WINDOWS
 namespace MongoDB.Driver.Core.Events.Diagnostics.PerformanceCounters
 {
     internal class ConnectionPoolPerformanceRecorder

--- a/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounters/PerformanceCounterAttribute.cs
+++ b/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounters/PerformanceCounterAttribute.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-#if NET472
+#if NET472 || WINDOWS
 using System;
 using System.Diagnostics;
 

--- a/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounters/PerformanceCounterPackage.cs
+++ b/src/MongoDB.Driver.Core/Core/Events/Diagnostics/PerformanceCounters/PerformanceCounterPackage.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-#if NET472
+#if NET472 || WINDOWS
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -8,6 +8,7 @@
     <Product>MongoDB.Driver.Core</Product>
     <Description>Official MongoDB supported Driver Core library. See https://www.mongodb.com/docs/drivers/csharp/ for more details.</Description>
     <PackageDescription>Core Component of the Official MongoDB .NET Driver.</PackageDescription>
+    <TargetFrameworks Condition="'$(IsWindows)'=='true'">$(TargetFrameworks);net6.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -32,6 +33,10 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MongoDB.Driver.Core/TargetFramework.cs
+++ b/src/MongoDB.Driver.Core/TargetFramework.cs
@@ -20,6 +20,8 @@ namespace MongoDB.Driver.Core
         public static string Moniker =>
 #if NET472
             "net472";
+#elif NET6_0 && WINDOWS
+            "net6.0-windows";
 #elif NETSTANDARD2_0
             "netstandard20";
 #elif NETSTANDARD2_1


### PR DESCRIPTION
While migrating an application to .NET6+ I noticed PerformanceCounter related code was not available. This is an attempt to put it back.

As a side effect, targetting `net6.0-windows` is enabling some code analyzers issues. I'm leaving the code at is for now. Let me know if you have interest to go forward with the changes.