### PR TITLE
CSHARP-4807: Support serialization of Memory<T> and ReadOnlyMemory<T>

### DIFF
--- a/src/MongoDB.Bson/Serialization/CollectionsSerializationProvider.cs
+++ b/src/MongoDB.Bson/Serialization/CollectionsSerializationProvider.cs
@@ -20,7 +20,6 @@ using System.Collections.ObjectModel;
 using System.Dynamic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using MongoDB.Bson.Serialization.Serializers;
 
 namespace MongoDB.Bson.Serialization
@@ -43,6 +42,8 @@ namespace MongoDB.Bson.Serialization
                 { typeof(Queue<>), typeof(QueueSerializer<>) },
                 { typeof(ReadOnlyCollection<>), typeof(ReadOnlyCollectionSerializer<>) },
                 { typeof(Stack<>), typeof(StackSerializer<>) },
+                { typeof(Memory<>), typeof(MemorySerializer<>) },
+                { typeof(ReadOnlyMemory<>), typeof(ReadonlyMemorySerializer<>) }
             };
         }
 

--- a/src/MongoDB.Bson/Serialization/Serializers/MemorySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/MemorySerializer.cs
@@ -25,7 +25,6 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// </summary>
     /// <typeparam name="TItem">The type of the item. Only primitive numeric types are supported.</typeparam>
     public sealed class ReadonlyMemorySerializer<TItem> : MemorySerializerBase<TItem, ReadOnlyMemory<TItem>>
-        where TItem : struct
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadonlyMemorySerializer{TItem}" /> class.
@@ -70,7 +69,6 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// </summary>
     /// <typeparam name="TItem">The type of the item. Only primitive numeric types are supported.</typeparam>
     public sealed class MemorySerializer<TItem> : MemorySerializerBase<TItem, Memory<TItem>>
-        where TItem : struct
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MemorySerializer{TItem}" /> class.
@@ -117,125 +115,11 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// <typeparam name="TMemory">The type of the memory struct.</typeparam>
     public abstract class MemorySerializerBase<TItem, TMemory> : StructSerializerBase<TMemory>, IRepresentationConfigurable<MemorySerializerBase<TItem, TMemory>>
         where TMemory : struct
