### PR TITLE
CSHARP-4985: Verify that operands to numeric operators in LINQ expressions are represented as numbers on the server.

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/AbsMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/AbsMethodToAggregationExpressionTranslator.cs
@@ -43,6 +43,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var valueExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var valueTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, valueExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(valueExpression, valueTranslation);
                 var ast = AstExpression.Abs(valueTranslation.Ast);
                 return new AggregationExpression(expression, ast, valueTranslation.Serializer);
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/CeilingMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/CeilingMethodToAggregationExpressionTranslator.cs
@@ -32,6 +32,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var argumentExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var argumentTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, argumentExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(argumentExpression, argumentTranslation);
                 var ast = AstExpression.Ceil(argumentTranslation.Ast);
                 var serializer = BsonSerializer.LookupSerializer(expression.Type);
                 return new AggregationExpression(expression, ast, serializer);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/DateTimeAddOrSubtractMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/DateTimeAddOrSubtractMethodToAggregationExpressionTranslator.cs
@@ -144,12 +144,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                         {
                             throw new ExpressionNotSupportedException(valueExpression, expression);
                         }
-                        var representation = timeSpanSerializer.Representation;
+                        SerializationHelper.EnsureRepresentationIsNumeric(valueExpression, timeSpanSerializer);
+
                         var serializerUnits = timeSpanSerializer.Units;
-                        if (representation != BsonType.Int32 && representation != BsonType.Int64 && representation != BsonType.Double)
-                        {
-                            throw new ExpressionNotSupportedException(valueExpression, expression);
-                        }
                         (unit, amount) = serializerUnits switch
                         {
                             TimeSpanUnits.Ticks => ("millisecond", AstExpression.Divide(valueTranslation.Ast, (double)TimeSpan.TicksPerMillisecond)),
@@ -174,6 +171,8 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 else
                 {
                     var valueTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, valueExpression);
+                    SerializationHelper.EnsureRepresentationIsNumeric(valueExpression, valueTranslation);
+
                     (unit, amount) = method.Name switch
                     {
                         "AddTicks" => ("millisecond", AstExpression.Divide(valueTranslation.Ast, (double)TimeSpan.TicksPerMillisecond)),

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/ExpMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/ExpMethodToAggregationExpressionTranslator.cs
@@ -32,6 +32,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var argumentExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var argumentTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, argumentExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(argumentExpression, argumentTranslation);
                 var ast = AstExpression.Exp(argumentTranslation.Ast);
                 return new AggregationExpression(expression, ast, new DoubleSerializer());
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/FloorMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/FloorMethodToAggregationExpressionTranslator.cs
@@ -32,6 +32,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var argumentExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var argumentTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, argumentExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(argumentExpression, argumentTranslation);
                 var ast = AstExpression.Floor(argumentTranslation.Ast);
                 var serializer = BsonSerializer.LookupSerializer(expression.Type);
                 return new AggregationExpression(expression, ast, serializer);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/IndexOfAnyMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/IndexOfAnyMethodToAggregationExpressionTranslator.cs
@@ -115,6 +115,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 
                 var startIndexExpression = arguments[1];
                 var startIndexTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, startIndexExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(startIndexExpression, startIndexTranslation);
                 return AstExpression.UseVarIfNotSimple("startIndex", startIndexTranslation.Ast);
             }
 
@@ -127,6 +128,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
 
                 var countExpression = arguments[2];
                 var countTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, countExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(countExpression, countTranslation);
                 return AstExpression.UseVarIfNotSimple("count", countTranslation.Ast);
             }
 

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/IndexOfMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/IndexOfMethodToAggregationExpressionTranslator.cs
@@ -83,8 +83,18 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var objectTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, objectExpression);
                 var valueTranslation = TranslateValue();
-                var startIndexTranslation = startIndexExpression == null ? null : ExpressionToAggregationExpressionTranslator.Translate(context, startIndexExpression);
-                var countTranslation = countExpression == null ? null : ExpressionToAggregationExpressionTranslator.Translate(context, countExpression);
+                AggregationExpression startIndexTranslation = null;
+                if (startIndexExpression != null)
+                {
+                    startIndexTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, startIndexExpression);
+                    SerializationHelper.EnsureRepresentationIsNumeric(startIndexExpression, startIndexTranslation);
+                }
+                AggregationExpression countTranslation = null;
+                if (countExpression != null)
+                {
+                    countTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, countExpression);
+                    SerializationHelper.EnsureRepresentationIsNumeric(countExpression, countTranslation);
+                }
                 var ordinal = GetOrdinalFromComparisonType();
 
                 var endAst = CreateEndAst(startIndexTranslation?.Ast, countTranslation?.Ast);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/LogMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/LogMethodToAggregationExpressionTranslator.cs
