### PR TITLE
CSHARP-4944: Update Libmongocrypt version and sbom lite

### DIFF
--- a/purls.txt
+++ b/purls.txt
@@ -1,1 +1,1 @@
-pkg:nuget/MongoDB.Libmongocrypt@1.8.2
+pkg:nuget/MongoDB.Libmongocrypt@1.9.0

--- a/sbom.json
+++ b/sbom.json
@@ -1,37 +1,30 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:nuget/MongoDB.Libmongocrypt@1.8.2",
+      "bom-ref": "pkg:nuget/MongoDB.Libmongocrypt@1.9.0",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://www.nuget.org/api/v2/package/MongoDB.Libmongocrypt/1.8.2"
+          "url": "https://www.nuget.org/api/v2/package/MongoDB.Libmongocrypt/1.9.0"
         },
         {
           "type": "website",
-          "url": "https://www.nuget.org/packages/MongoDB.Libmongocrypt/1.8.2"
-        }
-      ],
-      "licenses": [
-        {
-          "license": {
-            "name": "Other"
-          }
+          "url": "https://www.nuget.org/packages/MongoDB.Libmongocrypt/1.9.0"
         }
       ],
       "name": "MongoDB.Libmongocrypt",
-      "purl": "pkg:nuget/MongoDB.Libmongocrypt@1.8.2",
+      "purl": "pkg:nuget/MongoDB.Libmongocrypt@1.9.0",
       "type": "library",
-      "version": "1.8.2"
+      "version": "1.9.0"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:nuget/MongoDB.Libmongocrypt@1.8.2"
+      "ref": "pkg:nuget/MongoDB.Libmongocrypt@1.9.0"
     }
   ],
   "metadata": {
-    "timestamp": "2024-05-03T20:19:34.867974+00:00",
+    "timestamp": "2024-05-23T20:46:09.160033+00:00",
     "tools": [
       {
         "externalReferences": [
@@ -74,7 +67,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:137c9f19-2c41-488a-bacb-b367694656ff",
+  "serialNumber": "urn:uuid:77687498-fcba-4e54-880d-67b3b53d41af",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -23,8 +23,8 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.14" />
     <PackageReference Include="DnsClient" Version="1.6.1" />
-    <PackageReference Include="MongoDB.Libmongocrypt" Version="1.8.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="MongoDB.Libmongocrypt" Version="1.9.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="Snappier" Version="1.0.0" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Libmongocrypt" Version="1.8.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="MongoDB.Libmongocrypt" Version="1.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MongoDB.Driver.Tests/Packaging/PackagingTests.cs
+++ b/tests/MongoDB.Driver.Tests/Packaging/PackagingTests.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Tests.Packaging
         {
             var version = Library.Version;
 
-            version.Should().Be("1.8.4");
+            version.Should().Be("1.10.0");
         }
 
 #pragma warning disable IDE0051 // Remove unused private members


### PR DESCRIPTION
Native crypto has been enabled in the libmongocrypt bindings: https://github.com/mongodb/libmongocrypt/pull/796.
A new release was done and this PR is just syncing the driver to that release and updating the sbom.json accordingly.