### PR TITLE
CSHARP-4676: Add MongoDB.Driver support for big-endian clients.

### DIFF
--- a/src/MongoDB.Bson/IO/BinaryPrimitivesCompat.cs
+++ b/src/MongoDB.Bson/IO/BinaryPrimitivesCompat.cs
@@ -1,0 +1,35 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Buffers.Binary;
+
+namespace MongoDB.Bson.IO
+{
+    // this class implements a few BinaryPrimitives methods we need that don't exist in some of our target frameworks
+    // this class can be deleted once all our targeted frameworks have the needed methods
+    internal static class BinaryPrimitivesCompat
+    {
+        public static double ReadDoubleLittleEndian(ReadOnlySpan<byte> source)
+        {
+            return BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(source));
+        }
+
+        public static void WriteDoubleLittleEndian(Span<byte> destination, double value)
+        {
+            BinaryPrimitives.WriteInt64LittleEndian(destination, BitConverter.DoubleToInt64Bits(value));
+        }
+    }
+}

--- a/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
+++ b/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
@@ -16,6 +16,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Buffers.Binary;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -307,7 +308,7 @@ namespace MongoDB.Bson.IO
         {
             ThrowIfDisposed();
             this.ReadBytes(_temp, 0, 8);
-            return BitConverter.ToDouble(_temp, 0);
+            return BinaryPrimitivesCompat.ReadDoubleLittleEndian(_temp);
         }
 
         /// <inheritdoc/>
@@ -323,7 +324,7 @@ namespace MongoDB.Bson.IO
         {
             ThrowIfDisposed();
             this.ReadBytes(_temp, 0, 8);
-            return BitConverter.ToInt64(_temp, 0);
+            return BinaryPrimitives.ReadInt64LittleEndian(_temp);
         }
 
         /// <inheritdoc/>
@@ -494,7 +495,8 @@ namespace MongoDB.Bson.IO
         public override void WriteDouble(double value)
         {
             ThrowIfDisposed();
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = new byte[8];
+            BinaryPrimitivesCompat.WriteDoubleLittleEndian(bytes, value);
             _stream.Write(bytes, 0, 8);
         }
 
@@ -513,7 +515,8 @@ namespace MongoDB.Bson.IO
         public override void WriteInt64(long value)
         {
             ThrowIfDisposed();
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = new byte[8];
+            BinaryPrimitives.WriteInt64LittleEndian(bytes, value);
             _stream.Write(bytes, 0, 8);
         }
 

--- a/src/MongoDB.Bson/IO/ElementAppendingBsonWriter.cs
+++ b/src/MongoDB.Bson/IO/ElementAppendingBsonWriter.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Buffers.Binary;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 
@@ -83,7 +84,7 @@ namespace MongoDB.Bson.IO
                 // just copy the bytes (without the length and terminating null)
                 var lengthBytes = new byte[4];
                 slice.GetBytes(0, lengthBytes, 0, 4);
