### PR TITLE
CSHARP-2659: Adding support for $sample aggregation pipeline stage.

### DIFF
--- a/src/MongoDB.Driver/AggregateFluent.cs
+++ b/src/MongoDB.Driver/AggregateFluent.cs
@@ -267,6 +267,11 @@ namespace MongoDB.Driver
             return WithPipeline(_pipeline.ReplaceWith(newRoot));
         }
 
+        public override IAggregateFluent<TResult> Sample(long size)
+        {
+            return WithPipeline(_pipeline.Sample(size));
+        }
+
         public override IAggregateFluent<TResult> Search(
             SearchDefinition<TResult> searchDefinition,
             SearchHighlightOptions<TResult> highlight = null,
@@ -341,11 +346,6 @@ namespace MongoDB.Driver
         public override IAggregateFluent<AggregateSortByCountResult<TId>> SortByCount<TId>(AggregateExpressionDefinition<TResult, TId> id)
         {
             return WithPipeline(_pipeline.SortByCount(id));
-        }
-
-        public override IAggregateFluent<TResult> Sample(int size)
-        {
-            return WithPipeline(_pipeline.Sample(size));
         }
 
         public override IOrderedAggregateFluent<TResult> ThenBy(SortDefinition<TResult> newSort)

--- a/src/MongoDB.Driver/AggregateFluent.cs
+++ b/src/MongoDB.Driver/AggregateFluent.cs
@@ -343,6 +343,11 @@ namespace MongoDB.Driver
             return WithPipeline(_pipeline.SortByCount(id));
         }
 
+        public override IAggregateFluent<TResult> Sample(int size)
+        {
+            return WithPipeline(_pipeline.Sample(size));
+        }
+
         public override IOrderedAggregateFluent<TResult> ThenBy(SortDefinition<TResult> newSort)
         {
             Ensure.IsNotNull(newSort, nameof(newSort));

--- a/src/MongoDB.Driver/AggregateFluentBase.cs
+++ b/src/MongoDB.Driver/AggregateFluentBase.cs
@@ -300,6 +300,9 @@ namespace MongoDB.Driver
         public abstract IAggregateFluent<TResult> Sort(SortDefinition<TResult> sort);
 
         /// <inheritdoc />
+        public abstract IAggregateFluent<TResult> Sample(int size);
+
+        /// <inheritdoc />
         public virtual IAggregateFluent<AggregateSortByCountResult<TId>> SortByCount<TId>(AggregateExpressionDefinition<TResult, TId> id)
         {
             throw new NotImplementedException();

--- a/src/MongoDB.Driver/AggregateFluentBase.cs
+++ b/src/MongoDB.Driver/AggregateFluentBase.cs
@@ -238,6 +238,9 @@ namespace MongoDB.Driver
         }
 
         /// <inheritdoc />
+        public virtual IAggregateFluent<TResult> Sample(long size) => throw new NotImplementedException();
+
+        /// <inheritdoc />
         public virtual IAggregateFluent<TResult> Search(
             SearchDefinition<TResult> searchDefinition,
             SearchHighlightOptions<TResult> highlight = null,
@@ -298,9 +301,6 @@ namespace MongoDB.Driver
 
         /// <inheritdoc />
         public abstract IAggregateFluent<TResult> Sort(SortDefinition<TResult> sort);
-
-        /// <inheritdoc />
-        public abstract IAggregateFluent<TResult> Sample(int size);
 
         /// <inheritdoc />
         public virtual IAggregateFluent<AggregateSortByCountResult<TId>> SortByCount<TId>(AggregateExpressionDefinition<TResult, TId> id)

--- a/src/MongoDB.Driver/IAggregateFluent.cs
+++ b/src/MongoDB.Driver/IAggregateFluent.cs
@@ -382,6 +382,13 @@ namespace MongoDB.Driver
         IAggregateFluent<TNewResult> ReplaceWith<TNewResult>(AggregateExpressionDefinition<TResult, TNewResult> newRoot);
 
         /// <summary>
+        /// Appends a sample stage to the pipeline.
+        /// </summary>
+        /// <param name="size">The sample size.</param>
+        /// <returns>The fluent aggregate interface.</returns>
+        IAggregateFluent<TResult> Sample(long size);
+
+        /// <summary>
         /// Appends a $set stage to the pipeline.
         /// </summary>
         /// <param name="fields">The fields to set.</param>
@@ -551,13 +558,6 @@ namespace MongoDB.Driver
             QueryVector queryVector,
             int limit,
             VectorSearchOptions<TResult> options = null);
-
-        /// <summary>
-        /// Appends a sample stage to the pipeline.
-        /// </summary>
-        /// <param name="size">The sample size.</param>
-        /// <returns>The fluent aggregate interface.</returns>
-        IAggregateFluent<TResult> Sample(int size);
     }
 
     /// <summary>

