### PR TITLE
Allow the DEFAULT auth mechanism to be specified explicitly

### DIFF
--- a/specifications/auth/tests/connection-string.json
+++ b/specifications/auth/tests/connection-string.json
@@ -12,6 +12,18 @@
         "mechanism_properties": null
       }
     },
+      {
+          "description": "should use the default source and mechanism, when DEFAULT is specified",
+          "uri": "mongodb://user:password@localhost?authMechanism=DEFAULT",
+          "valid": true,
+          "credential": {
+              "username": "user",
+              "password": "password",
+              "source": "admin",
+              "mechanism": "DEFAULT",
+              "mechanism_properties": null
+          }
+      },
     {
       "description": "should use the database when no authSource is specified",
       "uri": "mongodb://user:password@localhost/foo",

--- a/src/MongoDB.Driver.Core/Core/Authentication/DefaultAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/DefaultAuthenticator.cs
@@ -37,6 +37,17 @@ namespace MongoDB.Driver.Core.Authentication
         private readonly ServerApi _serverApi;
         private IAuthenticator _speculativeAuthenticator;
 
+        /// <summary>
+        /// Gets the name of the mechanism.
+        /// </summary>
+        /// <value>
+        /// The name of the mechanism.
+        /// </value>
+        public static string MechanismName
+        {
+            get { return "DEFAULT"; }
+        }
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultAuthenticator"/> class.

--- a/src/MongoDB.Driver/MongoCredential.cs
+++ b/src/MongoDB.Driver/MongoCredential.cs
@@ -407,7 +407,7 @@ namespace MongoDB.Driver
                     _identity.Username,
                     insecurePassword);
 
-                if (_mechanism == null)
+                if (_mechanism == null || _mechanism == DefaultAuthenticator.MechanismName)
                 {
                     return new DefaultAuthenticator(credential, serverApi);
                 }


### PR DESCRIPTION
MongoDBCompass can copy a connectionstring, and for the DEFAULT auth mechanism it will include `authMechanism=DEFAULT` literaly. This PR makes the `ToAuthenticator` method accept that.

Before this, it would only use the default if the authMechanism was not specified at all, and including it in the connectionstring would lead to an exception.