### PR TITLE
CSHARP-5162: Continue to use FindExpressionProjectionDefinition to avoid regression against LINQ2

### DIFF
--- a/src/MongoDB.Driver/ProjectionDefinition.cs
+++ b/src/MongoDB.Driver/ProjectionDefinition.cs
@@ -307,6 +307,21 @@ namespace MongoDB.Driver
         /// <inheritdoc />
         public override RenderedProjectionDefinition<TProjection> Render(IBsonSerializer<TSource> sourceSerializer, IBsonSerializerRegistry serializerRegistry, LinqProvider linqProvider)
         {
+            if (linqProvider == LinqProvider.V2)
+            {
+                // this is slightly wrong because we're not actually rendering for a Find
+                // but this is required to avoid a regression with LINQ2
+                return RenderForFind(sourceSerializer, serializerRegistry, linqProvider);
+            }
+            else
+            {
+                return linqProvider.GetAdapter().TranslateExpressionToProjection(_expression, sourceSerializer, serializerRegistry, translationOptions: null);
+            }
+        }
+
+        /// <inheritdoc />
+        internal override RenderedProjectionDefinition<TProjection> RenderForFind(IBsonSerializer<TSource> sourceSerializer, IBsonSerializerRegistry serializerRegistry, LinqProvider linqProvider)
+        {
             return linqProvider.GetAdapter().TranslateExpressionToFindProjection(_expression, sourceSerializer, serializerRegistry);
         }
     }

--- a/src/MongoDB.Driver/ProjectionDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/ProjectionDefinitionBuilder.cs
@@ -544,7 +544,9 @@ namespace MongoDB.Driver
         /// </returns>
         public ProjectionDefinition<TSource, TProjection> Expression<TProjection>(Expression<Func<TSource, TProjection>> expression)
         {
-            return new ExpressionProjectionDefinition<TSource, TProjection>(expression, null);
+            // TODO: replace FindExpressionProjectionDefinition with ExpressionProjectionDefinition when LINQ2 is removed
+            // in the meantime we have to keep using FindExpressionProjectionDefinition here for compatibility with LINQ2
+            return new FindExpressionProjectionDefinition<TSource, TProjection>(expression);
         }
 
         /// <summary>

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4681Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4681Tests.cs
@@ -32,11 +32,8 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 
             var fluentFind = collection.Find(a => a.Id == "1").Project(a => a.Id);
 