--- a/src/MongoDB.Driver/IAggregateFluent.cs
+++ b/src/MongoDB.Driver/IAggregateFluent.cs
@@ -551,6 +551,13 @@ namespace MongoDB.Driver
             QueryVector queryVector,
             int limit,
             VectorSearchOptions<TResult> options = null);
+
+        /// <summary>
+        /// Appends a sample stage to the pipeline.
+        /// </summary>
+        /// <param name="size">The sample size.</param>
+        /// <returns>The fluent aggregate interface.</returns>
+        IAggregateFluent<TResult> Sample(int size);
     }
 
     /// <summary>

--- a/src/MongoDB.Driver/PipelineDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineDefinitionBuilder.cs
@@ -1357,6 +1357,25 @@ namespace MongoDB.Driver
             return pipeline.AppendStage(PipelineStageDefinitionBuilder.Sort(sort));
         }
 
+
+        /// <summary>
+        /// Appends a $sample stage to the pipeline.
+        /// </summary>
+        /// <typeparam name="TInput">The type of the input documents.</typeparam>
+        /// <typeparam name="TOutput">The type of the output documents.</typeparam>
+        /// <param name="pipeline">The pipeline.</param>
+        /// <param name="size">The sample size.</param>
+        /// <returns>
+        /// A new pipeline with an additional stage.
+        /// </returns>
+        public static PipelineDefinition<TInput, TOutput> Sample<TInput, TOutput>(
+            this PipelineDefinition<TInput, TOutput> pipeline,
+            int size)
+        {
+            Ensure.IsNotNull(pipeline, nameof(pipeline));
+            return pipeline.AppendStage(PipelineStageDefinitionBuilder.Sample<TOutput>(size));
+        }
+
         /// <summary>
         /// Appends a $sortByCount stage to the pipeline.
         /// </summary>

--- a/src/MongoDB.Driver/PipelineDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineDefinitionBuilder.cs
@@ -1098,6 +1098,24 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Appends a $sample stage to the pipeline.
+        /// </summary>
+        /// <typeparam name="TInput">The type of the input documents.</typeparam>
+        /// <typeparam name="TOutput">The type of the output documents.</typeparam>
+        /// <param name="pipeline">The pipeline.</param>
+        /// <param name="size">The sample size.</param>
+        /// <returns>
+        /// A new pipeline with an additional stage.
+        /// </returns>
+        public static PipelineDefinition<TInput, TOutput> Sample<TInput, TOutput>(
+            this PipelineDefinition<TInput, TOutput> pipeline,
+            long size)
+        {
+            Ensure.IsNotNull(pipeline, nameof(pipeline));
+            return pipeline.AppendStage(PipelineStageDefinitionBuilder.Sample<TOutput>(size));
+        }
+
+        /// <summary>
         /// Appends a $search stage to the pipeline.
         /// </summary>
         /// <typeparam name="TInput">The type of the input documents.</typeparam>
