### PR TITLE
CSHARP-4892: CSFLE/QE Support for more than 1 KMS provider per type

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -360,6 +360,8 @@ functions:
         include_expansions_in_env:
           - "FLE_AWS_ACCESS_KEY_ID"
           - "FLE_AWS_SECRET_ACCESS_KEY"
+          - "FLE_AWS_NAMED2_ACCESS_KEY_ID"
+          - "FLE_AWS_NAMED2_SECRET_ACCESS_KEY"
           - "FLE_AZURE_TENANT_ID"
           - "FLE_AZURE_CLIENT_ID"
           - "FLE_AZURE_CLIENT_SECRET"
@@ -394,6 +396,8 @@ functions:
         include_expansions_in_env:
           - "FLE_AWS_ACCESS_KEY_ID"
           - "FLE_AWS_SECRET_ACCESS_KEY"
+          - "FLE_AWS_NAMED2_ACCESS_KEY_ID"
+          - "FLE_AWS_NAMED2_SECRET_ACCESS_KEY"
           - "FLE_AZURE_TENANT_ID"
           - "FLE_AZURE_CLIENT_ID"
           - "FLE_AZURE_CLIENT_SECRET"
@@ -427,6 +431,8 @@ functions:
         include_expansions_in_env:
           - "FLE_AWS_ACCESS_KEY_ID"
           - "FLE_AWS_SECRET_ACCESS_KEY"
+          - "FLE_AWS_NAMED2_ACCESS_KEY_ID"
+          - "FLE_AWS_NAMED2_SECRET_ACCESS_KEY"
           - "FLE_AZURE_TENANT_ID"
           - "FLE_AZURE_CLIENT_ID"
           - "FLE_AZURE_CLIENT_SECRET"

