### PR TITLE
CSHARP-4827: Verify that driver does not add RetryableWriteError when it should not.

### DIFF
--- a/specifications/retryable-writes/tests/unified/insertOne-serverErrors.json
+++ b/specifications/retryable-writes/tests/unified/insertOne-serverErrors.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6",
+      "minServerVersion": "4.0",
       "topologies": [
         "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
       ]
     }
   ],
@@ -55,16 +61,7 @@
       "description": "InsertOne succeeds after retryable writeConcernError",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0",
-          "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded-replicaset"
-          ]
+          "minServerVersion": "4.3.1"
         }
       ],
       "operations": [
@@ -130,6 +127,309 @@
                 "databaseName": "retryable-writes-tests"
               }
             },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "RetryableWriteError label is added based on top-level code in pre-4.4 server response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "replicaset",
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 189
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "RetryableWriteError label is added based on writeConcernError in pre-4.4 mongod response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "RetryableWriteError label is not added based on writeConcernError in pre-4.4 mongos response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
             {
               "commandStartedEvent": {
                 "command": {

--- a/specifications/retryable-writes/tests/unified/insertOne-serverErrors.yml
+++ b/specifications/retryable-writes/tests/unified/insertOne-serverErrors.yml
@@ -3,8 +3,10 @@ description: "retryable-writes insertOne serverErrors"
 schemaVersion: "1.0"
 
 runOnRequirements:
-  - minServerVersion: "3.6"
+  - minServerVersion: "4.0"
     topologies: [ replicaset ]
+  - minServerVersion: "4.1.7"
+    topologies: [ sharded ]
 
 createEntities:
   - client:
@@ -30,10 +32,7 @@ initialData:
 tests:
   - description: "InsertOne succeeds after retryable writeConcernError"
     runOnRequirements:
-      - minServerVersion: "4.0"
-        topologies: [ replicaset ]
-      - minServerVersion: "4.1.7"
-        topologies: [ sharded-replicaset ]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
     operations:
       - name: failPoint
         object: testRunner
@@ -76,3 +75,123 @@ tests:
           - { _id: 1, x: 11 }
           - { _id: 2, x: 22 }
           - { _id: 3, x: 33 }  # The write was still applied
+
+  - description: "RetryableWriteError label is added based on top-level code in pre-4.4 server response"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.2.99"
+        topologies: [ replicaset, sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            # Trigger the fail point twice to allow asserting the error label in
+            # the retry attempt's response.
+            mode: { times: 2 }
+            data:
+              failCommands: [ "insert" ]
+              errorCode: 189 # PrimarySteppedDown
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsContain: [ "RetryableWriteError" ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &insertCommandStartedEvent
+              command:
+                insert: *collectionName
+                documents: [{ _id: 3, x: 33 }]
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent: *insertCommandStartedEvent
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+
+  - description: "RetryableWriteError label is added based on writeConcernError in pre-4.4 mongod response"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.2.99"
+        topologies: [ replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            # Trigger the fail point twice to allow asserting the error label in
+            # the retry attempt's response.
+            mode: { times: 2 }
+            data:
+              failCommands: [ "insert" ]
+              writeConcernError:
+                code: 91 # ShutdownInProgress
+                errmsg: "Replication is being shut down"
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsContain: [ "RetryableWriteError" ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: *insertCommandStartedEvent
+          - commandStartedEvent: *insertCommandStartedEvent
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          # writeConcernError doesn't prevent the server from applying the write
+          - { _id: 3, x: 33 }
+
+  - description: "RetryableWriteError label is not added based on writeConcernError in pre-4.4 mongos response"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.2.99"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            # Trigger the fail point only once since a RetryableWriteError label
+            # will not be added and the write will not be retried.
+            mode: { times: 1 }
+            data:
+              failCommands: [ "insert" ]
+              writeConcernError:
+                code: 91 # ShutdownInProgress
+                errmsg: "Replication is being shut down"
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsOmit: [ "RetryableWriteError" ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: *insertCommandStartedEvent
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          # writeConcernError doesn't prevent the server from applying the write
+          - { _id: 3, x: 33 }


### PR DESCRIPTION
The gist of  DRIVERS-1641 is:

 Drivers MUST NOT add a RetryableWriteError label based on the following:

  - any `writeErrors[].code` fields in a mongod or mongos response
  - the `writeConcernError.code` field in a mongos response

when connected to a pre-4.4 server.

I added the new unified tests and they pass without any changes to the driver.

I searched the driver code base for uses of `.Code` and verified that we are not adding a `RetryableWriteError` anywhere based on the value of `Code`.