### PR TITLE
CSHARP-4792: Verify that delimiting slash bewteen hosts and options is optional.

### DIFF
--- a/specifications/connection-string/tests/README.rst
+++ b/specifications/connection-string/tests/README.rst
@@ -12,41 +12,11 @@ a warning on repeated option keys.  As such these YAML tests are in no way a
 replacement for more thorough testing. However, they can provide an initial
 verification of your implementation.
 
-Converting to JSON
-------------------
-
-The tests are written in YAML because it is easier for humans to write and read,
-and because YAML includes a standard comment format. A JSONified version of each
-YAML file is included in this repository. Whenever you change the YAML,
-re-convert to JSON. One method to convert to JSON is with
-`jsonwidget-python <http://jsonwidget.org/wiki/Jsonwidget-python>`_::
-
-    pip install PyYAML urwid jsonwidget
-    make
-
-Or instead of "make"::
-
-    for i in `find . -iname '*.yml'`; do
-        echo "${i%.*}"
-        jwc yaml2json $i > ${i%.*}.json
-    done
-
-Alternatively, you can use `yamljs <https://www.npmjs.com/package/yamljs>`_::
-
-    npm install -g yamljs
-    yaml2json -s -p -r .
-
 Version
 -------
 
 Files in the "specifications" repository have no version scheme. They are not
-tied to a MongoDB server version, and it is our intention that each
-specification moves from "draft" to "final" with no further versions; it is
-superseded by a future spec, not revised.
-
-However, implementers must have stable sets of tests to target. As test files
-evolve they will be occasionally tagged like "uri-tests-tests-2015-07-16", until
-the spec is final.
+tied to a MongoDB server version.
 
 Format
 ------
@@ -72,7 +42,7 @@ array of test case objects, each of which have the following keys:
     (as discussed in `RFC 2396 <https://www.ietf.org/rfc/rfc2396.txt>`_).
   - ``password``: A string containing the parsed password.
   - ``db``: A string containing the parsed authentication database. For legacy
-    implementations that support namespaces (databases and collections) this may 
+    implementations that support namespaces (databases and collections) this may
     be the full namespace eg: ``<db>.<coll>``
 - ``options``: An object containing key/value pairs for each parsed query string
   option.

