### PR TITLE
CSHARP-4017: Fix flaky Aggregate_with__out_includes_read_preference_for_5.0__server error

### DIFF
--- a/tests/MongoDB.Driver.Tests/Jira/CSharp3397Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Jira/CSharp3397Tests.cs
@@ -27,36 +27,6 @@ namespace MongoDB.Driver.Tests.Jira
     public class CSharp3397Tests
     {
         [Fact]
-        public void Aggregate_out_to_collection_should_work()
-        {
-            var client = DriverTestConfiguration.Client;
-            var database = client.GetDatabase("test");
-            var collection = database.GetCollection<BsonDocument>("test");
-            var outCollection = database.GetCollection<AggregateCountResult>("out");
-
-            var writeConcern = WriteConcern.WMajority;
-            if (DriverTestConfiguration.IsReplicaSet(client))
-            {
-                var n = DriverTestConfiguration.GetReplicaSetNumberOfDataBearingMembers(client);
-                writeConcern = new WriteConcern(n);
-            }
-
-            database.DropCollection("test");
-            database.DropCollection("out");
-            collection
-                .WithWriteConcern(writeConcern)
-                .InsertOne(new BsonDocument("_id", 1));
-
-            var pipeline = new EmptyPipelineDefinition<BsonDocument>()
-                .Count()
-                .Out(outCollection)
-                .As<BsonDocument, AggregateCountResult, AggregateCountResultWithId>();
-            var results = collection.WithReadPreference(ReadPreference.SecondaryPreferred).Aggregate(pipeline).ToList();
-
-            results.Single().Count.Should().Be(1);
-        }
-
-        [Fact]
         public void Aggregate_out_to_time_series_collection_on_secondary_should_work()
         {
             RequireServer.Check().Supports(Feature.AggregateOutTimeSeries);

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -197,11 +197,11 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 #pragma warning restore CS0618 // Type or member is obsolete
 
             var writeConcern = WriteConcern.WMajority;
-            if (client.Cluster.Description.Type == ClusterType.ReplicaSet)
+            if (DriverTestConfiguration.IsReplicaSet(client))
             {
                 // Makes server to wait for ack from all data nodes to make sure the test data availability before running the test itself.
                 // It's limited to replica set only because there is no simple way to calculate proper w for sharded cluster.
-                var dataBearingServersCount = client.Cluster.Description.Servers.Count(s => s.IsDataBearing);
+                var dataBearingServersCount = DriverTestConfiguration.GetReplicaSetNumberOfDataBearingMembers(client);
                 writeConcern = WriteConcern.Acknowledged.With(w: dataBearingServersCount, journal:true);
             }
 


### PR DESCRIPTION
Found test that is duplicated with spec test "Aggregate with $out includes read preference for 5.0+ server" (defined in specifications\crud\tests\unified\aggregate-write-readPreference.yml)