### PR TITLE
CSHARP-5252: Fix possible null reference

### DIFF
--- a/src/MongoDB.Driver/Core/Clusters/DnsMonitor.cs
+++ b/src/MongoDB.Driver/Core/Clusters/DnsMonitor.cs
@@ -115,7 +115,7 @@ namespace MongoDB.Driver.Core.Clusters
         {
             var delay = TimeSpan.FromSeconds(60);
 
-            if (srvRecords.Count > 0)
+            if (srvRecords?.Count > 0)
             {
                 var minTimeToLive = srvRecords.Select(s => s.TimeToLive).Min();
                 if (minTimeToLive > delay)


### PR DESCRIPTION
When calling ComputeRescanDelay, there is a possibility that srvRecords is null so we should conditionally access it here.