--- a/specifications/connection-string/tests/invalid-uris.json
+++ b/specifications/connection-string/tests/invalid-uris.json
@@ -1,274 +1,283 @@
 {
-    "tests": [
-        {
-            "auth": null, 
-            "description": "Empty string", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid scheme", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongo://localhost:27017", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Missing host", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost::27017", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier and trailing slash", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost::27017/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier with missing host and port", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://::", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier with missing port", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost,localhost::", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier and second host", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost::27017,abc", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (negative number) with hostname", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:-1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (zero) with hostname", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:0/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (positive number) with hostname", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:65536", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (positive number) with hostname and trailing slash", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:65536/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (non-numeric string) with hostname", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:foo", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (negative number) with IP literal", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:-1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (zero) with IP literal", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:0/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (positive number) with IP literal", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:65536", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (positive number) with IP literal and trailing slash", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:65536/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (non-numeric string) with IP literal", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:foo", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Missing delimiting slash between hosts and options", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://example.com?w=1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Incomplete key value pair for option", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://example.com/?w", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Username with password containing an unescaped colon", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://alice:foo:bar@127.0.0.1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Username containing an unescaped at-sign", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://alice@@127.0.0.1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Username with password containing an unescaped at-sign", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://alice@foo:bar@127.0.0.1", 
-            "valid": false, 
-            "warning": null
-        },
-	    {
-            "auth": null,
-            "description": "Username containing an unescaped slash",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice/@localhost/db",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username containing unescaped slash with password",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice/bob:foo@localhost/db",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username with password containing an unescaped slash",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice:foo/bar@localhost/db",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null, 
-            "description": "Host with unescaped slash", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb:///tmp/mongodb-27017.sock/", 
-            "valid": false, 
-            "warning": null
-        },
-	    {
-            "auth": null,
-            "description": "mongodb+srv with multiple service names",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb+srv://test5.test.mongodb.com,test6.test.mongodb.com",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "mongodb+srv with port number",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb+srv://test7.test.mongodb.com:27018",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username with password containing an unescaped percent sign",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice%foo:bar@127.0.0.1",
-            "valid": false,
-            "warning": null
-        }
-    ]
+  "tests": [
+    {
+      "description": "Empty string",
+      "uri": "",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid scheme",
+      "uri": "mongo://localhost:27017",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Missing host",
+      "uri": "mongodb://",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier",
+      "uri": "mongodb://localhost::27017",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier and trailing slash",
+      "uri": "mongodb://localhost::27017/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier with missing host and port",
+      "uri": "mongodb://::",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier with missing port",
+      "uri": "mongodb://localhost,localhost::",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier and second host",
+      "uri": "mongodb://localhost::27017,abc",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (negative number) with hostname",
+      "uri": "mongodb://localhost:-1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (zero) with hostname",
+      "uri": "mongodb://localhost:0/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with hostname",
+      "uri": "mongodb://localhost:65536",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with hostname and trailing slash",
+      "uri": "mongodb://localhost:65536/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (non-numeric string) with hostname",
+      "uri": "mongodb://localhost:foo",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (negative number) with IP literal",
+      "uri": "mongodb://[::1]:-1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (zero) with IP literal",
+      "uri": "mongodb://[::1]:0/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with IP literal",
+      "uri": "mongodb://[::1]:65536",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with IP literal and trailing slash",
+      "uri": "mongodb://[::1]:65536/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (non-numeric string) with IP literal",
+      "uri": "mongodb://[::1]:foo",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Incomplete key value pair for option",
+      "uri": "mongodb://example.com/?w",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped colon",
+      "uri": "mongodb://alice:foo:bar@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing an unescaped at-sign",
+      "uri": "mongodb://alice@@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped at-sign",
+      "uri": "mongodb://alice@foo:bar@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing an unescaped slash",
+      "uri": "mongodb://alice/@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing unescaped slash with password",
+      "uri": "mongodb://alice/bob:foo@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped slash",
+      "uri": "mongodb://alice:foo/bar@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Host with unescaped slash",
+      "uri": "mongodb:///tmp/mongodb-27017.sock/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "mongodb+srv with multiple service names",
+      "uri": "mongodb+srv://test5.test.mongodb.com,test6.test.mongodb.com",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "mongodb+srv with port number",
+      "uri": "mongodb+srv://test7.test.mongodb.com:27018",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped percent sign",
+      "uri": "mongodb://alice%foo:bar@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped percent sign and an escaped one",
+      "uri": "mongodb://user%20%:password@localhost",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped percent sign (non hex digit)",
+      "uri": "mongodb://user%w:password@localhost",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    }
+  ]
 }

--- a/specifications/connection-string/tests/invalid-uris.yml
+++ b/specifications/connection-string/tests/invalid-uris.yml
@@ -144,14 +144,6 @@ tests:
         auth: ~
         options: ~
     -
-        description: "Missing delimiting slash between hosts and options"
-        uri: "mongodb://example.com?w=1"
-        valid: false
-        warning: ~
-        hosts: ~
-        auth: ~
-        options: ~
-    -
         description: "Incomplete key value pair for option"
         uri: "mongodb://example.com/?w"
         valid: false
@@ -239,3 +231,23 @@ tests:
         hosts: ~
         auth: ~
         options: ~
+
+    -
+        description: "Username with password containing an unescaped percent sign and an escaped one"
+        uri: "mongodb://user%20%:password@localhost"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+
+    -
+        description: "Username with password containing an unescaped percent sign (non hex digit)"
+        uri: "mongodb://user%w:password@localhost"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+
+    

