### PR TITLE
CSHARP-4828: Handling errors in WithTransaction

### DIFF
--- a/src/MongoDB.Driver/IClientSession.cs
+++ b/src/MongoDB.Driver/IClientSession.cs
@@ -139,6 +139,15 @@ namespace MongoDB.Driver
         /// <summary>
         /// Executes a callback within a transaction, with retries if needed.
         /// </summary>
+        /// <remarks>
+        /// If a command inside the callback fails, it may cause the transaction on the server to be
+        /// aborted. This situation is normally handled transparently by the driver. However, if the
+        /// application does not return that error from the callback, the driver will not be able to
+        /// determine whether the transaction was aborted or not. The driver will then retry the
+        /// callback indefinitely. To avoid this situation, the application MUST NOT silently handle
+        /// errors within the callback. If the application needs to handle errors within the
+        /// callback, it MUST return them after doing so.
+        /// </remarks>
         /// <param name="callback">The user defined callback.</param>
         /// <param name="transactionOptions">The transaction options.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -149,6 +158,15 @@ namespace MongoDB.Driver
         /// <summary>
         /// Executes a callback within a transaction, with retries if needed.
         /// </summary>
+        /// <remarks>
+        /// If a command inside the callback fails, it may cause the transaction on the server to be
+        /// aborted. This situation is normally handled transparently by the driver. However, if the
+        /// application does not return that error from the callback, the driver will not be able to
+        /// determine whether the transaction was aborted or not. The driver will then retry the
+        /// callback indefinitely. To avoid this situation, the application MUST NOT silently handle
+        /// errors within the callback. If the application needs to handle errors within the
+        /// callback, it MUST return them after doing so.
+        /// </remarks>
         /// <param name="callbackAsync">The user defined callback.</param>
         /// <param name="transactionOptions">The transaction options.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/tests/MongoDB.Driver.Examples/TransactionExamplesForDocs/WithTransactionExample1.cs
+++ b/tests/MongoDB.Driver.Examples/TransactionExamplesForDocs/WithTransactionExample1.cs
@@ -65,8 +65,16 @@ namespace MongoDB.Driver.Examples.TransactionExamplesForDocs
                 result = session.WithTransaction(
                     (s, ct) =>
                     {
-                        collection1.InsertOne(s, new BsonDocument("abc", 1), cancellationToken: ct);
-                        collection2.InsertOne(s, new BsonDocument("xyz", 999), cancellationToken: ct);
+                        try
+                        {
+                            collection1.InsertOne(s, new BsonDocument("abc", 1), cancellationToken: ct);
+                            collection2.InsertOne(s, new BsonDocument("xyz", 999), cancellationToken: ct);
+                        }
+                        catch (MongoWriteException)
+                        {
+                            // Do something in response to the exception
+                            throw; // NOTE: You must rethrow the exception otherwise an infinite loop can occur.
+                        }
                         return "Inserted into collections in different databases";
                     },
                     transactionOptions,


### PR DESCRIPTION
### Add error handling information to withTransaction docs
The withTransaction function docs now has more information on error handling to avoid an application entering an infinite loop in the event that a failed command aborts the transaction and causes the transaction to be retried. I've added "Docs Changes Needed" to the ticket description, asking the docs team to call this out when the transaction page is created.

