### PR TITLE
CSHARP-4797: Fix segfault when disposing of GSSAPI (Kerberos) security context on Linux.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/Libgssapi/GssapiSecurityContext.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Libgssapi/GssapiSecurityContext.cs
@@ -63,7 +63,7 @@ namespace MongoDB.Driver.Core.Authentication.Libgssapi
 
         protected override bool ReleaseHandle()
         {
-            var majorStatus = NativeMethods.gss_delete_sec_context(out var minorStatus, handle, IntPtr.Zero);
+            var majorStatus = NativeMethods.gss_delete_sec_context(out var minorStatus, ref handle, IntPtr.Zero);
             return majorStatus == 0 && minorStatus == 0;
         }
 

--- a/src/MongoDB.Driver.Core/Core/Authentication/Libgssapi/NativeMethods.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/Libgssapi/NativeMethods.cs
@@ -53,7 +53,7 @@ namespace MongoDB.Driver.Core.Authentication.Libgssapi
         public static extern uint gss_release_cred(out uint minorStatus, IntPtr credentialHandle);
 
         [DllImport(GSSAPI_LIBRARY)]
-        public static extern uint gss_delete_sec_context(out uint minorStatus, IntPtr securityContextHandle, IntPtr outputToken);
+        public static extern uint gss_delete_sec_context(out uint minorStatus, ref IntPtr securityContextHandle, IntPtr outputToken);
 
         [DllImport(GSSAPI_LIBRARY)]
         public static extern uint gss_wrap(out uint minorStatus, IntPtr securityContextHandle, int confidentialityRequested, int protectionType, GssInputBuffer inputBuffer, out int confidentialityState, [MarshalAs(UnmanagedType.LPStruct)] GssOutputBuffer outputBuffer);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/Libgssapi/GssapiSecurityCredentialTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/Libgssapi/GssapiSecurityCredentialTests.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication.Libgssapi
             RequireEnvironment.Check().EnvironmentVariable("GSSAPI_TESTS_ENABLED");
 
             var securePassword = SecureStringHelper.ToSecureString(_password);
-            var credential = GssapiSecurityCredential.Acquire(_username, securePassword);
+            using var credential = GssapiSecurityCredential.Acquire(_username, securePassword);
             credential.Should().NotBeNull();
         }
 
@@ -55,7 +55,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Authentication.Libgssapi
         {
             RequireEnvironment.Check().EnvironmentVariable("GSSAPI_TESTS_ENABLED");
 
-            var credential = GssapiSecurityCredential.Acquire(_username);
+            using var credential = GssapiSecurityCredential.Acquire(_username);
             credential.Should().NotBeNull();
         }
 


### PR DESCRIPTION
When calling `gss_delete_sec_context` we passed in a handle (aka `IntPtr` aka `void*`), but the function was expecting a `void**`. Strangely the function returned success even when passed a `void*` rather than a `void**`.