### PR TITLE
CSHARP-5120: Use single mongos in racy unacknowledged write tests.

### DIFF
--- a/specifications/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
+++ b/specifications/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
@@ -1,10 +1,11 @@
 {
   "description": "unacknowledged-write",
-  "schemaVersion": "1.13",
+  "schemaVersion": "1.16",
   "createEntities": [
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeLogMessages": {
           "command": "debug"
         }
@@ -53,11 +54,27 @@
               "_id": 2
             }
           }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
         }
       ],
       "expectLogMessages": [
         {
           "client": "client",
+          "ignoreExtraMessages": true,
           "messages": [
             {
               "level": "debug",

--- a/specifications/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
+++ b/specifications/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
@@ -1,10 +1,11 @@
 description: "unacknowledged-write"
 
-schemaVersion: "1.13"
+schemaVersion: "1.16"
 
 createEntities:
   - client:
       id: &client client
+      useMultipleMongoses: false
       observeLogMessages:
         command: debug
   - database:
@@ -31,8 +32,18 @@ tests:
         object: *collection
         arguments:
           document: { _id: 2 }
+      # Force completion of the w: 0 write by executing a find on the same connection
+      - name: find
+        object: *collection
+        arguments:
+          filter: { }
+        expectResult: [
+          { _id: 1 },
+          { _id: 2 }
+        ]
     expectLogMessages:
       - client: *client
+        ignoreExtraMessages: true
         messages:
           - level: debug
             component: command

--- a/specifications/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
+++ b/specifications/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
@@ -1,10 +1,11 @@
 {
   "description": "unacknowledgedBulkWrite",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.7",
   "createEntities": [
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeEvents": [
           "commandStartedEvent",
           "commandSucceededEvent",
@@ -64,11 +65,29 @@
             ],
             "ordered": false
           }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": "unorderedBulkWriteInsertW0",
+              "x": 44
+            }
+          ]
         }
       ],
       "expectEvents": [
         {
           "client": "client",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {

--- a/specifications/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
+++ b/specifications/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
@@ -1,10 +1,11 @@
 description: "unacknowledgedBulkWrite"
 
-schemaVersion: "1.0"
+schemaVersion: "1.7"
 
 createEntities:
   - client:
       id: &client client
+      useMultipleMongoses: false
       observeEvents:
         - commandStartedEvent
         - commandSucceededEvent
@@ -36,8 +37,18 @@ tests:
             - insertOne:
                 document: { _id: "unorderedBulkWriteInsertW0", x: 44 }
           ordered: false
+      # Force completion of the w: 0 write by executing a find on the same connection
+      - name: find
+        object: *collection
+        arguments:
+          filter: { }
+        expectResult: [
+          { _id: 1, x: 11 },
+          { _id: "unorderedBulkWriteInsertW0", x: 44 }
+        ]
     expectEvents:
       - client: *client
+        ignoreExtraEvents: true
         events:
           - commandStartedEvent:
               command:


### PR DESCRIPTION
Note that this also addresses CSHARP-5020. The same two unified tests are updated by both tickets, and the latest version of these files includes both sets of changes.