### PR TITLE
CSHARP-3745: Add support for srvServiceName URI option

### DIFF
--- a/specifications/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
+++ b/specifications/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true,
+    "srvServiceName": "customname"
+  }
+}

--- a/specifications/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
+++ b/specifications/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    ssl: true
+    srvServiceName: "customname"

--- a/src/MongoDB.Driver.Core/Core/Clusters/DnsMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/DnsMonitor.cs
@@ -52,6 +52,7 @@ namespace MongoDB.Driver.Core.Clusters
         // constructors
         public DnsMonitor(IDnsMonitoringCluster cluster,
             IDnsResolver dnsResolver,
+            string srvServiceName,
             string lookupDomainName,
             IEventSubscriber eventSubscriber,
             ILogger<LogCategories.SDAM> logger,
@@ -61,7 +62,7 @@ namespace MongoDB.Driver.Core.Clusters
             _dnsResolver = Ensure.IsNotNull(dnsResolver, nameof(dnsResolver));
             _lookupDomainName = EnsureLookupDomainNameIsValid(lookupDomainName);
             _cancellationToken = cancellationToken;
-            _service = "_mongodb._tcp." + _lookupDomainName;
+            _service = $"_{srvServiceName}._tcp." + _lookupDomainName;
             _state = DnsMonitorState.Created;
 
             _eventLogger = logger.ToEventLogger(eventSubscriber);

--- a/src/MongoDB.Driver.Core/Core/Clusters/DnsMonitorFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/DnsMonitorFactory.cs
@@ -32,10 +32,10 @@ namespace MongoDB.Driver.Core.Clusters
             _loggerFactory = loggerFactory;
         }
 
-        public IDnsMonitor CreateDnsMonitor(IDnsMonitoringCluster cluster, string lookupDomainName, CancellationToken cancellationToken)
+        public IDnsMonitor CreateDnsMonitor(IDnsMonitoringCluster cluster, string srvServiceName, string lookupDomainName, CancellationToken cancellationToken)
         {
             var dnsResolver = DnsClientWrapper.Instance;
-            return new DnsMonitor(cluster, dnsResolver, lookupDomainName, _eventSubscriber, _loggerFactory?.CreateLogger<LogCategories.SDAM>(), cancellationToken);
+            return new DnsMonitor(cluster, dnsResolver, srvServiceName, lookupDomainName, _eventSubscriber, _loggerFactory?.CreateLogger<LogCategories.SDAM>(), cancellationToken);
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Clusters/IDnsMonitorFactory.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/IDnsMonitorFactory.cs
@@ -19,6 +19,6 @@ namespace MongoDB.Driver.Core.Clusters
 {
     internal interface IDnsMonitorFactory
     {
-        IDnsMonitor CreateDnsMonitor(IDnsMonitoringCluster cluster, string lookupDomainName, CancellationToken cancellationToken);
+        IDnsMonitor CreateDnsMonitor(IDnsMonitoringCluster cluster, string srvServiceName, string lookupDomainName, CancellationToken cancellationToken);
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Clusters/LoadBalancedCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/LoadBalancedCluster.cs
@@ -183,7 +183,7 @@ namespace MongoDB.Driver.Core.Clusters
                     // _server will be created after srv resolving
                     var dnsEndPoint = (DnsEndPoint)endPoint;
                     var lookupDomainName = dnsEndPoint.Host;
-                    var monitor = _dnsMonitorFactory.CreateDnsMonitor(this, lookupDomainName, _dnsMonitorCancellationTokenSource.Token);
+                    var monitor = _dnsMonitorFactory.CreateDnsMonitor(this, _settings.SrvServiceName, lookupDomainName, _dnsMonitorCancellationTokenSource.Token);
                     _dnsMonitorThread = monitor.Start();
                 }
 

--- a/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
@@ -151,7 +151,7 @@ namespace MongoDB.Driver.Core.Clusters
                 {
                     var dnsEndPoint = (DnsEndPoint)Settings.EndPoints.Single();
                     var lookupDomainName = dnsEndPoint.Host;
-                    var dnsMonitor = _dnsMonitorFactory.CreateDnsMonitor(this, lookupDomainName, _monitorServersCancellationTokenSource.Token);
+                    var dnsMonitor = _dnsMonitorFactory.CreateDnsMonitor(this, Settings.SrvServiceName, lookupDomainName, _monitorServersCancellationTokenSource.Token);
                     _dnsMonitorThread = dnsMonitor.Start(); // store the Thread for use as evidence when testing that the DnsMonitor was started
                 }
             }

--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterSettings.cs
@@ -49,6 +49,7 @@ namespace MongoDB.Driver.Core.Configuration
         private readonly ServerApi _serverApi;
         private readonly TimeSpan _serverSelectionTimeout;
         private readonly int _srvMaxHosts;
+        private readonly string _srvServiceName;
         private readonly IServerSelector _preServerSelector;
         private readonly IServerSelector _postServerSelector;
 
@@ -71,6 +72,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// <param name="postServerSelector">The post server selector.</param>
         /// <param name="scheme">The connection string scheme.</param>
         /// <param name="srvMaxHosts">Limits the number of SRV records used to populate the seedlist during initial discovery, as well as the number of additional hosts that may be added during SRV polling.</param>
+        /// <param name="srvServiceName"> The SRV service name which modifies the srv URI to look like: `_{srvServiceName}._tcp.{hostname}.{domainname}`. Defaults to "mongodb"</param>
         public ClusterSettings(
 #pragma warning disable CS0618 // Type or member is obsolete
             Optional<ClusterConnectionMode> connectionMode = default(Optional<ClusterConnectionMode>),
@@ -88,7 +90,8 @@ namespace MongoDB.Driver.Core.Configuration
             Optional<IServerSelector> preServerSelector = default(Optional<IServerSelector>),
             Optional<IServerSelector> postServerSelector = default(Optional<IServerSelector>),
             Optional<ConnectionStringScheme> scheme = default(Optional<ConnectionStringScheme>),
-            Optional<int> srvMaxHosts = default)
+            Optional<int> srvMaxHosts = default,
+            Optional<string> srvServiceName = default(Optional<string>))
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             _connectionMode = connectionMode.WithDefault(ClusterConnectionMode.Automatic);
@@ -107,6 +110,7 @@ namespace MongoDB.Driver.Core.Configuration
             _postServerSelector = postServerSelector.WithDefault(null);
             _scheme = scheme.WithDefault(ConnectionStringScheme.MongoDB);
             _srvMaxHosts = Ensure.IsGreaterThanOrEqualToZero(srvMaxHosts.WithDefault(0), nameof(srvMaxHosts));
+            _srvServiceName = srvServiceName.WithDefault("mongodb");
 
             ClusterConnectionModeHelper.EnsureConnectionModeValuesAreValid(_connectionMode, _connectionModeSwitch, _directConnection);
         }
