### PR TITLE
Update performance tests to run on net8.0

### DIFF
--- a/benchmarks/MongoDB.Driver.Benchmarks/MongoDB.Driver.Benchmarks.csproj
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MongoDB.Driver.Benchmarks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1486,7 +1486,7 @@ tasks:
           vars:
             FRAMEWORK: net80
 
-    - name: performance-tests-net60-server-v6.0
+    - name: performance-tests-net80-server-v6.0
       commands:
         - func: bootstrap-mongo-orchestration
           vars:
@@ -2405,7 +2405,7 @@ buildvariants:
   run_on:
     - rhel90-dbx-perf-large
   tasks:
-    - name: performance-tests-net60-server-v6.0
+    - name: performance-tests-net80-server-v6.0
 
 # AWS Lambda tests
 - name: aws-lambda-tests


### PR DESCRIPTION
Change performance test to be run on net8.0 to follow the framework installed by install-dotnet function.

I've configured PR patch to include the perf tests variant to show it working now.