--- a/specifications/client-side-encryption/tests/legacy/namedKMS.json
+++ b/specifications/client-side-encryption/tests/legacy/namedKMS.json
@@ -1,0 +1,197 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "json_schema": {
+    "properties": {
+      "encrypted_string": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "local+name2+AAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      }
+    },
+    "bsonType": "object"
+  },
+  "key_vault_data": [
+    {
+      "_id": {
+        "$binary": {
+          "base64": "local+name2+AAAAAAAAAA==",
+          "subType": "04"
+        }
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "status": {
+        "$numberInt": "0"
+      },
+      "masterKey": {
+        "provider": "local:name2"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Automatically encrypt and decrypt with a named KMS provider",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local:name2": {
+              "key": {
+                "$binary": {
+                  "base64": "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          }
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": [
+            {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          ]
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "local+name2+AAAAAAAAAA==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault",
+              "readConcern": {
+                "level": "majority"
+              }
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 1,
+                  "encrypted_string": {
+                    "$binary": {
+                      "base64": "AZaHGpfp2pntvgAAAAAAAAAC07sFvTQ0I4O2U49hpr4HezaK44Ivluzv5ntQBTYHDlAJMLyRMyB6Dl+UGHBgqhHe/Xw+pcT9XdiUoOJYAx9g+w==",
+                      "subType": "06"
+                    }
+                  }
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "default",
+              "filter": {
+                "_id": 1
+              }
+            },
+            "command_name": "find"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "encrypted_string": {
+                "$binary": {
+                  "base64": "AZaHGpfp2pntvgAAAAAAAAAC07sFvTQ0I4O2U49hpr4HezaK44Ivluzv5ntQBTYHDlAJMLyRMyB6Dl+UGHBgqhHe/Xw+pcT9XdiUoOJYAx9g+w==",
+                  "subType": "06"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/specifications/client-side-encryption/tests/legacy/namedKMS.yml
+++ b/specifications/client-side-encryption/tests/legacy/namedKMS.yml
@@ -1,0 +1,56 @@
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+data: []
+json_schema: {'properties': {'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'local+name2+AAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+key_vault_data: [{'_id': {'$binary': {'base64': 'local+name2+AAAAAAAAAA==', 'subType': '04'}}, 'keyMaterial': {'$binary': {'base64': 'DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==', 'subType': '00'}}, 'creationDate': {'$date': {'$numberLong': '1552949630483'}}, 'updateDate': {'$date': {'$numberLong': '1552949630483'}}, 'status': {'$numberInt': '0'}, 'masterKey': {'provider': 'local:name2'}}]
+
+tests:
+  - description: "Automatically encrypt and decrypt with a named KMS provider"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          "local:name2": {'key': {'$binary': {'base64': 'local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1, encrypted_string: "string0" }
+      - name: find
+        arguments:
+          filter: { _id: 1 }
+        result: [*doc0]
+    expectations:
+      # Auto encryption will request the collection info.
+      - command_started_event:
+          command:
+            listCollections: 1
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      # Then key is fetched from the key vault.
+      - command_started_event:
+          command:
+            find: datakeys
+            filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'local+name2+AAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
+            $db: keyvault
+            readConcern: { level: "majority" }
+          command_name: find
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - &doc0_encrypted { _id: 1, encrypted_string: {'$binary': {'base64': 'AZaHGpfp2pntvgAAAAAAAAAC07sFvTQ0I4O2U49hpr4HezaK44Ivluzv5ntQBTYHDlAJMLyRMyB6Dl+UGHBgqhHe/Xw+pcT9XdiUoOJYAx9g+w==', 'subType': '06'}} }
+            ordered: true
+          command_name: insert
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: { _id: 1 }
+          command_name: find
+    outcome:
+      collection:
+        # Outcome is checked using a separate MongoClient without auto encryption.
+        data:
+          - *doc0_encrypted

--- a/specifications/client-side-encryption/tests/unified/namedKMS-createDataKey.json
+++ b/specifications/client-side-encryption/tests/unified/namedKMS-createDataKey.json
@@ -1,0 +1,396 @@
+{
+  "description": "namedKMS-createDataKey",
+  "schemaVersion": "1.18",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws:name1": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            },
+            "azure:name1": {
+              "tenantId": {
+                "$$placeholder": 1
+              },
+              "clientId": {
+                "$$placeholder": 1
+              },
+              "clientSecret": {
+                "$$placeholder": 1
+              }
+            },
+            "gcp:name1": {
+              "email": {
+                "$$placeholder": 1
+              },
+              "privateKey": {
+                "$$placeholder": 1
+              }
+            },
+            "kmip:name1": {
+              "endpoint": {
+                "$$placeholder": 1
+              }
+            },
+            "local:name1": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "keyvault"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "datakeys"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "create data key with named AWS KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "aws:name1",
+            "opts": {
+              "masterKey": {
+                "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+                "region": "us-east-1"
+              }
+            }
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "aws:name1",
+                        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+                        "region": "us-east-1"
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create datakey with named Azure KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "azure:name1",
+            "opts": {
+              "masterKey": {
+                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                "keyName": "key-name-csfle"
+              }
+            }
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "azure:name1",
+                        "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                        "keyName": "key-name-csfle"
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create datakey with named GCP KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "gcp:name1",
+            "opts": {
+              "masterKey": {
+                "projectId": "devprod-drivers",
+                "location": "global",
+                "keyRing": "key-ring-csfle",
+                "keyName": "key-name-csfle"
+              }
+            }
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "gcp:name1",
+                        "projectId": "devprod-drivers",
+                        "location": "global",
+                        "keyRing": "key-ring-csfle",
+                        "keyName": "key-name-csfle"
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create datakey with named KMIP KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "kmip:name1"
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "kmip:name1",
+                        "keyId": {
+                          "$$type": "string"
+                        }
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create datakey with named local KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "local:name1"
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "local:name1"
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/client-side-encryption/tests/unified/namedKMS-createDataKey.yml
+++ b/specifications/client-side-encryption/tests/unified/namedKMS-createDataKey.yml
@@ -1,0 +1,175 @@
+description: namedKMS-createDataKey
+
+schemaVersion: "1.18"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          "aws:name1": { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 } }
+          "azure:name1": { tenantId: { $$placeholder: 1 }, clientId: { $$placeholder: 1 }, clientSecret: { $$placeholder: 1 } }
+          "gcp:name1": { email: { $$placeholder: 1 }, privateKey: { $$placeholder: 1 } }
+          "kmip:name1": { endpoint: { $$placeholder: 1 } }
+          "local:name1": { key: { $$placeholder: 1 } }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name keyvault
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name datakeys
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents: []
+
+tests:
+  - description: create data key with named AWS KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "aws:name1"
+          opts:
+            masterKey: &new_aws_masterkey
+              key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+              region: us-east-1
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "aws:name1"
+                      <<: *new_aws_masterkey
+                writeConcern: { w: majority }
+
+  - description: create datakey with named Azure KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "azure:name1"
+          opts:
+            masterKey: &new_azure_masterkey
+              keyVaultEndpoint: key-vault-csfle.vault.azure.net
+              keyName: key-name-csfle
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "azure:name1"
+                      <<: *new_azure_masterkey
+                writeConcern: { w: majority }
+
+  - description: create datakey with named GCP KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "gcp:name1"
+          opts:
+            masterKey: &new_gcp_masterkey
+              projectId: devprod-drivers
+              location: global
+              keyRing: key-ring-csfle
+              keyName: key-name-csfle
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "gcp:name1"
+                      <<: *new_gcp_masterkey
+                writeConcern: { w: majority }
+
+  - description: create datakey with named KMIP KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "kmip:name1"
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "kmip:name1"
+                      keyId: { $$type: string }
+                writeConcern: { w: majority }
+
+  - description: create datakey with named local KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "local:name1"
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "local:name1"
+                writeConcern: { w: majority }

--- a/specifications/client-side-encryption/tests/unified/namedKMS-explicit.json
+++ b/specifications/client-side-encryption/tests/unified/namedKMS-explicit.json
@@ -1,0 +1,130 @@
+{
+  "description": "namedKMS-explicit",
+  "schemaVersion": "1.18",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "local:name2": {
+              "key": "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
+            }
+          }
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "keyvault"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "datakeys"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": [
+        {
+          "_id": {
+            "$binary": {
+              "base64": "local+name2+AAAAAAAAAA==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "local:name2"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1552949630483"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1552949630483"
+            }
+          },
+          "status": {
+            "$numberInt": "0"
+          },
+          "masterKey": {
+            "provider": "local:name2"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "can explicitly encrypt with a named KMS provider",
+      "operations": [
+        {
+          "name": "encrypt",
+          "object": "clientEncryption0",
+          "arguments": {
+            "value": "foobar",
+            "opts": {
+              "keyAltName": "local:name2",
+              "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+          },
+          "expectResult": {
+            "$binary": {
+              "base64": "AZaHGpfp2pntvgAAAAAAAAAC4yX2LTAuN253GAkEO2ZXp4GpCyM7yoVNJMQQl+6uzxMs03IprLC7DL2vr18x9LwOimjTS9YbMJhrnFkEPuNhbg==",
+              "subType": "06"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "can explicitly decrypt with a named KMS provider",
+      "operations": [
+        {
+          "name": "decrypt",
+          "object": "clientEncryption0",
+          "arguments": {
+            "value": {
+              "$binary": {
+                "base64": "AZaHGpfp2pntvgAAAAAAAAAC4yX2LTAuN253GAkEO2ZXp4GpCyM7yoVNJMQQl+6uzxMs03IprLC7DL2vr18x9LwOimjTS9YbMJhrnFkEPuNhbg==",
+                "subType": "06"
+              }
+            }
+          },
+          "expectResult": "foobar"
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/client-side-encryption/tests/unified/namedKMS-explicit.yml
+++ b/specifications/client-side-encryption/tests/unified/namedKMS-explicit.yml
@@ -1,0 +1,72 @@
+description: namedKMS-explicit
+
+schemaVersion: "1.18"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          "local:name2" : { key: "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk" }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name keyvault
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name datakeys
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents:
+      - {
+            "_id": {
+                "$binary": {
+                    "base64": "local+name2+AAAAAAAAAA==",
+                    "subType": "04"
+                }
+            },
+            "keyAltNames": ["local:name2"],
+            "keyMaterial": {
+                "$binary": {
+                    "base64": "DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==",
+                    "subType": "00"
+                }
+            },
+            "creationDate": {"$date": {"$numberLong": "1552949630483"}},
+            "updateDate": {"$date": {"$numberLong": "1552949630483"}},
+            "status": {"$numberInt": "0"},
+            "masterKey": {"provider": "local:name2"}
+        }
+
+tests:
+  - description: can explicitly encrypt with a named KMS provider
+    operations:
+      - name: encrypt
+        object: *clientEncryption0
+        arguments:
+          value: "foobar"
+          opts:
+            keyAltName: "local:name2"
+            algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        expectResult: { "$binary" : { "base64" : "AZaHGpfp2pntvgAAAAAAAAAC4yX2LTAuN253GAkEO2ZXp4GpCyM7yoVNJMQQl+6uzxMs03IprLC7DL2vr18x9LwOimjTS9YbMJhrnFkEPuNhbg==", "subType" : "06" } }
+
+  - description: can explicitly decrypt with a named KMS provider
+    operations:
+      - name: decrypt
+        object: *clientEncryption0
+        arguments:
+          value: { "$binary" : { "base64" : "AZaHGpfp2pntvgAAAAAAAAAC4yX2LTAuN253GAkEO2ZXp4GpCyM7yoVNJMQQl+6uzxMs03IprLC7DL2vr18x9LwOimjTS9YbMJhrnFkEPuNhbg==", "subType" : "06" } }
+        expectResult: "foobar"
+  

--- a/specifications/client-side-encryption/tests/unified/namedKMS-rewrapManyDataKey.json
+++ b/specifications/client-side-encryption/tests/unified/namedKMS-rewrapManyDataKey.json
@@ -1,0 +1,1385 @@
+{
+  "description": "namedKMS-rewrapManyDataKey",
+  "schemaVersion": "1.18",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws:name1": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            },
+            "azure:name1": {
+              "tenantId": {
+                "$$placeholder": 1
+              },
+              "clientId": {
+                "$$placeholder": 1
+              },
+              "clientSecret": {
+                "$$placeholder": 1
+              }
+            },
+            "gcp:name1": {
+              "email": {
+                "$$placeholder": 1
+              },
+              "privateKey": {
+                "$$placeholder": 1
+              }
+            },
+            "kmip:name1": {
+              "endpoint": {
+                "$$placeholder": 1
+              }
+            },
+            "local:name1": {
+              "key": {
+                "$$placeholder": 1
+              }
+            },
+            "local:name2": {
+              "key": "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
+            },
+            "aws:name2": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "keyvault"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "datakeys"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": [
+        {
+          "_id": {
+            "$binary": {
+              "base64": "YXdzYXdzYXdzYXdzYXdzYQ==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "aws:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gFXJqbF0Fy872MD7xl56D/2AAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDO7HPisPUlGzaio9vgIBEIB7/Qow46PMh/8JbEUbdXgTGhLfXPE+KIVW7T8s6YEMlGiRvMu7TV0QCIUJlSHPKZxzlJ2iwuz5yXeOag+EdY+eIQ0RKrsJ3b8UTisZYzGjfzZnxUKLzLoeXremtRCm3x47wCuHKd1dhh6FBbYt5TL2tDaj+vL2GBrKat2L",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "aws:name1",
+            "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+            "region": "us-east-1"
+          }
+        },
+        {
+          "_id": {
+            "$binary": {
+              "base64": "YXp1cmVhenVyZWF6dXJlYQ==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "azure:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "azure:name1",
+            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+            "keyName": "key-name-csfle"
+          }
+        },
+        {
+          "_id": {
+            "$binary": {
+              "base64": "Z2NwZ2NwZ2NwZ2NwZ2NwZw==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "gcp:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "CiQAIgLj0USbQtof/pYRLQO96yg/JEtZbD1UxKueaC37yzT5tTkSiQEAhClWB5ZCSgzHgxv8raWjNB4r7e8ePGdsmSuYTYmLC5oHHS/BdQisConzNKFaobEQZHamTCjyhy5NotKF8MWoo+dyfQApwI29+vAGyrUIQCXzKwRnNdNQ+lb3vJtS5bqvLTvSxKHpVca2kqyC9nhonV+u4qru5Q2bAqUgVFc8fL4pBuvlowZFTQ==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "gcp:name1",
+            "projectId": "devprod-drivers",
+            "location": "global",
+            "keyRing": "key-ring-csfle",
+            "keyName": "key-name-csfle"
+          }
+        },
+        {
+          "_id": {
+            "$binary": {
+              "base64": "a21pcGttaXBrbWlwa21pcA==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "kmip:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "kmip:name1",
+            "keyId": "1"
+          }
+        },
+        {
+          "_id": {
+            "$binary": {
+              "base64": "bG9jYWxrZXlsb2NhbGtleQ==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "local:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "ABKBldDEoDW323yejOnIRk6YQmlD9d3eQthd16scKL75nz2LjNL9fgPDZWrFFOlqlhMCFaSrNJfGrFUjYk5JFDO7soG5Syb50k1niJoKg4ilsj0L4mpimFUtTpOr2nzZOeQtvAksEXc7gsFgq8gV7t/U3lsaXPY7I0t42DfSE8EGlPdxRjFdHnxh+OR8h7U9b8Qs5K5UuhgyeyxaBZ1Hgw==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "local:name1"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "rewrap to aws:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "aws:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "aws:name1",
+              "masterKey": {
+                "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                "region": "us-east-1"
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "aws:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name1",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name1",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name1",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name1",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap to azure:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "azure:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "azure:name1",
+              "masterKey": {
+                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                "keyName": "key-name-csfle"
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "azure:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure:name1",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure:name1",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure:name1",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure:name1",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap to gcp:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "gcp:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "gcp:name1",
+              "masterKey": {
+                "projectId": "devprod-drivers",
+                "location": "global",
+                "keyRing": "key-ring-csfle",
+                "keyName": "key-name-csfle"
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "gcp:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp:name1",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp:name1",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp:name1",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp:name1",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap to kmip:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "kmip:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "kmip:name1"
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "kmip:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip:name1",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip:name1",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip:name1",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip:name1",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap to local:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "local:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "local:name1"
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "local:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap from local:name1 to local:name2",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$eq": "local:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "local:name2"
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 1,
+              "modifiedCount": 1,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$eq": "local:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name2"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap from aws:name1 to aws:name2",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$eq": "aws:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "aws:name2",
+              "masterKey": {
+                "key": "arn:aws:kms:us-east-1:857654397073:key/0f8468f0-f135-4226-aa0b-bd05c4c30df5",
+                "region": "us-east-1"
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 1,
+              "modifiedCount": 1,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$eq": "aws:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name2",
+                            "key": "arn:aws:kms:us-east-1:857654397073:key/0f8468f0-f135-4226-aa0b-bd05c4c30df5",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/client-side-encryption/tests/unified/namedKMS-rewrapManyDataKey.yml
+++ b/specifications/client-side-encryption/tests/unified/namedKMS-rewrapManyDataKey.yml
@@ -1,0 +1,432 @@
+description: namedKMS-rewrapManyDataKey
+
+schemaVersion: "1.18"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          "aws:name1": { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 } }
+          "azure:name1": { tenantId: { $$placeholder: 1 }, clientId: { $$placeholder: 1 }, clientSecret: { $$placeholder: 1 } }
+          "gcp:name1": { email: { $$placeholder: 1 }, privateKey: { $$placeholder: 1 } }
+          "kmip:name1": { endpoint: { $$placeholder: 1 } }
+          "local:name1": { key: { $$placeholder: 1 } }
+          # Use a different local master key for `local:name2`.
+          "local:name2": { key: "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk" }
+          # Use a different AWS account to test wrapping between different AWS accounts.
+          "aws:name2": { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 } }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name keyvault
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name datakeys
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents:
+      - _id: &aws:name1_key_id { $binary: { base64: YXdzYXdzYXdzYXdzYXdzYQ==, subType: "04" } }
+        keyAltNames: ["aws:name1_key"]
+        keyMaterial: { $binary: { base64: AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gFXJqbF0Fy872MD7xl56D/2AAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDO7HPisPUlGzaio9vgIBEIB7/Qow46PMh/8JbEUbdXgTGhLfXPE+KIVW7T8s6YEMlGiRvMu7TV0QCIUJlSHPKZxzlJ2iwuz5yXeOag+EdY+eIQ0RKrsJ3b8UTisZYzGjfzZnxUKLzLoeXremtRCm3x47wCuHKd1dhh6FBbYt5TL2tDaj+vL2GBrKat2L, subType: "00" } }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &aws:name1_masterkey
+          provider: aws:name1
+          key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+          region: us-east-1
+      - _id: &azure:name1_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
+        keyAltNames: ["azure:name1_key"]
+        keyMaterial: { $binary: { base64: pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==, subType: "00" } }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &azure:name1_masterkey
+          provider: "azure:name1"
+          keyVaultEndpoint: key-vault-csfle.vault.azure.net
+          keyName: key-name-csfle
+      - _id: &gcp:name1_key_id { $binary: { base64: Z2NwZ2NwZ2NwZ2NwZ2NwZw==, subType: "04" } }
+        keyAltNames: ["gcp:name1_key"]
+        keyMaterial: { $binary: { base64: CiQAIgLj0USbQtof/pYRLQO96yg/JEtZbD1UxKueaC37yzT5tTkSiQEAhClWB5ZCSgzHgxv8raWjNB4r7e8ePGdsmSuYTYmLC5oHHS/BdQisConzNKFaobEQZHamTCjyhy5NotKF8MWoo+dyfQApwI29+vAGyrUIQCXzKwRnNdNQ+lb3vJtS5bqvLTvSxKHpVca2kqyC9nhonV+u4qru5Q2bAqUgVFc8fL4pBuvlowZFTQ==, subType: "00" } }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &gcp:name1_masterkey
+          provider: "gcp:name1"
+          projectId: devprod-drivers
+          location: global
+          keyRing: key-ring-csfle
+          keyName: key-name-csfle
+      - _id: &kmip:name1_key_id { $binary: { base64: a21pcGttaXBrbWlwa21pcA==, subType: "04" } }
+        keyAltNames: ["kmip:name1_key"]
+        keyMaterial: { $binary: { base64: CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==, subType: "00" } }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &kmip:name1_masterkey
+          provider: "kmip:name1"
+          keyId: "1"
+      - _id: &local:name1_key_id { $binary: { base64: bG9jYWxrZXlsb2NhbGtleQ==, subType: "04" } }
+        keyAltNames: ["local:name1_key"]
+        keyMaterial: { $binary: { base64: ABKBldDEoDW323yejOnIRk6YQmlD9d3eQthd16scKL75nz2LjNL9fgPDZWrFFOlqlhMCFaSrNJfGrFUjYk5JFDO7soG5Syb50k1niJoKg4ilsj0L4mpimFUtTpOr2nzZOeQtvAksEXc7gsFgq8gV7t/U3lsaXPY7I0t42DfSE8EGlPdxRjFdHnxh+OR8h7U9b8Qs5K5UuhgyeyxaBZ1Hgw==, subType: "00" } }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &local:name1_masterkey
+          provider: "local:name1"
+
+tests:
+  - description: "rewrap to aws:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: "aws:name1_key" } }
+          opts:
+            provider: "aws:name1"
+            # Different key: 89fcc2c4-08b0-4bd9-9f25-e30687b580d0 -> 061334ae-07a8-4ceb-a813-8135540e837d.
+            masterKey: &new_aws_masterkey
+              key: "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d"
+              region: us-east-1
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: "aws:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "aws:name1", <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "aws:name1", <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "aws:name1", <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "aws:name1", <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap to azure:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: azure:name1_key } }
+          opts:
+            provider: "azure:name1"
+            masterKey: &new_azure_masterkey
+              keyVaultEndpoint: key-vault-csfle.vault.azure.net
+              keyName: key-name-csfle
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: azure:name1_key } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "azure:name1", <<: *new_azure_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "azure:name1", <<: *new_azure_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "azure:name1", <<: *new_azure_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "azure:name1", <<: *new_azure_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap to gcp:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: gcp:name1_key } }
+          opts:
+            provider: "gcp:name1"
+            masterKey: &new_gcp_masterkey
+              projectId: devprod-drivers
+              location: global
+              keyRing: key-ring-csfle
+              keyName: key-name-csfle
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: "gcp:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "gcp:name1", <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "gcp:name1", <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "gcp:name1", <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "gcp:name1", <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap to kmip:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: "kmip:name1_key" } }
+          opts:
+            provider: "kmip:name1"
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: "kmip:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "kmip:name1", keyId: { $$type: string } }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "kmip:name1", keyId: { $$type: string } }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "kmip:name1", keyId: { $$type: string } }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "kmip:name1", keyId: { $$type: string } }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap to local:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: "local:name1_key" } }
+          opts:
+            provider: "local:name1"
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: "local:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "local:name1" }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "local:name1" }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "local:name1" }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "local:name1" }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap from local:name1 to local:name2"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $eq: "local:name1_key" } }
+          opts:
+            provider: "local:name2"
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 1
+            modifiedCount: 1
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $eq: "local:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "local:name2" }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap from aws:name1 to aws:name2"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $eq: "aws:name1_key" } }
+          opts:
+            provider: "aws:name2"
+            masterKey: &new_awsname2_masterkey
+              # aws:name1 account does not have permissions to access this key.
+              key: "arn:aws:kms:us-east-1:857654397073:key/0f8468f0-f135-4226-aa0b-bd05c4c30df5"
+              region: us-east-1
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 1
+            modifiedCount: 1
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $eq: "aws:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u: { $set: { masterKey: { provider: "aws:name2", <<: *new_awsname2_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }

--- a/tests/MongoDB.Driver.Tests/Specifications/UnifiedTestSpecRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/UnifiedTestSpecRunner.cs
@@ -63,8 +63,8 @@ namespace MongoDB.Driver.Tests.Specifications
             RequirePlatform
                 .Check()
                 // rewrap tests calls gcp kms that is supported starting from netstandard2.1
-                .SkipWhen(() => exclusionKeywords.Any(keyword => testCaseNameLower.Contains(keyword)), SupportedOperatingSystem.Linux, SupportedTargetFramework.NetStandard20) // gcp is supported starting from netstandard2.1
-                .SkipWhen(() => exclusionKeywords.Any(keyword => testCaseNameLower.Contains(keyword)), SupportedOperatingSystem.MacOS, SupportedTargetFramework.NetStandard20); // gcp is supported starting from netstandard2.1
+                .SkipWhen(() => exclusionKeywords.Any(testCaseNameLower.Contains), SupportedOperatingSystem.Linux, SupportedTargetFramework.NetStandard20) // gcp is supported starting from netstandard2.1
+                .SkipWhen(() => exclusionKeywords.Any(testCaseNameLower.Contains), SupportedOperatingSystem.MacOS, SupportedTargetFramework.NetStandard20); // gcp is supported starting from netstandard2.1
 
             Run(testCase);
         }

--- a/tests/MongoDB.Driver.Tests/Specifications/UnifiedTestSpecRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/UnifiedTestSpecRunner.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.Events;
@@ -58,11 +59,12 @@ namespace MongoDB.Driver.Tests.Specifications
                 RequireKmsMock();
             }
 
+            var exclusionKeywords = new[] { "gcp", "rewrap with", "rewrap to" };
             RequirePlatform
                 .Check()
                 // rewrap tests calls gcp kms that is supported starting from netstandard2.1
-                .SkipWhen(() => testCaseNameLower.Contains("gcp") || testCaseNameLower.Contains("rewrap with"), SupportedOperatingSystem.Linux, SupportedTargetFramework.NetStandard20) // gcp is supported starting from netstandard2.1
-                .SkipWhen(() => testCaseNameLower.Contains("gcp") || testCaseNameLower.Contains("rewrap with"), SupportedOperatingSystem.MacOS, SupportedTargetFramework.NetStandard20); // gcp is supported starting from netstandard2.1
+                .SkipWhen(() => exclusionKeywords.Any(keyword => testCaseNameLower.Contains(keyword)), SupportedOperatingSystem.Linux, SupportedTargetFramework.NetStandard20) // gcp is supported starting from netstandard2.1
+                .SkipWhen(() => exclusionKeywords.Any(keyword => testCaseNameLower.Contains(keyword)), SupportedOperatingSystem.MacOS, SupportedTargetFramework.NetStandard20); // gcp is supported starting from netstandard2.1
 
             Run(testCase);
         }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/ClientSideEncryptionTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/ClientSideEncryptionTestRunner.cs
@@ -250,7 +250,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
                     case "kmsProviders":
                         kmsProviders = EncryptionTestHelper.ParseKmsProviders(option.Value.AsBsonDocument, legacy: true);
                         autoEncryptionOptions = autoEncryptionOptions.With(kmsProviders: Optional.Create(kmsProviders));
-                        var tlsSettings = EncryptionTestHelper.CreateTlsOptionsIfAllowed(kmsProviders, allowClientCertificateFunc: (kms) => kms == "kmip");
+                        var tlsSettings = EncryptionTestHelper.CreateTlsOptionsIfAllowed(kmsProviders, allowClientCertificateFunc: (kms) => kms.StartsWith("kmip"));
                         if (tlsSettings != null)
                         {
                             autoEncryptionOptions = autoEncryptionOptions.With(tlsOptions: tlsSettings);

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -1776,6 +1776,27 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
         [Trait("Category", "CsfleAZUREKMS")]
         [Trait("Category", "CsfleGCPKMS")]
+        [Fact]
+        public void OnDemandCredentialsTestWithNamed()
+        {
+            // This test specifically verifies part of the CSFLE specification that
+            // KMS providers that include a name do not support automatic credentials.
+            
+            RequireServer.Check().Supports(Feature.ClientSideEncryption);
+
+            var kmsProvider = "aws:name1";
+
+            var exception = Record.Exception(() =>
+            {
+                using var client = ConfigureClient();
+                using var clientEncryption = ConfigureClientEncryption(client, kmsDocument: new BsonDocument(kmsProvider, new BsonDocument()));
+            });
+
+            exception?.Message.Should().Contain("On-demand credentials are not supported for named KMS providers");
+        }
+
+        [Trait("Category", "CsfleAZUREKMS")]
+        [Trait("Category", "CsfleGCPKMS")]
         [Theory]
         [ParameterAttributeData]
         public void OnDemandCredentialsTest(

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -1446,8 +1446,8 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             RequireServer.Check().Supports(Feature.ClientSideEncryption);
             RequirePlatform
                 .Check()
-                .SkipWhen(() => kmsProvider == "gcp", SupportedOperatingSystem.Linux, SupportedTargetFramework.NetStandard20)  // gcp is supported starting from netstandard2.1
-                .SkipWhen(() => kmsProvider == "gcp", SupportedOperatingSystem.MacOS, SupportedTargetFramework.NetStandard20);
+                .SkipWhen(() => kmsProvider.StartsWith("gcp"), SupportedOperatingSystem.Linux, SupportedTargetFramework.NetStandard20)  // gcp is supported starting from netstandard2.1
+                .SkipWhen(() => kmsProvider.StartsWith("gcp"), SupportedOperatingSystem.MacOS, SupportedTargetFramework.NetStandard20);
             RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
 
             bool? isCertificateExpired = null, isInvalidHost = null; // will be assigned inside TestRelatedClientEncryptionOptionsConfigurator
@@ -2615,7 +2615,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             var tlsOptions = EncryptionTestHelper.CreateTlsOptionsIfAllowed(
                 kmsProviders,
                 // only kmip currently requires tls configuration for ClientEncrypted
-                allowClientCertificateFunc: kmsProviderName => kmsProviderName == "kmip");
+                allowClientCertificateFunc: kmsProviderName => kmsProviderName.StartsWith("kmip"));
 
             var clientEncryptedSettings =
                 CreateMongoClientSettings(
@@ -2672,7 +2672,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                         k => (IReadOnlyDictionary<string, object>)k.Value.AsBsonDocument.ToDictionary(ki => ki.Name, ki => (object)ki.Value));
             }
 
-            allowClientCertificateFunc = allowClientCertificateFunc ?? ((kmsProviderName) => kmsProviderName == "kmip"); // configure Tls for kmip by default
+            allowClientCertificateFunc = allowClientCertificateFunc ?? ((kmsProviderName) => kmsProviderName.StartsWith("kmip")); // configure Tls for kmip by default
             var tlsOptions = EncryptionTestHelper.CreateTlsOptionsIfAllowed(kmsProviders, allowClientCertificateFunc);
 
             var clientEncryptionOptions = new ClientEncryptionOptions(

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -1439,7 +1439,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
         [Theory]
         [ParameterAttributeData]
         public void KmsTlsOptionsTest(
-            [Values("aws", "azure", "gcp", "kmip")] string kmsProvider,
+            [Values("aws", "aws:name1", "azure", "azure:name1", "gcp", "gcp:name1", "kmip", "kmip:name1")] string kmsProvider,
             [Values(CertificateType.TlsWithoutClientCert, CertificateType.TlsWithClientCert, CertificateType.Expired, CertificateType.InvalidHostName)] CertificateType certificateType,
             [Values(false, true)] bool async)
         {
@@ -1464,25 +1464,25 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                     kmsProvider: kmsProvider,
                     customMasterKey: kmsProvider switch
                     {
-                        "aws" => new BsonDocument
+                        "aws" or "aws:name1" => new BsonDocument
                         {
                             { "region", "us-east-1" },
                             { "key", "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0" },
                             { "endpoint", GetMockedKmsEndpoint() }
                         },
-                        "azure" => new BsonDocument
+                        "azure" or "azure:name1" => new BsonDocument
                         {
                             { "keyVaultEndpoint", "doesnotexist.local" },
                             { "keyName", "foo" }
                         },
-                        "gcp" => new BsonDocument
+                        "gcp" or "gcp:name1" => new BsonDocument
                         {
                             { "projectId", "foo" },
                             { "location", "bar" },
                             { "keyRing", "baz" },
                             { "keyName", "foo" }
                         },
-                        "kmip" => new BsonDocument(), // empty doc
+                        "kmip" or "kmip:name1" => new BsonDocument(), // empty doc
                         _ => throw new Exception($"Unexpected kmsProvider {kmsProvider}."),
                     });
 
@@ -1501,7 +1501,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 var currentOperatingSystem = OperatingSystemHelper.CurrentOperatingSystem;
                 switch (kmsProvider)
                 {
-                    case "aws":
+                    case "aws" or "aws:name1":
                         {
                             switch (certificateType)
                             {
@@ -1542,7 +1542,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                             }
                         }
                         break;
-                    case "azure":
+                    case "azure" or "azure:name1":
                         switch (certificateType)
                         {
                             case CertificateType.TlsWithoutClientCert:
@@ -1580,7 +1580,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                             default: throw new Exception($"Unexpected certificate type {certificateType} for {kmsProvider}.");
                         }
                         break;
-                    case "gcp":
+                    case "gcp" or "gcp:name1":
                         switch (certificateType)
                         {
                             case CertificateType.TlsWithoutClientCert:
@@ -1618,7 +1618,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                             default: throw new Exception($"Unexpected certificate type {certificateType} for {kmsProvider}.");
                         }
                         break;
-                    case "kmip":
+                    case "kmip" or "kmip:name1":
                         switch (certificateType)
                         {
                             case CertificateType.TlsWithoutClientCert:
@@ -1718,19 +1718,19 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
                 switch (kmsProviderName)
                 {
-                    case "local":
+                    case "local" or "local:name1" or "local:name2":
                         // not related to this test, do nothing
                         break;
-                    case "aws":
+                    case "aws" or "aws:name1" or "aws:name2":
                         // do nothing since aws cannot configure endpoint on kms provider level
                         break;
-                    case "azure":
+                    case "azure" or "azure:name1":
                         kmsOptions.Add("identityPlatformEndpoint", endpoint);
                         break;
-                    case "gcp":
+                    case "gcp" or "gcp:name1":
                         kmsOptions.Add("endpoint", endpoint);
                         break;
-                    case "kmip":
+                    case "kmip" or "kmip:name1":
                         AddOrReplace(kmsOptions, "endpoint", endpoint);
                         break;
                     default:
@@ -1742,7 +1742,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             {
                 CertificateType.Expired => "127.0.0.1:8000",
                 CertificateType.InvalidHostName => "127.0.0.1:8001",
-                CertificateType.TlsWithClientCert or CertificateType.TlsWithoutClientCert => kmsProvider != "kmip" ? "127.0.0.1:8002" : "127.0.0.1:5698",
+                CertificateType.TlsWithClientCert or CertificateType.TlsWithoutClientCert => !kmsProvider.StartsWith("kmip") ? "127.0.0.1:8002" : "127.0.0.1:5698",
                 _ => throw new Exception($"Not supported client certificate type {certificateType}."),
             };
 

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDecryptOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDecryptOperation.cs
@@ -22,10 +22,11 @@ using MongoDB.Driver.Encryption;
 
 namespace MongoDB.Driver.Tests.UnifiedTestOperations
 {
-    public class UnifiedDecryptOperation : IUnifiedEntityTestOperation
+    public sealed class UnifiedDecryptOperation : IUnifiedEntityTestOperation
     {
         private readonly ClientEncryption _clientEncryption;
         private readonly BsonBinaryData _value;
+        
         public UnifiedDecryptOperation(ClientEncryption clientEncryption, BsonBinaryData value)
         {
             _clientEncryption = Ensure.IsNotNull(clientEncryption, nameof(clientEncryption));
@@ -61,7 +62,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         }
     }
 
-    public class UnifiedDecryptOperationBuilder
+    public sealed class UnifiedDecryptOperationBuilder
     {
         private readonly UnifiedEntityMap _entityMap;
 

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDecryptOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedDecryptOperation.cs
@@ -1,0 +1,93 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Encryption;
+
+namespace MongoDB.Driver.Tests.UnifiedTestOperations
+{
+    public class UnifiedDecryptOperation : IUnifiedEntityTestOperation
+    {
+        private readonly ClientEncryption _clientEncryption;
+        private readonly BsonBinaryData _value;
+        public UnifiedDecryptOperation(ClientEncryption clientEncryption, BsonBinaryData value)
+        {
+            _clientEncryption = Ensure.IsNotNull(clientEncryption, nameof(clientEncryption));
+            _value = value;
+        }
+
+        public OperationResult Execute(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = _clientEncryption.Decrypt(_value, cancellationToken);
+
+                return OperationResult.FromResult(result);
+            }
+            catch (Exception exception)
+            {
+                return OperationResult.FromException(exception);
+            }
+        }
+
+        public async Task<OperationResult> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = await _clientEncryption.DecryptAsync(_value, cancellationToken);
+
+                return OperationResult.FromResult(result);
+            }
+            catch (Exception exception)
+            {
+                return OperationResult.FromException(exception);
+            }
+        }
+    }
+
+    public class UnifiedDecryptOperationBuilder
+    {
+        private readonly UnifiedEntityMap _entityMap;
+
+        public UnifiedDecryptOperationBuilder(UnifiedEntityMap entityMap)
+        {
+            _entityMap = entityMap;
+        }
+
+        public UnifiedDecryptOperation Build(string targetSessionId, BsonDocument arguments)
+        {
+            var clientEncryption = _entityMap.ClientEncryptions[targetSessionId];
+            BsonBinaryData value = null;
+
+            foreach (var argument in arguments)
+            {
+                switch (argument.Name)
+                {
+                    case "value":
+                        value = argument.Value.AsBsonBinaryData;
+                        break;
+                    default:
+                        throw new FormatException($"Invalid {nameof(UnifiedDecryptOperation)} argument name: '{argument.Name}'.");
+                }
+            }
+            
+            return new UnifiedDecryptOperation(clientEncryption, value);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEncryptOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEncryptOperation.cs
@@ -1,0 +1,110 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Encryption;
+
+namespace MongoDB.Driver.Tests.UnifiedTestOperations
+{
+    public class UnifiedEncryptOperation : IUnifiedEntityTestOperation
+    {
+        private readonly ClientEncryption _clientEncryption;
+        private readonly BsonValue _value;
+        private readonly EncryptOptions _options;
+
+        public UnifiedEncryptOperation(ClientEncryption clientEncryption, BsonValue value, EncryptOptions options)
+        {
+            _clientEncryption = Ensure.IsNotNull(clientEncryption, nameof(clientEncryption));
+            _value = value;
+            _options = options;
+        }
+
+        public OperationResult Execute(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = _clientEncryption.Encrypt(_value, _options, cancellationToken);
+
+                return OperationResult.FromResult(result);
+            }
+            catch (Exception exception)
+            {
+                return OperationResult.FromException(exception);
+            }
+        }
+
+        public async Task<OperationResult> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = await _clientEncryption.EncryptAsync(_value, _options, cancellationToken);
+
+                return OperationResult.FromResult(result);
+            }
+            catch (Exception exception)
+            {
+                return OperationResult.FromException(exception);
+            }
+        }
+    }
+
+    public class UnifiedEncryptOperationBuilder
+    {
+        private readonly UnifiedEntityMap _entityMap;
+
+        public UnifiedEncryptOperationBuilder(UnifiedEntityMap entityMap)
+        {
+            _entityMap = entityMap;
+        }
+
+        public UnifiedEncryptOperation Build(string targetSessionId, BsonDocument arguments)
+        {
+            var clientEncryption = _entityMap.ClientEncryptions[targetSessionId];
+
+            BsonValue value = null;
+            string keyAltName = null;
+            string algorithm = null;
+
+            foreach (var argument in arguments)
+            {
+                switch (argument.Name)
+                {
+                    case "value":
+                        value = argument.Value;
+                        break;
+                    case "opts":
+                        foreach (var option in argument.Value.AsBsonDocument)
+                        {
+                            switch (option.Name)
+                            {
+                                case "keyAltName": keyAltName = option.Value.AsString; break;
+                                case "algorithm": algorithm = option.Value.AsString; break;
+                                default: throw new FormatException($"Invalid {nameof(EncryptOptions)} option argument name: '{option.Name}'.");
+                            }
+                        }
+                        break;
+                    default:
+                        throw new FormatException($"Invalid {nameof(UnifiedEncryptOperation)} argument name: '{argument.Name}'.");
+                }
+            }
+            
+            return new UnifiedEncryptOperation(clientEncryption, value, new EncryptOptions(algorithm, keyAltName));
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEncryptOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEncryptOperation.cs
@@ -22,7 +22,7 @@ using MongoDB.Driver.Encryption;
 
 namespace MongoDB.Driver.Tests.UnifiedTestOperations
 {
-    public class UnifiedEncryptOperation : IUnifiedEntityTestOperation
+    public sealed class UnifiedEncryptOperation : IUnifiedEntityTestOperation
     {
         private readonly ClientEncryption _clientEncryption;
         private readonly BsonValue _value;
@@ -64,7 +64,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         }
     }
 
-    public class UnifiedEncryptOperationBuilder
+    public sealed class UnifiedEncryptOperationBuilder
     {
         private readonly UnifiedEntityMap _entityMap;
 

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedEntityMap.cs
@@ -818,7 +818,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                                 }
                             }
 
-                            var tlsOptions = EncryptionTestHelper.CreateTlsOptionsIfAllowed(kmsProviders, ((kmsProviderName) => kmsProviderName == "kmip")); // configure Tls for kmip by default
+                            var tlsOptions = EncryptionTestHelper.CreateTlsOptionsIfAllowed(kmsProviders, ((kmsProviderName) => kmsProviderName.StartsWith("kmip"))); // configure Tls for kmip by default
                             options = new ClientEncryptionOptions(
                                 Ensure.IsNotNull(keyVaultClient, nameof(keyVaultClient)),
                                 Ensure.IsNotNull(keyVaultCollectionNamespace, nameof(keyVaultCollectionNamespace)),

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestOperationFactory.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestOperationFactory.cs
@@ -137,6 +137,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 {
                     "createDataKey" => new UnifiedCreateDataKeyOperationBuilder(_entityMap).Build(targetEntityId, operationArguments),
                     "rewrapManyDataKey" => new UnifiedRewrapManyDataKeyOperationBuilder(_entityMap).Build(targetEntityId, operationArguments),
+                    "encrypt" => new UnifiedEncryptOperationBuilder(_entityMap).Build(targetEntityId, operationArguments),
+                    "decrypt" => new UnifiedDecryptOperationBuilder(_entityMap).Build(targetEntityId, operationArguments),
                     "addKeyAltName" => new UnifiedAddKeyAltNameOperationBuilder(_entityMap).Build(targetEntityId, operationArguments),
                     "deleteKey" => new UnifiedDeleteKeyOperationBuilder(_entityMap).Build(targetEntityId, operationArguments),
                     "getKey" => new UnifiedGetKeyOperationBuilder(_entityMap).Build(targetEntityId, operationArguments),


### PR DESCRIPTION
## Summary
This PR implements the changes described in the "Downstream Changes Summary" of [DRIVERS-2731](https://jira.mongodb.org/browse/DRIVERS-2731).

- Sync to new unified tests
- Implement required spec tests.
- Pass new AWS credentials to test a rewrapManyDataKey with two different AWS accounts using Evergreen expansions: FLE_AWS_NAMED2_ACCESS_KEY_ID and FLE_AWS_NAMED2_SECRET_ACCESS_KEY, configured in the Evergreen Variables page.

NOTE: No changes to the CSFLE API are necessary. All relevant logic is encapsulated within libmongocrypt.

## Background
Named KMS providers is further described in [DBX Scope: Support Named KMS Providers](https://docs.google.com/document/d/1IUxkgGFx5VLjMr7HWxBOXerN0pUZwcqWb11gLoRtcJs/edit?usp=sharing).

The KMS provider identified by a string. Previously supported KMS providers were only: "aws", "azure", "gcp", "kmip", and "local". The KMS provider is now expanded to support name suffixes. (e.g. "local:myname").

Named KMS providers enables more than one of each KMS provider type to be configured.

```
kms_providers = {
    "local": {"key": local_kek1},        # Unnamed KMS provider.
    "local:myname": {"key": local_kek2 } # Named KMS provider with name "myname".
}
```