### PR TITLE
CSHARP-4615: Switch to polling monitoring on FaaS environment.

### DIFF
--- a/specifications/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.json
+++ b/specifications/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.json
@@ -1,0 +1,449 @@
+{
+  "description": "serverMonitoringMode",
+  "schemaVersion": "1.17",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "single",
+        "sharded",
+        "sharded-replicaset"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "connect with serverMonitoringMode=auto >=4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "auto"
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "connect with serverMonitoringMode=auto <4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "auto",
+                    "heartbeatFrequencyMS": 500
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "connect with serverMonitoringMode=stream >=4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "stream"
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "connect with serverMonitoringMode=stream <4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "stream",
+                    "heartbeatFrequencyMS": 500
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "connect with serverMonitoringMode=poll",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "poll",
+                    "heartbeatFrequencyMS": 500
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.yml
+++ b/specifications/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.yml
@@ -1,0 +1,173 @@
+description: serverMonitoringMode
+
+schemaVersion: "1.17"
+# These tests cannot run on replica sets because the order of the expected
+# SDAM events are non-deterministic when monitoring multiple servers.
+# They also cannot run on Serverless or load balanced clusters where SDAM is disabled.
+runOnRequirements:
+  - topologies: [single, sharded, sharded-replicaset]
+    serverless: forbid
+tests:
+  - description: "connect with serverMonitoringMode=auto >=4.4"
+    runOnRequirements:
+      - minServerVersion: "4.4.0"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "auto"
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - &ping
+        name: runCommand
+        object: db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectResult: { ok: 1 }
+      # Wait for the second serverHeartbeatStartedEvent to ensure we start streaming.
+      - &waitForSecondHeartbeatStarted
+        name: waitForEvent
+        object: testRunner
+        arguments:
+          client: client
+          event:
+            serverHeartbeatStartedEvent: {}
+          count: 2
+    expectEvents: &streamingStartedEvents
+      - client: client
+        eventType: sdam
+        ignoreExtraEvents: true
+        events:
+          - serverHeartbeatStartedEvent:
+              awaited: False
+          - serverHeartbeatSucceededEvent:
+              awaited: False
+          - serverHeartbeatStartedEvent:
+              awaited: True
+
+  - description: "connect with serverMonitoringMode=auto <4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "auto"
+                  heartbeatFrequencyMS: 500
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - *ping
+      # Wait for the second serverHeartbeatStartedEvent to ensure we do not stream.
+      - *waitForSecondHeartbeatStarted
+    expectEvents: &pollingStartedEvents
+      - client: client
+        eventType: sdam
+        ignoreExtraEvents: true
+        events:
+          - serverHeartbeatStartedEvent:
+              awaited: False
+          - serverHeartbeatSucceededEvent:
+              awaited: False
+          - serverHeartbeatStartedEvent:
+              awaited: False
+
+  - description: "connect with serverMonitoringMode=stream >=4.4"
+    runOnRequirements:
+      - minServerVersion: "4.4.0"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "stream"
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - *ping
+      # Wait for the second serverHeartbeatStartedEvent to ensure we start streaming.
+      - *waitForSecondHeartbeatStarted
+    expectEvents: *streamingStartedEvents
+
+  - description: "connect with serverMonitoringMode=stream <4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "stream"
+                  heartbeatFrequencyMS: 500
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - *ping
+      # Wait for the second serverHeartbeatStartedEvent to ensure we do not stream.
+      - *waitForSecondHeartbeatStarted
+    expectEvents: *pollingStartedEvents
+
+  - description: "connect with serverMonitoringMode=poll"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "poll"
+                  heartbeatFrequencyMS: 500
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - *ping
+      # Wait for the second serverHeartbeatStartedEvent to ensure we do not stream.
+      - *waitForSecondHeartbeatStarted
+    expectEvents: *pollingStartedEvents

--- a/specifications/uri-options/tests/sdam-options.json
+++ b/specifications/uri-options/tests/sdam-options.json
@@ -1,0 +1,46 @@
+{
+  "tests": [
+    {
+      "description": "serverMonitoringMode=auto",
+      "uri": "mongodb://example.com/?serverMonitoringMode=auto",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "serverMonitoringMode": "auto"
+      }
+    },
+    {
+      "description": "serverMonitoringMode=stream",
+      "uri": "mongodb://example.com/?serverMonitoringMode=stream",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "serverMonitoringMode": "stream"
+      }
+    },
+    {
+      "description": "serverMonitoringMode=poll",
+      "uri": "mongodb://example.com/?serverMonitoringMode=poll",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "serverMonitoringMode": "poll"
+      }
+    },
+    {
+      "description": "invalid serverMonitoringMode",
+      "uri": "mongodb://example.com/?serverMonitoringMode=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/specifications/uri-options/tests/sdam-options.yml
+++ b/specifications/uri-options/tests/sdam-options.yml
@@ -1,0 +1,35 @@
+tests:
+    - description: "serverMonitoringMode=auto"
+      uri: "mongodb://example.com/?serverMonitoringMode=auto"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          serverMonitoringMode: "auto"
+
+    - description: "serverMonitoringMode=stream"
+      uri: "mongodb://example.com/?serverMonitoringMode=stream"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          serverMonitoringMode: "stream"
+
+    - description: "serverMonitoringMode=poll"
+      uri: "mongodb://example.com/?serverMonitoringMode=poll"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          serverMonitoringMode: "poll"
+
+    - description: "invalid serverMonitoringMode"
+      uri: "mongodb://example.com/?serverMonitoringMode=invalid"
+      valid: true
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}

--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilder.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterBuilder.cs
@@ -311,7 +311,8 @@ namespace MongoDB.Driver.Core.Configuration
             var serverMonitorStreamFactory = CreateTcpStreamFactory(serverMonitorTcpStreamSettings);
             var serverMonitorSettings = new ServerMonitorSettings(
                 connectTimeout: serverMonitorTcpStreamSettings.ConnectTimeout,
-                heartbeatInterval: _serverSettings.HeartbeatInterval);
+                heartbeatInterval: _serverSettings.HeartbeatInterval,
+                serverMonitoringMode: _serverSettings.ServerMonitoringMode);
 
             var serverMonitorConnectionFactory = new BinaryConnectionFactory(
                 serverMonitorConnectionSettings,

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -455,7 +455,7 @@ namespace MongoDB.Driver.Core.Configuration
         }
 
         /// <summary>
-        /// Gets the server selection timeout.
+        /// Gets the server monitoring mode.
         /// </summary>
         public ServerMonitoringMode? ServerMonitoringMode
         {

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -26,6 +26,7 @@ using MongoDB.Bson.IO;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
 
 namespace MongoDB.Driver.Core.Configuration
 {
@@ -98,6 +99,7 @@ namespace MongoDB.Driver.Core.Configuration
         private bool? _retryReads;
         private bool? _retryWrites;
         private ConnectionStringScheme _scheme;
+        private ServerMonitoringMode? _serverMonitoringMode;
         private TimeSpan? _serverSelectionTimeout;
         private TimeSpan? _socketTimeout;
         private int? _srvMaxHosts;
@@ -450,6 +452,14 @@ namespace MongoDB.Driver.Core.Configuration
         public ConnectionStringScheme Scheme
         {
             get { return _scheme; }
+        }
+
+        /// <summary>
+        /// Gets the server selection timeout.
+        /// </summary>
+        public ServerMonitoringMode? ServerMonitoringMode
+        {
+            get { return _serverMonitoringMode; }
         }
 
         /// <summary>
@@ -1100,6 +1110,9 @@ namespace MongoDB.Driver.Core.Configuration
                 case "serverselectiontimeout":
                 case "serverselectiontimeoutms":
                     _serverSelectionTimeout = ParseTimeSpan(name, value);
+                    break;
+                case "servermonitoringmode":
+                    _serverMonitoringMode = ParseEnum<ServerMonitoringMode>(name, value);
                     break;
                 case "sockettimeout":
                 case "sockettimeoutms":

--- a/src/MongoDB.Driver.Core/Core/Configuration/ServerSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ServerSettings.cs
@@ -17,6 +17,7 @@ using System;
 using System.Net.Sockets;
 using System.Threading;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
 
 namespace MongoDB.Driver.Core.Configuration
 {
@@ -36,11 +37,17 @@ namespace MongoDB.Driver.Core.Configuration
         /// Gets the default heartbeat timeout.
         /// </summary>
         public static TimeSpan DefaultHeartbeatTimeout => Timeout.InfiniteTimeSpan;
+
+        /// <summary>
+        /// Gets the default heartbeat timeout.
+        /// </summary>
+        public static ServerMonitoringMode DefaultServerMonitoringMode => ServerMonitoringMode.Auto;
         #endregion
 
         // fields
         private readonly TimeSpan _heartbeatInterval;
         private readonly TimeSpan _heartbeatTimeout;
+        private readonly ServerMonitoringMode _serverMonitoringMode;
 
         // constructors
         /// <summary>
@@ -48,12 +55,15 @@ namespace MongoDB.Driver.Core.Configuration
         /// </summary>
         /// <param name="heartbeatInterval">The heartbeat interval.</param>
         /// <param name="heartbeatTimeout">The heartbeat timeout.</param>
+        /// <param name="serverMonitoringMode">The server monitoring mode.</param>
         public ServerSettings(
             Optional<TimeSpan> heartbeatInterval = default(Optional<TimeSpan>),
-            Optional<TimeSpan> heartbeatTimeout = default(Optional<TimeSpan>))
+            Optional<TimeSpan> heartbeatTimeout = default(Optional<TimeSpan>),
+            Optional<ServerMonitoringMode> serverMonitoringMode = default)
         {
             _heartbeatInterval = Ensure.IsInfiniteOrGreaterThanOrEqualToZero(heartbeatInterval.WithDefault(DefaultHeartbeatInterval), "heartbeatInterval");
             _heartbeatTimeout = Ensure.IsInfiniteOrGreaterThanOrEqualToZero(heartbeatTimeout.WithDefault(DefaultHeartbeatTimeout), "heartbeatTimeout");
+            _serverMonitoringMode = serverMonitoringMode.WithDefault(DefaultServerMonitoringMode);
         }
 
         // properties
@@ -79,20 +89,34 @@ namespace MongoDB.Driver.Core.Configuration
             get { return _heartbeatTimeout; }
         }
 
+        /// <summary>
+        /// Gets the server monitoring mode.
+        /// </summary>
+        /// <value>
+        /// The server monitoring mode.
+        /// </value>
+        public ServerMonitoringMode ServerMonitoringMode
+        {
+            get { return _serverMonitoringMode; }
+        }
+
         // methods
         /// <summary>
         /// Returns a new ServerSettings instance with some settings changed.
         /// </summary>
         /// <param name="heartbeatInterval">The heartbeat interval.</param>
         /// <param name="heartbeatTimeout">The heartbeat timeout.</param>
+        /// <param name="serverMonitoringMode">The server monitoring mode.</param>
         /// <returns>A new ServerSettings instance.</returns>
         public ServerSettings With(
             Optional<TimeSpan> heartbeatInterval = default(Optional<TimeSpan>),
-            Optional<TimeSpan> heartbeatTimeout = default(Optional<TimeSpan>))
+            Optional<TimeSpan> heartbeatTimeout = default(Optional<TimeSpan>),
+            Optional<ServerMonitoringMode> serverMonitoringMode = default)
         {
             return new ServerSettings(
                 heartbeatInterval: heartbeatInterval.WithDefault(_heartbeatInterval),
-                heartbeatTimeout: heartbeatTimeout.WithDefault(_heartbeatTimeout));
+                heartbeatTimeout: heartbeatTimeout.WithDefault(_heartbeatTimeout),
+                serverMonitoringMode: serverMonitoringMode.WithDefault(_serverMonitoringMode));
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Configuration/ServerSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ServerSettings.cs
@@ -39,7 +39,7 @@ namespace MongoDB.Driver.Core.Configuration
         public static TimeSpan DefaultHeartbeatTimeout => Timeout.InfiniteTimeSpan;
 
         /// <summary>