--- a/specifications/connection-string/tests/valid-auth.json
+++ b/specifications/connection-string/tests/valid-auth.json
@@ -1,246 +1,246 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "User info for single IPv4 host without database",
+      "uri": "mongodb://alice:foo@127.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": {
-                "db": null, 
-                "password": "foo", 
-                "username": "alice"
-            }, 
-            "description": "User info for single IPv4 host without database", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:foo@127.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "foo",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single IPv4 host with database",
+      "uri": "mongodb://alice:foo@127.0.0.1/test",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": {
-                "db": "test", 
-                "password": "foo", 
-                "username": "alice"
-            }, 
-            "description": "User info for single IPv4 host with database", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:foo@127.0.0.1/test", 
-            "valid": true, 
-            "warning": false
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "foo",
+        "db": "test"
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single IP literal host without database",
+      "uri": "mongodb://bob:bar@[::1]:27018",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27018
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single IP literal host with database",
+      "uri": "mongodb://bob:bar@[::1]:27018/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27018
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single hostname without database",
+      "uri": "mongodb://eve:baz@example.com",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "eve",
+        "password": "baz",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single hostname with database",
+      "uri": "mongodb://eve:baz@example.com/db2",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "eve",
+        "password": "baz",
+        "db": "db2"
+      },
+      "options": null
+    },
+    {
+      "description": "User info for multiple hosts without database",
+      "uri": "mongodb://alice:secret@127.0.0.1,example.com:27018",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
         },
         {
-            "auth": {
-                "db": null, 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "User info for single IP literal host without database", 
-            "hosts": [
-                {
-                    "host": "::1", 
-                    "port": 27018, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://bob:bar@[::1]:27018", 
-            "valid": true, 
-            "warning": false
-        }, 
+          "type": "hostname",
+          "host": "example.com",
+          "port": 27018
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "User info for multiple hosts with database",
+      "uri": "mongodb://alice:secret@example.com,[::1]:27019/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "User info for single IP literal host with database", 
-            "hosts": [
-                {
-                    "host": "::1", 
-                    "port": 27018, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://bob:bar@[::1]:27018/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "baz", 
-                "username": "eve"
-            }, 
-            "description": "User info for single hostname without database", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://eve:baz@example.com", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "db2", 
-                "password": "baz", 
-                "username": "eve"
-            }, 
-            "description": "User info for single hostname with database", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://eve:baz@example.com/db2", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "secret", 
-                "username": "alice"
-            }, 
-            "description": "User info for multiple hosts without database", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }, 
-                {
-                    "host": "example.com", 
-                    "port": 27018, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:secret@127.0.0.1,example.com:27018", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "secret", 
-                "username": "alice"
-            }, 
-            "description": "User info for multiple hosts with database", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }, 
-                {
-                    "host": "::1", 
-                    "port": 27019, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:secret@example.com,[::1]:27019/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": null, 
-                "username": "alice"
-            }, 
-            "description": "Username without password", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice@127.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "", 
-                "username": "alice"
-            }, 
-            "description": "Username with empty password", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:@127.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "my=db", 
-                "password": null, 
-                "username": "@l:ce/="
-            }, 
-            "description": "Escaped username and database without password", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%40l%3Ace%2F%3D@example.com/my%3Ddb", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin?", 
-                "password": "f:zzb@z/z=", 
-                "username": "$am"
-            }, 
-            "description": "Escaped user info and database (MONGODB-CR)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": {
-                "authmechanism": "MONGODB-CR"
-            }, 
-            "uri": "mongodb://%24am:f%3Azzb%40z%2Fz%3D@127.0.0.1/admin%3F?authMechanism=MONGODB-CR", 
-            "valid": true, 
-            "warning": false
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
         },