-                var length = BitConverter.ToInt32(lengthBytes, 0);
+                var length = BinaryPrimitives.ReadInt32LittleEndian(lengthBytes);
                 using (var elements = slice.GetSlice(4, length - 5))
                 {
                     var stream = binaryWriter.BsonStream;

--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MongoDB.Bson/ObjectModel/GuidConverter.cs
+++ b/src/MongoDB.Bson/ObjectModel/GuidConverter.cs
@@ -39,31 +39,19 @@ namespace MongoDB.Bson
             switch (representation)
             {
                 case GuidRepresentation.CSharpLegacy:
-                    if (!BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
                     break;
                 case GuidRepresentation.JavaLegacy:
                     Array.Reverse(bytes, 0, 8);
                     Array.Reverse(bytes, 8, 8);
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
+                    Array.Reverse(bytes, 0, 4);
+                    Array.Reverse(bytes, 4, 2);
+                    Array.Reverse(bytes, 6, 2);
                     break;
                 case GuidRepresentation.PythonLegacy:
                 case GuidRepresentation.Standard:
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
+                    Array.Reverse(bytes, 0, 4);
+                    Array.Reverse(bytes, 4, 2);
+                    Array.Reverse(bytes, 6, 2);
                     break;
                 case GuidRepresentation.Unspecified:
                     throw new InvalidOperationException("Unable to convert byte array to Guid because GuidRepresentation is Unspecified.");
@@ -107,31 +95,19 @@ namespace MongoDB.Bson
             switch (guidRepresentation)
             {
                 case GuidRepresentation.CSharpLegacy:
-                    if (!BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
                     break;
                 case GuidRepresentation.JavaLegacy:
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
+                    Array.Reverse(bytes, 0, 4);
+                    Array.Reverse(bytes, 4, 2);
+                    Array.Reverse(bytes, 6, 2);
                     Array.Reverse(bytes, 0, 8);
                     Array.Reverse(bytes, 8, 8);
                     break;
                 case GuidRepresentation.PythonLegacy:
                 case GuidRepresentation.Standard:
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Array.Reverse(bytes, 0, 4);
-                        Array.Reverse(bytes, 4, 2);
-                        Array.Reverse(bytes, 6, 2);
-                    }
+                    Array.Reverse(bytes, 0, 4);
+                    Array.Reverse(bytes, 4, 2);
+                    Array.Reverse(bytes, 6, 2);
                     break;
                 case GuidRepresentation.Unspecified:
                     throw new InvalidOperationException("Unable to convert Guid to byte array because GuidRepresentation is Unspecified.");

--- a/src/MongoDB.Bson/Serialization/IdGenerators/AscendingGuidGenerator.cs
+++ b/src/MongoDB.Bson/Serialization/IdGenerators/AscendingGuidGenerator.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Threading;
+using System.Buffers.Binary;
 
 namespace MongoDB.Bson.Serialization.IdGenerators
 {
@@ -39,7 +40,8 @@ namespace MongoDB.Bson.Serialization.IdGenerators
         static AscendingGuidGenerator()
         {
             var random = ObjectId.CalculateRandomValue();
-            var random8Bytes = BitConverter.GetBytes(random);
+            var random8Bytes = new byte[8];
+            BinaryPrimitives.WriteInt64LittleEndian(random8Bytes, random);
             __random = new byte[5];
             Array.Copy(random8Bytes, __random, 5); // the 5 bytes we need are the first 5 bytes assuming little-endian
         }

--- a/src/MongoDB.Bson/Serialization/IdGenerators/CombGuidGenerator.cs
+++ b/src/MongoDB.Bson/Serialization/IdGenerators/CombGuidGenerator.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Buffers.Binary;
 
 namespace MongoDB.Bson.Serialization.IdGenerators
 {
@@ -87,13 +88,10 @@ namespace MongoDB.Bson.Serialization.IdGenerators
 
             var bytes = guid.ToByteArray();
 
-            Array.Copy(BitConverter.GetBytes(days), 0, bytes, 10, 2);
-            Array.Copy(BitConverter.GetBytes(timeTicks), 0, bytes, 12, 4);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(bytes, 10, 2);
-                Array.Reverse(bytes, 12, 4);
-            }
+            BinaryPrimitives.WriteUInt16LittleEndian(new Span<byte>(bytes, 10, 2), days);
+            BinaryPrimitives.WriteInt32LittleEndian(new Span<byte>(bytes, 12, 4), timeTicks);
+            Array.Reverse(bytes, 10, 2);
+            Array.Reverse(bytes, 12, 4);
 
             return new Guid(bytes);
         }

--- a/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/BinaryConnection.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Buffers.Binary;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson.IO;
 using MongoDB.Driver.Core.Compression;
@@ -315,7 +316,7 @@ namespace MongoDB.Driver.Core.Connections
             {
                 var messageSizeBytes = new byte[4];
                 _stream.ReadBytes(messageSizeBytes, 0, 4, cancellationToken);
-                var messageSize = BitConverter.ToInt32(messageSizeBytes, 0);
+                var messageSize = BinaryPrimitives.ReadInt32LittleEndian(messageSizeBytes);
                 EnsureMessageSizeIsValid(messageSize);
                 var inputBufferChunkSource = new InputBufferChunkSource(BsonChunkPool.Default);
                 var buffer = ByteBufferFactory.Create(inputBufferChunkSource, messageSize);
@@ -385,7 +386,7 @@ namespace MongoDB.Driver.Core.Connections
                 var messageSizeBytes = new byte[4];
                 var readTimeout = _stream.CanTimeout ? TimeSpan.FromMilliseconds(_stream.ReadTimeout) : Timeout.InfiniteTimeSpan;
                 await _stream.ReadBytesAsync(messageSizeBytes, 0, 4, readTimeout, cancellationToken).ConfigureAwait(false);
-                var messageSize = BitConverter.ToInt32(messageSizeBytes, 0);
+                var messageSize = BinaryPrimitives.ReadInt32LittleEndian(messageSizeBytes);
                 EnsureMessageSizeIsValid(messageSize);
                 var inputBufferChunkSource = new InputBufferChunkSource(BsonChunkPool.Default);
                 var buffer = ByteBufferFactory.Create(inputBufferChunkSource, messageSize);
@@ -797,7 +798,7 @@ namespace MongoDB.Driver.Core.Connections
             private int GetResponseTo(IByteBuffer message)
             {
                 var backingBytes = message.AccessBackingBytes(8);
-                return BitConverter.ToInt32(backingBytes.Array, backingBytes.Offset);
+                return BinaryPrimitives.ReadInt32LittleEndian(new ReadOnlySpan<byte>(backingBytes.Array, backingBytes.Offset, 4));
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Connections/KeepAliveValues.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/KeepAliveValues.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Buffers.Binary;
 
 namespace MongoDB.Driver.Core.Connections
 {
@@ -30,9 +31,9 @@ namespace MongoDB.Driver.Core.Connections
         public byte[] ToBytes()
         {
             var bytes = new byte[12];
-            Array.Copy(BitConverter.GetBytes(OnOff), 0, bytes, 0, 4);
-            Array.Copy(BitConverter.GetBytes(KeepAliveTime), 0, bytes, 4, 4);
-            Array.Copy(BitConverter.GetBytes(KeepAliveInterval), 0, bytes, 8, 4);
+            BinaryPrimitives.WriteUInt32LittleEndian(new Span<byte>(bytes, 0, 4), OnOff);
+            BinaryPrimitives.WriteUInt32LittleEndian(new Span<byte>(bytes, 4, 4), KeepAliveTime);
+            BinaryPrimitives.WriteUInt32LittleEndian(new Span<byte>(bytes, 8, 4), KeepAliveInterval);
             return bytes;
         }
     }

--- a/tests/MongoDB.Bson.Tests/IO/BsonStreamAdapterTests.cs
+++ b/tests/MongoDB.Bson.Tests/IO/BsonStreamAdapterTests.cs
@@ -24,6 +24,7 @@ using MongoDB.Bson.IO;
 using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;
+using System.Buffers.Binary;
 
 namespace MongoDB.Bson.Tests
 {
@@ -754,8 +755,8 @@ namespace MongoDB.Bson.Tests
         {
             var value = Decimal128.Parse(valueString);
             var bytes = new byte[16];
-            Buffer.BlockCopy(BitConverter.GetBytes(value.GetIEEELowBits()), 0, bytes, 0, 8);
-            Buffer.BlockCopy(BitConverter.GetBytes(value.GetIEEEHighBits()), 0, bytes, 8, 8);
+            BinaryPrimitives.WriteUInt64LittleEndian(new Span<byte>(bytes, 0, 8), value.GetIEEELowBits());
+            BinaryPrimitives.WriteUInt64LittleEndian(new Span<byte>(bytes, 8, 8), value.GetIEEEHighBits());
             var stream = new MemoryStream(bytes);
             var subject = new BsonStreamAdapter(stream);
 
@@ -784,7 +785,8 @@ namespace MongoDB.Bson.Tests
             double value
             )
         {
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = new byte[8];
+            BinaryPrimitivesCompat.WriteDoubleLittleEndian(bytes, value);
             var stream = new MemoryStream(bytes);
             var subject = new BsonStreamAdapter(stream);
 
@@ -824,7 +826,8 @@ namespace MongoDB.Bson.Tests
             [Values(-1, 0, 1, int.MaxValue, int.MinValue)]
             int value)
         {
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = new byte[4];
+            BinaryPrimitives.WriteInt32LittleEndian(bytes, value);
             var stream = new MemoryStream(bytes);
             var subject = new BsonStreamAdapter(stream);
 
@@ -864,7 +867,8 @@ namespace MongoDB.Bson.Tests
             [Values(-1, 0, 1, long.MaxValue, long.MinValue)]
             long value)
         {
-            var bytes = BitConverter.GetBytes(value);
+            var bytes = new byte[8];
+            BinaryPrimitives.WriteInt64LittleEndian(bytes, value);
             var stream = new MemoryStream(bytes);
             var subject = new BsonStreamAdapter(stream);
 
@@ -1382,8 +1386,8 @@ namespace MongoDB.Bson.Tests
             var stream = new MemoryStream();
             var subject = new BsonStreamAdapter(stream);
             var expectedBytes = new byte[16];
-            Buffer.BlockCopy(BitConverter.GetBytes(value.GetIEEELowBits()), 0, expectedBytes, 0, 8);
-            Buffer.BlockCopy(BitConverter.GetBytes(value.GetIEEEHighBits()), 0, expectedBytes, 8, 8);
+            BinaryPrimitives.WriteUInt64LittleEndian(new Span<byte>(expectedBytes, 0, 8), value.GetIEEELowBits());
+            BinaryPrimitives.WriteUInt64LittleEndian(new Span<byte>(expectedBytes, 8, 8), value.GetIEEEHighBits());
 
             subject.WriteDecimal128(value);
 
@@ -1410,7 +1414,8 @@ namespace MongoDB.Bson.Tests
         {
             var stream = new MemoryStream();
             var subject = new BsonStreamAdapter(stream);
-            var expectedBytes = BitConverter.GetBytes(value);
+            var expectedBytes = new byte[8];
+            BinaryPrimitivesCompat.WriteDoubleLittleEndian(expectedBytes, value);
 
             subject.WriteDouble(value);
 
@@ -1462,7 +1467,8 @@ namespace MongoDB.Bson.Tests
         {
             var stream = new MemoryStream();
             var subject = new BsonStreamAdapter(stream);
-            var expectedBytes = BitConverter.GetBytes(value);
+            var expectedBytes = new byte[4];
+            BinaryPrimitives.WriteInt32LittleEndian(expectedBytes, value);
 
             subject.WriteInt32(value);
 
@@ -1502,7 +1508,8 @@ namespace MongoDB.Bson.Tests
         {
             var stream = new MemoryStream();
             var subject = new BsonStreamAdapter(stream);
-            var expectedBytes = BitConverter.GetBytes(value);
+            var expectedBytes = new byte[8];
+            BinaryPrimitives.WriteInt64LittleEndian(expectedBytes, value);
 
             subject.WriteInt64(value);
 
@@ -1611,7 +1618,9 @@ namespace MongoDB.Bson.Tests
             var subject = new BsonStreamAdapter(stream);
             var valueLength = ((tempUtf8LegacySize - 5) / 3) + delta;
             var value = new string('a', valueLength);
-            var expectedBytes = BitConverter.GetBytes(valueLength + 1)
+            var bytes = new byte[4];
+            BinaryPrimitives.WriteInt32LittleEndian(bytes, valueLength + 1);
+            var expectedBytes = bytes
                 .Concat(Enumerable.Repeat<byte>(97, valueLength))
                 .Concat(new byte[] { 0 })
                 .ToArray();

--- a/tests/MongoDB.Bson.Tests/IO/BsonStreamExtensionsTests.cs
+++ b/tests/MongoDB.Bson.Tests/IO/BsonStreamExtensionsTests.cs
@@ -22,6 +22,7 @@ using MongoDB.Bson.IO;
 using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;
+using System.Buffers.Binary;
 
 namespace MongoDB.Bson.Tests.IO
 {
@@ -36,7 +37,9 @@ namespace MongoDB.Bson.Tests.IO
             var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
             var length = bytes.Length - startPosition;
             var expectedBytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            Array.Copy(BitConverter.GetBytes(length), 0, expectedBytes, startPosition, 4);
+            var lengthBytes = new byte[4];
+            BinaryPrimitives.WriteInt32LittleEndian(lengthBytes, length);
+            Array.Copy(lengthBytes, 0, expectedBytes, startPosition, 4);
 
             using (var memoryStream = new MemoryStream())
             using (var stream = new BsonStreamAdapter(memoryStream))

--- a/tests/MongoDB.Bson.Tests/Serialization/IdGenerators/AscendingGuidGeneratorTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/IdGenerators/AscendingGuidGeneratorTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Linq;
 using MongoDB.Bson.Serialization.IdGenerators;
 using Xunit;
+using System.Buffers.Binary;
 
 namespace MongoDB.Bson.Tests.Serialization
 {
@@ -67,9 +68,9 @@ namespace MongoDB.Bson.Tests.Serialization
 
         private long GetTicks(byte[] bytes)
         {
-            var a = (ulong)BitConverter.ToUInt32(bytes, 0);
-            var b = (ulong)BitConverter.ToUInt16(bytes, 4);
-            var c = (ulong)BitConverter.ToUInt16(bytes, 6);
+            var a = (ulong)BinaryPrimitives.ReadUInt32LittleEndian(new ReadOnlySpan<byte>(bytes, 0, 4));
+            var b = (ulong)BinaryPrimitives.ReadUInt16LittleEndian(new ReadOnlySpan<byte>(bytes, 4, 2));
+            var c = (ulong)BinaryPrimitives.ReadUInt16LittleEndian(new ReadOnlySpan<byte>(bytes, 6, 2));
             return (long)((a << 32) | (b << 16) | c);
         }
 

--- a/tests/MongoDB.Bson.Tests/Serialization/IdGenerators/CombGuidGeneratorTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/IdGenerators/CombGuidGeneratorTests.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.IdGenerators;
 using Xunit;
+using System.Buffers.Binary;
 
 namespace MongoDB.Bson.Tests.Serialization
 {
@@ -36,13 +37,10 @@ namespace MongoDB.Bson.Tests.Serialization
             var expectedTimeTicks = 150; // half a second in SQL Server resolution
 
             var bytes = combGuid.ToByteArray();
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(bytes, 10, 2);
-                Array.Reverse(bytes, 12, 4);
-            }
-            var days = BitConverter.ToInt16(bytes, 10);
-            var timeTicks = BitConverter.ToInt32(bytes, 12);
+            Array.Reverse(bytes, 10, 2);
+            Array.Reverse(bytes, 12, 4);
+            var days = BinaryPrimitives.ReadInt16LittleEndian(new ReadOnlySpan<byte>(bytes, 10, 2));
+            var timeTicks = BinaryPrimitives.ReadInt32LittleEndian(new ReadOnlySpan<byte>(bytes, 12, 4));
 
             Assert.True(guid.ToByteArray().Take(10).SequenceEqual(bytes.Take(10))); // first 10 bytes are from the base Guid
             Assert.Equal(expectedDays, days);


### PR DESCRIPTION
Creating a new PR rebased on master to trigger a patch build.

Original PR is:

https://github.com/mongodb/mongo-csharp-driver/pull/1108