-        /// Gets the default heartbeat timeout.
+        /// Gets the default server monitoring mode.
         /// </summary>
         public static ServerMonitoringMode DefaultServerMonitoringMode => ServerMonitoringMode.Auto;
         #endregion

--- a/src/MongoDB.Driver.Core/Core/Servers/RoundTripTimeMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/RoundTripTimeMonitor.cs
@@ -27,7 +27,7 @@ namespace MongoDB.Driver.Core.Servers
     internal interface IRoundTripTimeMonitor : IDisposable
     {
         TimeSpan Average { get; }
-        bool Started { get; }
+        bool IsStarted { get; }
         void AddSample(TimeSpan roundTripTime);
         void Reset();
         void Start();
@@ -49,8 +49,6 @@ namespace MongoDB.Driver.Core.Servers
         private readonly ServerId _serverId;
         private readonly ILogger<RoundTripTimeMonitor> _logger;
 
-        private bool _started;
-
         public RoundTripTimeMonitor(
             IConnectionFactory connectionFactory,
             ServerId serverId,
@@ -66,7 +64,6 @@ namespace MongoDB.Driver.Core.Servers
             _serverApi = serverApi;
             _cancellationTokenSource = new CancellationTokenSource();
             _cancellationToken = _cancellationTokenSource.Token;
-            _started = false;
 
             _logger = logger;
         }
@@ -82,16 +79,7 @@ namespace MongoDB.Driver.Core.Servers
             }
         }
 
-        public bool Started
-        {
-            get
-            {
-                lock (_lock)
-                {
-                    return _started;
-                }
-            }
-        }
+        public bool IsStarted => _roundTripTimeMonitorThread != null;
 
         // public methods
         public void Dispose()
