### PR TITLE
CSHARP-4533: More informative message for invalid type

### DIFF
--- a/src/MongoDB.Bson/Serialization/TypeNameDiscriminator.cs
+++ b/src/MongoDB.Bson/Serialization/TypeNameDiscriminator.cs
@@ -56,6 +56,11 @@ namespace MongoDB.Bson.Serialization
         /// <returns>The type if type type name can be resolved; otherwise, null.</returns>
         public static Type GetActualType(string typeName)
         {
+            if (string.IsNullOrEmpty(typeName))
+            {
+                return null;
+            }
+            
             var type = Type.GetType(typeName);
             if (type != null)
             {


### PR DESCRIPTION
This will cause the method call above to thow an "Unknown discriminator value [type name]" which is much more descriptive than the current behavior where System...GetType throws "System.ArgumentException: String cannot have zero length." Also by returning null rather than throwing, it is more compliant with the method description.