-{
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27019
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Username without password",
+      "uri": "mongodb://alice@127.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": null,
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "Username with empty password",
+      "uri": "mongodb://alice:@127.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "Escaped username and database without password",
+      "uri": "mongodb://%40l%3Ace%2F%3D@example.com/my%3Ddb",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "@l:ce/=",
+        "password": null,
+        "db": "my=db"
+      },
+      "options": null
+    },
+    {
+      "description": "Escaped user info and database (MONGODB-CR)",
+      "uri": "mongodb://%24am:f%3Azzb%40z%2Fz%3D@127.0.0.1/admin%3F?authMechanism=MONGODB-CR",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "$am",
+        "password": "f:zzb@z/z=",
+        "db": "admin?"
+      },
+      "options": {
+        "authmechanism": "MONGODB-CR"
+      }
+    },
+    {
       "description": "Subdelimiters in user/pass don't need escaping (MONGODB-CR)",
       "uri": "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=MONGODB-CR",
       "valid": true,
@@ -260,73 +260,74 @@
       "options": {
         "authmechanism": "MONGODB-CR"
       }
-    },	
+    },
+    {
+      "description": "Escaped username (MONGODB-X509)",
+      "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": {
-                "db": null, 
-                "password": null, 
-                "username": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry"
-            }, 
-            "description": "Escaped username (MONGODB-X509)", 
-            "hosts": [
-                {
-                    "host": "localhost", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "authmechanism": "MONGODB-X509"
-            }, 
-            "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "secret", 
-                "username": "user@EXAMPLE.COM"
-            }, 
-            "description": "Escaped username (GSSAPI)", 
-            "hosts": [
-                {
-                    "host": "localhost", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "authmechanism": "GSSAPI", 
-                "authmechanismproperties": {
-                    "CANONICALIZE_HOST_NAME": true, 
-                    "SERVICE_NAME": "other"
-                }
-            }, 
-            "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "secret", 
-                "username": "alice"
-            }, 
-            "description": "At-signs in options aren't part of the userinfo", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "replicaset": "my@replicaset"
-            }, 
-            "uri": "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset", 
-            "valid": true, 
-            "warning": false
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
         }
-    ]
+      ],
+      "auth": {
+        "username": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
+        "password": null,
+        "db": null
+      },
+      "options": {
+        "authmechanism": "MONGODB-X509"
+      }
+    },
+    {
+      "description": "Escaped username (GSSAPI)",
+      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forward,SERVICE_HOST:example.com&authMechanism=GSSAPI",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "user@EXAMPLE.COM",
+        "password": "secret",
+        "db": null
+      },
+      "options": {
+        "authmechanism": "GSSAPI",
+        "authmechanismproperties": {
+          "SERVICE_NAME": "other",
+          "SERVICE_HOST": "example.com",
+          "CANONICALIZE_HOST_NAME": "forward"
+        }
+      }
+    },
+    {
+      "description": "At-signs in options aren't part of the userinfo",
+      "uri": "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": "admin"
+      },
+      "options": {
+        "replicaset": "my@replicaset"
+      }
+    }
+  ]
 }

--- a/specifications/connection-string/tests/valid-auth.yml
+++ b/specifications/connection-string/tests/valid-auth.yml
@@ -222,7 +222,7 @@ tests:
             authmechanism: "MONGODB-X509"
     -
         description: "Escaped username (GSSAPI)"
-        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI"
+        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forward,SERVICE_HOST:example.com&authMechanism=GSSAPI"
         valid: true
         warning: false
         hosts:
@@ -238,7 +238,8 @@ tests:
             authmechanism: "GSSAPI"
             authmechanismproperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true
+                SERVICE_HOST: "example.com"
+                CANONICALIZE_HOST_NAME: "forward"
     -
         description: "At-signs in options aren't part of the userinfo"
         uri: "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset"