@@ -1355,25 +1373,6 @@ namespace MongoDB.Driver
         {
             Ensure.IsNotNull(pipeline, nameof(pipeline));
             return pipeline.AppendStage(PipelineStageDefinitionBuilder.Sort(sort));
-        }
-
-
-        /// <summary>
-        /// Appends a $sample stage to the pipeline.
-        /// </summary>
-        /// <typeparam name="TInput">The type of the input documents.</typeparam>
-        /// <typeparam name="TOutput">The type of the output documents.</typeparam>
-        /// <param name="pipeline">The pipeline.</param>
-        /// <param name="size">The sample size.</param>
-        /// <returns>
-        /// A new pipeline with an additional stage.
-        /// </returns>
-        public static PipelineDefinition<TInput, TOutput> Sample<TInput, TOutput>(
-            this PipelineDefinition<TInput, TOutput> pipeline,
-            int size)
-        {
-            Ensure.IsNotNull(pipeline, nameof(pipeline));
-            return pipeline.AppendStage(PipelineStageDefinitionBuilder.Sample<TOutput>(size));
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
@@ -1764,7 +1764,7 @@ namespace MongoDB.Driver
         /// <param name="size">The size.</param>
         /// <returns>The stage.</returns>
         public static PipelineStageDefinition<TInput, TInput> Sample<TInput>(
-            int size)
+            long size)
         {
             Ensure.IsGreaterThanOrEqualToZero(size, nameof(size));
             return new BsonDocumentPipelineStageDefinition<TInput, TInput>(new BsonDocument("$sample", new BsonDocument("size", size)));

--- a/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
@@ -1758,6 +1758,19 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Creates a $sample stage.
+        /// </summary>
+        /// <typeparam name="TInput">The type of the input documents.</typeparam>
+        /// <param name="size">The size.</param>
+        /// <returns>The stage.</returns>
+        public static PipelineStageDefinition<TInput, TInput> Sample<TInput>(
+            int size)
+        {
+            Ensure.IsGreaterThanOrEqualToZero(size, nameof(size));
+            return new BsonDocumentPipelineStageDefinition<TInput, TInput>(new BsonDocument("$sample", new BsonDocument("size", size)));
+        }
+
+        /// <summary>
         /// Creates a $sortByCount stage.
         /// </summary>
         /// <typeparam name="TInput">The type of the input documents.</typeparam>

--- a/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
@@ -158,6 +158,42 @@ namespace MongoDB.Driver.Tests
             stages[0].Should().Be("{ $out: { db: 'database', coll: 'collection', timeseries: { timeField: 'time', metaField: 'symbol' } } }");
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(15)]
+        public void Sample_should_add_expected_stage(long size)
+        {
+            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
+
+            var result = pipeline.Sample(size);
+
+            var stages = RenderStages(result, BsonDocumentSerializer.Instance);
+            stages.Count.Should().Be(1);
+            stages[0].Should().Be("{ $sample: { size: " + size + " } }");
+        }
+
+        [Fact]
+        public void Sample_should_throw_when_pipeline_is_null()
+        {
+            PipelineDefinition<BsonDocument, BsonDocument> pipeline = null;
+
+            var exception = Record.Exception(() => pipeline.Sample(15));
+
+            exception.Should().BeOfType<ArgumentNullException>()
+                .Which.ParamName.Should().Be("pipeline");
+        }
+
+        [Fact]
+        public void Sample_should_throw_when_size_is_negative()
+        {
+            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
+
+            var exception = Record.Exception(() => pipeline.Sample(-1));
+
+            exception.Should().BeOfType<ArgumentOutOfRangeException>()
+                .Which.ParamName.Should().Be("size");
+        }
+
         [Fact]
         public void Search_should_add_expected_stage()
         {
@@ -350,18 +386,6 @@ namespace MongoDB.Driver.Tests
 
             exception.Should().BeOfType<ArgumentNullException>()
                 .Which.ParamName.Should().Be("searchDefinition");
-        }
-
-        [Fact]
-        public void Sample_should_add_expected_stage()
-        {
-            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
-
-            var result = pipeline.Sample(15);
-
-            var stages = RenderStages(result, BsonDocumentSerializer.Instance);
-            stages.Count.Should().Be(1);
-            stages[0].Should().Be("{ $sample: { size: 15 } }");
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
@@ -353,6 +353,18 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void Sample_should_add_expected_stage()
+        {
+            var pipeline = new EmptyPipelineDefinition<BsonDocument>();
+
+            var result = pipeline.Sample(15);
+
+            var stages = RenderStages(result, BsonDocumentSerializer.Instance);
+            stages.Count.Should().Be(1);
+            stages[0].Should().Be("{ $sample: { size: 15 } }");
+        }
+
+        [Fact]
         public void UnionWith_should_add_expected_stage()
         {
             var pipeline = new EmptyPipelineDefinition<BsonDocument>();


### PR DESCRIPTION
Added `$sample` stage to `Aggregate()`. Reorganized external PR, added some tests, and changed the `size` from `int` to `long`. The server accepts `NumberLong` for the `size` and throws on negative. Although the docs say that `size` must be a positive integer, empirical testing shows that zero is permissible and returns no documents as expected.