### PR TITLE
CSHARP-3994: Consider adding EmbedUntrackedSources for a build process

### DIFF
--- a/evergreen/build-packages.sh
+++ b/evergreen/build-packages.sh
@@ -9,4 +9,4 @@ fi
 echo Creating nuget package...
 
 dotnet clean ./CSharpDriver.sln
-dotnet pack ./CSharpDriver.sln -o ./artifacts/nuget -c Release -p:Version="$PACKAGE_VERSION" --include-symbols -p:SymbolPackageFormat=snupkg
+dotnet pack ./CSharpDriver.sln -o ./artifacts/nuget -c Release -p:Version="$PACKAGE_VERSION" --include-symbols -p:SymbolPackageFormat=snupkg -p:ContinuousIntegrationBuild=true

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,6 +24,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Version)'==''">


### PR DESCRIPTION
Added EmbedUntrackedSources attribute and set ContinuousIntegrationBuild to true to make nuget validation happy. Screenshot from the locally built package after the changes:

![image](https://github.com/mongodb/mongo-csharp-driver/assets/31327136/68687682-422b-4b62-968d-87c7d264433a)