@@ -114,7 +102,6 @@ namespace MongoDB.Driver.Core.Servers
         {
             _roundTripTimeMonitorThread = new Thread(ThreadStart) { IsBackground = true };
             _roundTripTimeMonitorThread.Start();
-            _started = true;
 
             void ThreadStart()
             {

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitor.cs
@@ -48,6 +48,7 @@ namespace MongoDB.Driver.Core.Servers
         private readonly ServerMonitorSettings _serverMonitorSettings;
 
         private Thread _serverMonitorThread;
+        private bool _streamingEnabled;
 
         public event EventHandler<ServerDescriptionChangedEventArgs> DescriptionChanged;
 
@@ -105,6 +106,13 @@ namespace MongoDB.Driver.Core.Servers
 
             _logger = loggerFactory?.CreateLogger<IServerMonitor>();
             _eventLoggerSdam = loggerFactory.CreateEventLogger<LogCategories.SDAM>(eventSubscriber);
+
+            _streamingEnabled = serverMonitorSettings.ServerMonitoringMode switch
+            {
+                ServerMonitoringMode.Stream => true,
+                ServerMonitoringMode.Poll => false,
+                _ => !IsRunningInFaaS() // ServerMonitoringMode.Auto
+            };
         }
 
         public ServerDescription Description => Interlocked.CompareExchange(ref _currentDescription, null, null);
@@ -155,7 +163,6 @@ namespace MongoDB.Driver.Core.Servers
             {
                 _logger?.LogDebug(_serverId, "Initializing");
 
-                _roundTripTimeMonitor.Start();
                 _serverMonitorThread = new Thread(new ParameterizedThreadStart(ThreadStart)) { IsBackground = true };
                 _serverMonitorThread.Start(_monitorCancellationToken);
 
@@ -182,7 +189,7 @@ namespace MongoDB.Driver.Core.Servers
         {
             BsonDocument helloCommand;
             var commandResponseHandling = CommandResponseHandling.Return;
-            if (connection.Description.HelloResult.TopologyVersion != null)
+            if (_streamingEnabled && connection.Description.HelloResult.TopologyVersion != null)
             {
                 connection.SetReadTimeout(_serverMonitorSettings.ConnectTimeout + _serverMonitorSettings.HeartbeatInterval);
                 commandResponseHandling = CommandResponseHandling.ExhaustAllowed;
@@ -411,13 +418,19 @@ namespace MongoDB.Driver.Core.Servers
                     SetDescription(newDescription);
                 }
 
-                processAnother =
-                    // serverSupportsStreaming
-                    (newDescription.Type != ServerType.Unknown && heartbeatHelloResult != null && heartbeatHelloResult.TopologyVersion != null) ||
-                    // connectionIsStreaming
-                    (helloProtocol != null && helloProtocol.MoreToCome) ||
-                    // transitionedWithNetworkError
+                var serverSupportsStreaming = (newDescription.Type != ServerType.Unknown &&
+                                               heartbeatHelloResult != null &&
+                                               heartbeatHelloResult.TopologyVersion != null);
+                var connectionIsStreaming = (helloProtocol != null && helloProtocol.MoreToCome);
+                var transitionedWithNetworkError =
                     (IsNetworkError(heartbeatException) && previousDescription.Type != ServerType.Unknown);
+
+                if (_streamingEnabled && serverSupportsStreaming && !_roundTripTimeMonitor.Started)
+                {
+                    _roundTripTimeMonitor.Start(); // start RTT monitoring on separate thread
+                }
+
+                processAnother = (_streamingEnabled && (serverSupportsStreaming || connectionIsStreaming)) || transitionedWithNetworkError;
             }
 
             bool IsNetworkError(Exception ex)
@@ -433,7 +446,7 @@ namespace MongoDB.Driver.Core.Servers
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            _eventLoggerSdam.LogAndPublish(new ServerHeartbeatStartedEvent(connection.ConnectionId, connection.Description.HelloResult.TopologyVersion != null));
+            _eventLoggerSdam.LogAndPublish(new ServerHeartbeatStartedEvent(connection.ConnectionId, _streamingEnabled && connection.Description.HelloResult.TopologyVersion != null));
 
             var stopwatch = Stopwatch.StartNew();
             try
@@ -441,14 +454,20 @@ namespace MongoDB.Driver.Core.Servers
                 var helloResult = HelloHelper.GetResult(connection, helloProtocol, cancellationToken);
                 stopwatch.Stop();
 
-                _eventLoggerSdam.LogAndPublish(new ServerHeartbeatSucceededEvent(connection.ConnectionId, stopwatch.Elapsed, connection.Description.HelloResult.TopologyVersion != null, helloResult.Wrapped));
+                // RTT check if using polling monitoring
+                if ((!_streamingEnabled || (_streamingEnabled && connection.Description.HelloResult.TopologyVersion == null)) && helloResult != null)
+                {
+                    _roundTripTimeMonitor.AddSample(stopwatch.Elapsed);
+                }
+
+                _eventLoggerSdam.LogAndPublish(new ServerHeartbeatSucceededEvent(connection.ConnectionId, stopwatch.Elapsed, _streamingEnabled && connection.Description.HelloResult.TopologyVersion != null, helloResult.Wrapped));
 
                 return helloResult;
             }
             catch (Exception ex)
             {
                 stopwatch.Stop();
-                _eventLoggerSdam.LogAndPublish(new ServerHeartbeatFailedEvent(connection.ConnectionId, stopwatch.Elapsed, ex, connection.Description.HelloResult.TopologyVersion != null));
+                _eventLoggerSdam.LogAndPublish(new ServerHeartbeatFailedEvent(connection.ConnectionId, stopwatch.Elapsed, ex, _streamingEnabled && connection.Description.HelloResult.TopologyVersion != null));
 
                 throw;
             }
@@ -475,6 +494,16 @@ namespace MongoDB.Driver.Core.Servers
         {
             Interlocked.Exchange(ref _currentDescription, newDescription);
             OnDescriptionChanged(oldDescription, newDescription);
+        }
+
+        private bool IsRunningInFaaS()
+        {
+            return (Environment.GetEnvironmentVariable("AWS_EXECUTION_ENV")?.StartsWith("AWS_Lambda_") ?? false) ||
+                   Environment.GetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API") != null ||
+                   Environment.GetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME") != null ||
+                   Environment.GetEnvironmentVariable("K_SERVICE") != null ||
+                   Environment.GetEnvironmentVariable("FUNCTION_NAME") != null ||
+                   Environment.GetEnvironmentVariable("VERCEL") != null;
         }
 
         private void ThrowIfDisposed()

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitorSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitorSettings.cs
@@ -23,16 +23,19 @@ namespace MongoDB.Driver.Core.Servers
         private readonly TimeSpan _connectTimeout;
         private readonly TimeSpan _heartbeatInterval;
         private readonly TimeSpan _minHeartbeatInterval;
+        private readonly ServerMonitoringMode _serverMonitoringMode;
 
-        public ServerMonitorSettings(TimeSpan connectTimeout, TimeSpan heartbeatInterval, Optional<TimeSpan> minHeartbeatInterval = default)
+        public ServerMonitorSettings(TimeSpan connectTimeout, TimeSpan heartbeatInterval, Optional<TimeSpan> minHeartbeatInterval = default, Optional<ServerMonitoringMode> serverMonitoringMode = default)
         {
             _connectTimeout = connectTimeout;
             _heartbeatInterval = heartbeatInterval;
             _minHeartbeatInterval = minHeartbeatInterval.WithDefault(TimeSpan.FromMilliseconds(500));
+            _serverMonitoringMode = serverMonitoringMode.WithDefault(ServerMonitoringMode.Auto);
         }
 
         public TimeSpan ConnectTimeout => _connectTimeout;
         public TimeSpan HeartbeatInterval => _heartbeatInterval;
         public TimeSpan MinHeartbeatInterval => _minHeartbeatInterval;
+        public ServerMonitoringMode ServerMonitoringMode => _serverMonitoringMode;
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitoringMode.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitoringMode.cs
@@ -1,20 +1,36 @@
-namespace MongoDB.Driver.Core.Servers;
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-/// <summary>
-///  Determine which server monitoring mode to use.
-/// </summary>
-public enum ServerMonitoringMode
+namespace MongoDB.Driver.Core.Servers
 {
     /// <summary>
-    /// Use polling protocol on FaaS platforms or streaming protocol otherwise. (Default)
+    ///  Represents the server monitoring mode.
     /// </summary>
-    Auto,
-    /// <summary>
-    /// Use polling protocol.
-    /// </summary>
-    Poll,
-    /// <summary>
-    /// Use streaming protocol.
-    /// </summary>
-    Stream
+    public enum ServerMonitoringMode
+    {
+        /// <summary>
+        /// Use polling protocol on FaaS platforms or streaming protocol otherwise. (Default)
+        /// </summary>
+        Auto,
+        /// <summary>
+        /// Use polling protocol.
+        /// </summary>
+        Poll,
+        /// <summary>
+        /// Use streaming protocol.
+        /// </summary>
+        Stream
+    }
 }

--- a/src/MongoDB.Driver.Core/Core/Servers/ServerMonitoringMode.cs
+++ b/src/MongoDB.Driver.Core/Core/Servers/ServerMonitoringMode.cs
@@ -1,0 +1,20 @@
+namespace MongoDB.Driver.Core.Servers;
+
+/// <summary>
+///  Determine which server monitoring mode to use.
+/// </summary>
+public enum ServerMonitoringMode
+{
+    /// <summary>
+    /// Use polling protocol on FaaS platforms or streaming protocol otherwise. (Default)
+    /// </summary>
+    Auto,
+    /// <summary>
+    /// Use polling protocol.
+    /// </summary>
+    Poll,
+    /// <summary>
+    /// Use streaming protocol.
+    /// </summary>
+    Stream
+}

--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -614,7 +614,7 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
-        /// Gets or sets the server selection timeout.
+        /// Gets or sets the server monitoring mode.
         /// </summary>
         /// <exception cref="System.InvalidOperationException">MongoServerSettings is frozen.</exception>
         public ServerMonitoringMode ServerMonitoringMode

--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -23,6 +23,7 @@ using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Shared;
 
 namespace MongoDB.Driver
@@ -63,6 +64,7 @@ namespace MongoDB.Driver
         private ConnectionStringScheme _scheme;
         private string _sdamLogFilename;
         private List<MongoServerAddress> _servers;
+        private ServerMonitoringMode _serverMonitoringMode;
         private TimeSpan _serverSelectionTimeout;
         private TimeSpan _socketTimeout;
         private SslSettings _sslSettings;
@@ -117,6 +119,7 @@ namespace MongoDB.Driver
             _scheme = ConnectionStringScheme.MongoDB;
             _sdamLogFilename = null;
             _servers = new List<MongoServerAddress> { new MongoServerAddress("localhost") };
+            _serverMonitoringMode = ServerMonitoringMode.Auto;
             _serverSelectionTimeout = MongoDefaults.ServerSelectionTimeout;
             _socketTimeout = MongoDefaults.SocketTimeout;
             _sslSettings = null;
@@ -614,6 +617,20 @@ namespace MongoDB.Driver
         /// Gets or sets the server selection timeout.
         /// </summary>
         /// <exception cref="System.InvalidOperationException">MongoServerSettings is frozen.</exception>
+        public ServerMonitoringMode ServerMonitoringMode
+        {
+            get { return _serverMonitoringMode; }
+            set
+            {
+                if (_isFrozen) { throw new InvalidOperationException("MongoServerSettings is frozen."); }
+                _serverMonitoringMode = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the server selection timeout.
+        /// </summary>
+        /// <exception cref="System.InvalidOperationException">MongoServerSettings is frozen.</exception>
         public TimeSpan ServerSelectionTimeout
         {
             get { return _serverSelectionTimeout; }
@@ -826,6 +843,7 @@ namespace MongoDB.Driver
             serverSettings.SdamLogFilename = clientSettings.SdamLogFilename;
 #pragma warning restore CS0618 // Type or member is obsolete
             serverSettings.Servers = new List<MongoServerAddress>(clientSettings.Servers);
+            serverSettings.ServerMonitoringMode = clientSettings.ServerMonitoringMode;
             serverSettings.ServerSelectionTimeout = clientSettings.ServerSelectionTimeout;
             serverSettings.SocketTimeout = clientSettings.SocketTimeout;
             serverSettings.SslSettings = (clientSettings.SslSettings == null) ? null : clientSettings.SslSettings.Clone();
@@ -904,6 +922,7 @@ namespace MongoDB.Driver
             serverSettings.SdamLogFilename = null; // SdamLogFilename must be provided in code
 #pragma warning restore CS0618 // Type or member is obsolete
             serverSettings.Servers = new List<MongoServerAddress>(url.Servers);
+            serverSettings.ServerMonitoringMode = url.ServerMonitoringMode ?? ServerMonitoringMode.Auto;
             serverSettings.ServerSelectionTimeout = url.ServerSelectionTimeout;
             serverSettings.SocketTimeout = url.SocketTimeout;
             serverSettings.SslSettings = null;
@@ -957,6 +976,7 @@ namespace MongoDB.Driver
             clone._scheme = _scheme;
             clone._sdamLogFilename = _sdamLogFilename;
             clone._servers = new List<MongoServerAddress>(_servers);
+            clone._serverMonitoringMode = _serverMonitoringMode;
             clone._serverSelectionTimeout = _serverSelectionTimeout;
             clone._socketTimeout = _socketTimeout;
             clone._sslSettings = (_sslSettings == null) ? null : _sslSettings.Clone();
@@ -1020,6 +1040,7 @@ namespace MongoDB.Driver
                _scheme == rhs._scheme &&
                _sdamLogFilename == rhs._sdamLogFilename &&
                _servers.SequenceEqual(rhs._servers) &&
+                _serverMonitoringMode == rhs._serverMonitoringMode &&
                _serverSelectionTimeout == rhs._serverSelectionTimeout &&
                _socketTimeout == rhs._socketTimeout &&
                _sslSettings == rhs._sslSettings &&
@@ -1101,6 +1122,7 @@ namespace MongoDB.Driver
                 .Hash(_scheme)
                 .Hash(_sdamLogFilename)
                 .HashElements(_servers)
+                .Hash(_serverMonitoringMode)
                 .Hash(_serverSelectionTimeout)
                 .Hash(_socketTimeout)
                 .Hash(_sslSettings)
@@ -1172,6 +1194,7 @@ namespace MongoDB.Driver
                 parts.Add($"SDAMLogFilename={_sdamLogFilename}");
             }
             parts.Add(string.Format("Servers={0}", string.Join(",", _servers.Select(s => s.ToString()).ToArray())));
+            parts.Add(string.Format("ServerMonitoringMode={0}", _serverMonitoringMode));
             parts.Add(string.Format("ServerSelectionTimeout={0}", _serverSelectionTimeout));
             parts.Add(string.Format("SocketTimeout={0}", _socketTimeout));
             if (_sslSettings != null)
@@ -1223,6 +1246,7 @@ namespace MongoDB.Driver
                 MongoDefaults.TcpSendBufferSize,
                 serverApi: null, // not supported for legacy
                 _servers.ToList(),
+                _serverMonitoringMode,
                 _serverSelectionTimeout,
                 _socketTimeout,
                 srvMaxHosts: 0, // not supported for legacy

--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -64,7 +64,6 @@ namespace MongoDB.Driver
         private ConnectionStringScheme _scheme;
         private string _sdamLogFilename;
         private List<MongoServerAddress> _servers;
-        private ServerMonitoringMode _serverMonitoringMode;
         private TimeSpan _serverSelectionTimeout;
         private TimeSpan _socketTimeout;
         private SslSettings _sslSettings;
@@ -119,7 +118,6 @@ namespace MongoDB.Driver
             _scheme = ConnectionStringScheme.MongoDB;
             _sdamLogFilename = null;
             _servers = new List<MongoServerAddress> { new MongoServerAddress("localhost") };
-            _serverMonitoringMode = ServerMonitoringMode.Auto;
             _serverSelectionTimeout = MongoDefaults.ServerSelectionTimeout;
             _socketTimeout = MongoDefaults.SocketTimeout;
             _sslSettings = null;
@@ -614,20 +612,6 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
-        /// Gets or sets the server monitoring mode.
-        /// </summary>
-        /// <exception cref="System.InvalidOperationException">MongoServerSettings is frozen.</exception>
-        public ServerMonitoringMode ServerMonitoringMode
-        {
-            get { return _serverMonitoringMode; }
-            set
-            {
-                if (_isFrozen) { throw new InvalidOperationException("MongoServerSettings is frozen."); }
-                _serverMonitoringMode = value;
-            }
-        }
-
-        /// <summary>
         /// Gets or sets the server selection timeout.
         /// </summary>
         /// <exception cref="System.InvalidOperationException">MongoServerSettings is frozen.</exception>
@@ -843,7 +827,6 @@ namespace MongoDB.Driver
             serverSettings.SdamLogFilename = clientSettings.SdamLogFilename;
 #pragma warning restore CS0618 // Type or member is obsolete
             serverSettings.Servers = new List<MongoServerAddress>(clientSettings.Servers);
-            serverSettings.ServerMonitoringMode = clientSettings.ServerMonitoringMode;
             serverSettings.ServerSelectionTimeout = clientSettings.ServerSelectionTimeout;
             serverSettings.SocketTimeout = clientSettings.SocketTimeout;
             serverSettings.SslSettings = (clientSettings.SslSettings == null) ? null : clientSettings.SslSettings.Clone();
@@ -922,7 +905,6 @@ namespace MongoDB.Driver
             serverSettings.SdamLogFilename = null; // SdamLogFilename must be provided in code
 #pragma warning restore CS0618 // Type or member is obsolete
             serverSettings.Servers = new List<MongoServerAddress>(url.Servers);
-            serverSettings.ServerMonitoringMode = url.ServerMonitoringMode ?? ServerMonitoringMode.Auto;
             serverSettings.ServerSelectionTimeout = url.ServerSelectionTimeout;
             serverSettings.SocketTimeout = url.SocketTimeout;
             serverSettings.SslSettings = null;
@@ -976,7 +958,6 @@ namespace MongoDB.Driver
             clone._scheme = _scheme;
             clone._sdamLogFilename = _sdamLogFilename;
             clone._servers = new List<MongoServerAddress>(_servers);
-            clone._serverMonitoringMode = _serverMonitoringMode;
             clone._serverSelectionTimeout = _serverSelectionTimeout;
             clone._socketTimeout = _socketTimeout;
             clone._sslSettings = (_sslSettings == null) ? null : _sslSettings.Clone();
@@ -1040,7 +1021,6 @@ namespace MongoDB.Driver
                _scheme == rhs._scheme &&
                _sdamLogFilename == rhs._sdamLogFilename &&
                _servers.SequenceEqual(rhs._servers) &&
-                _serverMonitoringMode == rhs._serverMonitoringMode &&
                _serverSelectionTimeout == rhs._serverSelectionTimeout &&
                _socketTimeout == rhs._socketTimeout &&
                _sslSettings == rhs._sslSettings &&
@@ -1122,7 +1102,6 @@ namespace MongoDB.Driver
                 .Hash(_scheme)
                 .Hash(_sdamLogFilename)
                 .HashElements(_servers)
-                .Hash(_serverMonitoringMode)
                 .Hash(_serverSelectionTimeout)
                 .Hash(_socketTimeout)
                 .Hash(_sslSettings)
@@ -1194,7 +1173,6 @@ namespace MongoDB.Driver
                 parts.Add($"SDAMLogFilename={_sdamLogFilename}");
             }
             parts.Add(string.Format("Servers={0}", string.Join(",", _servers.Select(s => s.ToString()).ToArray())));
-            parts.Add(string.Format("ServerMonitoringMode={0}", _serverMonitoringMode));
             parts.Add(string.Format("ServerSelectionTimeout={0}", _serverSelectionTimeout));
             parts.Add(string.Format("SocketTimeout={0}", _socketTimeout));
             if (_sslSettings != null)
@@ -1246,7 +1224,7 @@ namespace MongoDB.Driver
                 MongoDefaults.TcpSendBufferSize,
                 serverApi: null, // not supported for legacy
                 _servers.ToList(),
-                _serverMonitoringMode,
+                ServerMonitoringMode.Auto,
                 _serverSelectionTimeout,
                 _socketTimeout,
                 srvMaxHosts: 0, // not supported for legacy

--- a/src/MongoDB.Driver/ClusterKey.cs
+++ b/src/MongoDB.Driver/ClusterKey.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Shared;
 
 namespace MongoDB.Driver
@@ -58,6 +59,7 @@ namespace MongoDB.Driver
         private readonly int _sendBufferSize;
         private readonly ServerApi _serverApi;
         private readonly IReadOnlyList<MongoServerAddress> _servers;
+        private readonly ServerMonitoringMode _serverMonitoringMode;
         private readonly TimeSpan _serverSelectionTimeout;
         private readonly TimeSpan _socketTimeout;
         private readonly int _srvMaxHosts;
@@ -99,6 +101,7 @@ namespace MongoDB.Driver
             int sendBufferSize,
             ServerApi serverApi,
             IReadOnlyList<MongoServerAddress> servers,
+            ServerMonitoringMode serverMonitoringMode,
             TimeSpan serverSelectionTimeout,
             TimeSpan socketTimeout,
             int srvMaxHosts,
@@ -138,6 +141,7 @@ namespace MongoDB.Driver
             _sendBufferSize = sendBufferSize;
             _serverApi = serverApi;
             _servers = servers;
+            _serverMonitoringMode = serverMonitoringMode;
             _serverSelectionTimeout = serverSelectionTimeout;
             _socketTimeout = socketTimeout;
             _srvMaxHosts = srvMaxHosts;
@@ -203,6 +207,7 @@ namespace MongoDB.Driver
         public int SendBufferSize { get { return _sendBufferSize; } }
         public ServerApi ServerApi { get { return _serverApi; } }
         public IReadOnlyList<MongoServerAddress> Servers { get { return _servers; } }
+        public ServerMonitoringMode ServerMonitoringMode { get { return _serverMonitoringMode; } }
         public TimeSpan ServerSelectionTimeout { get { return _serverSelectionTimeout; } }
         public TimeSpan SocketTimeout { get { return _socketTimeout; } }
         public int SrvMaxHosts { get { return _srvMaxHosts; } }
@@ -259,6 +264,7 @@ namespace MongoDB.Driver
                 _sendBufferSize == rhs._sendBufferSize &&
                 _serverApi == rhs._serverApi &&
                 _servers.SequenceEqual(rhs._servers) &&
+                _serverMonitoringMode == rhs._serverMonitoringMode &&
                 _serverSelectionTimeout == rhs._serverSelectionTimeout &&
                 _socketTimeout == rhs._socketTimeout &&
                 _srvMaxHosts == rhs._srvMaxHosts &&

--- a/src/MongoDB.Driver/ClusterRegistry.cs
+++ b/src/MongoDB.Driver/ClusterRegistry.cs
@@ -139,7 +139,8 @@ namespace MongoDB.Driver
         {
             return settings.With(
                 heartbeatInterval: clusterKey.HeartbeatInterval,
-                heartbeatTimeout: clusterKey.HeartbeatTimeout);
+                heartbeatTimeout: clusterKey.HeartbeatTimeout,
+                serverMonitoringMode: clusterKey.ServerMonitoringMode);
         }
 
         private SslStreamSettings ConfigureSsl(SslStreamSettings settings, ClusterKey clusterKey)

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -1007,10 +1007,7 @@ namespace MongoDB.Driver
             clientSettings.RetryWrites = url.RetryWrites.GetValueOrDefault(true);
             clientSettings.Scheme = url.Scheme;
             clientSettings.Servers = new List<MongoServerAddress>(url.Servers);
-            if (url.ServerMonitoringMode.HasValue)
-            {
-                clientSettings.ServerMonitoringMode = (ServerMonitoringMode)url.ServerMonitoringMode;
-            }
+            clientSettings.ServerMonitoringMode = url.ServerMonitoringMode ?? ServerMonitoringMode.Auto;
             clientSettings.ServerSelectionTimeout = url.ServerSelectionTimeout;
             clientSettings.SocketTimeout = url.SocketTimeout;
             clientSettings.SrvMaxHosts = url.SrvMaxHosts.GetValueOrDefault(0);

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -23,6 +23,7 @@ using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Encryption;
 using MongoDB.Driver.Linq;
 using MongoDB.Shared;
@@ -71,6 +72,7 @@ namespace MongoDB.Driver
         private string _sdamLogFilename;
         private ServerApi _serverApi;
         private List<MongoServerAddress> _servers;
+        private ServerMonitoringMode _serverMonitoringMode;
         private TimeSpan _serverSelectionTimeout;
         private TimeSpan _socketTimeout;
         private int _srvMaxHosts;
@@ -131,6 +133,7 @@ namespace MongoDB.Driver
             _sdamLogFilename = null;
             _serverApi = null;
             _servers = new List<MongoServerAddress> { new MongoServerAddress("localhost") };
+            _serverMonitoringMode = ServerMonitoringMode.Auto;
             _serverSelectionTimeout = MongoDefaults.ServerSelectionTimeout;
             _socketTimeout = MongoDefaults.SocketTimeout;
             _srvMaxHosts = 0;
@@ -714,6 +717,19 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Gets or sets the server monitoring mode to use.
+        /// </summary>
+        public ServerMonitoringMode ServerMonitoringMode
+        {
+            get { return _serverMonitoringMode; }
+            set
+            {
+                if (_isFrozen) { throw new InvalidOperationException("MongoClientSettings is frozen."); }
+                _serverMonitoringMode = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the server selection timeout.
         /// </summary>
         public TimeSpan ServerSelectionTimeout
@@ -991,6 +1007,10 @@ namespace MongoDB.Driver
             clientSettings.RetryWrites = url.RetryWrites.GetValueOrDefault(true);
             clientSettings.Scheme = url.Scheme;
             clientSettings.Servers = new List<MongoServerAddress>(url.Servers);
+            if (url.ServerMonitoringMode.HasValue)
+            {
+                clientSettings.ServerMonitoringMode = (ServerMonitoringMode)url.ServerMonitoringMode;
+            }
             clientSettings.ServerSelectionTimeout = url.ServerSelectionTimeout;
             clientSettings.SocketTimeout = url.SocketTimeout;
             clientSettings.SrvMaxHosts = url.SrvMaxHosts.GetValueOrDefault(0);
@@ -1051,6 +1071,7 @@ namespace MongoDB.Driver
             clone._sdamLogFilename = _sdamLogFilename;
             clone._serverApi = _serverApi;
             clone._servers = new List<MongoServerAddress>(_servers);
+            clone._serverMonitoringMode = _serverMonitoringMode;
             clone._serverSelectionTimeout = _serverSelectionTimeout;
             clone._socketTimeout = _socketTimeout;
             clone._srvMaxHosts = _srvMaxHosts;
@@ -1121,6 +1142,7 @@ namespace MongoDB.Driver
                 _sdamLogFilename == rhs._sdamLogFilename &&
                 _serverApi == rhs._serverApi &&
                 _servers.SequenceEqual(rhs._servers) &&
+                _serverMonitoringMode == rhs._serverMonitoringMode &&
                 _serverSelectionTimeout == rhs._serverSelectionTimeout &&
                 _socketTimeout == rhs._socketTimeout &&
                 _srvMaxHosts == rhs._srvMaxHosts &&
@@ -1207,6 +1229,7 @@ namespace MongoDB.Driver
                 .Hash(_sdamLogFilename)
                 .Hash(_serverApi)
                 .HashElements(_servers)
+                .Hash(_serverMonitoringMode)
                 .Hash(_serverSelectionTimeout)
                 .Hash(_socketTimeout)
                 .Hash(_srvMaxHosts)
@@ -1294,6 +1317,7 @@ namespace MongoDB.Driver
                 sb.AppendFormat("ServerApi={0};", _serverApi);
             }
             sb.AppendFormat("Servers={0};", string.Join(",", _servers.Select(s => s.ToString()).ToArray()));
+            sb.AppendFormat("serverMonitoringMode={0};", _serverMonitoringMode);
             sb.AppendFormat("ServerSelectionTimeout={0};", _serverSelectionTimeout);
             sb.AppendFormat("SocketTimeout={0};", _socketTimeout);
             sb.AppendFormat("SrvMaxHosts={0}", _srvMaxHosts);
@@ -1346,6 +1370,7 @@ namespace MongoDB.Driver
                 MongoDefaults.TcpSendBufferSize, // TODO: add SendBufferSize to MongoClientSettings?
                 _serverApi,
                 _servers.ToList(),
+                _serverMonitoringMode,
                 _serverSelectionTimeout,
                 _socketTimeout,
                 _srvMaxHosts,

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -23,6 +23,7 @@ using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
 
 namespace MongoDB.Driver
 {
@@ -73,6 +74,7 @@ namespace MongoDB.Driver
         private readonly TimeSpan _localThreshold;
         private readonly ConnectionStringScheme _scheme;
         private readonly IEnumerable<MongoServerAddress> _servers;
+        private readonly ServerMonitoringMode? _serverMonitoringMode;
         private readonly TimeSpan _serverSelectionTimeout;
         private readonly TimeSpan _socketTimeout;
         private readonly int? _srvMaxHosts;
@@ -147,6 +149,7 @@ namespace MongoDB.Driver
             _retryWrites = builder.RetryWrites;
             _scheme = builder.Scheme;
             _servers = builder.Servers;
+            _serverMonitoringMode = builder.ServerMonitoringMode;
             _serverSelectionTimeout = builder.ServerSelectionTimeout;
             _socketTimeout = builder.SocketTimeout;
             _srvMaxHosts = builder.SrvMaxHosts;
@@ -491,6 +494,14 @@ namespace MongoDB.Driver
         public IEnumerable<MongoServerAddress> Servers
         {
             get { return _srvMaxHosts > 0 ? _servers.Take(_srvMaxHosts.Value) : _servers; }
+        }
+
+        /// <summary>
+        /// Gets the server monitoring mode to use.
+        /// </summary>
+        public ServerMonitoringMode? ServerMonitoringMode
+        {
+            get { return _serverMonitoringMode; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -24,6 +24,7 @@ using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Support;
 
 namespace MongoDB.Driver
@@ -69,6 +70,7 @@ namespace MongoDB.Driver
         private bool? _retryWrites;
         private ConnectionStringScheme _scheme;
         private IEnumerable<MongoServerAddress> _servers;
+        private ServerMonitoringMode? _serverMonitoringMode;
         private TimeSpan _serverSelectionTimeout;
         private TimeSpan _socketTimeout;
         private int? _srvMaxHosts;
@@ -126,6 +128,7 @@ namespace MongoDB.Driver
             _retryWrites = null;
             _scheme = ConnectionStringScheme.MongoDB;
             _servers = new[] { new MongoServerAddress("localhost", 27017) };
+            _serverMonitoringMode = null;
             _serverSelectionTimeout = MongoDefaults.ServerSelectionTimeout;
             _socketTimeout = MongoDefaults.SocketTimeout;
             _srvMaxHosts = null;
@@ -611,6 +614,15 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Gets or sets the server monitoring mode to use.
+        /// </summary>
+        public ServerMonitoringMode? ServerMonitoringMode
+        {
+            get { return _serverMonitoringMode; }
+            set { _serverMonitoringMode = value; }
+        }
+
+        /// <summary>
         /// Gets or sets the server selection timeout.
         /// </summary>
         public TimeSpan ServerSelectionTimeout
@@ -1024,6 +1036,10 @@ namespace MongoDB.Driver
             {
                 query.AppendFormat("minPoolSize={0}&", _minConnectionPoolSize);
             }
+            if (_serverMonitoringMode != null)
+            {
+                query.AppendFormat("serverMonitoringMode={0}&", _serverMonitoringMode);
+            }
             if (_serverSelectionTimeout != MongoDefaults.ServerSelectionTimeout)
             {
                 query.AppendFormat("serverSelectionTimeout={0}&", FormatTimeSpan(_serverSelectionTimeout));
@@ -1163,6 +1179,7 @@ namespace MongoDB.Driver
             _retryWrites = connectionString.RetryWrites;
             _scheme = connectionString.Scheme;
             _servers = connectionString.Hosts.ToMongoServerAddresses();
+            _serverMonitoringMode = connectionString.ServerMonitoringMode;
             _serverSelectionTimeout = connectionString.ServerSelectionTimeout.GetValueOrDefault(MongoDefaults.ServerSelectionTimeout);
             _socketTimeout = connectionString.SocketTimeout.GetValueOrDefault(MongoDefaults.SocketTimeout);
             _srvMaxHosts = connectionString.SrvMaxHosts;

--- a/tests/MongoDB.Driver.Core.TestHelpers/DisposableEnvironmentVariable.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/DisposableEnvironmentVariable.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace MongoDB.Driver.Core.TestHelpers;
 
-public class DisposableEnvironmentVariable : IDisposable
+public sealed class DisposableEnvironmentVariable : IDisposable
 {
     private readonly string _initialValue;
     private readonly string _name;

--- a/tests/MongoDB.Driver.Core.TestHelpers/DisposableEnvironmentVariable.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/DisposableEnvironmentVariable.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace MongoDB.Driver.Core.TestHelpers;
+
+public class DisposableEnvironmentVariable : IDisposable
+{
+    private readonly string _initialValue;
+    private readonly string _name;
+
+    public DisposableEnvironmentVariable(string variable)
+    {
+        var parts = variable.Split(new [] {'='}, StringSplitOptions.RemoveEmptyEntries);
+        _name = parts[0];
+        var value = parts.Length > 1 ? parts[1] : "dummy";
+        _initialValue = Environment.GetEnvironmentVariable(_name);
+        Environment.SetEnvironmentVariable(_name, value);
+    }
+
+    public void Dispose() => Environment.SetEnvironmentVariable(_name, _initialValue);
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ClusterBuilderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ClusterBuilderTests.cs
@@ -39,12 +39,13 @@ namespace MongoDB.Driver.Core.Configuration
             var connectTimeout = TimeSpan.FromMilliseconds(connectTimeoutMilliseconds);
             var authenticatorFactories = new[] { new AuthenticatorFactory(() => new DefaultAuthenticator(new UsernamePasswordCredential("source", "username", "password"), serverApi: null)) };
             var heartbeatTimeout = TimeSpan.FromMilliseconds(heartbeatTimeoutMilliseconds);
+            var serverMonitoringMode = ServerMonitoringMode.Stream;
             var expectedServerMonitorConnectTimeout = TimeSpan.FromMilliseconds(expectedServerMonitorConnectTimeoutMilliseconds);
             var expectedServerMonitorSocketTimeout = TimeSpan.FromMilliseconds(expectedServerMonitorSocketTimeoutMilliseconds);
             var subject = new ClusterBuilder()
                 .ConfigureTcp(s => s.With(connectTimeout: connectTimeout))
                 .ConfigureConnection(s => s.With(authenticatorFactories: authenticatorFactories))
-                .ConfigureServer(s => s.With(heartbeatTimeout: heartbeatTimeout));
+                .ConfigureServer(s => s.With(heartbeatTimeout: heartbeatTimeout, serverMonitoringMode: serverMonitoringMode));
 
             var result = (ServerMonitorFactory)subject.CreateServerMonitorFactory();
 
@@ -61,6 +62,7 @@ namespace MongoDB.Driver.Core.Configuration
             var eventSuscriber = result._eventSubscriber();
 
             var serverSettings = result._serverMonitorSettings();
+            serverSettings.ServerMonitoringMode.Should().Be(ServerMonitoringMode.Stream);
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
@@ -26,6 +26,7 @@ using MongoDB.Bson.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Compression;
+using MongoDB.Driver.Core.Servers;
 using Xunit;
 
 namespace MongoDB.Driver.Core.Configuration
@@ -356,6 +357,7 @@ namespace MongoDB.Driver.Core.Configuration
             subject.ReplicaSet.Should().BeNull();
             subject.LocalThreshold.Should().Be(null);
             subject.SocketTimeout.Should().Be(null);
+            subject.ServerMonitoringMode.Should().Be(null);
 #pragma warning disable 618
             subject.Ssl.Should().Be(null);
             subject.SslVerifyCertificate.Should().Be(null);
@@ -404,6 +406,7 @@ namespace MongoDB.Driver.Core.Configuration
                 "retryWrites=true;" +
                 "loadBalanced=false;" +
                 "localThreshold=50ms;" +
+                "serverMonitoringMode=stream;" +
                 "socketTimeout=40ms;" +
                 "ssl=false;" +
                 "sslVerifyCertificate=true;" +
@@ -450,6 +453,7 @@ namespace MongoDB.Driver.Core.Configuration
             subject.LoadBalanced.Should().BeFalse();
             subject.LocalThreshold.Should().Be(TimeSpan.FromMilliseconds(50));
             subject.SocketTimeout.Should().Be(TimeSpan.FromMilliseconds(40));
+            subject.ServerMonitoringMode.Should().Be(ServerMonitoringMode.Stream);
 #pragma warning disable 618
             subject.Ssl.Should().BeFalse();
             subject.SslVerifyCertificate.Should().Be(true);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ServerSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ServerSettingsTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Threading;
 using FluentAssertions;
+using MongoDB.Driver.Core.Servers;
 using Xunit;
 
 namespace MongoDB.Driver.Core.Configuration
@@ -39,12 +40,21 @@ namespace MongoDB.Driver.Core.Configuration
         }
 
         [Fact]
+        public void DefaultServerMonitoringMode_should_return_expected_result()
+        {
+            var result = ServerSettings.DefaultServerMonitoringMode;
+
+            result.Should().Be(ServerMonitoringMode.Auto);
+        }
+
+        [Fact]
         public void constructor_should_initialize_instance()
         {
             var subject = new ServerSettings();
 
             subject.HeartbeatInterval.Should().Be(ServerSettings.DefaultHeartbeatInterval);
             subject.HeartbeatTimeout.Should().Be(ServerSettings.DefaultHeartbeatTimeout);
+            subject.ServerMonitoringMode.Should().Be(ServerSettings.DefaultServerMonitoringMode);
         }
 
         [Fact]
@@ -86,6 +96,18 @@ namespace MongoDB.Driver.Core.Configuration
         }
 
         [Fact]
+        public void constructor_with_serverMonitoringMode_should_initialize_instance()
+        {
+            var serverMonitoringMode = ServerMonitoringMode.Stream;
+
+            var subject = new ServerSettings(serverMonitoringMode: serverMonitoringMode);
+
+            subject.HeartbeatInterval.Should().Be(ServerSettings.DefaultHeartbeatInterval);
+            subject.HeartbeatTimeout.Should().Be(ServerSettings.DefaultHeartbeatTimeout);
+            subject.ServerMonitoringMode.Should().Be(ServerMonitoringMode.Stream);
+        }
+
+        [Fact]
         public void With_heartbeatInterval_should_return_expected_result()
         {
             var oldHeartbeatInterval = TimeSpan.FromSeconds(1);
@@ -109,6 +131,18 @@ namespace MongoDB.Driver.Core.Configuration
 
             result.HeartbeatInterval.Should().Be(subject.HeartbeatInterval);
             result.HeartbeatTimeout.Should().Be(newHeartbeatTimeout);
+        }
+
+        [Fact]
+        public void With_serverMonitoringMode_should_return_expected_result()
+        {
+            var subject = new ServerSettings(serverMonitoringMode: ServerMonitoringMode.Poll);
+
+            var result = subject.With(serverMonitoringMode: ServerMonitoringMode.Stream);
+
+            result.HeartbeatInterval.Should().Be(ServerSettings.DefaultHeartbeatInterval);
+            result.HeartbeatTimeout.Should().Be(ServerSettings.DefaultHeartbeatTimeout);
+            result.ServerMonitoringMode.Should().Be(ServerMonitoringMode.Stream);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ServerSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ServerSettingsTests.cs
@@ -102,8 +102,6 @@ namespace MongoDB.Driver.Core.Configuration
 
             var subject = new ServerSettings(serverMonitoringMode: serverMonitoringMode);
 
-            subject.HeartbeatInterval.Should().Be(ServerSettings.DefaultHeartbeatInterval);
-            subject.HeartbeatTimeout.Should().Be(ServerSettings.DefaultHeartbeatTimeout);
             subject.ServerMonitoringMode.Should().Be(ServerMonitoringMode.Stream);
         }
 
@@ -140,8 +138,6 @@ namespace MongoDB.Driver.Core.Configuration
 
             var result = subject.With(serverMonitoringMode: ServerMonitoringMode.Stream);
 
-            result.HeartbeatInterval.Should().Be(ServerSettings.DefaultHeartbeatInterval);
-            result.HeartbeatTimeout.Should().Be(ServerSettings.DefaultHeartbeatTimeout);
             result.ServerMonitoringMode.Should().Be(ServerMonitoringMode.Stream);
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ClientDocumentHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ClientDocumentHelperTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
+using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
@@ -369,24 +370,6 @@ namespace MongoDB.Driver.Core.Connections
             string fieldName;
             document = NavigateDots(document, dottedFieldName, out fieldName);
             document[fieldName] = value;
-        }
-
-        // nested type
-        private class DisposableEnvironmentVariable : IDisposable
-        {
-            private readonly string _initialValue;
-            private readonly string _name;
-
-            public DisposableEnvironmentVariable(string variable)
-            {
-                var parts = variable.Split(new [] {'='}, StringSplitOptions.RemoveEmptyEntries);
-                _name = parts[0];
-                var value = parts.Length > 1 ? parts[1] : "dummy";
-                _initialValue = Environment.GetEnvironmentVariable(_name);
-                Environment.SetEnvironmentVariable(_name, value);
-            }
-
-            public void Dispose() => Environment.SetEnvironmentVariable(_name, _initialValue);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -344,14 +344,14 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatSucceededEvent>();
 
             var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1), serverMonitoringMode: ServerMonitoringMode.Poll);
-            var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
+            var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage());
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage());
 
             subject.Initialize();
-            SpinWait.SpinUntil(() => mockConnection.GetSentMessages().Count >= 2, TimeSpan.FromSeconds(5)).Should().BeTrue();
+            SpinWait.SpinUntil(() => capturedEvents.Count >= 4, TimeSpan.FromSeconds(5)).Should().BeTrue();
 
             capturedEvents.Next().Should().BeOfType<ServerHeartbeatStartedEvent>().Subject.Awaited.Should().Be(false);
             capturedEvents.Next().Should().BeOfType<ServerHeartbeatSucceededEvent>().Subject.Awaited.Should().Be(false);
@@ -440,12 +440,12 @@ namespace MongoDB.Driver.Core.Servers
             var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
             var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
-            SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
+            SetupHeartbeatConnection(mockConnection, isStreamable: false, autoFillStreamingResponses: false);
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage());
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage());
 
             subject.Initialize();