@@ -32,6 +32,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var argumentExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var argumentTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, argumentExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(argumentExpression, argumentTranslation);
                 AstExpression ast;
                 if (method.Is(MathMethod.LogWithNewBase))
                 {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/PowMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/PowMethodToAggregationExpressionTranslator.cs
@@ -32,8 +32,10 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var xExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var xTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, xExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(xExpression, xTranslation);
                 var yExpression = ConvertHelper.RemoveWideningConvert(arguments[1]);
                 var yTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, yExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(yExpression, yTranslation);
                 var ast = AstExpression.Pow(xTranslation.Ast, yTranslation.Ast);
                 return new AggregationExpression(expression, ast, new DoubleSerializer());
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/RangeMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/RangeMethodToAggregationExpressionTranslator.cs
@@ -34,10 +34,14 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var startExpression = arguments[0];
                 var startTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, startExpression);
-                var (startVar, startAst) = AstExpression.UseVarIfNotSimple("start", startTranslation.Ast);
+                SerializationHelper.EnsureRepresentationIsNumeric(startExpression, startTranslation);
                 var countExpression = arguments[1];
                 var countTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, countExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(countExpression, countTranslation);
+
+                var (startVar, startAst) = AstExpression.UseVarIfNotSimple("start", startTranslation.Ast);
                 var (countVar, countAst) = AstExpression.UseVarIfNotSimple("count", countTranslation.Ast);
+
                 var ast = AstExpression.Let(
                     startVar,
                     countVar,

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/RoundMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/RoundMethodToAggregationExpressionTranslator.cs
@@ -46,12 +46,14 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var argumentExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var argumentTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, argumentExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(argumentExpression, argumentTranslation);
 
                 AstExpression ast;
                 if (method.IsOneOf(__roundWithPlaceMethods))
                 {
                     var placeExpression = arguments[1];
                     var placeTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, placeExpression);
+                    SerializationHelper.EnsureRepresentationIsNumeric(placeExpression, placeTranslation);
                     ast = AstExpression.Round(argumentTranslation.Ast, placeTranslation.Ast);
                 }
                 else

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/SqrtMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/SqrtMethodToAggregationExpressionTranslator.cs
@@ -32,6 +32,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var argumentExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var argumentTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, argumentExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(argumentExpression, argumentTranslation);
                 var ast = AstExpression.Sqrt(argumentTranslation.Ast);
                 return new AggregationExpression(expression, ast, new DoubleSerializer());
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/SubstringMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/SubstringMethodToAggregationExpressionTranslator.cs
@@ -53,6 +53,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
         {
             var stringTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, stringExpression);
             var startIndexTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, startIndexExpression);
+            SerializationHelper.EnsureRepresentationIsNumeric(startIndexExpression, startIndexTranslation);
 
             AstExpression ast;
             if (lengthExpression == null)

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/TruncateMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/TruncateMethodToAggregationExpressionTranslator.cs
@@ -73,6 +73,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             {
                 var argumentExpression = ConvertHelper.RemoveWideningConvert(arguments[0]);
                 var argumentTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, argumentExpression);
+                SerializationHelper.EnsureRepresentationIsNumeric(argumentExpression, argumentTranslation);
                 var ast = AstExpression.Trunc(argumentTranslation.Ast);
                 return new AggregationExpression(expression, ast, argumentTranslation.Serializer);
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/NegateExpressionToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/NegateExpressionToAggregationExpressionTranslator.cs
@@ -26,7 +26,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             if (expression.NodeType == ExpressionType.Negate)
             {
                 var operandTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, expression.Operand);
-                SerializationHelper.EnsureRepresentationIsNumeric(expression, operandTranslation.Serializer);
+                SerializationHelper.EnsureRepresentationIsNumeric(expression, operandTranslation);
 
                 var ast = AstExpression.Subtract(0, operandTranslation.Ast);
                 return new AggregationExpression(expression, ast, operandTranslation.Serializer);

--- a/src/MongoDB.Driver/Support/ReflectionExtensions.cs
+++ b/src/MongoDB.Driver/Support/ReflectionExtensions.cs
@@ -72,6 +72,21 @@ namespace MongoDB.Driver.Support
                 type == typeof(Decimal128);
         }
 