-        where TItem : struct
     {
-        private static readonly bool __isByte;
-        private static readonly Func<IBsonReader, TItem[]> __readItems;
-        private static readonly Action<IBsonWriter, Memory<TItem>> __writeItems;
+        private static readonly bool __isByte = (typeof(TItem) == typeof(byte));
 
-        static MemorySerializerBase()
-        {
-            switch (typeof(TItem))
-            {
-                case var t when t == typeof(bool):
-                    __readItems = reader => PrimitivesArrayReader.ReadBool(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<bool>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteBool(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(sbyte):
-                    __readItems = reader => PrimitivesArrayReader.ReadInt8(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<sbyte>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteInt8(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(byte):
-                    __isByte = true;
-                    __readItems = reader => PrimitivesArrayReader.ReadUInt8(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<byte>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteUInt8(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(char):
-                    __readItems = reader => PrimitivesArrayReader.ReadChar(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<char>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteChar(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(short):
-                    __readItems = reader => PrimitivesArrayReader.ReadInt16(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<short>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteInt16(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(ushort):
-                    __readItems = reader => PrimitivesArrayReader.ReadUInt16(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<ushort>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteUInt16(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(int):
-                    __readItems = reader => PrimitivesArrayReader.ReadInt32(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<int>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteInt32(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(uint):
-                    __readItems = reader => PrimitivesArrayReader.ReadUInt32(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<uint>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteUInt32(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(long):
-                    __readItems = reader => PrimitivesArrayReader.ReadInt64(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<long>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteInt64(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(ulong):
-                    __readItems = reader => PrimitivesArrayReader.ReadUInt64(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<ulong>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteUInt64(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(float):
-                    __readItems = reader => PrimitivesArrayReader.ReadSingles(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<float>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteSingles(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(double):
-                    __readItems = reader => PrimitivesArrayReader.ReadDoubles(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<double>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteDoubles(writer, span);
-                    };
-                    break;
-                case var t when t == typeof(decimal):
-                    __readItems = reader => PrimitivesArrayReader.ReadDecimal128(reader) as TItem[];
-                    __writeItems = (writer, memory) =>
-                    {
-                        var span = Unsafe.As<Memory<TItem>, Memory<decimal>>(ref memory).Span;
-                        PrimitivesArrayWriter.WriteDecimal128(writer, span);
-                    };
-                    break;
-                default:
-                    throw new NotSupportedException($"Not supported memory type {typeof(TItem)}. Only primitive numeric types are supported.");
-            };
-        }
+        private readonly Func<IBsonReader, TItem[]> _readItems;
+        private readonly Action<IBsonWriter, Memory<TItem>> _writeItems;
 
         /// <inheritdoc/>
         public BsonType Representation { get; }
@@ -252,6 +136,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentOutOfRangeException(nameof(representation));
             }
 
+            (_readItems, _writeItems) = GetReaderAndWriter();
             Representation = representation;
         }
 
@@ -273,7 +158,7 @@ namespace MongoDB.Bson.Serialization.Serializers
             switch (bsonType)
             {
                 case BsonType.Array:
-                    var items = __readItems(reader);
+                    var items = _readItems(reader);
 
                     return CreateMemory(items);
                 case BsonType.Binary:
@@ -296,10 +181,11 @@ namespace MongoDB.Bson.Serialization.Serializers
             switch (Representation)
             {
                 case BsonType.Array:
-                    __writeItems(context.Writer, memory);
+                    _writeItems(context.Writer, memory);
                     break;
                 case BsonType.Binary:
-                    var bytes = MemoryMarshal.AsBytes(memory.Span);
+                    var bytesMemory = Unsafe.As<Memory<TItem>, Memory<byte>>(ref memory);
+                    var bytes = MemoryMarshal.AsBytes(bytesMemory.Span);
                     context.Writer.WriteBytes(bytes.ToArray());
                     break;
                 default:
@@ -326,5 +212,123 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// </summary>
         /// <returns>The Memory{TITem} structure.</returns>
         protected abstract Memory<TItem> GetMemory(TMemory memory);
+
+        private static (Func<IBsonReader, TItem[]> reader, Action<IBsonWriter, Memory<TItem>> writer) GetReaderAndWriter()
+        {
+            Func<IBsonReader, TItem[]> readItems;
+            Action<IBsonWriter, Memory<TItem>> writeItems;
+
+            switch (typeof(TItem))
+            {
+                case var t when t == typeof(bool):
+                    readItems = reader => PrimitivesArrayReader.ReadBool(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<bool>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteBool(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(sbyte):
+                    readItems = reader => PrimitivesArrayReader.ReadInt8(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<sbyte>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteInt8(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(byte):
+                    readItems = reader => PrimitivesArrayReader.ReadUInt8(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<byte>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteUInt8(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(char):
+                    readItems = reader => PrimitivesArrayReader.ReadChar(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<char>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteChar(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(short):
+                    readItems = reader => PrimitivesArrayReader.ReadInt16(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<short>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteInt16(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(ushort):
+                    readItems = reader => PrimitivesArrayReader.ReadUInt16(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<ushort>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteUInt16(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(int):
+                    readItems = reader => PrimitivesArrayReader.ReadInt32(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<int>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteInt32(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(uint):
+                    readItems = reader => PrimitivesArrayReader.ReadUInt32(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<uint>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteUInt32(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(long):
+                    readItems = reader => PrimitivesArrayReader.ReadInt64(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<long>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteInt64(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(ulong):
+                    readItems = reader => PrimitivesArrayReader.ReadUInt64(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<ulong>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteUInt64(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(float):
+                    readItems = reader => PrimitivesArrayReader.ReadSingles(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<float>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteSingles(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(double):
+                    readItems = reader => PrimitivesArrayReader.ReadDoubles(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<double>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteDoubles(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(decimal):
+                    readItems = reader => PrimitivesArrayReader.ReadDecimal128(reader) as TItem[];
+                    writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<decimal>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteDecimal128(writer, span);
+                    };
+                    break;
+                default:
+                    throw new NotSupportedException($"Not supported memory type {typeof(TItem)}. Only primitive numeric types are supported.");
+            };
+
+            return (readItems, writeItems);
+        }
     }
 }

--- a/src/MongoDB.Bson/Serialization/Serializers/MemorySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/MemorySerializer.cs
@@ -1,0 +1,307 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using MongoDB.Bson.IO;
+
+namespace MongoDB.Bson.Serialization.Serializers
+{
+    /// <summary>
+    /// Represents a serializer for <see cref="ReadOnlyMemory{TItem}"/>.
+    /// </summary>
+    /// <typeparam name="TItem">The type of the item. Only primitive numeric types are supported.</typeparam>
+    public sealed class ReadonlyMemorySerializer<TItem> : MemorySerializerBase<TItem, ReadOnlyMemory<TItem>>
+        where TItem : struct
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadonlyMemorySerializer{TItem}" /> class.
+        /// </summary>
+        public ReadonlyMemorySerializer() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadonlyMemorySerializer{TItem}" /> class.
+        /// </summary>
+        public ReadonlyMemorySerializer(BsonType representation) : base(representation)
+        {
+        }
+
+        /// <summary>
+        /// Returns a serializer that has been reconfigured with the specified representation.
+        /// </summary>
+        /// <param name="representation">The representation.</param>
+        /// <returns>The reconfigured serializer.</returns>
+        public override MemorySerializerBase<TItem, ReadOnlyMemory<TItem>> WithRepresentation(BsonType representation)
+        {
+            if (representation == Representation)
+            {
+                return this;
+            }
+            else
+            {
+                return new ReadonlyMemorySerializer<TItem>(representation);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override ReadOnlyMemory<TItem> CreateMemory(TItem[] items) => items;
+
+        /// <inheritdoc/>
+        protected override Memory<TItem> GetMemory(ReadOnlyMemory<TItem> memory) => MemoryMarshal.AsMemory(memory);
+    }
+
+    /// <summary>
+    /// Represents a serializer for <see cref="Memory{TItem}"/>.
+    /// </summary>
+    /// <typeparam name="TItem">The type of the item. Only primitive numeric types are supported.</typeparam>
+    public sealed class MemorySerializer<TItem> : MemorySerializerBase<TItem, Memory<TItem>>
+        where TItem : struct
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemorySerializer{TItem}" /> class.
+        /// </summary>
+        public MemorySerializer() : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemorySerializer{TItem}" /> class.
+        /// </summary>
+        public MemorySerializer(BsonType representation) : base(representation)
+        {
+        }
+
+        /// <summary>
+        /// Returns a serializer that has been reconfigured with the specified representation.
+        /// </summary>
+        /// <param name="representation">The representation.</param>
+        /// <returns>The reconfigured serializer.</returns>
+        public override MemorySerializerBase<TItem, Memory<TItem>> WithRepresentation(BsonType representation)
+        {
+            if (representation == Representation)
+            {
+                return this;
+            }
+            else
+            {
+                return new MemorySerializer<TItem>(representation);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Memory<TItem> CreateMemory(TItem[] items) => items;
+
+        /// <inheritdoc/>
+        protected override Memory<TItem> GetMemory(Memory<TItem> memory) => memory;
+    }
+
+    /// <summary>
+    /// Represents an abstract base class for <see cref="Memory{TItem}"/> and <see cref="ReadOnlyMemory{TItem}"/> serializers.
+    /// </summary>
+    /// <typeparam name="TItem">The type of the item. Only primitive numeric types are supported.</typeparam>
+    /// <typeparam name="TMemory">The type of the memory struct.</typeparam>
+    public abstract class MemorySerializerBase<TItem, TMemory> : StructSerializerBase<TMemory>, IRepresentationConfigurable<MemorySerializerBase<TItem, TMemory>>
+        where TMemory : struct
+        where TItem : struct
+    {
+        private static readonly bool __isByte;
+        private static readonly Func<IBsonReader, TItem[]> __readItems;
+        private static readonly Action<IBsonWriter, Memory<TItem>> __writeItems;
+
+        static MemorySerializerBase()
+        {
+            switch (typeof(TItem))
+            {
+                case var t when t == typeof(sbyte):
+                    __readItems = reader => PrimitivesArrayReader.ReadInt8(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<sbyte>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteInt8(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(byte):
+                    __isByte = true;
+                    __readItems = reader => PrimitivesArrayReader.ReadUInt8(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<byte>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteUInt8(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(short):
+                    __readItems = reader => PrimitivesArrayReader.ReadInt16(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<short>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteInt16(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(ushort):
+                    __readItems = reader => PrimitivesArrayReader.ReadUInt16(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<ushort>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteUInt16(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(int):
+                    __readItems = reader => PrimitivesArrayReader.ReadInt32(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<int>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteInt32(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(uint):
+                    __readItems = reader => PrimitivesArrayReader.ReadUInt32(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<uint>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteUInt32(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(long):
+                    __readItems = reader => PrimitivesArrayReader.ReadInt64(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<long>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteInt64(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(ulong):
+                    __readItems = reader => PrimitivesArrayReader.ReadUInt64(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<ulong>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteUInt64(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(float):
+                    __readItems = reader => PrimitivesArrayReader.ReadSingles(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<float>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteSingles(writer, span);
+                    };
+
+                    break;
+                case var t when t == typeof(double):
+                    __readItems = reader => PrimitivesArrayReader.ReadDoubles(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<double>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteDoubles(writer, span);
+                    };
+                    break;
+                default:
+                    throw new NotSupportedException($"Not supported memory type {typeof(TItem)}. Only primitive numeric types are supported.");
+            };
+        }
+
+        /// <inheritdoc/>
+        public BsonType Representation { get; }
+
+        // constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemorySerializerBase{TItem, TMemory}" /> class.
+        /// </summary>
+        public MemorySerializerBase(BsonType representation)
+        {
+            if (representation != BsonType.Array &&
+                !(__isByte && representation == BsonType.Binary))
+            {
+                throw new ArgumentOutOfRangeException(nameof(representation));
+            }
+
+            Representation = representation;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemorySerializerBase{TItem, TMemory}" /> class.
+        /// </summary>
+        public MemorySerializerBase() :
+            this(__isByte ? BsonType.Binary : BsonType.Array) // Match the serialization behavior for arrays
+        {
+        }
+
+        // public methods
+        /// <inheritdoc/>
+        public override TMemory Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            var reader = context.Reader;
+
+            var bsonType = reader.GetCurrentBsonType();
+            switch (bsonType)
+            {
+                case BsonType.Array:
+                    var items = __readItems(reader);
+
+                    return CreateMemory(items);
+                case BsonType.Binary:
+                    if (!__isByte)
+                    {
+                        throw CreateCannotDeserializeFromBsonTypeException(bsonType);
+                    }
+                    var bytes = reader.ReadBytes();
+                    return CreateMemory(bytes as TItem[]);
+                default:
+                    throw CreateCannotDeserializeFromBsonTypeException(bsonType);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, TMemory value)
+        {
+            var memory = GetMemory(value);
+
+            switch (Representation)
+            {
+                case BsonType.Array:
+                    __writeItems(context.Writer, memory);
+                    break;
+                case BsonType.Binary:
+                    var bytes = MemoryMarshal.AsBytes(memory.Span);
+                    context.Writer.WriteBytes(bytes.ToArray());
+                    break;
+                default:
+                    throw new NotSupportedException(nameof(Representation));
+            }
+        }
+
+        /// <inheritdoc/>
+        public abstract MemorySerializerBase<TItem, TMemory> WithRepresentation(BsonType representation);
+
+        // explicit interface implementations
+        IBsonSerializer IRepresentationConfigurable.WithRepresentation(BsonType representation) =>
+            WithRepresentation(representation);
+
+        /// <summary>
+        /// Creates the Memory{TITem} structure.
+        /// </summary>
+        /// <param name="items">The items to initialize the resulting instance with.</param>
+        /// <returns>The created memory structure.</returns>
+        protected abstract TMemory CreateMemory(TItem[] items);
+
+        /// <summary>
+        /// Get the memory structure from TMemory instance.
+        /// </summary>
+        /// <returns>The Memory{TITem} structure.</returns>
+        protected abstract Memory<TItem> GetMemory(TMemory memory);
+    }
+}

--- a/src/MongoDB.Bson/Serialization/Serializers/MemorySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/MemorySerializer.cs
@@ -127,6 +127,14 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             switch (typeof(TItem))
             {
+                case var t when t == typeof(bool):
+                    __readItems = reader => PrimitivesArrayReader.ReadBool(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<bool>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteBool(writer, span);
+                    };
+                    break;
                 case var t when t == typeof(sbyte):
                     __readItems = reader => PrimitivesArrayReader.ReadInt8(reader) as TItem[];
                     __writeItems = (writer, memory) =>
@@ -142,6 +150,14 @@ namespace MongoDB.Bson.Serialization.Serializers
                     {
                         var span = Unsafe.As<Memory<TItem>, Memory<byte>>(ref memory).Span;
                         PrimitivesArrayWriter.WriteUInt8(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(char):
+                    __readItems = reader => PrimitivesArrayReader.ReadChar(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<char>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteChar(writer, span);
                     };
                     break;
                 case var t when t == typeof(short):
@@ -199,7 +215,6 @@ namespace MongoDB.Bson.Serialization.Serializers
                         var span = Unsafe.As<Memory<TItem>, Memory<float>>(ref memory).Span;
                         PrimitivesArrayWriter.WriteSingles(writer, span);
                     };
-
                     break;
                 case var t when t == typeof(double):
                     __readItems = reader => PrimitivesArrayReader.ReadDoubles(reader) as TItem[];
@@ -207,6 +222,14 @@ namespace MongoDB.Bson.Serialization.Serializers
                     {
                         var span = Unsafe.As<Memory<TItem>, Memory<double>>(ref memory).Span;
                         PrimitivesArrayWriter.WriteDoubles(writer, span);
+                    };
+                    break;
+                case var t when t == typeof(decimal):
+                    __readItems = reader => PrimitivesArrayReader.ReadDecimal128(reader) as TItem[];
+                    __writeItems = (writer, memory) =>
+                    {
+                        var span = Unsafe.As<Memory<TItem>, Memory<decimal>>(ref memory).Span;
+                        PrimitivesArrayWriter.WriteDecimal128(writer, span);
                     };
                     break;
                 default:

--- a/src/MongoDB.Bson/Serialization/Serializers/PrimitivesArrayReader.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/PrimitivesArrayReader.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using MongoDB.Bson.IO;
+
+namespace MongoDB.Bson.Serialization.Serializers
+{
+    internal static class PrimitivesArrayReader
+    {
+        private enum ConversionType
+        {
+            DoubleToSingle,
+            DoubleToDouble,
+            Int32ToInt8,
+            Int32ToUInt8,
+            Int32ToInt16,
+            Int32ToUInt16,
+            Int32ToInt32,
+            Int32ToUInt32,
+            Int64ToInt64,
+            Int64ToUInt64
+        }
+
+        public static byte[] ReadInt8(IBsonReader bsonReader) =>
+            ReadBsonArray<byte>(bsonReader, ConversionType.Int32ToInt8);
+
+        public static sbyte[] ReadUInt8(IBsonReader bsonReader) =>
+            ReadBsonArray<sbyte>(bsonReader, ConversionType.Int32ToUInt8);
+
+        public static short[] ReadInt16(IBsonReader bsonReader) =>
+            ReadBsonArray<short>(bsonReader, ConversionType.Int32ToInt16);
+
+        public static ushort[] ReadUInt16(IBsonReader bsonReader) =>
+            ReadBsonArray<ushort>(bsonReader, ConversionType.Int32ToUInt16);
+
+        public static int[] ReadInt32(IBsonReader bsonReader) =>
+            ReadBsonArray<int>(bsonReader, ConversionType.Int32ToInt32);
+
+        public static int[] ReadUInt32(IBsonReader bsonReader) =>
+            ReadBsonArray<int>(bsonReader, ConversionType.Int32ToUInt32);
+
+        public static float[] ReadSingles(IBsonReader bsonReader) =>
+            ReadBsonArray<float>(bsonReader, ConversionType.DoubleToSingle);
+
+        public static double[] ReadDoubles(IBsonReader bsonReader) =>
+            ReadBsonArray<double>(bsonReader, ConversionType.DoubleToDouble);
+
+        public static long[] ReadInt64(IBsonReader bsonReader) =>
+            ReadBsonArray<long>(bsonReader, ConversionType.Int64ToInt64);
+
+        public static ulong[] ReadUInt64(IBsonReader bsonReader) =>
+            ReadBsonArray<ulong>(bsonReader, ConversionType.Int64ToUInt64);
+
+        private static T[] ReadBsonArray<T>(
+            IBsonReader bsonReader,
+            ConversionType conversionType)
+        {
+            var (bsonDataType, bsonDataSize) = GetBsonDataTypeAndSize(conversionType);
+
+            var array = bsonReader.ReadRawBsonArray();
+            using var buffer = ThreadStaticBuffer.RentBuffer(array.Length);
+
+            var bytes = buffer.Bytes;
+            array.GetBytes(0, bytes, 0, array.Length);
+
+            var result = new List<T>();
+
+            var index = 4; // 4 first bytes are array object size in bytes
+            var maxIndex = array.Length - 1;
+
+            while (index < maxIndex)
+            {
+                ValidateBsonType(bsonDataType);
+
+                // Skip name
+                while (bytes[index] != 0) { index++; };
+                index++; // Skip string terminating 0
+
+                T value = default;
+
+                // Read next item
+                switch (conversionType)
+                {
+                    case ConversionType.DoubleToSingle:
+                        {
+                            var from = BitConverter.ToDouble(bytes, index);
+                            var to = (float)from;
+
+                            value = Unsafe.As<float, T>(ref to);
+                            break;
+                        }
+                    case ConversionType.DoubleToDouble:
+                        {
+                            var v = BitConverter.ToDouble(bytes, index);
+                            value = Unsafe.As<double, T>(ref v);
+                            break;
+                        }
+                    case ConversionType.Int32ToInt8:
+                        {
+                            var v = (sbyte)BitConverter.ToInt32(bytes, index);
+                            value = Unsafe.As<sbyte, T>(ref v);
+
+                            break;
+                        }
+                    case ConversionType.Int32ToUInt8:
+                        {
+                            var v = (byte)BitConverter.ToInt32(bytes, index);
+                            value = Unsafe.As<byte, T>(ref v);
+                            break;
+                        }
+                    case ConversionType.Int32ToInt16:
+                        {
+                            var v = (short)BitConverter.ToInt32(bytes, index);
+                            value = Unsafe.As<short, T>(ref v);
+                            break;
+                        }
+                    case ConversionType.Int32ToUInt16:
+                        {
+                            var v = (ushort)BitConverter.ToInt32(bytes, index);
+                            value = Unsafe.As<ushort, T>(ref v);
+                            break;
+                        }
+                    case ConversionType.Int32ToInt32:
+                        {
+                            var v = BitConverter.ToInt32(bytes, index);
+                            value = Unsafe.As<int, T>(ref v);
+                            break;
+                        }
+                    case ConversionType.Int32ToUInt32:
+                        {
+                            var v = BitConverter.ToUInt32(bytes, index);
+                            value = Unsafe.As<uint, T>(ref v);
+                            break;
+                        }
+                    case ConversionType.Int64ToInt64:
+                        {
+                            var v = BitConverter.ToInt64(bytes, index);
+                            value = Unsafe.As<long, T>(ref v);
+                            break;
+                        }
+                    case ConversionType.Int64ToUInt64:
+                        {
+                            var v = BitConverter.ToUInt64(bytes, index);
+                            value = Unsafe.As<ulong, T>(ref v);
+                            break;
+                        }
+                    default:
+                        throw new InvalidOperationException();
+                }
+
+                result.Add(value);
+
+                index += bsonDataSize;
+            }
+
+            ValidateBsonType(BsonType.EndOfDocument);
+
+            return result.ToArray();
+
+            void ValidateBsonType(BsonType bsonType)
+            {
+                if ((BsonType)bytes[index] != bsonType)
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+        }
+
+        private static (BsonType, int) GetBsonDataTypeAndSize(ConversionType conversionType) =>
+            conversionType switch
+            {
+                ConversionType.DoubleToSingle or
+                ConversionType.DoubleToDouble => (BsonType.Double, 8),
+
+                ConversionType.Int32ToUInt8 or
+                ConversionType.Int32ToInt8 or
+                ConversionType.Int32ToUInt16 or
+                ConversionType.Int32ToInt16 or
+                ConversionType.Int32ToInt32 or
+                ConversionType.Int32ToUInt32 => (BsonType.Int32, 4),
+
+                ConversionType.Int64ToInt64 or
+                ConversionType.Int64ToUInt64 => (BsonType.Int64, 8),
+
+                _ => throw new NotSupportedException()
+            };
+    }
+}

--- a/src/MongoDB.Bson/Serialization/Serializers/PrimitivesArrayWriter.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/PrimitivesArrayWriter.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using MongoDB.Bson.IO;
+
+namespace MongoDB.Bson.Serialization.Serializers
+{
+    internal static class PrimitivesArrayWriter
+    {
+        public static void WriteInt8(IBsonWriter bsonWriter, Span<sbyte> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt32(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteUInt8(IBsonWriter bsonWriter, Span<byte> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt32(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteInt16(IBsonWriter bsonWriter, Span<short> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt32(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteUInt16(IBsonWriter bsonWriter, Span<ushort> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt32(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteInt32(IBsonWriter bsonWriter, Span<int> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt32(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteUInt32(IBsonWriter bsonWriter, Span<uint> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt32((int)span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteInt64(IBsonWriter bsonWriter, Span<long> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt64(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteUInt64(IBsonWriter bsonWriter, Span<ulong> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt64((long)span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteSingles(IBsonWriter bsonWriter, Span<float> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteDouble(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteDoubles(IBsonWriter bsonWriter, Span<double> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteDouble(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+    }
+}

--- a/src/MongoDB.Bson/Serialization/Serializers/PrimitivesArrayWriter.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/PrimitivesArrayWriter.cs
@@ -5,6 +5,16 @@ namespace MongoDB.Bson.Serialization.Serializers
 {
     internal static class PrimitivesArrayWriter
     {
+        public static void WriteBool(IBsonWriter bsonWriter, Span<bool> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteBoolean(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
         public static void WriteInt8(IBsonWriter bsonWriter, Span<sbyte> span)
         {
             bsonWriter.WriteStartArray();
@@ -36,6 +46,16 @@ namespace MongoDB.Bson.Serialization.Serializers
         }
 
         public static void WriteUInt16(IBsonWriter bsonWriter, Span<ushort> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteInt32(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteChar(IBsonWriter bsonWriter, Span<char> span)
         {
             bsonWriter.WriteStartArray();
             for (int i = 0; i < span.Length; i++)
@@ -101,6 +121,16 @@ namespace MongoDB.Bson.Serialization.Serializers
             for (int i = 0; i < span.Length; i++)
             {
                 bsonWriter.WriteDouble(span[i]);
+            }
+            bsonWriter.WriteEndArray();
+        }
+
+        public static void WriteDecimal128(IBsonWriter bsonWriter, Span<decimal> span)
+        {
+            bsonWriter.WriteStartArray();
+            for (int i = 0; i < span.Length; i++)
+            {
+                bsonWriter.WriteDecimal128(span[i]);
             }
             bsonWriter.WriteEndArray();
         }

--- a/tests/BuildProps/Tests.Build.props
+++ b/tests/BuildProps/Tests.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/MemorySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/MemorySerializerTests.cs
@@ -1,0 +1,336 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Serializers;
+using Xunit;
+
+namespace MongoDB.Bson.Tests.Serialization
+{
+    public class MemorySerializerTests
+    {
+        public class ReadonlyMemoryHolder<T>
+        {
+            public ReadOnlyMemory<T> Items { get; set; }
+        }
+
+        public class ReadonlyMemoryHolderBytesAsArray
+        {
+            [BsonRepresentation(BsonType.Array)]
+            public ReadOnlyMemory<byte> Items { get; set; }
+        }
+
+        public class ReadonlyMemoryHolderBytesAsBinary
+        {
+            [BsonRepresentation(BsonType.Binary)]
+            public ReadOnlyMemory<byte> Items { get; set; }
+        }
+
+        public class MemoryHolder<T>
+        {
+            public Memory<T> Items { get; set; }
+        }
+
+        public class MemoryHolderBytesAsArray
+        {
+            [BsonRepresentation(BsonType.Array)]
+            public Memory<byte> Items { get; set; }
+        }
+
+        public class MemoryHolderBytesAsBinary
+        {
+            [BsonRepresentation(BsonType.Binary)]
+            public Memory<byte> Items { get; set; }
+        }
+
+        public class ArrayHolder<T>
+        {
+            public T[] Items { get; set; }
+        }
+
+        public class MultiHolder
+        {
+            public Memory<byte> ItemsBytes { get; set; }
+            public Memory<float> ItemsFloat { get; set; }
+            public ReadOnlyMemory<int> ItemsInt { get; set; }
+            public ReadOnlyMemory<double> ItemsDouble { get; set; }
+        }
+
+        [Theory]
+        [MemberData(nameof(NonSupportedTestData))]
+        public void Memory_should_throw_on_non_primitive_numeric_types<T>(T[] notSupportedData)
+        {
+            var memoryHolder = new MemoryHolder<T>() { Items = notSupportedData };
+
+            var exception = Record.Exception(() => memoryHolder.ToBson());
+            var e = exception.Should().BeOfType<BsonSerializationException>().Subject;
+
+            if (typeof(T).IsClass)
+            {
+                var inner = e.InnerException.Should().BeOfType<ArgumentException>().Subject;
+                inner.Message.Should().Contain("violates the constraint of type 'TItem'");
+            }
+            else
+            {
+                var inner = e.InnerException.Should().BeOfType<TypeInitializationException>().Subject.InnerException;
+                inner.Message.Should().StartWith("Not supported memory type");
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NonSupportedTestData))]
+        public void ReadonlyMemory_should_throw_on_non_primitive_numeric_types<T>(T[] notSupportedData)
+        {
+            var memoryHolder = new ReadonlyMemoryHolder<T>() { Items = notSupportedData };
+
+            var exception = Record.Exception(() => memoryHolder.ToBson());
+            var e = exception.Should().BeOfType<BsonSerializationException>().Subject;
+
+            if (typeof(T).IsClass)
+            {
+                var inner = e.InnerException.Should().BeOfType<ArgumentException>().Subject;
+                inner.Message.Should().Contain("violates the constraint of type 'TItem'");
+            }
+            else
+            {
+                var inner = e.InnerException.Should().BeOfType<TypeInitializationException>().Subject.InnerException;
+                inner.Message.Should().StartWith("Not supported memory type");
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void Memory_should_roundtrip_equivalent_to_array<T>(T[] array)
+        {
+            var memoryHolder = new MemoryHolder<T>() { Items = array };
+            var arrayHolder = new ArrayHolder<T>() { Items = array };
+
+            var memoryBson = memoryHolder.ToBson();
+            var arrayBson = arrayHolder.ToBson();
+            memoryBson.ShouldAllBeEquivalentTo(arrayBson);
+
+            var memoryHolderMaterialized = BsonSerializer.Deserialize<MemoryHolder<T>>(memoryBson);
+            memoryHolderMaterialized.Items.ToArray().ShouldAllBeEquivalentTo(memoryHolder.Items.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void ReadonlyMemory_should_roundtrip_equivalent_to_array<T>(T[] array)
+        {
+            var memoryHolder = new ReadonlyMemoryHolder<T>() { Items = array };
+            var arrayHolder = new ArrayHolder<T>() { Items = array };
+
+            var memoryBson = memoryHolder.ToBson();
+            var arrayBson = arrayHolder.ToBson();
+            memoryBson.ShouldAllBeEquivalentTo(arrayBson);
+
+            var memoryHolderMaterialized = BsonSerializer.Deserialize<ReadonlyMemoryHolder<T>>(memoryBson);
+            memoryHolderMaterialized.Items.ToArray().ShouldAllBeEquivalentTo(memoryHolder.Items.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestDataSpecialValues))]
+        public void Memory_should_roundtrip_special_values<T>(T[] array)
+        {
+            var memoryHolder = new MemoryHolder<T>() { Items = array };
+
+            var memoryBson = memoryHolder.ToBson();
+
+            var memoryHolderMaterialized = BsonSerializer.Deserialize<MemoryHolder<T>>(memoryBson);
+            memoryHolderMaterialized.Items.ToArray().ShouldAllBeEquivalentTo(memoryHolder.Items.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestDataSpecialValues))]
+        public void ReadonlyMemory_should_roundtrip_special_values<T>(T[] array)
+        {
+            var memoryHolder = new ReadonlyMemoryHolder<T>() { Items = array };
+
+            var memoryBson = memoryHolder.ToBson();
+
+            var memoryHolderMaterialized = BsonSerializer.Deserialize<MemoryHolder<T>>(memoryBson);
+            memoryHolderMaterialized.Items.ToArray().ShouldAllBeEquivalentTo(memoryHolder.Items.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void Memory_should_roundtrip_special_values_correctly<T>(T[] array)
+        {
+            var memoryHolder = new MemoryHolder<T>() { Items = array };
+            var arrayHolder = new ArrayHolder<T>() { Items = array };
+
+            var memoryBson = memoryHolder.ToBson();
+            var arrayBson = arrayHolder.ToBson();
+            memoryBson.ShouldAllBeEquivalentTo(arrayBson);
+
+            var memoryHolderMaterialized = BsonSerializer.Deserialize<MemoryHolder<T>>(memoryBson);
+            memoryHolderMaterialized.Items.ToArray().ShouldAllBeEquivalentTo(memoryHolder.Items.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(NonSupportedRepresentationTypes))]
+        public void MemorySerializer_should_throw_on_not_supported_representation<T>(T item, BsonType representation)
+            where T : struct
+        {
+            var exception = Record.Exception(() => new MemorySerializer<T>(representation));
+            var e = exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject;
+            e.ParamName.Should().Be("representation");
+        }
+
+        [Fact]
+        public void Memory_should_support_array_representation_for_bytes()
+        {
+            var bytes = new byte[] { 1, 2, 3 };
+            var memoryHolder = new MemoryHolderBytesAsArray() { Items = bytes };
+
+            var bsonDocument = BsonSerializer.Deserialize<BsonDocument>(memoryHolder.ToBson());
+            var itemsElement = bsonDocument[nameof(memoryHolder.Items)];
+
+            itemsElement.BsonType.Should().Be(BsonType.Array);
+            itemsElement.AsBsonArray.ShouldAllBeEquivalentTo(bytes);
+        }
+
+        [Fact]
+        public void ReadonlyMemory_should_support_array_representation_for_bytes()
+        {
+            var bytes = new byte[] { 1, 2, 3 };
+            var memoryHolder = new ReadonlyMemoryHolderBytesAsArray() { Items = bytes };
+
+            var bsonDocument = BsonSerializer.Deserialize<BsonDocument>(memoryHolder.ToBson());
+            var itemsElement = bsonDocument[nameof(memoryHolder.Items)];
+
+            itemsElement.BsonType.Should().Be(BsonType.Array);
+            itemsElement.AsBsonArray.ShouldAllBeEquivalentTo(bytes);
+        }
+
+        [Fact]
+        public void Memory_should_support_binary_representation_for_bytes()
+        {
+            var bytes = new byte[] { 1, 2, 3 };
+            var memoryHolder = new ReadonlyMemoryHolderBytesAsBinary() { Items = bytes };
+
+            var bsonDocument = BsonSerializer.Deserialize<BsonDocument>(memoryHolder.ToBson());
+            var itemsElement = bsonDocument[nameof(memoryHolder.Items)];
+
+            itemsElement.BsonType.Should().Be(BsonType.Binary);
+            itemsElement.AsByteArray.ShouldAllBeEquivalentTo(bytes);
+        }
+
+        [Fact]
+        public void ReadonlyMemory_should_support_binary_representation_for_bytes()
+        {
+            var bytes = new byte[] { 1, 2, 3 };
+            var memoryHolder = new ReadonlyMemoryHolderBytesAsBinary() { Items = bytes };
+
+            var bsonDocument = BsonSerializer.Deserialize<BsonDocument>(memoryHolder.ToBson());
+            var itemsElement = bsonDocument[nameof(memoryHolder.Items)];
+
+            itemsElement.BsonType.Should().Be(BsonType.Binary);
+            itemsElement.AsByteArray.ShouldAllBeEquivalentTo(bytes);
+        }
+
+        [Fact]
+        public void Mixed_memory_types_should_roundtrip_correctly()
+        {
+            var multiHolder = new MultiHolder()
+            {
+                ItemsBytes = new byte[] { 1, 2, 3 },
+                ItemsDouble = new double[] { 1.1, 2.2, 3.3 },
+                ItemsFloat = new float[] { 11.1f, 22.2f, 33.3f },
+                ItemsInt = new int[] { 10, 100, 1000 }
+            };
+
+            var bson = multiHolder.ToBson();
+            var materialized = BsonSerializer.Deserialize<MultiHolder>(bson);
+
+            materialized.ItemsBytes.ToArray().ShouldAllBeEquivalentTo(multiHolder.ItemsBytes.ToArray());
+            materialized.ItemsDouble.ToArray().ShouldAllBeEquivalentTo(multiHolder.ItemsDouble.ToArray());
+            materialized.ItemsFloat.ToArray().ShouldAllBeEquivalentTo(multiHolder.ItemsFloat.ToArray());
+            materialized.ItemsInt.ToArray().ShouldAllBeEquivalentTo(multiHolder.ItemsInt.ToArray());
+        }
+
+        [Fact]
+        public void Empty_memory_should_roundtrip_correctly()
+        {
+            var multiHolder = new MultiHolder()
+            {
+                ItemsBytes = new byte[0],
+                ItemsDouble = new double[0]
+            };
+
+            var bson = multiHolder.ToBson();
+            var materialized = BsonSerializer.Deserialize<MultiHolder>(bson);
+
+            materialized.ItemsBytes.ToArray().ShouldAllBeEquivalentTo(multiHolder.ItemsBytes.ToArray());
+            materialized.ItemsDouble.ToArray().ShouldAllBeEquivalentTo(multiHolder.ItemsDouble.ToArray());
+            materialized.ItemsFloat.ToArray().ShouldAllBeEquivalentTo(multiHolder.ItemsFloat.ToArray());
+            materialized.ItemsInt.ToArray().ShouldAllBeEquivalentTo(multiHolder.ItemsInt.ToArray());
+        }
+
+        public readonly static IEnumerable<object[]> TestData =
+        [
+            [ GetArray(i => (sbyte)i) ],
+            [ GetArray(i => (byte)i) ],
+            [ GetArray(i => (short)i) ],
+            [ GetArray(i => (ushort)i) ],
+            [ GetArray(i => (int)i) ],
+            [ GetArray(i => (uint)i) ],
+            [ GetArray(i => (long)i) ],
+            [ GetArray(i => (ulong)i) ],
+            [ GetArray(i => (float)i) ],
+            [ GetArray(i => (double)i) ]
+        ];
+
+        public static readonly IEnumerable<object[]> TestDataSpecialValues =
+        [
+            [ new[] { sbyte.MaxValue, sbyte.MinValue } ],
+            [ new[] { byte.MaxValue, byte.MinValue } ],
+            [ new[] { short.MaxValue, short.MinValue } ],
+            [ new[] { ushort.MaxValue, ushort.MinValue } ],
+            [ new[] { int.MaxValue, int.MinValue } ],
+            [ new[] { uint.MaxValue, uint.MinValue } ],
+            [ new[] { long.MaxValue, long.MinValue } ],
+            [ new[] { ulong.MaxValue, ulong.MinValue } ],
+            [ new[] { float.MaxValue, float.MinValue, float.Epsilon, float.NegativeInfinity, float.PositiveInfinity, float.NaN } ],
+            [ new[] { double.MaxValue, double.MinValue, double.Epsilon, double.NegativeInfinity, double.PositiveInfinity, double.NaN } ]
+        ];
+
+        public static readonly IEnumerable<object[]> NonSupportedTestData =
+        [
+            [ new[] { "str" } ],
+            [ new[] { new object() }],
+            [ new[] { new TimeSpan() }]
+        ];
+
+        public static IEnumerable<object[]> NonSupportedRepresentationTypes()
+        {
+            foreach (var bsonType in Enum.GetValues(typeof(BsonType)).Cast<BsonType>())
+            {
+                if (bsonType == BsonType.Array)
+                    continue;
+
+                yield return new object[] { 1, bsonType };
+            }
+        }
+
+        private static T[] GetArray<T>(Func<int, T> converter) =>
+            Enumerable.Range(0, 16).Select(converter).ToArray();
+    }
+}

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/MemorySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/MemorySerializerTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using FluentAssertions;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
@@ -86,18 +87,12 @@ namespace MongoDB.Bson.Tests.Serialization
             var memoryHolder = new MemoryHolder<T>() { Items = notSupportedData };
 
             var exception = Record.Exception(() => memoryHolder.ToBson());
-            var e = exception.Should().BeOfType<BsonSerializationException>().Subject;
+            var e = exception.Should()
+                .BeOfType<BsonSerializationException>().Subject.InnerException.Should()
+                .BeOfType<TargetInvocationException>().Subject.InnerException.Should()
+                .BeOfType<NotSupportedException>().Subject;
 
-            if (typeof(T).IsClass)
-            {
-                var inner = e.InnerException.Should().BeOfType<ArgumentException>().Subject;
-                inner.Message.Should().Contain("violates the constraint of type 'TItem'");
-            }
-            else
-            {
-                var inner = e.InnerException.Should().BeOfType<TypeInitializationException>().Subject.InnerException;
-                inner.Message.Should().StartWith("Not supported memory type");
-            }
+            e.Message.Should().StartWith("Not supported memory type");
         }
 
         [Theory]
@@ -107,18 +102,12 @@ namespace MongoDB.Bson.Tests.Serialization
             var memoryHolder = new ReadonlyMemoryHolder<T>() { Items = notSupportedData };
 
             var exception = Record.Exception(() => memoryHolder.ToBson());
-            var e = exception.Should().BeOfType<BsonSerializationException>().Subject;
+            var e = exception.Should()
+                .BeOfType<BsonSerializationException>().Subject.InnerException.Should()
+                .BeOfType<TargetInvocationException>().Subject.InnerException.Should()
+                .BeOfType<NotSupportedException>().Subject;
 
-            if (typeof(T).IsClass)
-            {
-                var inner = e.InnerException.Should().BeOfType<ArgumentException>().Subject;
-                inner.Message.Should().Contain("violates the constraint of type 'TItem'");
-            }
-            else
-            {
-                var inner = e.InnerException.Should().BeOfType<TypeInitializationException>().Subject.InnerException;
-                inner.Message.Should().StartWith("Not supported memory type");
-            }
+            e.Message.Should().StartWith("Not supported memory type");
         }
 
         [Theory]


### PR DESCRIPTION
This PR introduces custom fast serialization path for `Memory<T> `and `ReadOnlyMemory<T>`.
Deserializing `Memory`/`ReadOnlyMemory` is x4.5 times faster than regular arrays on .net8, and x7 faster on .net6.

The main performance gain is in the deserialization path, while the main serialization improvements are left out from this PR. 
Overflow and truncations checks are not implement yet, as the use-cases this scenario is optimized for exclude such need.

Deserialization performance results:

.net8

| Method               | Mean      | Error    | StdDev   |
|--------------------- |----------:|---------:|---------:|
| ArrayDecoding_int    | 379.96 ms | 6.854 ms | 6.076 ms |
| ArrayDecoding_float  | 385.77 ms | 4.181 ms | 3.911 ms |
| ArrayDecoding_double | 351.71 ms | 6.262 ms | 6.700 ms |
| MemDecoding_int      |  85.37 ms | 1.638 ms | 1.950 ms |
| MemDecoding_float    |  87.77 ms | 1.738 ms | 1.626 ms |
| MemDecoding_double   |  93.51 ms | 1.448 ms | 1.283 ms |

.net6
| Method               | Mean     | Error    | StdDev   |
|--------------------- |---------:|---------:|---------:|
| ArrayDecoding_int    | 792.8 ms | 11.57 ms | 10.83 ms |
| ArrayDecoding_float  | 916.5 ms |  7.86 ms |  6.96 ms |
| ArrayDecoding_double | 838.2 ms | 10.08 ms |  9.43 ms |
| MemDecoding_int      | 107.9 ms |  2.13 ms |  2.09 ms |
| MemDecoding_float    | 120.0 ms |  1.97 ms |  1.84 ms |
| MemDecoding_double   | 123.2 ms |  1.96 ms |  1.63 ms |