--- a/specifications/connection-string/tests/valid-host_identifiers.json
+++ b/specifications/connection-string/tests/valid-host_identifiers.json
@@ -1,154 +1,154 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Single IPv4 host without port",
+      "uri": "mongodb://127.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": null, 
-            "description": "Single IPv4 host without port", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single IPv4 host with port", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": 27018, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1:27018", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single IP literal host without port", 
-            "hosts": [
-                {
-                    "host": "::1", 
-                    "port": null, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://[::1]", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single IP literal host with port", 
-            "hosts": [
-                {
-                    "host": "::1", 
-                    "port": 27019, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://[::1]:27019", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single hostname without port", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://example.com", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single hostname with port", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": 27020, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://example.com:27020", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single hostname (resembling IPv4) without port", 
-            "hosts": [
-                {
-                    "host": "256.0.0.1", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://256.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (mixed formats)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }, 
-                {
-                    "host": "::1", 
-                    "port": 27018, 
-                    "type": "ip_literal"
-                }, 
-                {
-                    "host": "example.com", 
-                    "port": 27019, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1,[::1]:27018,example.com:27019", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "UTF-8 hosts", 
-            "hosts": [
-                {
-                    "host": "b\u00fccher.example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }, 
-                {
-                    "host": "uml\u00e4ut.example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://b\u00fccher.example.com,uml\u00e4ut.example.com/", 
-            "valid": true, 
-            "warning": false
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
         }
-    ]
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single IPv4 host with port",
+      "uri": "mongodb://127.0.0.1:27018",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": 27018
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single IP literal host without port",
+      "uri": "mongodb://[::1]",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single IP literal host with port",
+      "uri": "mongodb://[::1]:27019",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27019
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single hostname without port",
+      "uri": "mongodb://example.com",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single hostname with port",
+      "uri": "mongodb://example.com:27020",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": 27020
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single hostname (resembling IPv4) without port",
+      "uri": "mongodb://256.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "256.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (mixed formats)",
+      "uri": "mongodb://127.0.0.1,[::1]:27018,example.com:27019",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        },
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27018
+        },
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": 27019
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "UTF-8 hosts",
+      "uri": "mongodb://bücher.example.com,umläut.example.com/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "bücher.example.com",
+          "port": null
+        },
+        {
+          "type": "hostname",
+          "host": "umläut.example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    }
+  ]
 }

--- a/specifications/connection-string/tests/valid-options.json
+++ b/specifications/connection-string/tests/valid-options.json
@@ -1,25 +1,42 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Option names are normalized to lowercase",
+      "uri": "mongodb://alice:secret@example.com/admin?AUTHMechanism=MONGODB-CR",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": {
-                "db": "admin", 
-                "password": "secret", 
-                "username": "alice"
-            }, 
-            "description": "Option names are normalized to lowercase", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "authmechanism": "MONGODB-CR"
-            }, 
-            "uri": "mongodb://alice:secret@example.com/admin?AUTHMechanism=MONGODB-CR", 
-            "valid": true, 
-            "warning": false
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
         }
-    ]
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": "admin"
+      },
+      "options": {
+        "authmechanism": "MONGODB-CR"
+      }
+    },
+    {
+      "description": "Missing delimiting slash between hosts and options",
+      "uri": "mongodb://example.com?tls=true",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "tls": true
+      }
+    }
+  ]
 }

--- a/specifications/connection-string/tests/valid-options.yml
+++ b/specifications/connection-string/tests/valid-options.yml
@@ -15,3 +15,16 @@ tests:
             db: "admin"
         options:
             authmechanism: "MONGODB-CR"
+    -
+        description: "Missing delimiting slash between hosts and options"
+        uri: "mongodb://example.com?tls=true"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+              tls: true

