### PR TITLE
CSHARP-4733: Add implementation for Atlas Search Tracking search terms

### DIFF
--- a/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
@@ -1370,6 +1370,7 @@ namespace MongoDB.Driver
                     renderedSearchDefinition.Add("index", searchOptions.IndexName, searchOptions.IndexName != null);
                     renderedSearchDefinition.Add("returnStoredSource", searchOptions.ReturnStoredSource, searchOptions.ReturnStoredSource);
                     renderedSearchDefinition.Add("scoreDetails", searchOptions.ScoreDetails, searchOptions.ScoreDetails);
+                    renderedSearchDefinition.Add("tracking", () => searchOptions.Tracking.Render(), searchOptions.Tracking != null);
 
                     var document = new BsonDocument(operatorName, renderedSearchDefinition);
                     return new RenderedPipelineStageDefinition<TInput>(operatorName, document, s);

--- a/src/MongoDB.Driver/Search/SearchOptions.cs
+++ b/src/MongoDB.Driver/Search/SearchOptions.cs
@@ -51,5 +51,10 @@ namespace MongoDB.Driver.Search
         /// Gets or sets the sort specification.
         /// </summary>
         public SortDefinition<TResult> Sort { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options for tracking search terms.
+        /// </summary>
+        public SearchTrackingOptions Tracking { get; set; }
     }
 }

--- a/src/MongoDB.Driver/Search/SearchTrackingOptions.cs
+++ b/src/MongoDB.Driver/Search/SearchTrackingOptions.cs
@@ -1,0 +1,43 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Bson;
+using MongoDB.Driver.Core.Misc;
+
+namespace MongoDB.Driver.Search
+{
+    /// <summary>
+    /// Options for tracking the search query.
+    /// </summary>
+    public sealed class SearchTrackingOptions
+    {
+        private string _searchTerms;
+
+        /// <summary>
+        /// Text or term associated with the query to track. You can specify only one term per query.
+        /// </summary>
+        public string SearchTerms
+        {
+            get => _searchTerms;
+            set => _searchTerms = Ensure.IsNotNullOrEmpty(value, nameof(value));
+        }
+
+        internal BsonDocument Render() =>
+            new()
+            {
+                { "searchTerms", _searchTerms, !string.IsNullOrEmpty(_searchTerms) }
+            };
+    }
+}

--- a/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
@@ -195,6 +195,19 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void Search_should_add_expected_stage_with_sort()
+        {
+            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
+            var builder = new SearchDefinitionBuilder<BsonDocument>();
+            var sortBuilder = new SortDefinitionBuilder<BsonDocument>();
+
+            var result = pipeline.Search(builder.Text("bar", "foo"), new() { Sort = sortBuilder.Ascending("foo") });
+
+            var stages = RenderStages(result, BsonDocumentSerializer.Instance);
+            stages[0].Should().Be("{ $search: { text: { query: 'foo', path: 'bar' }, sort: { 'foo': 1 } } }");
+        }
+
+        [Fact]
         public void Search_should_add_expected_stage_with_tracking()
         {
             var pipeline = new EmptyPipelineDefinition<BsonDocument>();
@@ -211,19 +224,6 @@ namespace MongoDB.Driver.Tests
 
             var stages = RenderStages(result, BsonDocumentSerializer.Instance);
             stages[0].Should().Be("{ $search: { text: { query: 'foo', path: 'bar' }, tracking: { searchTerms: 'foo' } } }");
-        }
-
-        [Fact]
-        public void Search_should_add_expected_stage_with_sort()
-        {
-            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
-            var builder = new SearchDefinitionBuilder<BsonDocument>();
-            var sortBuilder = new SortDefinitionBuilder<BsonDocument>();
-
-            var result = pipeline.Search(builder.Text("bar", "foo"), new() { Sort = sortBuilder.Ascending("foo") });
-
-            var stages = RenderStages(result, BsonDocumentSerializer.Instance);
-            stages[0].Should().Be("{ $search: { text: { query: 'foo', path: 'bar' }, sort: { 'foo': 1 } } }");
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
@@ -195,6 +195,25 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void Search_should_add_expected_stage_with_tracking()
+        {
+            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
+            var builder = new SearchDefinitionBuilder<BsonDocument>();
+            var searchOptions = new SearchOptions<BsonDocument>()
+            {
+                Tracking = new SearchTrackingOptions()
+                {
+                    SearchTerms = "foo"
+                }
+            };
+
+            var result = pipeline.Search(builder.Text("bar", "foo"), searchOptions);
+
+            var stages = RenderStages(result, BsonDocumentSerializer.Instance);
+            stages[0].Should().Be("{ $search: { text: { query: 'foo', path: 'bar' }, tracking: { searchTerms: 'foo' } } }");
+        }
+
+        [Fact]
         public void Search_should_add_expected_stage_with_sort()
         {
             var pipeline = new EmptyPipelineDefinition<BsonDocument>();


### PR DESCRIPTION
The 7 June 2023 release of MongoDB Atlas Search introduced support for tracking search terms.

[07 June 2023 Release](https://www.mongodb.com/docs/atlas/atlas-search/changelog/#07-june-2023-release)

[Track search terms](https://www.mongodb.com/docs/atlas/atlas-search/tracking/#std-label-fts-tracking-ref)

It would be very nice to have access to the tracking field from the C# driver