+        public static bool IsNumericOrNullableNumeric(this Type type)
+        {
+            if (type.IsConstructedGenericType &&
+                type.GetGenericTypeDefinition() is var genericTypeDefinition &&
+                genericTypeDefinition == typeof(Nullable<>))
+            {
+                var valueType = type.GetGenericArguments()[0];
+                return IsNumeric(valueType);
+            }
+            else
+            {
+                return IsNumeric(type);
+            }
+        }
+
         public static bool IsConvertibleToEnum(this Type type)
         {
             return

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4985Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4985Tests.cs
@@ -1,0 +1,137 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Driver.Linq;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
+{
+    public class CSharp4985Tests : Linq3IntegrationTest
+    {
+        [Theory]
+        [InlineData(1, "{ $project : { _v : '$X', _id : 0 } }", new[] { 1, 3 })]
+        [InlineData(2, "{ $project : { _v : { $add : ['$X', 2] }, _id : 0 } }", new[] { 3, 5 })]
+        [InlineData(3, "{ $project : { _v : { $add : ['$X', '$Y'] }, _id : 0 } }", new[] { 3, 7 })]
+        [InlineData(4, "{ $project : { _v : { $add : ['$X', '$NY'] }, _id : 0 } }", null)]
+        [InlineData(5, "{ $project : { _v : '$NX', _id : 0 } }", null)]
+        [InlineData(6, "{ $project : { _v : { $add : ['$NX', 2] }, _id : 0 } }", null)]
+        [InlineData(7, "{ $project : { _v : { $add : ['$NX', '$Y'] }, _id : 0 } }", null)]
+        [InlineData(8, "{ $project : { _v : { $add : ['$NX', '$NY'] }, _id : 0 } }", null)]
+        [InlineData(9, "{ $project : { _v : { $add : [1, '$Y'] }, _id : 0 } }", new[] { 3, 5 })]
+        [InlineData(10, "{ $project : { _v : { $add : [1, '$NY'] }, _id : 0 } }", null)]
+        public void Select_with_int_result_should_work(
+             int test,
+             string expectedStage,
+             int[] expectedResults)
+        {
+            var collection = GetCollection();
+            Expression<Func<C, int>> selector = test switch
+            {
+                1 => x => x.X,
+                2 => x => x.X + 2,
+                3 => x => x.X + x.Y,
+                4 => x => x.X + x.NY.Value,
+                5 => x => x.NX.Value,
+                6 => x => x.NX.Value + 2,
+                7 => x => x.NX.Value + x.Y,
+                8 => x => x.NX.Value + x.NY.Value,
+                9 => x => 1 + x.Y,
+                10 => x => 1 + x.NY.Value,
+                _ => throw new Exception()
+            };
+            var queryable = collection.AsQueryable().Select(selector);
+
+            var stages = Translate(collection, queryable);
+            AssertStages(stages, expectedStage);
+
+            List<int> results = null;
+            var exception = Record.Exception(() => { results = queryable.ToList(); });
+            if (expectedResults != null)
+            {
+                exception.Should().BeNull();
+                results.Should().Equal(expectedResults);
+            }
+            else
+            {
+                exception.Should().BeOfType<FormatException>();
+                exception.Message.Should().Contain("Cannot deserialize a 'Int32' from BsonType 'Null'");
+            }
+        }
+
+        [Theory]
+        [InlineData(1, "{ $project : { _v : '$X', _id : 0 } }", new object[] { 1, 3 })]
+        [InlineData(2, "{ $project : { _v : { $add : ['$X', 2] }, _id : 0 } }", new object[] { 3, 5 })]
+        [InlineData(3, "{ $project : { _v : { $add : ['$X', '$Y'] }, _id : 0 } }", new object[] { 3, 7 })]
+        [InlineData(4, "{ $project : { _v : { $add : ['$X', '$NY'] }, _id : 0 } }", new object[] { 3, null })]
+        [InlineData(5, "{ $project : { _v : '$NX', _id : 0 } }", new object[] { 1, null })]
+        [InlineData(6, "{ $project : { _v : { $add : ['$NX', 2] }, _id : 0 } }", new object[] { 3, null })]
+        [InlineData(7, "{ $project : { _v : { $add : ['$NX', '$Y'] }, _id : 0 } }", new object[] { 3, null })]
+        [InlineData(8, "{ $project : { _v : { $add : ['$NX', '$NY'] }, _id : 0 } }", new object[] { 3, null })]
+        [InlineData(9, "{ $project : { _v : { $add : [1, '$Y'] }, _id : 0 } }", new object[] { 3, 5 })]
+        [InlineData(10, "{ $project : { _v : { $add : [1, '$NY'] }, _id : 0 } }", new object[] { 3, null })]
+        public void Select_with_nullable_int_result_should_work(
+            int test,
+            string expectedStage,
+            object[] expectedResults)
+        {
+            var collection = GetCollection();
+            Expression<Func<C, int?>> selector = test switch
+            {
+                1 => x => x.X,
+                2 => x => x.X + 2,
+                3 => x => x.X + x.Y,
+                4 => x => x.X + x.NY,
+                5 => x => x.NX,
+                6 => x => x.NX + 2,
+                7 => x => x.NX + x.Y,
+                8 => x => x.NX + x.NY,
+                9 => x => 1 + x.Y,
+                10 => x => 1 + x.NY,
+                _ => throw new Exception()
+            };
+            var queryable = collection.AsQueryable().Select(selector);
+
+            var stages = Translate(collection, queryable);
+            AssertStages(stages, expectedStage);
+
+            var results = queryable.ToList();
+            results.Should().Equal(expectedResults.Select(r => r == null ? null : (int?)r));
+        }
+
+        private IMongoCollection<C> GetCollection()
+        {
+            var collection = GetCollection<C>("test");
+            CreateCollection(
+                collection,
+                new C { Id = 1, X = 1, Y = 2, NX = 1, NY = 2 },
+                new C { Id = 2, X = 3, Y = 4, NX = null, NY = null });
+            return collection;
+        }
+
+        private class C
+        {
+            public int Id { get; set; }
+            public int X { get; set; }
+            public int Y { get; set; }
+            public int? NX { get; set; }
+            public int? NY { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Let's not try and push this to master until after I get back. Feel free to take a look and comment. Mainly I wanted to get this work backed up.

I probably need a few more tests (though there are some tests already).