-            var documentSerializer = collection.DocumentSerializer;
-            var serializerRegistry = BsonSerializer.SerializerRegistry;
-            var renderedProjection = fluentFind.Options.Projection.Render(documentSerializer, serializerRegistry, linqProvider);
-
-            renderedProjection.Document.Should().Be("{ _id : 1 }");
+            var renderedProjection = TranslateFindProjection(collection, fluentFind);
+            renderedProjection.Should().Be("{ _id : 1 }");
 
             var result = fluentFind.Single();
             result.Should().Be("1");

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5162Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5162Tests.cs
@@ -1,0 +1,184 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver.Linq;
+using MongoDB.TestHelpers.XunitExtensions;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
+{
+    public class CSharp5162Tests : Linq3IntegrationTest
+    {
+        [Theory]
+        [ParameterAttributeData]
+        public void Builders_Projection_Expression_with_camel_casing_should_work(
+            [Values(LinqProvider.V2, LinqProvider.V3)] LinqProvider linqProvider)
+        {
+            var collection = GetCamelCollection(linqProvider);
+
+            var projection = Builders<CamelDocument>.Projection.Expression(x => new CamelDocument { Id = x.Id, Name = x.Name });
+            var aggregate = collection.Aggregate().Project(projection);
+
+            var stages = Translate(collection, aggregate);
+            if (linqProvider == LinqProvider.V2)
+            {
+                AssertStages(stages, "{ $project : { _id : 1, name : 1 } }");
+            }
+            else
+            {
+                AssertStages(stages, "{ $project : { _id : '$_id', name : '$name' } }");
+            }
+
+            var result = aggregate.ToList().Single();
+            result.Id.Should().Be(1);
+            result.Name.Should().Be("John Doe");
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void Builders_Projection_Expression_with_pascal_casing_should_work(
+            [Values(LinqProvider.V2, LinqProvider.V3)] LinqProvider linqProvider)
+        {
+            var collection = GetPascalCollection(linqProvider);
+
+            var projection = Builders<PascalDocument>.Projection.Expression(x => new PascalDocument { Id = x.Id, Name = x.Name });
+            var aggregate = collection.Aggregate().Project(projection);
+
+            var stages = Translate(collection, aggregate);
+            if (linqProvider == LinqProvider.V2)
+            {
+                stages = NormalizeProjectFieldOrder(stages);
+                AssertStages(stages, "{ $project : { _id : 1, Name : 1 } }");
+            }
+            else
+            {
+                AssertStages(stages, "{ $project : { _id : '$_id', Name : '$Name' } }");
+            }
+
+            var result = aggregate.ToList().Single();
+            result.Id.Should().Be(1);
+            result.Name.Should().Be("John Doe");
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void FindExpressionDefinition_with_camel_casing_should_work(
+            [Values(LinqProvider.V2, LinqProvider.V3)] LinqProvider linqProvider)
+        {
+            var collection = GetCamelCollection(linqProvider);
+
+            var projection = new FindExpressionProjectionDefinition<CamelDocument, CamelDocument>(x => new CamelDocument { Id = x.Id, Name = x.Name });
+            var aggregate = collection.Aggregate().Project(projection);
+
+            var stages = Translate(collection, aggregate);
+            if (linqProvider == LinqProvider.V2)
+            {
+                AssertStages(stages, "{ $project : { _id : 1, name : 1 } }");
+            }
+            else
+            {
+                AssertStages(stages, "{ $project : { _id : '$_id', name : '$name' } }");
+            }
+
+            var result = aggregate.ToList().Single();
+            result.Id.Should().Be(1);
+            result.Name.Should().Be("John Doe");
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void FindExpressionDefinition_with_pascal_casing_should_work(
+            [Values(LinqProvider.V2, LinqProvider.V3)] LinqProvider linqProvider)
+        {
+            var collection = GetPascalCollection(linqProvider);
+
+            var projection = new FindExpressionProjectionDefinition<PascalDocument, PascalDocument>(x => new PascalDocument { Id = x.Id, Name = x.Name });
+            var aggregate = collection.Aggregate().Project(projection);
+
+            var stages = Translate(collection, aggregate);
+            if (linqProvider == LinqProvider.V2)
+            {
+                stages = NormalizeProjectFieldOrder(stages);
+                AssertStages(stages, "{ $project : { _id : 1, Name : 1 } }");
+            }
+            else
+            {
+                AssertStages(stages, "{ $project : { _id : '$_id', Name : '$Name' } }");
+            }
+
+            var result = aggregate.ToList().Single();
+            result.Id.Should().Be(1);
+            result.Name.Should().Be("John Doe");
+        }
+
+        private IMongoCollection<CamelDocument> GetCamelCollection(LinqProvider linqProvider)
+        {
+            var collection = GetCollection<CamelDocument>("test", linqProvider);
+            var document = new CamelDocument { Id = 1, Name = "John Doe" };
+            CreateCollection(collection, document);
+            return collection;
+        }
+
+        private IMongoCollection<PascalDocument> GetPascalCollection(LinqProvider linqProvider)
+        {
+            var collection = GetCollection<PascalDocument>("test", linqProvider);
+            var document = new PascalDocument { Id = 1, Name = "John Doe" };
+            CreateCollection(collection, document);
+            return collection;
+        }
+
+        private List<BsonDocument> NormalizeProjectFieldOrder(List<BsonDocument> stages)
+        {
+            if (stages.Count == 1 &&
+                stages[0] is BsonDocument projectStage &&
+                projectStage.ElementCount == 1 &&
+                projectStage.GetElement(0).Name == "$project" &&
+                projectStage[0] is BsonDocument projection &&
+                projection.ElementCount == 2 &&
+                projection.Names.SequenceEqual(["Name", "_id"]))
+            {
+                stages[0]["$project"] = new BsonDocument
+                {
+                    { "_id", projection["_id"] },
+                    { "Name", projection["Name"] }
+                };
+            }
+
+            return stages;
+        }
+
+        private class CamelDocument
+        {
+            public int Id { get; set; }
+            [BsonElement("name")] public string Name { get; set; }
+            [BsonElement("activeSince")] public DateTime ActiveSince { get; set; }
+            [BsonElement("isActive")] public bool IsActive { get; set; }
+        }
+
+        private class PascalDocument
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DateTime ActiveSince { get; set; }
+            public bool IsActive { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
About a year ago we added `RenderForFind` and stopped using `FindExpressionProjectionDefinition`. That resulted in a subtle regression affecting LINQ2 that was only discovered relatively recently.

This PR fixes the regression by reverting back to using `FindExpressionProjectionDefinition` wherever it was used before, BUT then making `FindExpressionProjectionDefinition` behave the same as it used when using LINQ2 while behaving the SAME as `ExpressionProjectionDefinition` when using LINQ3.

The net effect is that when using LINQ2 everything works the same as it used to, and when using LINQ3 we have effectively (but not actually) replaced `FindExpressionProjectionDefinition` with `ExpressionProjectionDefinition`.