### PR TITLE
CSHARP-5070: Add SBOM file

### DIFF
--- a/purls.txt
+++ b/purls.txt
@@ -1,0 +1,1 @@
+pkg:nuget/MongoDB.Libmongocrypt@1.8.2

--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,82 @@
+{
+  "components": [
+    {
+      "bom-ref": "pkg:nuget/MongoDB.Libmongocrypt@1.8.2",
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://www.nuget.org/api/v2/package/MongoDB.Libmongocrypt/1.8.2"
+        },
+        {
+          "type": "website",
+          "url": "https://www.nuget.org/packages/MongoDB.Libmongocrypt/1.8.2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Other"
+          }
+        }
+      ],
+      "name": "MongoDB.Libmongocrypt",
+      "purl": "pkg:nuget/MongoDB.Libmongocrypt@1.8.2",
+      "type": "library",
+      "version": "1.8.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:nuget/MongoDB.Libmongocrypt@1.8.2"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2024-05-03T20:19:34.867974+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "6.4.4"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:137c9f19-2c41-488a-bacb-b367694656ff",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}


### PR DESCRIPTION
Adds the generated SBOM file as part of the Silk prep work.

purls.txt - this file houses the [package URLs](https://github.com/package-url/purl-spec) for the third-party dependencies bundled in the driver. Presently, it includes the C# wrapper libmongocrypt nuget package since we bundle the libmongocrypt library dlls in that package. This is used when generating/updating sbom.json with the third-party dependencies.

sbom.json - This file serves as the SBOM-lite, documenting the third-party dependencies bundled within the shipped driver. Its purpose is vital for DevProd, as it's required to furnish to Silk.

For now, generating/updating sbom.json is to be done manually every time we update our third-party dependencies.