-            SpinWait.SpinUntil(() => mockConnection.GetSentMessages().Count >= 2, TimeSpan.FromSeconds(5)).Should().BeTrue();
+            SpinWait.SpinUntil(() => capturedEvents.Count >= 4, TimeSpan.FromSeconds(5)).Should().BeTrue();
 
             capturedEvents.Next().Should().BeOfType<ServerHeartbeatStartedEvent>().Subject.Awaited.Should().Be(false);
             capturedEvents.Next().Should().BeOfType<ServerHeartbeatSucceededEvent>().Subject.Awaited.Should().Be(false);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -303,7 +303,7 @@ namespace MongoDB.Driver.Core.Servers
         public void RoundTripTimeMonitor_should_be_started_only_once_if_using_streaming_protocol()
         {
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -329,7 +329,7 @@ namespace MongoDB.Driver.Core.Servers
         {
             var serverMonitorSettings = new ServerMonitorSettings(
                 TimeSpan.FromSeconds(5),
-                TimeSpan.FromMilliseconds(10),
+                TimeSpan.FromMilliseconds(100),
                 serverMonitoringMode: ServerMonitoringMode.Poll);
 
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
@@ -375,7 +375,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatStartedEvent>()
                 .Capture<ServerHeartbeatSucceededEvent>();
 
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10), serverMonitoringMode: ServerMonitoringMode.Poll);
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100), serverMonitoringMode: ServerMonitoringMode.Poll);
             var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -470,7 +470,7 @@ namespace MongoDB.Driver.Core.Servers
                     .Capture<ServerHeartbeatStartedEvent>()
                     .Capture<ServerHeartbeatSucceededEvent>();
 