--- a/specifications/connection-string/tests/valid-unix_socket-absolute.json
+++ b/specifications/connection-string/tests/valid-unix_socket-absolute.json
@@ -1,251 +1,251 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Unix domain socket (absolute path with trailing slash)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": null, 
-            "description": "Unix domain socket (absolute path with trailing slash)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock/", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket (absolute path without trailing slash)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket (absolute path with spaces in path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/ /mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple Unix domain sockets (absolute paths)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (absolute path and ipv4)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": 27017, 
-                    "type": "ipv4"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1:27017,%2Ftmp%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (absolute path and hostname resembling relative path)", 
-            "hosts": [
-                {
-                    "host": "mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "hostname"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://mongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "foo", 
-                "username": "alice"
-            }, 
-            "description": "Unix domain socket with auth database (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:foo@%2Ftmp%2Fmongodb-27017.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket with path resembling socket file (absolute path with trailing slash)", 
-            "hosts": [
-                {
-                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket with path resembling socket file (absolute path without trailing slash)", 
-            "hosts": [
-                {
-                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "Unix domain socket with path resembling socket file and auth (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://bob:bar@%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": null, 
-                "username": null
-            }, 
-            "description": "Multiple Unix domain sockets and auth DB (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": null, 
-                "username": null
-            }, 
-            "description": "Multiple Unix domain sockets with auth DB (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin.shoe", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "Multiple Unix domain sockets with auth and query string (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": {
-                "w": 1
-            }, 
-            "uri": "mongodb://bob:bar@%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin?w=1", 
-            "valid": true, 
-            "warning": false
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
         }
-    ]
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket (absolute path without trailing slash)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket (absolute path with spaces in path)",
+      "uri": "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/ /mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets (absolute paths)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (absolute path and ipv4)",
+      "uri": "mongodb://127.0.0.1:27017,%2Ftmp%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": 27017
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (absolute path and hostname resembling relative path)",
+      "uri": "mongodb://mongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with auth database (absolute path)",
+      "uri": "mongodb://alice:foo@%2Ftmp%2Fmongodb-27017.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "foo",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file (absolute path with trailing slash)",
+      "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file (absolute path without trailing slash)",
+      "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file and auth (absolute path)",
+      "uri": "mongodb://bob:bar@%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets and auth DB (absolute path)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": null,
+        "password": null,
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets with auth DB (absolute path)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": null,
+        "password": null,
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets with auth and query string (absolute path)",
+      "uri": "mongodb://bob:bar@%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin?w=1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": {
+        "w": 1
+      }
+    }
+  ]
 }

--- a/specifications/connection-string/tests/valid-unix_socket-relative.json
+++ b/specifications/connection-string/tests/valid-unix_socket-relative.json
@@ -1,271 +1,271 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Unix domain socket (relative path with trailing slash)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": null, 
-            "description": "Unix domain socket (relative path with trailing slash)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock/", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket (relative path without trailing slash)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket (relative path with spaces)", 
-            "hosts": [
-                {
-                    "host": "rel/ /mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2F %2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple Unix domain sockets (relative paths)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple Unix domain sockets (relative and absolute paths)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (relative path and ipv4)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": 27017, 
-                    "type": "ipv4"
-                }, 
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1:27017,rel%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (relative path and hostname resembling relative path)", 
-            "hosts": [
-                {
-                    "host": "mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "hostname"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://mongodb-27017.sock,rel%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "foo", 
-                "username": "alice"
-            }, 
-            "description": "Unix domain socket with auth database (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:foo@rel%2Fmongodb-27017.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket with path resembling socket file (relative path with trailing slash)", 
-            "hosts": [
-                {
-                    "host": "rel/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock/", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket with path resembling socket file (relative path without trailing slash)", 
-            "hosts": [
-                {
-                    "host": "rel/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "Unix domain socket with path resembling socket file and auth (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://bob:bar@rel%2Fpath.to.sock%2Fmongodb-27017.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": null, 
-                "username": null
-            }, 
-            "description": "Multiple Unix domain sockets and auth DB resembling a socket (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": null, 
-                "username": null
-            }, 
-            "description": "Multiple Unix domain sockets with auth DB resembling a path (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "Multiple Unix domain sockets with auth and query string (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": {
-                "w": 1
-            }, 
-            "uri": "mongodb://bob:bar@rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin?w=1", 
-            "valid": true, 
-            "warning": false
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
         }
-    ]
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket (relative path without trailing slash)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket (relative path with spaces)",
+      "uri": "mongodb://rel%2F %2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/ /mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets (relative paths)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets (relative and absolute paths)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (relative path and ipv4)",
+      "uri": "mongodb://127.0.0.1:27017,rel%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": 27017
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (relative path and hostname resembling relative path)",
+      "uri": "mongodb://mongodb-27017.sock,rel%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with auth database (relative path)",
+      "uri": "mongodb://alice:foo@rel%2Fmongodb-27017.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "foo",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file (relative path with trailing slash)",
+      "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file (relative path without trailing slash)",
+      "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file and auth (relative path)",
+      "uri": "mongodb://bob:bar@rel%2Fpath.to.sock%2Fmongodb-27017.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets and auth DB resembling a socket (relative path)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": null,
+        "password": null,
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets with auth DB resembling a path (relative path)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": null,
+        "password": null,
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets with auth and query string (relative path)",
+      "uri": "mongodb://bob:bar@rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin?w=1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": {
+        "w": 1
+      }
+    }
+  ]
 }

