### PR TITLE
CSHARP-4935 allow Linq Translation conversion from interface to deriv…

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/DiscriminatedInterfaceSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DiscriminatedInterfaceSerializer.cs
@@ -74,7 +74,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <exception cref="System.ArgumentException">interfaceType</exception>
         /// <exception cref="System.ArgumentNullException">interfaceType</exception>
         public DiscriminatedInterfaceSerializer(IDiscriminatorConvention discriminatorConvention)
-            : this(discriminatorConvention, CreateInterfaceSerializer())
+            : this(discriminatorConvention, CreateInterfaceSerializer(), null)
         {
         }
 
@@ -86,6 +86,19 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <exception cref="System.ArgumentException">interfaceType</exception>
         /// <exception cref="System.ArgumentNullException">interfaceType</exception>
         public DiscriminatedInterfaceSerializer(IDiscriminatorConvention discriminatorConvention, IBsonSerializer<TInterface> interfaceSerializer)
+            : this(discriminatorConvention, interfaceSerializer, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DiscriminatedInterfaceSerializer{TInterface}" /> class.
+        /// </summary>
+        /// <param name="discriminatorConvention">The discriminator convention.</param>
+        /// <param name="interfaceSerializer">The interface serializer (necessary to support LINQ queries).</param>
+        /// <param name="objectSerializer">The serializer that is used to serialize any objects.</param>
+        /// <exception cref="System.ArgumentException">interfaceType</exception>
+        /// <exception cref="System.ArgumentNullException">interfaceType</exception>
+        public DiscriminatedInterfaceSerializer(IDiscriminatorConvention discriminatorConvention, IBsonSerializer<TInterface> interfaceSerializer, IBsonSerializer<object> objectSerializer)
         {
             var interfaceTypeInfo = typeof(TInterface).GetTypeInfo();
             if (!interfaceTypeInfo.IsInterface)
@@ -96,7 +109,7 @@ namespace MongoDB.Bson.Serialization.Serializers
 
             _interfaceType = typeof(TInterface);
             _discriminatorConvention = discriminatorConvention ?? BsonSerializer.LookupDiscriminatorConvention(typeof(TInterface));
-            _objectSerializer = BsonSerializer.LookupSerializer<object>();
+            _objectSerializer = objectSerializer ?? new ObjectSerializer(type => typeof(TInterface).IsAssignableFrom(type));
             if (_objectSerializer is ObjectSerializer standardObjectSerializer)
             {
                 _objectSerializer = standardObjectSerializer.WithDiscriminatorConvention(_discriminatorConvention);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ConvertExpressionToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ConvertExpressionToAggregationExpressionTranslator.cs
@@ -128,7 +128,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 
         private static bool IsConvertToDerivedType(Type sourceType, Type targetType)
         {
-            return targetType.IsSubclassOf(sourceType);
+            return targetType.IsSubclassOf(sourceType) || sourceType.IsAssignableFrom(targetType);
         }
 
         private static bool IsConvertUnderlyingTypeToEnum(UnaryExpression expression)

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ToFilterFieldTranslators/ConvertExpressionToFilterFieldTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ToFilterFieldTranslators/ConvertExpressionToFilterFieldTranslator.cs
@@ -87,7 +87,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
 
         private static bool IsConvertToDerivedType(Type fieldType, Type targetType)
         {
-            return targetType.IsSubclassOf(fieldType);
+            return targetType.IsSubclassOf(fieldType) || fieldType.IsAssignableFrom(targetType);
         }
 
         private static bool IsConvertToNullable(Type fieldType, Type targetType)

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ConvertExpressionToAggregationExpressionTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ConvertExpressionToAggregationExpressionTranslatorTests.cs
@@ -191,7 +191,47 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Translators.ExpressionTo
             result.EnumAsNullableInt.Should().Be(2);
         }
 
+        [Fact]
+        public void Should_translate_from_base_interface_to_derived_class_on_method_call()
+        {
+            var collection = GetInterfaceCollection();
+            var queryable = collection.AsQueryable()
+                .Select(p => new DerivedClass
+                {
+                    Id = p.Id,
+                    A = ((DerivedClass)p).A.ToUpper()
+                });
 
+            var stages = Translate(collection, queryable);
+            AssertStages(
+                stages,
+                "{ '$project' : { _id : '$_id', A : { '$toUpper' : '$A' } } }");
+
+            var result = queryable.Single();
+            result.Id.Should().Be(1);
+            result.A.Should().Be("ABC");
+        }
+
+        [Fact]
+        public void Should_translate_from_base_interface_to_derived_class_on_projection()
+        {
+            var collection = GetInterfaceCollection();
+            var queryable = collection.AsQueryable()
+                .Select(p => new DerivedClass()
+                {
+                    Id = p.Id,
+                    A = ((DerivedClass)p).A
+                });
+
+            var stages = Translate(collection, queryable);
+            AssertStages(
+                stages,
+                "{ '$project' : { _id : '$_id', A : '$A' } }");
+
+            var result = queryable.Single();
+            result.Id.Should().Be(1);
+            result.A.Should().Be("abc");
+        }
 
         private IMongoCollection<BaseClass> GetCollection()
         {
@@ -208,7 +248,31 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Translators.ExpressionTo
             return collection;
         }
 
-        private class BaseClass
+        private IMongoCollection<IBaseInterface> GetInterfaceCollection()
+        {
+            var collection = GetCollection<IBaseInterface>("test");
+            CreateCollection(collection, new DerivedClass()
+            {
+                Id = 1,
+                A = "abc",
+                Enum = Enum.Two,
+                NullableEnum = Enum.Two,
+                EnumAsInt = 2,
+                EnumAsNullableInt = 2
+            });
+            return collection;
+        }
+
+        private interface IBaseInterface
+        {
+            public int Id { get; set; }
+            public Enum Enum { get; set; }
+            public Enum? NullableEnum { get; set; }
+            public int EnumAsInt { get; set; }
+            public int? EnumAsNullableInt { get; set; }
+        }
+
+        private class BaseClass : IBaseInterface
         {
             public int Id { get; set; }
             public Enum Enum { get; set; }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/ConvertExpressionToFilterTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionTranslators/ConvertExpressionToFilterTranslatorTests.cs
@@ -85,6 +85,17 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Translators.ExpressionTo
             result.Id.Should().Be(2);
         }
 
+        [Fact]
+        public void Filter_using_field_from_underlying_type_should_work()
+        {
+            var collection = GetInterfaceCollection();
+
+            var filter = Builders<IData>.Filter.Eq(x => ((Data)x).AdditionalValue, "value");
+
+            var result = collection.Find(filter).Single();
+            result.Id.Should().Be(2);
+        }
+
         private IMongoCollection<Data> GetCollection()
         {
             var collection = GetCollection<Data>("test");
@@ -95,13 +106,33 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Translators.ExpressionTo
             return collection;
         }
 
-        private class Data
+        private IMongoCollection<IData> GetInterfaceCollection()
+        {
+            var collection = GetCollection<IData>("test");
+            CreateCollection(
+                collection,
+                new Data { Id = 1, Enum = Enum.One, NullableEnum = Enum.One, EnumAsInt = 1, EnumAsNullableInt = 1 },
+                new Data { Id = 2, Enum = Enum.Two, NullableEnum = Enum.Two, EnumAsInt = 2, EnumAsNullableInt = 2, AdditionalValue = "value"});
+            return collection;
+        }
+
+        private interface IData
         {
             public int Id { get; set; }
             public Enum Enum { get; set; }
             public Enum? NullableEnum { get; set; }
             public int EnumAsInt { get; set; }
             public int? EnumAsNullableInt { get; set; }
+        }
+
+        private class Data : IData
+        {
+            public int Id { get; set; }
+            public Enum Enum { get; set; }
+            public Enum? NullableEnum { get; set; }
+            public int EnumAsInt { get; set; }
+            public int? EnumAsNullableInt { get; set; }
+            public string AdditionalValue { get; set; }
         }
 
         private enum Enum


### PR DESCRIPTION
…ed type.

This will allow for a proper "downcasing" of the type. With my proposed changes we will now be able to run filters if the collection type is an interface.

I also had to change the default implementation of how the DiscriminatedInterfaceSerializer works as there would always be an exception as the object serializer enforces a whitelist for types to be serialized. I would actually like it better if we would instead resolve the class map of the underlying type to serialize a dependent object, but I did not want to touch on this in this PR.

I am unsure about the placement of the ConvertExpressionToFilterTranslatorTest as it is a bit different to the other tests in that file, but it was the only way to trigger the conversion in ConvertExpressionToFilterFieldTranslator