@@ -259,6 +263,13 @@ namespace MongoDB.Driver.Core.Configuration
         public int SrvMaxHosts => _srvMaxHosts;
 
         /// <summary>
+        /// Gets the SRV service name which modifies the srv URI to look like:
+        /// `_{srvServiceName}._tcp.{hostname}.{domainname}`.
+        /// The default value is "mongodb".
+        /// </summary>
+        public string SrvServiceName => _srvServiceName;
+
+        /// <summary>
         /// Gets the pre server selector.
         /// </summary>
         /// <value>
@@ -299,6 +310,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// <param name="postServerSelector">The post server selector.</param>
         /// <param name="scheme">The connection string scheme.</param>
         /// <param name="srvMaxHosts">Limits the number of SRV records used to populate the seedlist during initial discovery, as well as the number of additional hosts that may be added during SRV polling.</param>
+        /// <param name="srvServiceName"> The SRV service name which modifies the srv URI to look like: `_{srvServiceName}._tcp.{hostname}.{domainname}`. Defaults to "mongodb"</param>
         /// <returns>A new ClusterSettings instance.</returns>
         public ClusterSettings With(
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -317,7 +329,8 @@ namespace MongoDB.Driver.Core.Configuration
             Optional<IServerSelector> preServerSelector = default(Optional<IServerSelector>),
             Optional<IServerSelector> postServerSelector = default(Optional<IServerSelector>),
             Optional<ConnectionStringScheme> scheme = default(Optional<ConnectionStringScheme>),
-            Optional<int> srvMaxHosts = default)
+            Optional<int> srvMaxHosts = default,
+            Optional<string> srvServiceName = default(Optional<string>))
         {
             return new ClusterSettings(
                 connectionMode: connectionMode.WithDefault(_connectionMode),
@@ -334,7 +347,8 @@ namespace MongoDB.Driver.Core.Configuration
                 preServerSelector: Optional.Create(preServerSelector.WithDefault(_preServerSelector)),
                 postServerSelector: Optional.Create(postServerSelector.WithDefault(_postServerSelector)),
                 scheme: scheme.WithDefault(_scheme),
-                srvMaxHosts: srvMaxHosts.WithDefault(_srvMaxHosts));
+                srvMaxHosts: srvMaxHosts.WithDefault(_srvMaxHosts),
+                srvServiceName: srvServiceName.WithDefault(_srvServiceName));
         }
 
         // internal methods

--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterSettings.cs
@@ -72,7 +72,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// <param name="postServerSelector">The post server selector.</param>
         /// <param name="scheme">The connection string scheme.</param>
         /// <param name="srvMaxHosts">Limits the number of SRV records used to populate the seedlist during initial discovery, as well as the number of additional hosts that may be added during SRV polling.</param>
-        /// <param name="srvServiceName"> The SRV service name which modifies the srv URI to look like: `_{srvServiceName}._tcp.{hostname}.{domainname}`. Defaults to "mongodb"</param>
+        /// <param name="srvServiceName"> The SRV service name which modifies the srv URI to look like: <code>_{srvServiceName}._tcp.{hostname}.{domainname}</code> Defaults to "mongodb".</param>
         public ClusterSettings(
 #pragma warning disable CS0618 // Type or member is obsolete
             Optional<ClusterConnectionMode> connectionMode = default(Optional<ClusterConnectionMode>),
@@ -264,7 +264,7 @@ namespace MongoDB.Driver.Core.Configuration
 
         /// <summary>
         /// Gets the SRV service name which modifies the srv URI to look like:
-        /// `_{srvServiceName}._tcp.{hostname}.{domainname}`.
+        /// <code>_{srvServiceName}._tcp.{hostname}.{domainname}</code>
         /// The default value is "mongodb".
         /// </summary>
         public string SrvServiceName => _srvServiceName;
@@ -310,7 +310,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// <param name="postServerSelector">The post server selector.</param>
         /// <param name="scheme">The connection string scheme.</param>
         /// <param name="srvMaxHosts">Limits the number of SRV records used to populate the seedlist during initial discovery, as well as the number of additional hosts that may be added during SRV polling.</param>
-        /// <param name="srvServiceName"> The SRV service name which modifies the srv URI to look like: `_{srvServiceName}._tcp.{hostname}.{domainname}`. Defaults to "mongodb"</param>
+        /// <param name="srvServiceName"> The SRV service name which modifies the srv URI to look like: <code>_{srvServiceName}._tcp.{hostname}.{domainname}</code> Defaults to "mongodb".</param>
         /// <returns>A new ClusterSettings instance.</returns>
         public ClusterSettings With(
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/MongoDB.Driver.Core/Core/Configuration/ClusterSettings.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ClusterSettings.cs
@@ -110,7 +110,7 @@ namespace MongoDB.Driver.Core.Configuration
             _postServerSelector = postServerSelector.WithDefault(null);
             _scheme = scheme.WithDefault(ConnectionStringScheme.MongoDB);
             _srvMaxHosts = Ensure.IsGreaterThanOrEqualToZero(srvMaxHosts.WithDefault(0), nameof(srvMaxHosts));
-            _srvServiceName = srvServiceName.WithDefault("mongodb");
+            _srvServiceName = srvServiceName.WithDefault(MongoInternalDefaults.MongoClientSettings.SrvServiceName);
 
             ClusterConnectionModeHelper.EnsureConnectionModeValuesAreValid(_connectionMode, _connectionModeSwitch, _directConnection);
         }

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -1142,6 +1142,10 @@ namespace MongoDB.Driver.Core.Configuration
                     break;
                 case "srvservicename":
                     _srvServiceName = value;
+                    if (string.IsNullOrEmpty(_srvServiceName))
+                    {
+                        throw new MongoConfigurationException("SrvServiceName cannot be null or empty.");
+                    }
                     break;
                 case "ssl": // Obsolete
                 case "tls":

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -136,7 +136,7 @@ namespace MongoDB.Driver.Core.Configuration
             _dnsResolver = Ensure.IsNotNull(dnsResolver, nameof(dnsResolver));
             Parse();
 
-            _srvPrefix = $"_{_srvServiceName ?? "mongodb"}._tcp.";
+            _srvPrefix = $"_{_srvServiceName ?? MongoInternalDefaults.MongoClientSettings.SrvServiceName}._tcp.";
 
             _isResolved = _scheme != ConnectionStringScheme.MongoDBPlusSrv;
         }

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -1142,9 +1142,9 @@ namespace MongoDB.Driver.Core.Configuration
                     break;
                 case "srvservicename":
                     _srvServiceName = value;
