### PR TITLE
CSHARP-4714: Reset EC2 instance profile at end of test if necessary.

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -961,6 +961,16 @@ functions:
   cleanup:
     - command: shell.exec
       params:
+        shell: "bash"
+        script: |
+          ${PREPARE_SHELL}
+          cd "${DRIVERS_TOOLS}/.evergreen/auth_aws"
+          if [ -f "./aws_e2e_setup.json" ]; then
+            . ./activate-authawsvenv.sh
+            python ./lib/aws_assign_instance_profile.py
+          fi
+    - command: shell.exec
+      params:
         script: |
           ${PREPARE_SHELL}
           cd "$MONGO_ORCHESTRATION_HOME"


### PR DESCRIPTION
This is an additional cleanup step if the EC2 instance profile was changed during variant setup for MONGODB-AWS auth testing. This should improve the stability of the EG environment and avoid failures on future runs by any driver when run on the same host.