-                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
+                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
                 var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
                 SetupHeartbeatConnection(mockConnection, isStreamable: false, autoFillStreamingResponses: false);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -303,7 +303,7 @@ namespace MongoDB.Driver.Core.Servers
         public void RoundTripTimeMonitor_should_be_started_only_once_if_using_streaming_protocol()
         {
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(5));
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -329,7 +329,7 @@ namespace MongoDB.Driver.Core.Servers
         {
             var serverMonitorSettings = new ServerMonitorSettings(
                 TimeSpan.FromSeconds(5),
-                TimeSpan.FromMilliseconds(5),
+                TimeSpan.FromMilliseconds(10),
                 serverMonitoringMode: ServerMonitoringMode.Poll);
 
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
@@ -375,7 +375,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatStartedEvent>()
                 .Capture<ServerHeartbeatSucceededEvent>();
 
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(5), serverMonitoringMode: ServerMonitoringMode.Poll);
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10), serverMonitoringMode: ServerMonitoringMode.Poll);
             var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -470,7 +470,7 @@ namespace MongoDB.Driver.Core.Servers
                     .Capture<ServerHeartbeatStartedEvent>()
                     .Capture<ServerHeartbeatSucceededEvent>();
 
-                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(5));
+                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
                 var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
                 SetupHeartbeatConnection(mockConnection, isStreamable: false, autoFillStreamingResponses: false);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -1,17 +1,17 @@
 /* Copyright 2016-present MongoDB Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,.Setup software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,.Setup software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 using System;
 using System.Collections.Generic;
@@ -303,7 +303,7 @@ namespace MongoDB.Driver.Core.Servers
         public void RoundTripTimeMonitor_should_be_started_only_once_if_using_streaming_protocol()
         {
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(5));
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -321,6 +321,7 @@ namespace MongoDB.Driver.Core.Servers
             SpinWait.SpinUntil(() => capturedEvents.Count >= 4, TimeSpan.FromSeconds(5)).Should().BeTrue();
 
             mockRoundTripTimeMonitor.Verify(m => m.Start(), Times.Once);
+            mockRoundTripTimeMonitor.Verify(m => m.IsStarted, Times.AtLeast(4));
         }
 
         [Fact]
@@ -328,7 +329,7 @@ namespace MongoDB.Driver.Core.Servers
         {
             var serverMonitorSettings = new ServerMonitorSettings(
                 TimeSpan.FromSeconds(5),
-                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromMilliseconds(5),
                 serverMonitoringMode: ServerMonitoringMode.Poll);
 
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
@@ -374,7 +375,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatStartedEvent>()
                 .Capture<ServerHeartbeatSucceededEvent>();
 
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100), serverMonitoringMode: ServerMonitoringMode.Poll);
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(5), serverMonitoringMode: ServerMonitoringMode.Poll);
             var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -469,7 +470,7 @@ namespace MongoDB.Driver.Core.Servers
                     .Capture<ServerHeartbeatStartedEvent>()
                     .Capture<ServerHeartbeatSucceededEvent>();
 
-                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
+                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(5));
                 var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
                 SetupHeartbeatConnection(mockConnection, isStreamable: false, autoFillStreamingResponses: false);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -303,7 +303,7 @@ namespace MongoDB.Driver.Core.Servers
         public void RoundTripTimeMonitor_should_be_started_only_once_if_using_streaming_protocol()
         {
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(25));
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -329,7 +329,7 @@ namespace MongoDB.Driver.Core.Servers
         {
             var serverMonitorSettings = new ServerMonitorSettings(
                 TimeSpan.FromSeconds(5),
-                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromMilliseconds(25),
                 serverMonitoringMode: ServerMonitoringMode.Poll);
 
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
@@ -375,7 +375,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatStartedEvent>()
                 .Capture<ServerHeartbeatSucceededEvent>();
 
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100), serverMonitoringMode: ServerMonitoringMode.Poll);
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(25), serverMonitoringMode: ServerMonitoringMode.Poll);
             var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -470,7 +470,7 @@ namespace MongoDB.Driver.Core.Servers
                     .Capture<ServerHeartbeatStartedEvent>()
                     .Capture<ServerHeartbeatSucceededEvent>();
 
-                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
+                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(25));
                 var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
                 SetupHeartbeatConnection(mockConnection, isStreamable: false, autoFillStreamingResponses: false);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -303,7 +303,7 @@ namespace MongoDB.Driver.Core.Servers
         public void RoundTripTimeMonitor_should_be_started_only_once_if_using_streaming_protocol()
         {
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50));
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, false);
@@ -328,7 +328,7 @@ namespace MongoDB.Driver.Core.Servers
         {
             var serverMonitorSettings = new ServerMonitorSettings(
                 TimeSpan.FromSeconds(5),
-                TimeSpan.FromMilliseconds(50),
+                TimeSpan.FromMilliseconds(100),
                 serverMonitoringMode: ServerMonitoringMode.Poll);
 
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
@@ -374,7 +374,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatStartedEvent>()
                 .Capture<ServerHeartbeatSucceededEvent>();
 
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(50), serverMonitoringMode: ServerMonitoringMode.Poll);
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100), serverMonitoringMode: ServerMonitoringMode.Poll);
             var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -469,7 +469,7 @@ namespace MongoDB.Driver.Core.Servers
                     .Capture<ServerHeartbeatStartedEvent>()
                     .Capture<ServerHeartbeatSucceededEvent>();
 
-                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(50));
+                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
                 var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
                 SetupHeartbeatConnection(mockConnection, isStreamable: false, autoFillStreamingResponses: false);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -303,7 +303,7 @@ namespace MongoDB.Driver.Core.Servers
         public void RoundTripTimeMonitor_should_be_started_only_once_if_using_streaming_protocol()
         {
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(25));
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -322,6 +322,7 @@ namespace MongoDB.Driver.Core.Servers
 
             mockRoundTripTimeMonitor.Verify(m => m.Start(), Times.Once);
             mockRoundTripTimeMonitor.Verify(m => m.IsStarted, Times.AtLeast(4));
+            subject.Dispose();
         }
 
         [Fact]
@@ -329,7 +330,7 @@ namespace MongoDB.Driver.Core.Servers
         {
             var serverMonitorSettings = new ServerMonitorSettings(
                 TimeSpan.FromSeconds(5),
-                TimeSpan.FromMilliseconds(25),
+                TimeSpan.FromMilliseconds(10),
                 serverMonitoringMode: ServerMonitoringMode.Poll);
 
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
@@ -344,6 +345,7 @@ namespace MongoDB.Driver.Core.Servers
             SpinWait.SpinUntil(() => capturedEvents.Count >= 4, TimeSpan.FromSeconds(5)).Should().BeTrue();
 
             mockRoundTripTimeMonitor.Verify(m => m.Start(), Times.Never);
+            subject.Dispose();
         }
 
         [Fact]
@@ -375,7 +377,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatStartedEvent>()
                 .Capture<ServerHeartbeatSucceededEvent>();
 
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(25), serverMonitoringMode: ServerMonitoringMode.Poll);
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10), serverMonitoringMode: ServerMonitoringMode.Poll);
             var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -384,6 +386,7 @@ namespace MongoDB.Driver.Core.Servers
 
             subject.Initialize();
             SpinWait.SpinUntil(() => capturedEvents.Count >= 6, TimeSpan.FromSeconds(5)).Should().BeTrue();
+            subject.Dispose();
 
             capturedEvents.Next().Should().BeOfType<ServerHeartbeatStartedEvent>().Subject.Awaited.Should().Be(false);
             capturedEvents.Next().Should().BeOfType<ServerHeartbeatSucceededEvent>().Subject.Awaited.Should().Be(false);
@@ -470,7 +473,7 @@ namespace MongoDB.Driver.Core.Servers
                     .Capture<ServerHeartbeatStartedEvent>()
                     .Capture<ServerHeartbeatSucceededEvent>();
 
-                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(25));
+                var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(10));
                 var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
                 SetupHeartbeatConnection(mockConnection, isStreamable: false, autoFillStreamingResponses: false);
@@ -479,6 +482,7 @@ namespace MongoDB.Driver.Core.Servers
 
                 subject.Initialize();
                 SpinWait.SpinUntil(() => capturedEvents.Count >= 6, TimeSpan.FromSeconds(5)).Should().BeTrue();
+                subject.Dispose();
 
                 capturedEvents.Next().Should().BeOfType<ServerHeartbeatStartedEvent>().Subject.Awaited.Should().Be(false);
                 capturedEvents.Next().Should().BeOfType<ServerHeartbeatSucceededEvent>().Subject.Awaited.Should().Be(false);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -306,7 +306,7 @@ namespace MongoDB.Driver.Core.Servers
             var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
-            SetupHeartbeatConnection(mockConnection, isStreamable: true, false);
+            SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage(), null);
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage(), null);
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage(), null);
@@ -334,7 +334,7 @@ namespace MongoDB.Driver.Core.Servers
             var capturedEvents = new EventCapturer().Capture<ServerHeartbeatSucceededEvent>();
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
-            SetupHeartbeatConnection(mockConnection,true, false);
+            SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage());
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage());
             mockConnection.EnqueueCommandResponseMessage(CreateHeartbeatCommandResponseMessage());

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerMonitorTests.cs
@@ -343,7 +343,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatStartedEvent>()
                 .Capture<ServerHeartbeatSucceededEvent>();
 
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2), serverMonitoringMode: ServerMonitoringMode.Poll);
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1), serverMonitoringMode: ServerMonitoringMode.Poll);
             var subject = CreateSubject(out var mockConnection, out _, out var mockRoundTripTimeMonitor, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);
@@ -431,7 +431,7 @@ namespace MongoDB.Driver.Core.Servers
                 .Capture<ServerHeartbeatStartedEvent>()
                 .Capture<ServerHeartbeatSucceededEvent>();
 
-            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2));
+            var serverMonitorSettings = new ServerMonitorSettings(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
             var subject = CreateSubject(out var mockConnection, out _, out _, capturedEvents, serverMonitorSettings: serverMonitorSettings);
 
             SetupHeartbeatConnection(mockConnection, isStreamable: true, autoFillStreamingResponses: false);

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoServerSettingsTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoServerSettingsTests.cs
@@ -21,6 +21,7 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Servers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests
@@ -94,7 +95,7 @@ namespace MongoDB.Driver.Tests
                 "connect=direct;connectTimeout=123;ipv6=true;heartbeatInterval=1m;heartbeatTimeout=2m;localThreshold=128;" +
                 "maxIdleTime=124;maxLifeTime=125;maxPoolSize=126;minPoolSize=127;" +
                 "readPreference=secondary;readPreferenceTags=a:1,b:2;readPreferenceTags=c:3,d:4;socketTimeout=129;" +
-                "serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
+                "serverMonitoringMode=Poll;serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
                 "w=1;fsync=true;journal=true;w=2;wtimeout=131;gssapiServiceName=other";
 #pragma warning disable 618
             if (BsonDefaults.GuidRepresentationMode == GuidRepresentationMode.V2)
@@ -555,7 +556,7 @@ namespace MongoDB.Driver.Tests
                 "appname=app;connect=direct;connectTimeout=123;ipv6=true;heartbeatInterval=1m;heartbeatTimeout=2m;localThreshold=128;" +
                 "maxIdleTime=124;maxLifeTime=125;maxPoolSize=126;minPoolSize=127;" +
                 "readPreference=secondary;readPreferenceTags=a:1,b:2;readPreferenceTags=c:3,d:4;retryReads=false;retryWrites=true;socketTimeout=129;" +
-                "serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
+                "serverMonitoringMode=Poll;serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
                 "w=1;fsync=true;journal=true;w=2;wtimeout=131;gssapiServiceName=other";
 #pragma warning disable 618
             if (BsonDefaults.GuidRepresentationMode == GuidRepresentationMode.V2)
@@ -610,6 +611,7 @@ namespace MongoDB.Driver.Tests
             Assert.Equal(clientSettings.SdamLogFilename, settings.SdamLogFilename);
 #pragma warning restore CS0618 // Type or member is obsolete
             Assert.True(url.Servers.SequenceEqual(settings.Servers));
+            Assert.Equal(url.ServerMonitoringMode, settings.ServerMonitoringMode);
             Assert.Equal(url.ServerSelectionTimeout, settings.ServerSelectionTimeout);
             Assert.Equal(url.SocketTimeout, settings.SocketTimeout);
             Assert.Equal(url.TlsDisableCertificateRevocationCheck, !settings.SslSettings.CheckCertificateRevocation);
@@ -664,7 +666,7 @@ namespace MongoDB.Driver.Tests
                 "connect=direct;connectTimeout=123;ipv6=true;heartbeatInterval=1m;heartbeatTimeout=2m;localThreshold=128;" +
                 "maxIdleTime=124;maxLifeTime=125;maxPoolSize=126;minPoolSize=127;" +
                 "readPreference=secondary;readPreferenceTags=a:1,b:2;readPreferenceTags=c:3,d:4;retryReads=false;retryWrites=true;socketTimeout=129;" +
-                "serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
+                "serverMonitoringMode=Poll;serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
                 "w=1;fsync=true;journal=true;w=2;wtimeout=131";
 #pragma warning disable 618
             if (BsonDefaults.GuidRepresentationMode == GuidRepresentationMode.V2)
@@ -710,6 +712,7 @@ namespace MongoDB.Driver.Tests
             Assert.Equal(url.RetryWrites, settings.RetryWrites);
             Assert.Equal(url.Scheme, settings.Scheme);
             Assert.True(url.Servers.SequenceEqual(settings.Servers));
+            Assert.Equal(url.ServerMonitoringMode, settings.ServerMonitoringMode);
             Assert.Equal(url.ServerSelectionTimeout, settings.ServerSelectionTimeout);
             Assert.Equal(url.SocketTimeout, settings.SocketTimeout);
             Assert.Equal(url.TlsDisableCertificateRevocationCheck, !settings.SslSettings.CheckCertificateRevocation);
@@ -1071,6 +1074,21 @@ namespace MongoDB.Driver.Tests
             Assert.Throws<InvalidOperationException>(() => { var s = settings.Server; });
             Assert.True(servers.SequenceEqual(settings.Servers));
             Assert.Throws<InvalidOperationException>(() => { settings.Servers = servers; });
+        }
+
+        [Fact]
+        public void TestServerMonitoringMode()
+        {
+            var settings = new MongoServerSettings();
+            Assert.Equal(ServerMonitoringMode.Auto, settings.ServerMonitoringMode);
+
+            var serverMonitoringMode = ServerMonitoringMode.Poll;
+            settings.ServerMonitoringMode = serverMonitoringMode;
+            Assert.Equal(serverMonitoringMode, settings.ServerMonitoringMode);
+
+            settings.Freeze();
+            Assert.Equal(serverMonitoringMode, settings.ServerMonitoringMode);
+            Assert.Throws<InvalidOperationException>(() => { settings.ServerMonitoringMode = serverMonitoringMode; });
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoServerSettingsTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoServerSettingsTests.cs
@@ -21,7 +21,6 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
-using MongoDB.Driver.Core.Servers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests
@@ -95,7 +94,7 @@ namespace MongoDB.Driver.Tests
                 "connect=direct;connectTimeout=123;ipv6=true;heartbeatInterval=1m;heartbeatTimeout=2m;localThreshold=128;" +
                 "maxIdleTime=124;maxLifeTime=125;maxPoolSize=126;minPoolSize=127;" +
                 "readPreference=secondary;readPreferenceTags=a:1,b:2;readPreferenceTags=c:3,d:4;socketTimeout=129;" +
-                "serverMonitoringMode=Poll;serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
+                "serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
                 "w=1;fsync=true;journal=true;w=2;wtimeout=131;gssapiServiceName=other";
 #pragma warning disable 618
             if (BsonDefaults.GuidRepresentationMode == GuidRepresentationMode.V2)
@@ -556,7 +555,7 @@ namespace MongoDB.Driver.Tests
                 "appname=app;connect=direct;connectTimeout=123;ipv6=true;heartbeatInterval=1m;heartbeatTimeout=2m;localThreshold=128;" +
                 "maxIdleTime=124;maxLifeTime=125;maxPoolSize=126;minPoolSize=127;" +
                 "readPreference=secondary;readPreferenceTags=a:1,b:2;readPreferenceTags=c:3,d:4;retryReads=false;retryWrites=true;socketTimeout=129;" +
-                "serverMonitoringMode=Poll;serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
+                "serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
                 "w=1;fsync=true;journal=true;w=2;wtimeout=131;gssapiServiceName=other";
 #pragma warning disable 618
             if (BsonDefaults.GuidRepresentationMode == GuidRepresentationMode.V2)
@@ -611,7 +610,6 @@ namespace MongoDB.Driver.Tests
             Assert.Equal(clientSettings.SdamLogFilename, settings.SdamLogFilename);
 #pragma warning restore CS0618 // Type or member is obsolete
             Assert.True(url.Servers.SequenceEqual(settings.Servers));
-            Assert.Equal(url.ServerMonitoringMode, settings.ServerMonitoringMode);
             Assert.Equal(url.ServerSelectionTimeout, settings.ServerSelectionTimeout);
             Assert.Equal(url.SocketTimeout, settings.SocketTimeout);
             Assert.Equal(url.TlsDisableCertificateRevocationCheck, !settings.SslSettings.CheckCertificateRevocation);
@@ -666,7 +664,7 @@ namespace MongoDB.Driver.Tests
                 "connect=direct;connectTimeout=123;ipv6=true;heartbeatInterval=1m;heartbeatTimeout=2m;localThreshold=128;" +
                 "maxIdleTime=124;maxLifeTime=125;maxPoolSize=126;minPoolSize=127;" +
                 "readPreference=secondary;readPreferenceTags=a:1,b:2;readPreferenceTags=c:3,d:4;retryReads=false;retryWrites=true;socketTimeout=129;" +
-                "serverMonitoringMode=Poll;serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
+                "serverSelectionTimeout=20s;ssl=true;sslVerifyCertificate=false;waitqueuesize=130;waitQueueTimeout=131;" +
                 "w=1;fsync=true;journal=true;w=2;wtimeout=131";
 #pragma warning disable 618
             if (BsonDefaults.GuidRepresentationMode == GuidRepresentationMode.V2)
@@ -712,7 +710,6 @@ namespace MongoDB.Driver.Tests
             Assert.Equal(url.RetryWrites, settings.RetryWrites);
             Assert.Equal(url.Scheme, settings.Scheme);
             Assert.True(url.Servers.SequenceEqual(settings.Servers));
-            Assert.Equal(url.ServerMonitoringMode, settings.ServerMonitoringMode);
             Assert.Equal(url.ServerSelectionTimeout, settings.ServerSelectionTimeout);
             Assert.Equal(url.SocketTimeout, settings.SocketTimeout);
             Assert.Equal(url.TlsDisableCertificateRevocationCheck, !settings.SslSettings.CheckCertificateRevocation);
@@ -1074,21 +1071,6 @@ namespace MongoDB.Driver.Tests
             Assert.Throws<InvalidOperationException>(() => { var s = settings.Server; });
             Assert.True(servers.SequenceEqual(settings.Servers));
             Assert.Throws<InvalidOperationException>(() => { settings.Servers = servers; });
-        }
-
-        [Fact]
-        public void TestServerMonitoringMode()
-        {
-            var settings = new MongoServerSettings();
-            Assert.Equal(ServerMonitoringMode.Auto, settings.ServerMonitoringMode);
-
-            var serverMonitoringMode = ServerMonitoringMode.Poll;
-            settings.ServerMonitoringMode = serverMonitoringMode;
-            Assert.Equal(serverMonitoringMode, settings.ServerMonitoringMode);
-
-            settings.Freeze();
-            Assert.Equal(serverMonitoringMode, settings.ServerMonitoringMode);
-            Assert.Throws<InvalidOperationException>(() => { settings.ServerMonitoringMode = serverMonitoringMode; });
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
@@ -22,6 +22,7 @@ using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
@@ -73,6 +74,7 @@ namespace MongoDB.Driver.Tests
         [InlineData("SendBufferSize", true)]
         [InlineData("ServerApi", true)]
         [InlineData("Servers", false)]
+        [InlineData("ServerMonitoringMode", true)]
         [InlineData("ServerSelectionTimeout", true)]
         [InlineData("SocketTimeout", true)]
         [InlineData("SrvMaxHosts", true)]
@@ -220,6 +222,7 @@ namespace MongoDB.Driver.Tests
             var sendBufferSize = 1;
             var serverApi = new ServerApi(ServerApiVersion.V1, true, true);
             var servers = new[] { new MongoServerAddress("localhost") };
+            var serverMonitoringMode = ServerMonitoringMode.Stream;
             var serverSelectionTimeout = TimeSpan.FromSeconds(6);
             var socketTimeout = TimeSpan.FromSeconds(4);
             var srvMaxHosts = 0;
@@ -282,6 +285,7 @@ namespace MongoDB.Driver.Tests
                     case "SendBufferSize": sendBufferSize = 2; break;
                     case "ServerApi": serverApi = new ServerApi(ServerApiVersion.V1); break;
                     case "Servers": servers = new[] { new MongoServerAddress("different") }; break;
+                    case "ServerMonitoringMode": serverMonitoringMode = ServerMonitoringMode.Poll; break;
                     case "ServerSelectionTimeout": serverSelectionTimeout = TimeSpan.FromSeconds(98); break;
                     case "SocketTimeout": socketTimeout = TimeSpan.FromSeconds(99); break;
                     case "SrvMaxHosts": srvMaxHosts = 3; break;
@@ -323,6 +327,7 @@ namespace MongoDB.Driver.Tests
                 sendBufferSize,
                 serverApi,
                 servers,
+                serverMonitoringMode,
                 serverSelectionTimeout,
                 socketTimeout,
                 srvMaxHosts,
@@ -374,6 +379,7 @@ namespace MongoDB.Driver.Tests
             var sendBufferSize = 1;
             var serverApi = new ServerApi(ServerApiVersion.V1, true, true);
             var servers = new[] { new MongoServerAddress("localhost") };
+            var serverMonitoringMode = ServerMonitoringMode.Stream;
             var serverSelectionTimeout = TimeSpan.FromSeconds(6);
             var socketTimeout = TimeSpan.FromSeconds(4);
             var srvMaxHosts = 3;
@@ -416,6 +422,7 @@ namespace MongoDB.Driver.Tests
                 sendBufferSize,
                 serverApi,
                 servers,
+                serverMonitoringMode,
                 serverSelectionTimeout,
                 socketTimeout,
                 srvMaxHosts,

--- a/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
@@ -110,6 +110,7 @@ namespace MongoDB.Driver.Tests
                 sendBufferSize: 10,
                 serverApi: serverApi,
                 servers: servers,
+                serverMonitoringMode: ServerMonitoringMode.Stream,
                 serverSelectionTimeout: TimeSpan.FromSeconds(11),
                 socketTimeout: TimeSpan.FromSeconds(12),
                 srvMaxHosts: 0,

--- a/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
@@ -22,6 +22,7 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;

--- a/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
@@ -23,6 +23,7 @@ using MongoDB.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Servers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests
@@ -94,6 +95,7 @@ namespace MongoDB.Driver.Tests
                 RetryWrites = true,
                 LocalThreshold = TimeSpan.FromSeconds(6),
                 Server = new MongoServerAddress("host"),
+                ServerMonitoringMode = ServerMonitoringMode.Poll,
                 ServerSelectionTimeout = TimeSpan.FromSeconds(10),
                 SocketTimeout = TimeSpan.FromSeconds(7),
                 Username = "username",
@@ -145,6 +147,7 @@ namespace MongoDB.Driver.Tests
                 "maxLifeTime=3s",
                 "maxPoolSize=4",
                 "minPoolSize=5",
+                "serverMonitoringMode=Poll",
                 "serverSelectionTimeout=10s",
                 "socketTimeout=7s",
                 "waitQueueSize=123",
@@ -205,6 +208,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(TimeSpan.FromSeconds(6), builder.LocalThreshold);
                 Assert.Equal(ConnectionStringScheme.MongoDB, builder.Scheme);
                 Assert.Equal(new MongoServerAddress("host", 27017), builder.Server);
+                Assert.Equal(ServerMonitoringMode.Poll, builder.ServerMonitoringMode);
                 Assert.Equal(TimeSpan.FromSeconds(10), builder.ServerSelectionTimeout);
                 Assert.Equal(TimeSpan.FromSeconds(7), builder.SocketTimeout);
                 Assert.Equal("username", builder.Username);

--- a/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
@@ -23,6 +23,7 @@ using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
@@ -188,6 +189,7 @@ namespace MongoDB.Driver.Tests
                 LoadBalanced = false,
                 LocalThreshold = TimeSpan.FromSeconds(6),
                 Server = new MongoServerAddress("host"),
+                ServerMonitoringMode = ServerMonitoringMode.Poll,
                 ServerSelectionTimeout = TimeSpan.FromSeconds(10),
                 SocketTimeout = TimeSpan.FromSeconds(7),
                 Username = "username",
@@ -233,6 +235,7 @@ namespace MongoDB.Driver.Tests
                 "maxLifeTime=3s",
                 "maxPoolSize=4",
                 "minPoolSize=5",
+                "serverMonitoringMode=Poll",
                 "serverSelectionTimeout=10s",
                 "socketTimeout=7s",
                 "waitQueueSize=123",
@@ -292,6 +295,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(TimeSpan.FromSeconds(6), url.LocalThreshold);
                 Assert.Equal(ConnectionStringScheme.MongoDB, url.Scheme);
                 Assert.Equal(new MongoServerAddress("host", 27017), url.Server);
+                Assert.Equal(ServerMonitoringMode.Poll, url.ServerMonitoringMode);
                 Assert.Equal(TimeSpan.FromSeconds(10), url.ServerSelectionTimeout);
                 Assert.Equal(TimeSpan.FromSeconds(7), url.SocketTimeout);
                 Assert.Equal(true, url.TlsDisableCertificateRevocationCheck);

--- a/tests/MongoDB.Driver.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
@@ -154,7 +154,7 @@ namespace MongoDB.Driver.Tests.Specifications.connection_string
                         case "retrywrites":
                             AssertBoolean(connectionString.RetryWrites, expectedOption.Value);
                             break;
-                        case "serverMonitoringMode":
+                        case "servermonitoringmode":
                             AssertEnum(connectionString.ServerMonitoringMode, expectedOption.Value);
                             break;
                         case "serverselectiontimeoutms":

--- a/tests/MongoDB.Driver.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
@@ -154,6 +154,9 @@ namespace MongoDB.Driver.Tests.Specifications.connection_string
                         case "retrywrites":
                             AssertBoolean(connectionString.RetryWrites, expectedOption.Value);
                             break;
+                        case "serverMonitoringMode":
+                            AssertEnum(connectionString.ServerMonitoringMode, expectedOption.Value);
+                            break;
                         case "serverselectiontimeoutms":
                             AssertTimeSpan(connectionString.ServerSelectionTimeout, expectedOption.Value);
                             break;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedEventMatcher.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedEventMatcher.cs
@@ -319,6 +319,45 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
                             throw new FormatException($"Unexpected {expectedEventType} fields.");
                         }
                         break;
+                    case ServerHeartbeatStartedEvent serverHeartbeatStartedEvent:
+                        foreach (var element in expectedEventValue)
+                        {
+                            switch (element.Name)
+                            {
+                                case "awaited":
+                                    serverHeartbeatStartedEvent.Awaited.Should().Be(element.Value.AsBoolean);
+                                    break;
+                                default:
+                                    throw new FormatException($"Unexpected {expectedEventType} field: '{element.Name}'.");
+                            }
+                        }
+                        break;
+                    case ServerHeartbeatSucceededEvent serverHeartbeatSucceededEvent:
+                        foreach (var element in expectedEventValue)
+                        {
+                            switch (element.Name)
+                            {
+                                case "awaited":
+                                    serverHeartbeatSucceededEvent.Awaited.Should().Be(element.Value.AsBoolean);
+                                    break;
+                                default:
+                                    throw new FormatException($"Unexpected {expectedEventType} field: '{element.Name}'.");
+                            }
+                        }
+                        break;
+                    case ServerHeartbeatFailedEvent serverHeartbeatFailedEvent:
+                        foreach (var element in expectedEventValue)
+                        {
+                            switch (element.Name)
+                            {
+                                case "awaited":
+                                    serverHeartbeatFailedEvent.Awaited.Should().Be(element.Value.AsBoolean);
+                                    break;
+                                default:
+                                    throw new FormatException($"Unexpected {expectedEventType} field: '{element.Name}'.");
+                            }
+                        }
+                        break;
                     default:
                         throw new FormatException($"Unrecognized event type: '{expectedEventType}'.");
                 }
@@ -370,6 +409,30 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
                             { "timestamp", commandFailedEvent.Timestamp.ToString("HH:mm:ss.fffffffK") }
                         };
                         actualEventsDocuments.Add(new BsonDocument("commandFailedEvent", commandFailedDocument));
+                        break;
+                    case ServerHeartbeatStartedEvent serverHeartbeatStartedEvent:
+                        var serverHeartbeatStartedEventDocument = new BsonDocument
+                        {
+                            { "awaited", serverHeartbeatStartedEvent.Awaited }
+                        };
+                        actualEventsDocuments.Add(new BsonDocument(actualEvent.GetType().Name,
+                            serverHeartbeatStartedEventDocument));
+                        break;
+                    case ServerHeartbeatSucceededEvent serverHeartbeatSucceededEvent:
+                        var serverHeartbeatSucceededEventDocument = new BsonDocument
+                        {
+                            { "awaited", serverHeartbeatSucceededEvent.Awaited }
+                        };
+                        actualEventsDocuments.Add(new BsonDocument(actualEvent.GetType().Name,
+                            serverHeartbeatSucceededEventDocument));
+                        break;
+                    case ServerHeartbeatFailedEvent serverHeartbeatFailedEvent:
+                        var serverHeartbeatFailedEventDocument = new BsonDocument
+                        {
+                            { "awaited", serverHeartbeatFailedEvent.Awaited }
+                        };
+                        actualEventsDocuments.Add(new BsonDocument(actualEvent.GetType().Name,
+                            serverHeartbeatFailedEventDocument));
                         break;
                     default:
                         actualEventsDocuments.Add(new BsonDocument(actualEvent.GetType().Name, actualEvent.ToString()));

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
@@ -709,8 +709,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                         settings.WriteConcern = writeConcern;
                         settings.HeartbeatInterval = heartbeatFrequency.GetValueOrDefault(defaultValue: TimeSpan.FromMilliseconds(5)); // 5 ms default value for spec tests
                         settings.ServerApi = serverApi;
-                        settings.ServerMonitoringMode =
-                            serverMonitoringMode.GetValueOrDefault(settings.ServerMonitoringMode);
+                        settings.ServerMonitoringMode = serverMonitoringMode.GetValueOrDefault(settings.ServerMonitoringMode);
                         settings.ServerSelectionTimeout = serverSelectionTimeout.GetValueOrDefault(defaultValue: settings.ServerSelectionTimeout);
                         settings.SocketTimeout = socketTimeout.GetValueOrDefault(defaultValue: settings.SocketTimeout);
                         if (eventCapturers.Length > 0)

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
@@ -18,7 +18,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver.Core;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
@@ -18,6 +18,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver.Core;
@@ -25,6 +26,7 @@ using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Encryption;
@@ -498,9 +500,10 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 var readConcern = ReadConcern.Default;
                 var retryReads = true;
                 var retryWrites = true;
+                ServerMonitoringMode? serverMonitoringMode = null;
                 TimeSpan? serverSelectionTimeout = null;
                 int? waitQueueSize = null;
-                TimeSpan? socketTimeout = null;                
+                TimeSpan? socketTimeout = null;
                 var useMultipleShardRouters = false;
                 TimeSpan? waitQueueTimeout = null;
                 var writeConcern = WriteConcern.Acknowledged;
@@ -553,6 +556,9 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                                         var levelValue = option.Value.AsString;
                                         var level = (ReadConcernLevel)Enum.Parse(typeof(ReadConcernLevel), levelValue, true);
                                         readConcern = new ReadConcern(level);
+                                        break;
+                                    case "serverMonitoringMode":
+                                        serverMonitoringMode = (ServerMonitoringMode)Enum.Parse(typeof(ServerMonitoringMode), option.Value.AsString, true);
                                         break;
                                     case "serverSelectionTimeoutMS":
                                         serverSelectionTimeout = TimeSpan.FromMilliseconds(option.Value.AsInt32);
@@ -703,6 +709,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                         settings.WriteConcern = writeConcern;
                         settings.HeartbeatInterval = heartbeatFrequency.GetValueOrDefault(defaultValue: TimeSpan.FromMilliseconds(5)); // 5 ms default value for spec tests
                         settings.ServerApi = serverApi;
+                        settings.ServerMonitoringMode =
+                            serverMonitoringMode.GetValueOrDefault(settings.ServerMonitoringMode);
                         settings.ServerSelectionTimeout = serverSelectionTimeout.GetValueOrDefault(defaultValue: settings.ServerSelectionTimeout);
                         settings.SocketTimeout = socketTimeout.GetValueOrDefault(defaultValue: settings.SocketTimeout);
                         if (eventCapturers.Length > 0)

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -110,7 +110,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 
             var schemaSemanticVersion = SemanticVersion.Parse(schemaVersion);
             if (schemaSemanticVersion < new SemanticVersion(1, 0, 0) ||
-                schemaSemanticVersion > new SemanticVersion(1, 16, 0))
+                schemaSemanticVersion > new SemanticVersion(1, 17, 0))
             {
                 throw new FormatException($"Schema version '{schemaVersion}' is not supported.");
             }


### PR DESCRIPTION
- Adds serverMonitoringMode (stream|poll|auto) to URI options and MongoClientOptions
- Updates monitor behaviour to poll or stream based on options or environment.
- Ensures no dedicated connection is used for RTT pinging in polling mode.
- Updates Unified test runner to work with schema 1.17
- Syncs SDAM unified tests
- Syncs URI options tests

### Highlight

For users that want to control the behaviour of the server monitoring connection between each node in the topology, a new option, `serverMonitoringMode`, has been added. This defaults to auto but can be forced into a specific mode by providing a value of poll or stream. A polling monitor periodically issues a hello command to the node at an interval of `heartbeatFrequencyMS`. A streaming monitor sends an initial hello and then will automatically get a response from the Node when a change in server configuration occurs or at a maximum time of `heartbeatFrequencyMS`