-                    if (string.IsNullOrEmpty(_srvServiceName))
+                    if (_srvServiceName.Length == 0)
                     {
-                        throw new MongoConfigurationException("SrvServiceName cannot be null or empty.");
+                        throw new MongoConfigurationException("SrvServiceName cannot be empty.");
                     }
                     break;
                 case "ssl": // Obsolete

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -301,7 +301,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// </summary>
         public IReadOnlyList<EndPoint> Hosts
         {
-            get { return  _srvMaxHosts > 0 ? _hosts.Take(_srvMaxHosts.Value).ToList() : _hosts; }
+            get { return _srvMaxHosts > 0 ? _hosts.Take(_srvMaxHosts.Value).ToList() : _hosts; }
         }
 
         /// <summary>
@@ -490,7 +490,7 @@ namespace MongoDB.Driver.Core.Configuration
 
         /// <summary>
         /// Gets the SRV service name which modifies the srv URI to look like:
-        /// `_{srvServiceName}._tcp.{hostname}.{domainname}`
+        /// <code>_{srvServiceName}._tcp.{hostname}.{domainname}</code>
         /// </summary>
         public string SrvServiceName => _srvServiceName;
 

--- a/src/MongoDB.Driver.Core/MongoInternalDefaults.cs
+++ b/src/MongoDB.Driver.Core/MongoInternalDefaults.cs
@@ -26,5 +26,10 @@ namespace MongoDB.Driver
         {
             public const int MaxConnecting = 2;
         }
+
+        public static class MongoClientSettings
+        {
+            public const string SrvServiceName = "mongodb";
+        }
     }
 }

--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -1228,7 +1228,7 @@ namespace MongoDB.Driver
                 _serverSelectionTimeout,
                 _socketTimeout,
                 srvMaxHosts: 0, // not supported for legacy
-                srvServiceName: null,
+                srvServiceName: MongoInternalDefaults.MongoClientSettings.SrvServiceName,
                 _sslSettings,
                 _useTls,
                 _waitQueueSize,

--- a/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
+++ b/src/MongoDB.Driver.Legacy/MongoServerSettings.cs
@@ -1228,6 +1228,7 @@ namespace MongoDB.Driver
                 _serverSelectionTimeout,
                 _socketTimeout,
                 srvMaxHosts: 0, // not supported for legacy
+                srvServiceName: null,
                 _sslSettings,
                 _useTls,
                 _waitQueueSize,

--- a/src/MongoDB.Driver/ClusterKey.cs
+++ b/src/MongoDB.Driver/ClusterKey.cs
@@ -63,6 +63,7 @@ namespace MongoDB.Driver
         private readonly TimeSpan _serverSelectionTimeout;
         private readonly TimeSpan _socketTimeout;
         private readonly int _srvMaxHosts;
+        private readonly string _srvServiceName;
         private readonly SslSettings _sslSettings;
         private readonly bool _useTls;
         private readonly int _waitQueueSize;
@@ -105,6 +106,7 @@ namespace MongoDB.Driver
             TimeSpan serverSelectionTimeout,
             TimeSpan socketTimeout,
             int srvMaxHosts,
+            string srvServiceName,
             SslSettings sslSettings,
             bool useTls,
             int waitQueueSize,
@@ -145,6 +147,7 @@ namespace MongoDB.Driver
             _serverSelectionTimeout = serverSelectionTimeout;
             _socketTimeout = socketTimeout;
             _srvMaxHosts = srvMaxHosts;
+            _srvServiceName = srvServiceName;
             _sslSettings = sslSettings;
             _useTls = useTls;
             _waitQueueSize = waitQueueSize;
@@ -211,6 +214,7 @@ namespace MongoDB.Driver
         public TimeSpan ServerSelectionTimeout { get { return _serverSelectionTimeout; } }
         public TimeSpan SocketTimeout { get { return _socketTimeout; } }
         public int SrvMaxHosts { get { return _srvMaxHosts; } }
+        public string SrvServiceName { get { return _srvServiceName; } }
         public SslSettings SslSettings { get { return _sslSettings; } }
         public bool UseTls => _useTls;
         public int WaitQueueSize { get { return _waitQueueSize; } }
@@ -268,6 +272,7 @@ namespace MongoDB.Driver
                 _serverSelectionTimeout == rhs._serverSelectionTimeout &&
                 _socketTimeout == rhs._socketTimeout &&
                 _srvMaxHosts == rhs._srvMaxHosts &&
+                _srvServiceName == rhs.SrvServiceName &&
                 object.Equals(_sslSettings, rhs._sslSettings) &&
                 _useTls == rhs._useTls &&
                 _waitQueueSize == rhs._waitQueueSize &&

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -783,7 +783,7 @@ namespace MongoDB.Driver
             set
             {
                 if (_isFrozen) { throw new InvalidOperationException("MongoClientSettings is frozen."); }
-                _srvServiceName = value;
+                _srvServiceName = Ensure.IsNotNullOrEmpty(value, nameof(SrvServiceName));
             }
         }
 
@@ -1028,7 +1028,7 @@ namespace MongoDB.Driver
             clientSettings.ServerSelectionTimeout = url.ServerSelectionTimeout;
             clientSettings.SocketTimeout = url.SocketTimeout;
             clientSettings.SrvMaxHosts = url.SrvMaxHosts.GetValueOrDefault(0);
