### PR TITLE
CSHARP-4718: Enable Container and kubernetes awareness

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
@@ -32,7 +32,7 @@ namespace MongoDB.Driver.Core.Connections
         private static Lazy<BsonDocument> __osDocument;
         private static Lazy<string> __platformString;
         private static Lazy<IEnvironmentVariableProvider> __environmentVariableProvider;
-        private static Lazy<IFileSystemProvider> __filesystem;
+        private static Lazy<IFileSystemProvider> __fileSystemProvider;
 
         private static void Initialize()
         {
@@ -41,7 +41,7 @@ namespace MongoDB.Driver.Core.Connections
             __osDocument = new Lazy<BsonDocument>(CreateOSDocument);
             __platformString = new Lazy<string>(GetPlatformString);
             __environmentVariableProvider = new Lazy<IEnvironmentVariableProvider>(() => new EnvironmentVariableProvider());
-            __filesystem = new Lazy<IFileSystemProvider>(() => new FileSystemProvider());
+            __fileSystemProvider = new Lazy<IFileSystemProvider>(() => new FileSystemProvider());
         }
 
         static ClientDocumentHelper() => Initialize();
@@ -53,7 +53,7 @@ namespace MongoDB.Driver.Core.Connections
 
         internal static void SetFileSystemProvider(IFileSystemProvider fileSystemProvider)
         {
-            __filesystem = new Lazy<IFileSystemProvider>(() => fileSystemProvider);
+            __fileSystemProvider = new Lazy<IFileSystemProvider>(() => fileSystemProvider);
         }
 
         // private static methods
