### PR TITLE
CSHARP-4965: Bump maxWireVersion for MongoDB 7.2

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/WireVersion.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/WireVersion.cs
@@ -104,6 +104,14 @@ namespace MongoDB.Driver.Core.Misc
         /// Wire version 21.
         /// </summary>
         public const int Server70 = 21;
+        /// <summary>
+        /// Wire version 22.
+        /// </summary>
+        public const int Server71 = 22;
+        /// <summary>
+        /// Wire version 23.
+        /// </summary>
+        public const int Server72 = 23;
 
         #region static
         private static List<WireVersionInfo> __knownWireVersions = new()
@@ -134,10 +142,12 @@ namespace MongoDB.Driver.Core.Misc
             new WireVersionInfo(wireVersion: 18, major: 6, minor: 1),
             new WireVersionInfo(wireVersion: 19, major: 6, minor: 2),
             new WireVersionInfo(wireVersion: 20, major: 6, minor: 3),
-            new WireVersionInfo(wireVersion: 21, major: 7, minor: 0)
+            new WireVersionInfo(wireVersion: 21, major: 7, minor: 0),
+            new WireVersionInfo(wireVersion: 22, major: 7, minor: 1),
+            new WireVersionInfo(wireVersion: 23, major: 7, minor: 2)
         };
 
-        private static Range<int> __supportedWireVersionRange = CreateSupportedWireVersionRange(minWireVersion: 6, maxWireVersion: 21);
+        private static Range<int> __supportedWireVersionRange = CreateSupportedWireVersionRange(minWireVersion: 6, maxWireVersion: 23);
 
         private static Range<int> CreateSupportedWireVersionRange(int minWireVersion, int maxWireVersion)
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterTests.cs
@@ -64,7 +64,7 @@ namespace MongoDB.Driver.Core.Clusters
         {
             var result = Cluster.SupportedWireVersionRange;
 
-            result.Should().Be(new Range<int>(6, 21));
+            result.Should().Be(new Range<int>(6, 23));
         }
 
         [Fact]
@@ -331,8 +331,8 @@ namespace MongoDB.Driver.Core.Clusters
         [Theory]
         [InlineData(0, 0, false)]
         [InlineData(0, 0, true)]
-        [InlineData(22, 23, false)]
-        [InlineData(22, 23, true)]
+        [InlineData(24, 25, false)]
+        [InlineData(24, 25, true)]
         public void SelectServer_should_throw_if_any_servers_are_incompatible(int min, int max, bool async)
         {
             var subject = CreateSubject();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Misc/WireVersionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Misc/WireVersionTests.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Misc
         [Fact]
         public void SupportedWireRange_should_be_correct()
         {
-            WireVersion.SupportedWireVersionRange.Should().Be(new Range<int>(6, 21));
+            WireVersion.SupportedWireVersionRange.Should().Be(new Range<int>(6, 23));
         }
 
         [Fact]
@@ -59,7 +59,9 @@ namespace MongoDB.Driver.Core.Tests.Core.Misc
 
         [Theory]
         [InlineData(99, null, null)]
-        [InlineData(22, null, null)]
+        [InlineData(24, null, null)]
+        [InlineData(23, 7, 2)]
+        [InlineData(22, 7, 1)]
         [InlineData(21, 7, 0)]
         [InlineData(20, 6, 3)]
         [InlineData(19, 6, 2)]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Servers/ServerDescriptionTests.cs
@@ -280,10 +280,11 @@ namespace MongoDB.Driver.Core.Servers
         [InlineData(new[] { 16, 17 }, true)]
         [InlineData(new[] { 18, 19 }, true)]
         [InlineData(new[] { 19, 20 }, true)]
-        [InlineData(new[] { 19, 20 }, true)]
         [InlineData(new[] { 20, 21 }, true)]
         [InlineData(new[] { 21, 22 }, true)]
-        [InlineData(new[] { 22, 23 }, false)]
+        [InlineData(new[] { 22, 23 }, true)]
+        [InlineData(new[] { 23, 24 }, true)]
+        [InlineData(new[] { 24, 25 }, false)]
         public void IsCompatibleWithDriver_should_return_expected_result(int[] minMaxWireVersions, bool expectedResult)
         {
             var clusterId = new ClusterId(1);


### PR DESCRIPTION
- Add wireVersions 22 and 23 to list of known wireVersions and updates tests as needed.

- Check that I updated everything that needs to be updated.