-            clientSettings.SrvServiceName = url.SrvServiceName ?? MongoInternalDefaults.MongoClientSettings.SrvServiceName;
+            clientSettings.SrvServiceName = url.SrvServiceName;
             clientSettings.SslSettings = null;
             if (url.TlsDisableCertificateRevocationCheck)
             {

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -1320,8 +1320,8 @@ namespace MongoDB.Driver
             sb.AppendFormat("ReadConcern={0};", _readConcern);
             sb.AppendFormat("ReadPreference={0};", _readPreference);
             sb.AppendFormat("ReplicaSetName={0};", _replicaSetName);
-            sb.AppendFormat("RetryReads={0}", _retryReads);
-            sb.AppendFormat("RetryWrites={0}", _retryWrites);
+            sb.AppendFormat("RetryReads={0};", _retryReads);
+            sb.AppendFormat("RetryWrites={0};", _retryWrites);
             if (_scheme != ConnectionStringScheme.MongoDB)
             {
                 sb.AppendFormat("Scheme={0};", _scheme);
@@ -1338,7 +1338,7 @@ namespace MongoDB.Driver
             sb.AppendFormat("serverMonitoringMode={0};", _serverMonitoringMode);
             sb.AppendFormat("ServerSelectionTimeout={0};", _serverSelectionTimeout);
             sb.AppendFormat("SocketTimeout={0};", _socketTimeout);
-            sb.AppendFormat("SrvMaxHosts={0}", _srvMaxHosts);
+            sb.AppendFormat("SrvMaxHosts={0};", _srvMaxHosts);
             sb.AppendFormat("SrvServiceName={0};", _srvServiceName);
             if (_sslSettings != null)
             {

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -774,8 +774,8 @@ namespace MongoDB.Driver
 
         /// <summary>
         /// Gets or sets the SRV service name which modifies the srv URI to look like:
-        /// `_{srvServiceName}._tcp.{hostname}.{domainname}`.
-        /// Defaults to "mongodb".
+        /// <code>_{srvServiceName}._tcp.{hostname}.{domainname}</code>
+        /// The default value is "mongodb".
         /// </summary>
         public string SrvServiceName
         {

--- a/src/MongoDB.Driver/MongoClientSettings.cs
+++ b/src/MongoDB.Driver/MongoClientSettings.cs
@@ -138,7 +138,7 @@ namespace MongoDB.Driver
             _serverSelectionTimeout = MongoDefaults.ServerSelectionTimeout;
             _socketTimeout = MongoDefaults.SocketTimeout;
             _srvMaxHosts = 0;
-            _srvServiceName = MongoDefaults.SrvServiceName;
+            _srvServiceName = MongoInternalDefaults.MongoClientSettings.SrvServiceName;
             _sslSettings = null;
             _useTls = false;
 #pragma warning disable 618
@@ -1028,7 +1028,7 @@ namespace MongoDB.Driver
             clientSettings.ServerSelectionTimeout = url.ServerSelectionTimeout;
             clientSettings.SocketTimeout = url.SocketTimeout;
             clientSettings.SrvMaxHosts = url.SrvMaxHosts.GetValueOrDefault(0);
-            clientSettings.SrvServiceName = url.SrvServiceName ?? MongoDefaults.SrvServiceName;
+            clientSettings.SrvServiceName = url.SrvServiceName ?? MongoInternalDefaults.MongoClientSettings.SrvServiceName;
             clientSettings.SslSettings = null;
             if (url.TlsDisableCertificateRevocationCheck)
             {
@@ -1441,7 +1441,7 @@ namespace MongoDB.Driver
                 throw new InvalidOperationException("Specifying srvMaxHosts when connecting to a replica set is invalid.");
             }
 
-            if (_srvServiceName != MongoDefaults.SrvServiceName && _scheme != ConnectionStringScheme.MongoDBPlusSrv)
+            if (_srvServiceName != MongoInternalDefaults.MongoClientSettings.SrvServiceName && _scheme != ConnectionStringScheme.MongoDBPlusSrv)
             {
                 throw new InvalidOperationException("Specifying srvServiceName is only allowed with the mongodb+srv scheme.");
             }

--- a/src/MongoDB.Driver/MongoDefaults.cs
+++ b/src/MongoDB.Driver/MongoDefaults.cs
@@ -41,6 +41,7 @@ namespace MongoDB.Driver
         private static UTF8Encoding __readEncoding = Utf8Encodings.Strict;
         private static TimeSpan __serverSelectionTimeout = TimeSpan.FromSeconds(30);
         private static TimeSpan __socketTimeout = TimeSpan.Zero; // use operating system default (presumably infinite)
+        private static string __srvServiceName = "mongodb";
         private static int __tcpReceiveBufferSize = 64 * 1024; // 64KiB (note: larger than 2MiB fails on Mac using Mono)
         private static int __tcpSendBufferSize = 64 * 1024; // 64KiB (TODO: what is the optimum value for the buffers?)
         private static double __waitQueueMultiple = 5.0; // default wait queue multiple is 5.0
@@ -221,6 +222,14 @@ namespace MongoDB.Driver
         {
             get { return __socketTimeout; }
             set { __socketTimeout = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the SRV service name.
+        /// </summary>
+        public static string SrvServiceName
+        {
+            get { return __srvServiceName; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoDefaults.cs
+++ b/src/MongoDB.Driver/MongoDefaults.cs
@@ -225,7 +225,7 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
-        /// Gets or sets the SRV service name.
+        /// Gets the SRV service name.
         /// </summary>
         public static string SrvServiceName
         {

--- a/src/MongoDB.Driver/MongoDefaults.cs
+++ b/src/MongoDB.Driver/MongoDefaults.cs
@@ -41,7 +41,6 @@ namespace MongoDB.Driver
         private static UTF8Encoding __readEncoding = Utf8Encodings.Strict;
         private static TimeSpan __serverSelectionTimeout = TimeSpan.FromSeconds(30);
         private static TimeSpan __socketTimeout = TimeSpan.Zero; // use operating system default (presumably infinite)
-        private static string __srvServiceName = "mongodb";
         private static int __tcpReceiveBufferSize = 64 * 1024; // 64KiB (note: larger than 2MiB fails on Mac using Mono)
         private static int __tcpSendBufferSize = 64 * 1024; // 64KiB (TODO: what is the optimum value for the buffers?)
         private static double __waitQueueMultiple = 5.0; // default wait queue multiple is 5.0
@@ -222,14 +221,6 @@ namespace MongoDB.Driver
         {
             get { return __socketTimeout; }
             set { __socketTimeout = value; }
-        }
-
-        /// <summary>
-        /// Gets the SRV service name.
-        /// </summary>
-        public static string SrvServiceName
-        {
-            get { return __srvServiceName; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -78,6 +78,7 @@ namespace MongoDB.Driver
         private readonly TimeSpan _serverSelectionTimeout;
         private readonly TimeSpan _socketTimeout;
         private readonly int? _srvMaxHosts;
+        private readonly string _srvServiceName;
         private readonly bool _tlsDisableCertificateRevocationCheck;
         private readonly string _username;
         private readonly bool _useTls;
@@ -153,6 +154,7 @@ namespace MongoDB.Driver
             _serverSelectionTimeout = builder.ServerSelectionTimeout;
             _socketTimeout = builder.SocketTimeout;
             _srvMaxHosts = builder.SrvMaxHosts;
+            _srvServiceName = builder.SrvServiceName;
             _tlsDisableCertificateRevocationCheck = builder.TlsDisableCertificateRevocationCheck;
             _username = builder.Username;
             _useTls = builder.UseTls;
@@ -526,6 +528,15 @@ namespace MongoDB.Driver
         /// that may be added during SRV polling.
         /// </summary>
         public int? SrvMaxHosts => _srvMaxHosts;
+
+        /// <summary>
+        /// Gets the SRV service name which modifies the srv URI to look like:
+        /// `_{srvServiceName}._tcp.{hostname}.{domainname}`
+        /// </summary>
+        public string SrvServiceName
+        {
+            get { return _srvServiceName; }
+        }
 
         /// <summary>
         /// Gets whether or not to disable checking certificate revocation status during the TLS handshake.

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -531,7 +531,7 @@ namespace MongoDB.Driver
 
         /// <summary>
         /// Gets the SRV service name which modifies the srv URI to look like:
-        /// `_{srvServiceName}._tcp.{hostname}.{domainname}`
+        /// <code>_{srvServiceName}._tcp.{hostname}.{domainname}</code>
         /// </summary>
         public string SrvServiceName
         {

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -133,7 +133,7 @@ namespace MongoDB.Driver
             _serverSelectionTimeout = MongoDefaults.ServerSelectionTimeout;
             _socketTimeout = MongoDefaults.SocketTimeout;
             _srvMaxHosts = null;
-            _srvServiceName = null;
+            _srvServiceName = MongoInternalDefaults.MongoClientSettings.SrvServiceName;
             _username = null;
             _useTls = false;
             _w = null;
@@ -681,7 +681,10 @@ namespace MongoDB.Driver
         public string SrvServiceName
         {
             get { return _srvServiceName; }
-            set { _srvServiceName = value; }
+            set
+            {
+                _srvServiceName = Ensure.IsNotNullOrEmpty(value, nameof(SrvServiceName));
+            }
         }
 
         /// <summary>
@@ -1095,7 +1098,7 @@ namespace MongoDB.Driver
             {
                 query.AppendFormat("srvMaxHosts={0}&", _srvMaxHosts);
             }
-            if (!string.IsNullOrEmpty(_srvServiceName))
+            if (_srvServiceName != MongoInternalDefaults.MongoClientSettings.SrvServiceName)
             {
                 query.AppendFormat("srvServiceName={0}&", _srvServiceName);
             }
@@ -1199,7 +1202,7 @@ namespace MongoDB.Driver
             _serverSelectionTimeout = connectionString.ServerSelectionTimeout.GetValueOrDefault(MongoDefaults.ServerSelectionTimeout);
             _socketTimeout = connectionString.SocketTimeout.GetValueOrDefault(MongoDefaults.SocketTimeout);
             _srvMaxHosts = connectionString.SrvMaxHosts;
-            _srvServiceName = connectionString.SrvServiceName;
+            _srvServiceName = connectionString.SrvServiceName ?? MongoInternalDefaults.MongoClientSettings.SrvServiceName;
             _tlsDisableCertificateRevocationCheck = connectionString.TlsDisableCertificateRevocationCheck;
             _username = connectionString.Username;
             _useTls = connectionString.Tls.GetValueOrDefault(false);

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -74,6 +74,7 @@ namespace MongoDB.Driver
         private TimeSpan _serverSelectionTimeout;
         private TimeSpan _socketTimeout;
         private int? _srvMaxHosts;
+        private string _srvServiceName;
         private bool? _tlsDisableCertificateRevocationCheck;
         private string _username;
         private bool _useTls;
@@ -132,6 +133,7 @@ namespace MongoDB.Driver
             _serverSelectionTimeout = MongoDefaults.ServerSelectionTimeout;
             _socketTimeout = MongoDefaults.SocketTimeout;
             _srvMaxHosts = null;
+            _srvServiceName = null;
             _username = null;
             _useTls = false;
             _w = null;
@@ -673,6 +675,16 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Gets or sets the SRV service name which modifies the srv URI to look like:
+        /// `_{srvServiceName}._tcp.{hostname}.{domainname}`.
+        /// </summary>
+        public string SrvServiceName
+        {
+            get { return _srvServiceName; }
+            set { _srvServiceName = value; }
+        }
+
+        /// <summary>
         /// Gets or sets whether to disable certificate revocation checking during the TLS handshake.
         /// </summary>
         public bool TlsDisableCertificateRevocationCheck
@@ -1083,6 +1095,10 @@ namespace MongoDB.Driver
             {
                 query.AppendFormat("srvMaxHosts={0}&", _srvMaxHosts);
             }
+            if (!string.IsNullOrEmpty(_srvServiceName))
+            {
+                query.AppendFormat("srvServiceName={0}&", _srvServiceName);
+            }
             if (query.Length != 0)
             {
                 query.Length = query.Length - 1; // remove trailing "&"
@@ -1183,6 +1199,7 @@ namespace MongoDB.Driver
             _serverSelectionTimeout = connectionString.ServerSelectionTimeout.GetValueOrDefault(MongoDefaults.ServerSelectionTimeout);
             _socketTimeout = connectionString.SocketTimeout.GetValueOrDefault(MongoDefaults.SocketTimeout);
             _srvMaxHosts = connectionString.SrvMaxHosts;
+            _srvServiceName = connectionString.SrvServiceName;
             _tlsDisableCertificateRevocationCheck = connectionString.TlsDisableCertificateRevocationCheck;
             _username = connectionString.Username;
             _useTls = connectionString.Tls.GetValueOrDefault(false);

--- a/src/MongoDB.Driver/MongoUrlBuilder.cs
+++ b/src/MongoDB.Driver/MongoUrlBuilder.cs
@@ -676,7 +676,7 @@ namespace MongoDB.Driver
 
         /// <summary>
         /// Gets or sets the SRV service name which modifies the srv URI to look like:
-        /// `_{srvServiceName}._tcp.{hostname}.{domainname}`.
+        /// <code>_{srvServiceName}._tcp.{hostname}.{domainname}</code>
         /// </summary>
         public string SrvServiceName
         {

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsMonitorFactoryTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsMonitorFactoryTests.cs
@@ -56,7 +56,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Clusters
             using var cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = cancellationTokenSource.Token;
 
-            var result = subject.CreateDnsMonitor(cluster, lookupDomainName, cancellationToken);
+            var result = subject.CreateDnsMonitor(cluster, "mongodb", lookupDomainName, cancellationToken);
 
             var dnsMonitor = result.Should().BeOfType<DnsMonitor>().Subject;
             dnsMonitor._cluster().Should().BeSameAs(cluster);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsMonitorTests.cs
@@ -75,7 +75,7 @@ namespace MongoDB.Driver.Core.Clusters
             using var cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = cancellationTokenSource.Token;
 
-            var subject = new DnsMonitor(cluster, dnsResolver, lookupDomainName, mockEventSubscriber.Object, null, cancellationToken);
+            var subject = new DnsMonitor(cluster, dnsResolver, "mongodb", lookupDomainName, mockEventSubscriber.Object, null, cancellationToken);
 
             subject.State.Should().Be(DnsMonitorState.Created);
             subject._cancellationToken().Should().Be(cancellationToken);
@@ -95,7 +95,7 @@ namespace MongoDB.Driver.Core.Clusters
             using var cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = cancellationTokenSource.Token;
 
-            var exception = Record.Exception(() => new DnsMonitor(null, dnsResolver, lookupDomainName, null, null, cancellationToken));
+            var exception = Record.Exception(() => new DnsMonitor(null, dnsResolver, "mongodb", lookupDomainName, null, null, cancellationToken));
 
             var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
             e.ParamName.Should().Be("cluster");
@@ -109,7 +109,7 @@ namespace MongoDB.Driver.Core.Clusters
             using var cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = cancellationTokenSource.Token;
 
-            var exception = Record.Exception(() => new DnsMonitor(cluster, null, lookupDomainName, null, null, cancellationToken));
+            var exception = Record.Exception(() => new DnsMonitor(cluster, null, "mongodb", lookupDomainName, null, null, cancellationToken));
 
             var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
             e.ParamName.Should().Be("dnsResolver");
@@ -123,7 +123,7 @@ namespace MongoDB.Driver.Core.Clusters
             using var cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = cancellationTokenSource.Token;
 
-            var exception = Record.Exception(() => new DnsMonitor(cluster, dnsResolver, null, null, null, cancellationToken));
+            var exception = Record.Exception(() => new DnsMonitor(cluster, dnsResolver, "mongodb", null, null, null, cancellationToken));
 
             var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
             e.ParamName.Should().Be("lookupDomainName");
@@ -140,7 +140,7 @@ namespace MongoDB.Driver.Core.Clusters
             using var cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = cancellationTokenSource.Token;
 
-            var exception = Record.Exception(() => new DnsMonitor(cluster, dnsResolver, lookupDomainName, null, null, cancellationToken));
+            var exception = Record.Exception(() => new DnsMonitor(cluster, dnsResolver, "mongodb", lookupDomainName, null, null, cancellationToken));
 
             var e = exception.Should().BeOfType<ArgumentException>().Subject;
             e.ParamName.Should().Be("lookupDomainName");
@@ -499,6 +499,7 @@ namespace MongoDB.Driver.Core.Clusters
         private DnsMonitor CreateSubject(
             IDnsMonitoringCluster cluster = null,
             IDnsResolver dnsResolver = null,
+            string srvServiceName = "mongodb",
             string lookupDomainName = null,
             IEventSubscriber eventSubscriber = null,
             CancellationToken cancellationToken = default)
@@ -506,7 +507,7 @@ namespace MongoDB.Driver.Core.Clusters
             cluster = cluster ?? Mock.Of<IDnsMonitoringCluster>();
             dnsResolver = dnsResolver ?? Mock.Of<IDnsResolver>();
             lookupDomainName = lookupDomainName ?? "a.b.c.com";
-            return new DnsMonitor(cluster, dnsResolver, lookupDomainName, eventSubscriber, null, cancellationToken);
+            return new DnsMonitor(cluster, dnsResolver, srvServiceName, lookupDomainName, eventSubscriber, null, cancellationToken);
         }
     }
 
@@ -518,7 +519,7 @@ namespace MongoDB.Driver.Core.Clusters
         public static IDnsMonitoringCluster _cluster(this DnsMonitor obj) => (IDnsMonitoringCluster)Reflector.GetFieldValue(obj, nameof(_cluster));
         public static IDnsResolver _dnsResolver(this DnsMonitor obj) => (IDnsResolver)Reflector.GetFieldValue(obj, nameof(_dnsResolver));
         public static string _lookupDomainName(this DnsMonitor obj) => (string)Reflector.GetFieldValue(obj, nameof(_lookupDomainName));
-        public static bool _processDnsResultHasEverBeenCalled(this DnsMonitor obj) => (bool)Reflector.GetFieldValue(obj, nameof(_processDnsResultHasEverBeenCalled));        
+        public static bool _processDnsResultHasEverBeenCalled(this DnsMonitor obj) => (bool)Reflector.GetFieldValue(obj, nameof(_processDnsResultHasEverBeenCalled));
         public static string _service(this DnsMonitor obj) => (string)Reflector.GetFieldValue(obj, nameof(_service));
         public static Exception _unhandledException(this DnsMonitor obj) => (Exception)Reflector.GetFieldValue(obj, nameof(_unhandledException));
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsMonitorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsMonitorTests.cs
@@ -519,7 +519,7 @@ namespace MongoDB.Driver.Core.Clusters
         public static IDnsMonitoringCluster _cluster(this DnsMonitor obj) => (IDnsMonitoringCluster)Reflector.GetFieldValue(obj, nameof(_cluster));
         public static IDnsResolver _dnsResolver(this DnsMonitor obj) => (IDnsResolver)Reflector.GetFieldValue(obj, nameof(_dnsResolver));
         public static string _lookupDomainName(this DnsMonitor obj) => (string)Reflector.GetFieldValue(obj, nameof(_lookupDomainName));
-        public static bool _processDnsResultHasEverBeenCalled(this DnsMonitor obj) => (bool)Reflector.GetFieldValue(obj, nameof(_processDnsResultHasEverBeenCalled));
+        public static bool _processDnsResultHasEverBeenCalled(this DnsMonitor obj) => (bool)Reflector.GetFieldValue(obj, nameof(_processDnsResultHasEverBeenCalled));        
         public static string _service(this DnsMonitor obj) => (string)Reflector.GetFieldValue(obj, nameof(_service));
         public static Exception _unhandledException(this DnsMonitor obj) => (Exception)Reflector.GetFieldValue(obj, nameof(_unhandledException));
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/LoadBalancedClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/LoadBalancedClusterTests.cs
@@ -484,7 +484,7 @@ namespace MongoDB.Driver.Core.Tests.Core.Clusters
         {
             var mockDnsMonitorFactory = new Mock<IDnsMonitorFactory>();
             mockDnsMonitorFactory
-                .Setup(m => m.CreateDnsMonitor(It.IsAny<IDnsMonitoringCluster>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.CreateDnsMonitor(It.IsAny<IDnsMonitoringCluster>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Mock.Of<IDnsMonitor>());
             return mockDnsMonitorFactory;
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
@@ -1187,7 +1187,7 @@ namespace MongoDB.Driver.Core.Clusters
         {
             var mockDnsMonitorFactory = new Mock<IDnsMonitorFactory>();
             mockDnsMonitorFactory
-                .Setup(m => m.CreateDnsMonitor(It.IsAny<IDnsMonitoringCluster>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.CreateDnsMonitor(It.IsAny<IDnsMonitoringCluster>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Mock.Of<IDnsMonitor>());
             return mockDnsMonitorFactory;
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ClusterSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ClusterSettingsTests.cs
@@ -600,6 +600,17 @@ namespace MongoDB.Driver.Core.Configuration
         }
 
         [Fact]
+        public void With_srvServiceName_should_return_expected_result()
+        {
+            var srvServiceName = "customname";
+            var subject = new ClusterSettings();
+
+            var result = subject.With(srvServiceName: srvServiceName);
+
+            result.SrvServiceName.Should().Be(srvServiceName);
+        }
+
+        [Fact]
         public void With_negative_srvMaxHosts_should_throw()
         {
             var subject = new ClusterSettings();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ClusterSettingsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ClusterSettingsTests.cs
@@ -49,6 +49,7 @@ namespace MongoDB.Driver.Core.Configuration
             subject.ServerApi.Should().BeNull();
             subject.ServerSelectionTimeout.Should().Be(TimeSpan.FromSeconds(30));
             subject.SrvMaxHosts.Should().Be(0);
+            subject.SrvServiceName.Should().Be("mongodb");
         }
 
         [Fact]
@@ -314,6 +315,15 @@ namespace MongoDB.Driver.Core.Configuration
 
             exception.Should().BeOfType<ArgumentOutOfRangeException>()
                 .Subject.ParamName.Should().Be("srvMaxHosts");
+        }
+
+        [Fact]
+        public void Constructor_with_srvServiceName_should_initialize_instance()
+        {
+            var srvServiceName = "customname";
+            var subject = new ClusterSettings(srvServiceName: srvServiceName);
+
+            subject.SrvServiceName.Should().Be(srvServiceName);
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
@@ -1263,9 +1263,10 @@ namespace MongoDB.Driver.Core.Configuration
         [Fact]
         public void Invalid_srvServiceName_configuration_should_throw()
         {
-            var exception = Record.Exception(() => new ConnectionString("mongodb://example.com/?srvServiceName="));
+            var exception = Record.Exception(() => new ConnectionString("mongodb://example.com/?srvServiceName= "));
 
             exception.Should().BeOfType<MongoConfigurationException>();
+            exception.Message.Should().Contain("SrvServiceName");
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
@@ -1230,6 +1230,27 @@ namespace MongoDB.Driver.Core.Configuration
             exception.Should().BeOfType<MongoConfigurationException>();
         }
 
+        [Fact]
+        public void When_srvServiceName_is_specified_with_a_srv_scheme()
+        {
+            var connectionString = "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname";
+
+            var subject = new ConnectionString(connectionString);
+
+            subject.SrvServiceName.Should().Be("customname");
+        }
+
+        [Fact]
+        public void When_srvServiceName_is_specified_without_a_srv_scheme()
+        {
+            var connectionString = "mongodb://example.com/?srvServiceName=customname";
+
+            var exception = Record.Exception(() => new ConnectionString(connectionString));
+
+            exception.Should().BeOfType<MongoConfigurationException>();
+            exception.Message.Should().Contain("srvServiceName");
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void Valid_srvMaxHosts_with_mongodbsrv_scheme_should_be_valid([Values(0, 42)]int srvMaxHosts)
@@ -1237,6 +1258,14 @@ namespace MongoDB.Driver.Core.Configuration
             var subject = new ConnectionString($"mongodb+srv://cluster0.10gen.cc/?srvMaxHosts={srvMaxHosts}");
 
             subject.SrvMaxHosts.Should().Be(srvMaxHosts);
+        }
+
+        [Fact]
+        public void Invalid_srvServiceName_configuration_should_throw()
+        {
+            var exception = Record.Exception(() => new ConnectionString("mongodb://example.com/?srvServiceName="));
+
+            exception.Should().BeOfType<MongoConfigurationException>();
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterKeyTests.cs
@@ -226,6 +226,7 @@ namespace MongoDB.Driver.Tests
             var serverSelectionTimeout = TimeSpan.FromSeconds(6);
             var socketTimeout = TimeSpan.FromSeconds(4);
             var srvMaxHosts = 0;
+            var srvServiceName = "mongodb";
             var sslSettings = new SslSettings
             {
                 CheckCertificateRevocation = true,
@@ -289,6 +290,7 @@ namespace MongoDB.Driver.Tests
                     case "ServerSelectionTimeout": serverSelectionTimeout = TimeSpan.FromSeconds(98); break;
                     case "SocketTimeout": socketTimeout = TimeSpan.FromSeconds(99); break;
                     case "SrvMaxHosts": srvMaxHosts = 3; break;
+                    case "SrvServiceName": srvServiceName = "customname"; break;
                     case "SslSettings": sslSettings.CheckCertificateRevocation = !sslSettings.CheckCertificateRevocation; break;
                     case "UseTls": useTls = !useTls; break;
                     case "WaitQueueSize": waitQueueSize = 99; break;
@@ -331,6 +333,7 @@ namespace MongoDB.Driver.Tests
                 serverSelectionTimeout,
                 socketTimeout,
                 srvMaxHosts,
+                srvServiceName,
                 sslSettings,
                 useTls,
                 waitQueueSize,
@@ -383,6 +386,7 @@ namespace MongoDB.Driver.Tests
             var serverSelectionTimeout = TimeSpan.FromSeconds(6);
             var socketTimeout = TimeSpan.FromSeconds(4);
             var srvMaxHosts = 3;
+            var srvServiceName = "customname";
             var sslSettings = new SslSettings
             {
                 CheckCertificateRevocation = true,
@@ -426,6 +430,7 @@ namespace MongoDB.Driver.Tests
                 serverSelectionTimeout,
                 socketTimeout,
                 srvMaxHosts,
+                srvServiceName,
                 sslSettings,
                 useTls,
                 waitQueueSize,

--- a/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterRegistryTests.cs
@@ -115,6 +115,7 @@ namespace MongoDB.Driver.Tests
                 serverSelectionTimeout: TimeSpan.FromSeconds(11),
                 socketTimeout: TimeSpan.FromSeconds(12),
                 srvMaxHosts: 0,
+                srvServiceName: "mongodb",
                 sslSettings: sslSettings,
                 useTls: true,
                 waitQueueSize: 13,

--- a/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
@@ -677,6 +677,12 @@ namespace MongoDB.Driver.Tests
                 settings.SrvMaxHosts = 2;
             });
 
+            AssertException(settings =>
+            {
+                settings.Scheme = ConnectionStringScheme.MongoDB;
+                settings.SrvServiceName = "customname";
+            });
+
             void AssertException(Action<MongoClientSettings> setAction)
             {
                 var settings = new MongoClientSettings();

--- a/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
@@ -1635,16 +1635,6 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
-        public void Freezing_instance_with_SrvServiceName_and_non_srv_scheme_should_throw()
-        {
-            var subject = new MongoClientSettings { SrvServiceName = "customname", Scheme = ConnectionStringScheme.MongoDB };
-
-            var exception = Record.Exception(() => subject.Freeze());
-
-            exception.Should().BeOfType<InvalidOperationException>();
-        }
-
-        [Fact]
         public void Freezing_instance_with_SrvMaxHosts_and_ReplicaSetName_should_throw()
         {
             var subject = new MongoClientSettings { SrvMaxHosts = 2, ReplicaSetName = "replSet0" };

--- a/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
@@ -1590,6 +1590,23 @@ namespace MongoDB.Driver.Tests
             result.WaitQueueTimeout.Should().Be(subject.WaitQueueTimeout);
         }
 
+        [Fact]
+        public void TestSrvServiceName()
+        {
+            var subject = new MongoClientSettings { Scheme = ConnectionStringScheme.MongoDBPlusSrv };
+            subject.SrvServiceName.Should().Be(MongoInternalDefaults.MongoClientSettings.SrvServiceName);
+
+            var srvServicName = "customname";
+            subject.SrvServiceName = srvServicName;
+            subject.SrvServiceName.Should().Be(srvServicName);
+
+            subject.Freeze();
+            subject.SrvServiceName.Should().Be(srvServicName);
+
+            var exception = Record.Exception(() => subject.SrvServiceName = srvServicName);
+            exception.Should().BeOfType<InvalidOperationException>();
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void TestSrvMaxHosts([Values(0, 1, 5)]int srvMaxHosts)
@@ -1615,6 +1632,16 @@ namespace MongoDB.Driver.Tests
             var exception = Record.Exception(() => subject.SrvMaxHosts = -1);
 
             exception.Should().BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void Freezing_instance_with_SrvServiceName_and_non_srv_scheme_should_throw()
+        {
+            var subject = new MongoClientSettings { SrvServiceName = "customname", Scheme = ConnectionStringScheme.MongoDB };
+
+            var exception = Record.Exception(() => subject.Freeze());
+
+            exception.Should().BeOfType<InvalidOperationException>();
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
@@ -1498,6 +1498,8 @@ namespace MongoDB.Driver.Tests
         [InlineData("mongodb+srv://localhost/?ssl=false", "mongodb+srv://localhost/?tls=false")]
         [InlineData("mongodb+srv://localhost/?ssl=true", "mongodb+srv://localhost")]
         [InlineData("mongodb+srv://localhost/?srvMaxHosts=2", "mongodb+srv://localhost/?srvMaxHosts=2")]
+        [InlineData("mongodb+srv://localhost/?srvServiceName=customname", "mongodb+srv://localhost/?srvServiceName=customname")]
+        [InlineData("mongodb+srv://localhost/?srvServiceName= ", "mongodb+srv://localhost")]
         public void ToString_should_return_expected_result_for_scheme_port_and_ssl(string connectionString, string expectedResult)
         {
             var subject = new MongoUrlBuilder(connectionString);

--- a/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlBuilderTests.cs
@@ -511,6 +511,7 @@ namespace MongoDB.Driver.Tests
                 Assert.Equal(MongoDefaults.LocalThreshold, builder.LocalThreshold);
                 Assert.Equal(MongoDefaults.ServerSelectionTimeout, builder.ServerSelectionTimeout);
                 Assert.Equal(MongoDefaults.SocketTimeout, builder.SocketTimeout);
+                Assert.Equal(MongoInternalDefaults.MongoClientSettings.SrvServiceName, builder.SrvServiceName);
                 Assert.Equal(null, builder.Username);
 #pragma warning disable 618
                 Assert.Equal(false, builder.UseSsl);
@@ -1315,6 +1316,33 @@ namespace MongoDB.Driver.Tests
             builder.SocketTimeout = TimeSpan.FromSeconds(1);
         }
 
+        [Fact]
+        public void TestSrvServiceName()
+        {
+            var srvServiceName = "customname";
+            var canonicalConnectionString = $"mongodb+srv://localhost/?srvServiceName={srvServiceName}";
+
+            var built = new MongoUrlBuilder { UseTls = true, Scheme = ConnectionStringScheme.MongoDBPlusSrv };
+
+            Assert.Throws<ArgumentException>(() => built.SrvServiceName = "");
+
+            built.SrvServiceName = srvServiceName;
+            foreach (var builder in EnumerateBuiltAndParsedBuilders(built, canonicalConnectionString))
+            {
+                Assert.Equal(srvServiceName, builder.SrvServiceName);
+                Assert.Equal(canonicalConnectionString, builder.ToString());
+            }
+        }
+
+        [Fact]
+        public void TestSrvServiceName_WithNonSRVScheme()
+        {
+            Assert.Throws<MongoConfigurationException>(() =>
+            {
+                _ = new MongoUrlBuilder("mongodb://localhost/?srvServiceName=customname");
+            });
+        }
+
         [Theory]
         [InlineData(null, "mongodb://localhost", new[] { "" })]
         [InlineData(false, "mongodb://localhost/?tls={0}", new[] { "false", "False" })]
@@ -1499,7 +1527,6 @@ namespace MongoDB.Driver.Tests
         [InlineData("mongodb+srv://localhost/?ssl=true", "mongodb+srv://localhost")]
         [InlineData("mongodb+srv://localhost/?srvMaxHosts=2", "mongodb+srv://localhost/?srvMaxHosts=2")]
         [InlineData("mongodb+srv://localhost/?srvServiceName=customname", "mongodb+srv://localhost/?srvServiceName=customname")]
-        [InlineData("mongodb+srv://localhost/?srvServiceName= ", "mongodb+srv://localhost")]
         public void ToString_should_return_expected_result_for_scheme_port_and_ssl(string connectionString, string expectedResult)
         {
             var subject = new MongoUrlBuilder(connectionString);

--- a/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
@@ -453,6 +453,18 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void TestSrvServiceName()
+        {
+            var built = new MongoUrlBuilder { Scheme = ConnectionStringScheme.MongoDBPlusSrv, SrvServiceName = "customname" };
+            var connectionString = "mongodb+srv://test22.test.build.10gen.cc/test?srvServiceName=customname";
+
+            foreach (var url in EnumerateBuiltAndParsedUrls(built, connectionString))
+            {
+                url.SrvServiceName.Should().Be("customname");
+            }
+        }
+
+        [Fact]
         public void TestSrvMaxHosts()
         {
             var connectionString = "mongodb+srv://test5.test.build.10gen.cc/test?srvMaxHosts=2";

--- a/tests/MongoDB.Driver.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
@@ -166,6 +166,9 @@ namespace MongoDB.Driver.Tests.Specifications.connection_string
                         case "srvmaxhosts":
                             connectionString.SrvMaxHosts.Should().Be(expectedOption.Value.ToInt32());
                             break;
+                        case "srvservicename":
+                            connectionString.SrvServiceName.Should().Be(expectedOption.Value.AsString);
+                            break;
                         case "ssl":
 #pragma warning disable 618
                             AssertBoolean(connectionString.Ssl, expectedOption.Value);
@@ -351,9 +354,6 @@ namespace MongoDB.Driver.Tests.Specifications.connection_string
             {
                 // Not supported readConcernLevel options are not allowed for parsing
                 "concern-options.json:Arbitrary string readConcernLevel does not cause a warning",
-                // srvServiceName not yet implemented (CSHARP-3745)
-                "srv-options.json:Non-SRV URI with custom srvServiceName",
-                "srv-options.json:SRV URI with custom srvServiceName",
                 // tlsAllowInvalidCertificates and tlsAllowInvalidHostnames are not supported
                 "tls-options.json:tlsAllowInvalidCertificates and tlsInsecure both present (and false) raises an error",
                 "tls-options.json:tlsAllowInvalidCertificates and tlsInsecure both present (and true) raises an error",


### PR DESCRIPTION
- Added a new URI options `srvServiceName` which allows the user to change the srv address prefix from the default of `mongodb`