@@ -195,7 +195,7 @@ namespace MongoDB.Driver.Core.Connections
 
             BsonDocument GetContainerDocument()
             {
-                var isExecutionContainerDocker = __filesystem.Value.File.Exists("/.dockerenv");
+                var isExecutionContainerDocker = __fileSystemProvider.Value.File.Exists("/.dockerenv");
                 var isOrchestratorKubernetes = __environmentVariableProvider.Value.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST") != null;
 
                 if (isExecutionContainerDocker || isOrchestratorKubernetes)

--- a/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
@@ -200,7 +200,7 @@ namespace MongoDB.Driver.Core.Connections
 
                 if (isExecutionContainerDocker || isOrchestratorKubernetes)
                 {
-                    return new BsonDocument
+                    return new()
                     {
                         { "runtime", "docker", isExecutionContainerDocker },
                         { "orchestrator", "kubernetes", isOrchestratorKubernetes }

--- a/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/ClientDocumentHelper.cs
@@ -31,8 +31,8 @@ namespace MongoDB.Driver.Core.Connections
         private static Lazy<BsonDocument> __envDocument;
         private static Lazy<BsonDocument> __osDocument;
         private static Lazy<string> __platformString;
-        private static Lazy<IEnvironmentVariableProvider> __environmentVariableProvider;
-        private static Lazy<IFileSystemProvider> __fileSystemProvider;
+        private static IEnvironmentVariableProvider __environmentVariableProvider;
+        private static IFileSystemProvider __fileSystemProvider;
 
         private static void Initialize()
         {
@@ -40,20 +40,20 @@ namespace MongoDB.Driver.Core.Connections
             __envDocument = new Lazy<BsonDocument>(CreateEnvDocument);
             __osDocument = new Lazy<BsonDocument>(CreateOSDocument);
             __platformString = new Lazy<string>(GetPlatformString);
-            __environmentVariableProvider = new Lazy<IEnvironmentVariableProvider>(() => new EnvironmentVariableProvider());
-            __fileSystemProvider = new Lazy<IFileSystemProvider>(() => new FileSystemProvider());
+            __environmentVariableProvider = EnvironmentVariableProvider.Instance;
+            __fileSystemProvider = FileSystemProvider.Instance;
         }
 
         static ClientDocumentHelper() => Initialize();
 
         internal static void SetEnvironmentVariableProvider(IEnvironmentVariableProvider environmentVariableProvider)
         {
-            __environmentVariableProvider = new Lazy<IEnvironmentVariableProvider>(() => environmentVariableProvider);
+            __environmentVariableProvider = environmentVariableProvider;
         }
 
         internal static void SetFileSystemProvider(IFileSystemProvider fileSystemProvider)
         {
-            __fileSystemProvider = new Lazy<IFileSystemProvider>(() => fileSystemProvider);
+            __fileSystemProvider = fileSystemProvider;
         }
 
         // private static methods
@@ -195,8 +195,8 @@ namespace MongoDB.Driver.Core.Connections
 
             BsonDocument GetContainerDocument()
             {
-                var isExecutionContainerDocker = __fileSystemProvider.Value.File.Exists("/.dockerenv");
-                var isOrchestratorKubernetes = __environmentVariableProvider.Value.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST") != null;
+                var isExecutionContainerDocker = __fileSystemProvider.File.Exists("/.dockerenv");
+                var isOrchestratorKubernetes = __environmentVariableProvider.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST") != null;
 
                 if (isExecutionContainerDocker || isOrchestratorKubernetes)
                 {

--- a/src/MongoDB.Driver.Core/Core/Misc/FileSystemProvider.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/FileSystemProvider.cs
@@ -1,0 +1,35 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.IO;
+
+namespace MongoDB.Driver.Core.Misc
+{
+    /// <summary>
+    /// Abstractions of the file system.
+    /// </summary>
+    internal interface IFileSystemProvider
+    {
+        IFile File { get; }
+    }
+
+    internal class FileSystemProvider : IFileSystemProvider
+    {
+        private static readonly IFileSystemProvider __instance = new FileSystemProvider();
+        public static IFileSystemProvider Instance => __instance;
+
+        public IFile File { get; } = new FileWrapper();
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Misc/FileSystemProvider.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/FileSystemProvider.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System.IO;
-
 namespace MongoDB.Driver.Core.Misc
 {
     /// <summary>

--- a/src/MongoDB.Driver.Core/Core/Misc/FileSystemProvider.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/FileSystemProvider.cs
@@ -25,9 +25,7 @@ namespace MongoDB.Driver.Core.Misc
 
     internal class FileSystemProvider : IFileSystemProvider
     {
-        private static readonly IFileSystemProvider __instance = new FileSystemProvider();
-        public static IFileSystemProvider Instance => __instance;
-
+        public static IFileSystemProvider Instance { get; } = new FileSystemProvider();
         public IFile File { get; } = new FileWrapper();
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/FileWrapper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/FileWrapper.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Driver.Core.Misc
         bool Exists(string name);
     }
 
-    internal class FileWrapper : IFile
+    internal sealed class FileWrapper : IFile
     {
         public bool Exists(string name)
         {

--- a/src/MongoDB.Driver.Core/Core/Misc/FileWrapper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/FileWrapper.cs
@@ -1,0 +1,35 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.IO;
+
+namespace MongoDB.Driver.Core.Misc
+{
+    /// <summary>
+    /// Abstraction for static methods in <see cref="System.IO.File" />.
+    /// </summary>
+    internal interface IFile
+    {
+        bool Exists(string name);
+    }
+
+    internal class FileWrapper : IFile
+    {
+        public bool Exists(string name)
+        {
+            return File.Exists(name);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ClientDocumentHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ClientDocumentHelperTests.cs
@@ -133,6 +133,17 @@ namespace MongoDB.Driver.Core.Connections
         }
 
         [Fact]
+        public void CreateEnvDocument_should_return_expected_result()
+        {
+            using (new DisposableEnvironmentVariable("VERCEL"))
+            using (new DisposableEnvironmentVariable("KUBERNETES_SERVICE_HOST"))
+            {
+                var result = ClientDocumentHelper.CreateEnvDocument();
+                result.Should().Be($"{{ name : 'vercel', container : {{ orchestrator : 'kubernetes' }} }}");
+            }
+        }
+
+        [Fact]
         public void CreateOSDocument_should_return_expected_result()
         {
             var result = ClientDocumentHelper.CreateOSDocument();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ClientDocumentHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ClientDocumentHelperTests.cs
@@ -19,7 +19,9 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.TestHelpers.XunitExtensions;
+using Moq;
 using Xunit;
 
 namespace MongoDB.Driver.Core.Connections
@@ -132,14 +134,41 @@ namespace MongoDB.Driver.Core.Connections
             result.Should().Be($"{{ name : 'mongo-csharp-driver', version : '{driverVersion}' }}");
         }
 
-        [Fact]
-        public void CreateEnvDocument_should_return_expected_result()
+        [Theory]
+        [InlineData(true, true, "{ name : 'vercel', container : { \"runtime\" : \"docker\", \"orchestrator\" : \"kubernetes\" }}")]
+        [InlineData(false, true, "{ name : 'vercel', container : { \"orchestrator\" : \"kubernetes\" }}")]
+        [InlineData(true, false, "{ name : 'vercel', container : { \"runtime\" : \"docker\" }}")]
+        [InlineData(false, false, "{ name : 'vercel' }")]
+        public void CreateEnvDocument_should_return_expected_result(bool isDockerToBeDetected, bool isKubernetesToBeDetected, string expected)
         {
+            var fileSystemProviderMock  = new Mock<IFileSystemProvider>();
+            var environmentVariableProviderMock = new Mock<IEnvironmentVariableProvider>();
+
+            if (isKubernetesToBeDetected)
+            {
+                environmentVariableProviderMock.Setup(p => p.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST")).Returns("dummy");
+            }
+            else
+            {
+                environmentVariableProviderMock.Setup(p => p.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST")).Returns(null as string);
+            }
+
+            if (isDockerToBeDetected)
+            {
+                fileSystemProviderMock.Setup(p => p.File.Exists("/.dockerenv")).Returns(true);
+            }
+            else
+            {
+                fileSystemProviderMock.Setup(p => p.File.Exists("/.dockerenv")).Returns(false);
+
+            }
+
+            ClientDocumentHelper.SetEnvironmentVariableProvider(environmentVariableProviderMock.Object);
+            ClientDocumentHelper.SetFileSystemProvider(fileSystemProviderMock.Object);
             using (new DisposableEnvironmentVariable("VERCEL"))
-            using (new DisposableEnvironmentVariable("KUBERNETES_SERVICE_HOST"))
             {
                 var result = ClientDocumentHelper.CreateEnvDocument();
-                result.Should().Be($"{{ name : 'vercel', container : {{ orchestrator : 'kubernetes' }} }}");
+                result.Should().Be(expected);
             }
         }
 


### PR DESCRIPTION
Enables container and kubernetes awareness in the driver as specified in the [MongoDB Handshake Spec](https://github.com/abr-egn/specifications/blob/c4831b426c7eab8749723d7f3cd6bb5c237bcbbe/source/mongodb-handshake/handshake.rst#container) .


#### What is the motivation for this change?
 - Allows Product to track user usage of docker and kubernetes.