--- a/specifications/connection-string/tests/valid-warnings.json
+++ b/specifications/connection-string/tests/valid-warnings.json
@@ -1,68 +1,98 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Unrecognized option keys are ignored",
+      "uri": "mongodb://example.com/?foo=bar",
+      "valid": true,
+      "warning": true,
+      "hosts": [
         {
-            "auth": null, 
-            "description": "Unrecognized option keys are ignored", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://example.com/?foo=bar", 
-            "valid": true, 
-            "warning": true
-        }, 
-        {
-            "auth": null, 
-            "description": "Unsupported option values are ignored", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://example.com/?fsync=ifPossible", 
-            "valid": true, 
-            "warning": true
-        }, 
-        {
-            "auth": null, 
-            "description": "Repeated option keys", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "replicaset": "test"
-            }, 
-            "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test", 
-            "valid": true, 
-            "warning": true
-        }, 
-        {
-            "auth": null, 
-            "description": "Deprecated (or unknown) options are ignored if replacement exists", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "wtimeoutms": 10
-            }, 
-            "uri": "mongodb://example.com/?wtimeout=5&wtimeoutMS=10", 
-            "valid": true, 
-            "warning": true
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
         }
-    ]
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unsupported option values are ignored",
+      "uri": "mongodb://example.com/?fsync=ifPossible",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Repeated option keys",
+      "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "Deprecated (or unknown) options are ignored if replacement exists",
+      "uri": "mongodb://example.com/?wtimeout=5&wtimeoutMS=10",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "wtimeoutms": 10
+      }
+    },
+    {
+      "description": "Empty integer option values are ignored",
+      "uri": "mongodb://localhost/?maxIdleTimeMS=",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Empty boolean option value are ignored",
+      "uri": "mongodb://localhost/?journal=",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    }
+  ]
 }

--- a/specifications/connection-string/tests/valid-warnings.yml
+++ b/specifications/connection-string/tests/valid-warnings.yml
@@ -49,3 +49,27 @@ tests:
         auth: ~
         options:
             wtimeoutms: 10
+    -
+        description: "Empty integer option values are ignored"
+        uri: "mongodb://localhost/?maxIdleTimeMS="
+        valid: true
+        warning: true
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Empty boolean option value are ignored"
+        uri: "mongodb://localhost/?journal="
+        valid: true
+        warning: true
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~

--- a/tests/MongoDB.Driver.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
@@ -346,7 +346,6 @@ namespace MongoDB.Driver.Tests.Specifications.connection_string
         {
             private static readonly string[] __ignoredTestNames =
             {
-                "invalid-uris.json:Missing delimiting slash between hosts and options",
                 // Not supported readConcernLevel options are not allowed for parsing
                 "concern-options.json:Arbitrary string readConcernLevel does not cause a warning",
                 // srvServiceName not yet implemented (CSHARP-3745)


### PR DESCRIPTION
I sync'd `$/specifications/connection-string/tests` to the spec repo. The changes are minimal and all tests pass. The reason for the large diff is a formatting change in the JSON files. The YAML files (from which the JSON files were generated) were not significantly altered.