### PR TITLE
Make ThreadingUtilities.ExecuteTasksOnNewThreads await on the operations completion.

### DIFF
--- a/tests/MongoDB.Bson.TestHelpers/Threading/TasksUtils.cs
+++ b/tests/MongoDB.Bson.TestHelpers/Threading/TasksUtils.cs
@@ -45,6 +45,15 @@ namespace MongoDB.Bson.TestHelpers
                 new ThreadPerTaskScheduler()))
             .ToArray();
 
+        public static Task[] RunTasksOnOwnThread(int count, Func<int, Task> taskCreator, CancellationToken cancellationToken = default) =>
+            Enumerable.Range(0, count)
+                .Select(i => Task.Factory.StartNew(
+                    () => taskCreator(i),
+                    cancellationToken,
+                    TaskCreationOptions.None,
+                    new ThreadPerTaskScheduler()).Unwrap())
+                .ToArray();
+
         public static Task<T>[] CreateTasks<T>(int count, Func<int, Task<T>> taskCreator) =>
             Enumerable.Range(0, count)
             .Select(i => taskCreator(i))

--- a/tests/MongoDB.Bson.TestHelpers/Threading/ThreadingUtilities.cs
+++ b/tests/MongoDB.Bson.TestHelpers/Threading/ThreadingUtilities.cs
@@ -92,7 +92,7 @@ namespace MongoDB.Bson.TestHelpers
             var exceptions = new ConcurrentBag<Exception>();
             var tasksExecutingCountEvent = new CountdownEvent(threadsCount);
 
-            var allTasks = TasksUtils.CreateTasksOnOwnThread(threadsCount, async i =>
+            var allTasks = TasksUtils.RunTasksOnOwnThread(threadsCount, async i =>
             {
                 try
                 {


### PR DESCRIPTION
Test console before the fix:
1 - sync method works as expected.
2 - async method "exit" before inner operations are completed.
![image](https://github.com/mongodb/mongo-csharp-driver/assets/31327136/c6087572-2df7-46b3-a41c-872fddd28cfa)
![image](https://github.com/mongodb/mongo-csharp-driver/assets/31327136/16275717-c0d8-4bd8-8eb5-abdc49c0c433)

Test console after the fix:
both sync and async methods work as expected:
![image](https://github.com/mongodb/mongo-csharp-driver/assets/31327136/ff01c096-c97a-4d67-a274-a2c9c71a319b)
![image](https://github.com/mongodb/mongo-csharp-driver/assets/31327136/17998ac6-e506-4749-81a6-7deba5e9f730)

