### PR TITLE
CSHARP-3995: Fix flaky pool-checkout-maxConnecting-is-enforced.json:maxConnecting_is_enforced

### DIFF
--- a/specifications/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.json
+++ b/specifications/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.json
@@ -19,7 +19,7 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 750
+      "blockTimeMS": 800
     }
   },
   "poolOptions": {
@@ -53,7 +53,7 @@
     },
     {
       "name": "wait",
-      "ms": 100
+      "ms": 400
     },
     {
       "name": "checkOut",

--- a/specifications/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
+++ b/specifications/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
@@ -13,7 +13,7 @@ failPoint:
     failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
-    blockTimeMS: 750
+    blockTimeMS: 800
 poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
@@ -36,7 +36,7 @@ operations:
     count: 1
   # wait some more time to ensure thread1 has begun establishing a Connection
   - name: wait
-    ms: 100
+    ms: 400
   # start 2 check out requests. Only one thread should
   # start creating a Connection and the other one should be
   # waiting for pendingConnectionCount to be less than maxConnecting,

--- a/tests/MongoDB.Driver.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
@@ -648,7 +648,7 @@ namespace MongoDB.Driver.Tests.Specifications.connection_monitoring_and_pooling
                 var async = test.GetValue(Schema.async).ToBoolean();
                 cluster = CoreTestConfiguration.CreateCluster(b => b
                     .ConfigureServer(s => s.With(
-                        heartbeatInterval: TimeSpan.FromMinutes(10)))
+                        heartbeatInterval: TimeSpan.FromMinutes(10), serverMonitoringMode: ServerMonitoringMode.Poll))
                     .ConfigureConnectionPool(c => c.With(
                         maxConnecting: connectionPoolSettings.MaxConnecting,
                         maxConnections: connectionPoolSettings.MaxConnections,


### PR DESCRIPTION
These timings seem to solve the issue.