### PR TITLE
CSHARP-4862: Include TLS1.3 in the list of acceptable TLS protocols.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Configuration/SslStreamSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/SslStreamSettings.cs
@@ -53,9 +53,9 @@ namespace MongoDB.Driver.Core.Configuration
             _checkCertificateRevocation = checkCertificateRevocation.WithDefault(false);
             _clientCertificates = Ensure.IsNotNull(clientCertificates.WithDefault(Enumerable.Empty<X509Certificate>()), "clientCertificates").ToList();
             _clientCertificateSelectionCallback = clientCertificateSelectionCallback.WithDefault(null);
-            // SslProtocols.Tls13 not available until netcoreapp3.1 (not in netstandard2.1) and net5.0
-            const SslProtocols SslProtocolsTls13 = (SslProtocols)12288;
-            _enabledSslProtocols = enabledProtocols.WithDefault(SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
+            // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
+            const SslProtocols sslProtocolsTls13 = (SslProtocols)12288;
+            _enabledSslProtocols = enabledProtocols.WithDefault(sslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
             _serverCertificateValidationCallback = serverCertificateValidationCallback.WithDefault(null);
         }
 

--- a/src/MongoDB.Driver.Core/Core/Configuration/SslStreamSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/SslStreamSettings.cs
@@ -34,6 +34,9 @@ namespace MongoDB.Driver.Core.Configuration
         private readonly SslProtocols _enabledSslProtocols;
         private readonly RemoteCertificateValidationCallback _serverCertificateValidationCallback;
 
+        // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
+        internal const SslProtocols SslProtocolsTls13 = (SslProtocols)12288;
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the <see cref="SslStreamSettings"/> class.
@@ -53,9 +56,7 @@ namespace MongoDB.Driver.Core.Configuration
             _checkCertificateRevocation = checkCertificateRevocation.WithDefault(false);
             _clientCertificates = Ensure.IsNotNull(clientCertificates.WithDefault(Enumerable.Empty<X509Certificate>()), "clientCertificates").ToList();
             _clientCertificateSelectionCallback = clientCertificateSelectionCallback.WithDefault(null);
-            // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
-            const SslProtocols sslProtocolsTls13 = (SslProtocols)12288;
-            _enabledSslProtocols = enabledProtocols.WithDefault(sslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
+            _enabledSslProtocols = enabledProtocols.WithDefault(SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
             _serverCertificateValidationCallback = serverCertificateValidationCallback.WithDefault(null);
         }
 

--- a/src/MongoDB.Driver.Core/Core/Configuration/SslStreamSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/SslStreamSettings.cs
@@ -53,7 +53,9 @@ namespace MongoDB.Driver.Core.Configuration
             _checkCertificateRevocation = checkCertificateRevocation.WithDefault(false);
             _clientCertificates = Ensure.IsNotNull(clientCertificates.WithDefault(Enumerable.Empty<X509Certificate>()), "clientCertificates").ToList();
             _clientCertificateSelectionCallback = clientCertificateSelectionCallback.WithDefault(null);
-            _enabledSslProtocols = enabledProtocols.WithDefault(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
+            // SslProtocols.Tls13 not available until netcoreapp3.1 (not in netstandard2.1) and net5.0
+            const SslProtocols SslProtocolsTls13 = (SslProtocols)12288;
+            _enabledSslProtocols = enabledProtocols.WithDefault(SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
             _serverCertificateValidationCallback = serverCertificateValidationCallback.WithDefault(null);
         }
 

--- a/src/MongoDB.Driver/SslSettings.cs
+++ b/src/MongoDB.Driver/SslSettings.cs
@@ -38,7 +38,9 @@ namespace MongoDB.Driver
         private bool _checkCertificateRevocation = false;
         private X509CertificateCollection _clientCertificateCollection;
         private LocalCertificateSelectionCallback _clientCertificateSelectionCallback;
-        private SslProtocols _enabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
+        // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
+        private const SslProtocols SslProtocolsTls13 = (SslProtocols)12288;
+        private SslProtocols _enabledSslProtocols = SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
         private RemoteCertificateValidationCallback _serverCertificateValidationCallback;
 
         // the following fields are set when the SslSettings are frozen
@@ -209,7 +211,7 @@ namespace MongoDB.Driver
         /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
         public override int GetHashCode()
         {

--- a/src/MongoDB.Driver/SslSettings.cs
+++ b/src/MongoDB.Driver/SslSettings.cs
@@ -38,9 +38,7 @@ namespace MongoDB.Driver
         private bool _checkCertificateRevocation = false;
         private X509CertificateCollection _clientCertificateCollection;
         private LocalCertificateSelectionCallback _clientCertificateSelectionCallback;
-        // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
-        private const SslProtocols SslProtocolsTls13 = (SslProtocols)12288;
-        private SslProtocols _enabledSslProtocols = SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
+        private SslProtocols _enabledSslProtocols = SslStreamSettings.SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
         private RemoteCertificateValidationCallback _serverCertificateValidationCallback;
 
         // the following fields are set when the SslSettings are frozen

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/SslStreamSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/SslStreamSettingsTests.cs
@@ -34,7 +34,9 @@ namespace MongoDB.Driver.Core.Configuration
             subject.CheckCertificateRevocation.Should().BeFalse();
             subject.ClientCertificates.Should().BeEmpty();
             subject.ClientCertificateSelectionCallback.Should().BeNull();
-            subject.EnabledSslProtocols.Should().Be((SslProtocols)12288 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
+            // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
+            const SslProtocols sslProtocolsTls13 = (SslProtocols)12288;
+            subject.EnabledSslProtocols.Should().Be(sslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
             subject.ServerCertificateValidationCallback.Should().BeNull();
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/SslStreamSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/SslStreamSettingsTests.cs
@@ -34,9 +34,7 @@ namespace MongoDB.Driver.Core.Configuration
             subject.CheckCertificateRevocation.Should().BeFalse();
             subject.ClientCertificates.Should().BeEmpty();
             subject.ClientCertificateSelectionCallback.Should().BeNull();
-            // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
-            const SslProtocols sslProtocolsTls13 = (SslProtocols)12288;
-            subject.EnabledSslProtocols.Should().Be(sslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
+            subject.EnabledSslProtocols.Should().Be(SslStreamSettings.SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
             subject.ServerCertificateValidationCallback.Should().BeNull();
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/SslStreamSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/SslStreamSettingsTests.cs
@@ -34,7 +34,7 @@ namespace MongoDB.Driver.Core.Configuration
             subject.CheckCertificateRevocation.Should().BeFalse();
             subject.ClientCertificates.Should().BeEmpty();
             subject.ClientCertificateSelectionCallback.Should().BeNull();
-            subject.EnabledSslProtocols.Should().Be(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
+            subject.EnabledSslProtocols.Should().Be((SslProtocols)12288 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
             subject.ServerCertificateValidationCallback.Should().BeNull();
         }
 

--- a/tests/MongoDB.Driver.Tests/SslSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/SslSettingsTests.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using FluentAssertions;
 using System;
 using System.IO;
 using System.Linq;
@@ -20,9 +21,8 @@ using System.Net.Security;
 using System.Reflection;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
-using Xunit;
-using FluentAssertions;
 using MongoDB.Driver.Core.Configuration;
+using Xunit;
 
 namespace MongoDB.Driver.Tests
 {

--- a/tests/MongoDB.Driver.Tests/SslSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/SslSettingsTests.cs
@@ -22,6 +22,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Xunit;
 using FluentAssertions;
+using MongoDB.Driver.Core.Configuration;
 
 namespace MongoDB.Driver.Tests
 {
@@ -118,9 +119,7 @@ namespace MongoDB.Driver.Tests
             settings.CheckCertificateRevocation.Should().BeFalse();
             Assert.Equal(null, settings.ClientCertificates);
             Assert.Equal(null, settings.ClientCertificateSelectionCallback);
-            // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
-            const SslProtocols sslProtocolsTls13 = (SslProtocols)12288;
-            Assert.Equal(sslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, settings.EnabledSslProtocols);
+            Assert.Equal(SslStreamSettings.SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, settings.EnabledSslProtocols);
             Assert.Equal(null, settings.ServerCertificateValidationCallback);
         }
 
@@ -158,9 +157,7 @@ namespace MongoDB.Driver.Tests
         public void TestEnabledSslProtocols()
         {
             var settings = new SslSettings();
-            // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
-            const SslProtocols sslProtocolsTls13 = (SslProtocols)12288;
-            Assert.Equal(sslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, settings.EnabledSslProtocols);
+            Assert.Equal(SslStreamSettings.SslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, settings.EnabledSslProtocols);
 
             var enabledSslProtocols = SslProtocols.Tls;
             settings.EnabledSslProtocols = enabledSslProtocols;

--- a/tests/MongoDB.Driver.Tests/SslSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/SslSettingsTests.cs
@@ -118,7 +118,9 @@ namespace MongoDB.Driver.Tests
             settings.CheckCertificateRevocation.Should().BeFalse();
             Assert.Equal(null, settings.ClientCertificates);
             Assert.Equal(null, settings.ClientCertificateSelectionCallback);
-            Assert.Equal(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, settings.EnabledSslProtocols);
+            // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
+            const SslProtocols sslProtocolsTls13 = (SslProtocols)12288;
+            Assert.Equal(sslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, settings.EnabledSslProtocols);
             Assert.Equal(null, settings.ServerCertificateValidationCallback);
         }
 
@@ -156,7 +158,9 @@ namespace MongoDB.Driver.Tests
         public void TestEnabledSslProtocols()
         {
             var settings = new SslSettings();
-            Assert.Equal(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, settings.EnabledSslProtocols);
+            // SslProtocols.Tls13 is not available until netcoreapp3.1 (but not part of netstandard2.1) and net5.0
+            const SslProtocols sslProtocolsTls13 = (SslProtocols)12288;
+            Assert.Equal(sslProtocolsTls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, settings.EnabledSslProtocols);
 
             var enabledSslProtocols = SslProtocols.Tls;
             settings.EnabledSslProtocols = enabledSslProtocols;


### PR DESCRIPTION
We don't explicitly test different TLS versions as we rely on the underlying TLS libraries to negotiate the protocol. This commit opts into TLS1.3 as an option. I verified that a `netcoreapp2.1` could still connect to an Atlas cluster with TLS1.2 enabled after adding the enum value for TLS1.3 to the flags. The value of the `SslProtocols.Tls13` flag is from:

https://learn.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=net-8.0