### PR TITLE
CSHARP-5209: remove-aws-sdk-from-deps

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.14" />
     <PackageReference Include="DnsClient" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.11.0" />

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.14" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-5209
cant upgrade my mongo driver because i have references to aws sdk, and its not in match with your reference, also its look like the reference for aws its only for ut, so i move it to the ut project