### PR TITLE
CSHARP-5261: Add DateOnly support

### DIFF
--- a/src/MongoDB.Bson/Serialization/PrimitiveSerializationProvider.cs
+++ b/src/MongoDB.Bson/Serialization/PrimitiveSerializationProvider.cs
@@ -40,6 +40,9 @@ namespace MongoDB.Bson.Serialization
                 { typeof(Char), typeof(CharSerializer) },
                 { typeof(CultureInfo), typeof(CultureInfoSerializer) },
                 { typeof(DateTime), typeof(DateTimeSerializer) },
+#if NET6_0_OR_GREATER
+                { typeof(DateOnly), typeof(DateOnlySerializer) },
+#endif
                 { typeof(DateTimeOffset), typeof(DateTimeOffsetSerializer) },
                 { typeof(Decimal), typeof(DecimalSerializer) },
                 { typeof(Decimal128), typeof(Decimal128Serializer) },

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -15,6 +15,7 @@
 
 using System;
 using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization.Options;
 
 namespace MongoDB.Bson.Serialization.Serializers
 {
@@ -42,6 +43,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         // private fields
         private readonly BsonType _representation;
         private readonly SerializerHelper _helper;
+        private readonly RepresentationConverter _converter;
 
         // constructors
         /// <summary>
@@ -71,6 +73,7 @@ namespace MongoDB.Bson.Serialization.Serializers
             }
 
             _representation = representation;
+            _converter = new RepresentationConverter(false, false);
 
             _helper = new SerializerHelper
             (
@@ -113,10 +116,19 @@ namespace MongoDB.Bson.Serialization.Serializers
                     break;
 
                 case BsonType.Decimal128:
+                    value = VerifyAndMakeDateOnly(new DateTime(_converter.ToInt64(bsonReader.ReadDecimal128()), DateTimeKind.Utc));
+                    break;
+
                 case BsonType.Double:
+                    value = VerifyAndMakeDateOnly(new DateTime(_converter.ToInt64(bsonReader.ReadDouble()), DateTimeKind.Utc));
+                    break;
+
                 case BsonType.Int32:
+                    value = VerifyAndMakeDateOnly(new DateTime(bsonReader.ReadInt32(), DateTimeKind.Utc));
+                    break;
+
                 case BsonType.Int64:
-                    value = VerifyAndMakeDateOnly(new DateTime(Int64Serializer.Instance.Deserialize(context), DateTimeKind.Utc));
+                    value = VerifyAndMakeDateOnly(new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc));
                     break;
 
                 case BsonType.String:

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -23,7 +23,7 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// <summary>
     /// Represents a serializer for DateOnlys.
     /// </summary>
-    public class DateOnlySerializer : StructSerializerBase<DateOnly>, IRepresentationConfigurable<DateOnlySerializer>
+    public sealed class DateOnlySerializer : StructSerializerBase<DateOnly>, IRepresentationConfigurable<DateOnlySerializer>
     {
         // static
         private static readonly DateOnlySerializer __instance = new DateOnlySerializer();
@@ -41,9 +41,9 @@ namespace MongoDB.Bson.Serialization.Serializers
         }
 
         // private fields
-        private readonly BsonType _representation;
-        private readonly SerializerHelper _helper;
         private readonly RepresentationConverter _converter;
+        private readonly SerializerHelper _helper;
+        private readonly BsonType _representation;
 
         // constructors
         /// <summary>

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -1,0 +1,170 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using MongoDB.Bson.IO;
+
+namespace MongoDB.Bson.Serialization.Serializers
+{
+    #if NET6_0_OR_GREATER
+    /// <summary>
+    /// Represents a serializer for DateOnlys.
+    /// </summary>
+    public class DateOnlySerializer : StructSerializerBase<DateOnly>, IRepresentationConfigurable<DateOnlySerializer>
+    {
+        #region static
+        private static readonly DateOnlySerializer __instance = new DateOnlySerializer();
+
+        /// <summary>
+        /// Gets the default DateOnlySerializer.
+        /// </summary>
+        public static DateOnlySerializer Instance => __instance;
+        #endregion
+
+        private static class Flags
+        {
+            public const long DateTime = 1;
+            public const long Ticks = 2;
+        }
+
+        private readonly SerializerHelper _helper;
+
+        /// <inheritdoc />
+        public BsonType Representation { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateOnlySerializer"/> class.
+        /// </summary>
+        public DateOnlySerializer()
+            : this(BsonType.DateTime)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateOnlySerializer"/> class.
+        /// </summary>
+        /// <param name="representation">The representation.</param>
+        public DateOnlySerializer(BsonType representation)
+        {
+            switch (representation)
+            {
+                case BsonType.DateTime:
+                case BsonType.Document:
+                case BsonType.Int64:
+                case BsonType.String:
+                    break;
+
+                default:
+                    throw new ArgumentException($"{representation} is not a valid representation for a DateOnlySerializer.");
+            }
+
+            Representation = representation;
+
+            _helper = new SerializerHelper
+            (
+                new SerializerHelper.Member("DateTime", Flags.DateTime),
+                new SerializerHelper.Member("Ticks", Flags.Ticks)
+            );
+        }
+
+        /// <inheritdoc />
+        public override DateOnly Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            var bsonReader = context.Reader;
+            DateOnly value;
+
+            var bsonType = bsonReader.GetCurrentBsonType();
+
+            switch (bsonType)
+            {
+                case BsonType.DateTime:
+                    value = DateOnly.FromDateTime(new DateTime(bsonReader.ReadDateTime(), DateTimeKind.Utc));
+                    break;
+
+                case BsonType.Document:
+                    value = default;
+                    _helper.DeserializeMembers(context, (_, flag) =>
+                    {
+                        switch (flag)
+                        {
+                            case Flags.DateTime: bsonReader.SkipValue(); break; // ignore value (use Ticks instead)
+                            case Flags.Ticks: value = DateOnly.FromDateTime(new DateTime(Int64Serializer.Instance.Deserialize(context), DateTimeKind.Utc)); break;
+                        }
+                    });
+                    break;
+
+                case BsonType.Int64:
+                    value = DateOnly.FromDateTime(new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc));
+                    break;
+
+                case BsonType.String:
+                    value = DateOnly.ParseExact(bsonReader.ReadString(), "yyyy-MM-dd");
+                    break;
+
+                default:
+                    throw CreateCannotDeserializeFromBsonTypeException(bsonType);
+            }
+
+            return value;
+        }
+
+        /// <inheritdoc />
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, DateOnly value)
+        {
+            var bsonWriter = context.Writer;
+
+            var utcDateTime = value.ToDateTime(new TimeOnly(0), DateTimeKind.Utc);
+            var millisecondsSinceEpoch = BsonUtils.ToMillisecondsSinceEpoch(utcDateTime);
+
+            switch (Representation)
+            {
+                case BsonType.DateTime:
+                    bsonWriter.WriteDateTime(millisecondsSinceEpoch);
+                    break;
+
+                case BsonType.Document:
+                    bsonWriter.WriteStartDocument();
+                    bsonWriter.WriteDateTime("DateTime", millisecondsSinceEpoch);
+                    bsonWriter.WriteInt64("Ticks", utcDateTime.Ticks);
+                    bsonWriter.WriteEndDocument();
+                    break;
+
+                case BsonType.Int64:
+                    bsonWriter.WriteInt64(utcDateTime.Ticks);
+                    break;
+
+                case BsonType.String:
+                    bsonWriter.WriteString(value.ToString("yyyy-MM-dd"));
+                    break;
+
+                default:
+                    throw new BsonSerializationException($"'{Representation}' is not a valid DateTime representation.");
+            }
+        }
+
+        /// <inheritdoc />
+        public DateOnlySerializer WithRepresentation(BsonType representation)
+        {
+            return representation == Representation ? this : new DateOnlySerializer(representation);
+        }
+
+        IBsonSerializer IRepresentationConfigurable.WithRepresentation(BsonType representation)
+        {
+            return WithRepresentation(representation);
+        }
+    }
+    #endif
+}
+

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -94,9 +94,7 @@ namespace MongoDB.Bson.Serialization.Serializers
             switch (bsonType)
             {
                 case BsonType.DateTime:
-                    var dt = BsonUtils.ToDateTimeFromMillisecondsSinceEpoch(bsonReader.ReadDateTime());
-                    VerifyTimeOfDayIsZero(dt);
-                    value = DateOnly.FromDateTime(dt);
+                    value = VerifyTimeOfDayIsZero(BsonUtils.ToDateTimeFromMillisecondsSinceEpoch(bsonReader.ReadDateTime()));
                     break;
 
                 case BsonType.Document:
@@ -107,17 +105,14 @@ namespace MongoDB.Bson.Serialization.Serializers
                         {
                             case Flags.DateTime: bsonReader.SkipValue(); break; // ignore value (use Ticks instead)
                             case Flags.Ticks:
-                                var dtd = new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc);
-                                VerifyTimeOfDayIsZero(dtd);
-                                value = DateOnly.FromDateTime(dtd); break;
+                                value = VerifyTimeOfDayIsZero(new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc));
+                                break;
                         }
                     });
                     break;
 
                 case BsonType.Int64:
-                    var dti = new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc);
-                    VerifyTimeOfDayIsZero(dti);
-                    value = DateOnly.FromDateTime(dti);
+                    value = VerifyTimeOfDayIsZero(new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc));
                     break;
 
                 case BsonType.String:
@@ -130,12 +125,14 @@ namespace MongoDB.Bson.Serialization.Serializers
 
             return value;
 
-            void VerifyTimeOfDayIsZero(DateTime dt)
+            DateOnly VerifyTimeOfDayIsZero(DateTime dt)
             {
                 if (dt.TimeOfDay != TimeSpan.Zero)
                 {
                     throw new FormatException("TimeOfDay component for DateOnly value is not zero.");
                 }
+
+                return DateOnly.FromDateTime(dt);
             }
         }
 

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -24,14 +24,13 @@ namespace MongoDB.Bson.Serialization.Serializers
     /// </summary>
     public class DateOnlySerializer : StructSerializerBase<DateOnly>, IRepresentationConfigurable<DateOnlySerializer>
     {
-        #region static
+        // static
         private static readonly DateOnlySerializer __instance = new DateOnlySerializer();
 
         /// <summary>
         /// Gets the default DateOnlySerializer.
         /// </summary>
         public static DateOnlySerializer Instance => __instance;
-        #endregion
 
         // private constants
         private static class Flags

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -18,7 +18,7 @@ using MongoDB.Bson.IO;
 
 namespace MongoDB.Bson.Serialization.Serializers
 {
-    #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
     /// <summary>
     /// Represents a serializer for DateOnlys.
     /// </summary>
@@ -200,6 +200,6 @@ namespace MongoDB.Bson.Serialization.Serializers
             return WithRepresentation(representation);
         }
     }
-    #endif
+#endif
 }
 

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -129,7 +129,7 @@ namespace MongoDB.Bson.Serialization.Serializers
             {
                 if (dt.TimeOfDay != TimeSpan.Zero)
                 {
-                    throw new FormatException("TimeOfDay component for DateOnly value is not zero.");
+                    throw new FormatException("Deserialized value has a non-zero time component.");
                 }
 
                 return DateOnly.FromDateTime(dt);

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -142,10 +142,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(obj, null)) { return false; }
-            if (ReferenceEquals(this, obj)) { return true; }
-            return
-                base.Equals(obj) &&
+            return base.Equals(obj) &&
                 obj is DateOnlySerializer other &&
                 Representation.Equals(other.Representation);
         }

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -94,7 +94,7 @@ namespace MongoDB.Bson.Serialization.Serializers
             switch (bsonType)
             {
                 case BsonType.DateTime:
-                    value = VerifyTimeOfDayIsZero(BsonUtils.ToDateTimeFromMillisecondsSinceEpoch(bsonReader.ReadDateTime()));
+                    value = VerifyAndMakeDateOnly(BsonUtils.ToDateTimeFromMillisecondsSinceEpoch(bsonReader.ReadDateTime()));
                     break;
 
                 case BsonType.Document:
@@ -105,14 +105,14 @@ namespace MongoDB.Bson.Serialization.Serializers
                         {
                             case Flags.DateTime: bsonReader.SkipValue(); break; // ignore value (use Ticks instead)
                             case Flags.Ticks:
-                                value = VerifyTimeOfDayIsZero(new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc));
+                                value = VerifyAndMakeDateOnly(new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc));
                                 break;
                         }
                     });
                     break;
 
                 case BsonType.Int64:
-                    value = VerifyTimeOfDayIsZero(new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc));
+                    value = VerifyAndMakeDateOnly(new DateTime(bsonReader.ReadInt64(), DateTimeKind.Utc));
                     break;
 
                 case BsonType.String:
@@ -125,7 +125,7 @@ namespace MongoDB.Bson.Serialization.Serializers
 
             return value;
 
-            DateOnly VerifyTimeOfDayIsZero(DateTime dt)
+            DateOnly VerifyAndMakeDateOnly(DateTime dt)
             {
                 if (dt.TimeOfDay != TimeSpan.Zero)
                 {

--- a/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateOnlySerializer.cs
@@ -33,17 +33,17 @@ namespace MongoDB.Bson.Serialization.Serializers
         public static DateOnlySerializer Instance => __instance;
         #endregion
 
+        // private constants
         private static class Flags
         {
             public const long DateTime = 1;
             public const long Ticks = 2;
         }
 
+        // private fields
         private readonly SerializerHelper _helper;
 
-        /// <inheritdoc />
-        public BsonType Representation { get; }
-
+        // constructors
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlySerializer"/> class.
         /// </summary>
@@ -79,6 +79,11 @@ namespace MongoDB.Bson.Serialization.Serializers
             );
         }
 
+        // public properties
+        /// <inheritdoc />
+        public BsonType Representation { get; }
+
+        //public methods
         /// <inheritdoc />
         public override DateOnly Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
         {
@@ -160,6 +165,7 @@ namespace MongoDB.Bson.Serialization.Serializers
             return representation == Representation ? this : new DateOnlySerializer(representation);
         }
 
+        // explicit interface implementations
         IBsonSerializer IRepresentationConfigurable.WithRepresentation(BsonType representation)
         {
             return WithRepresentation(representation);

--- a/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
@@ -213,6 +213,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                     {
                         switch (flag)
                         {
+                            //TODO Why for ticks we use Int64Serializer instead of bsonReader.ReadInt64 like we do some lines after?
                             case Flags.DateTime: bsonReader.SkipValue(); break; // ignore value (use Ticks instead)
                             case Flags.Ticks: value = new DateTime(Int64Serializer.Instance.Deserialize(context), DateTimeKind.Utc); break;
                         }

--- a/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
@@ -208,7 +208,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                     break;
 
                 case BsonType.Document:
-                    value = default(DateTime);
+                    value = default;
                     _helper.DeserializeMembers(context, (elementName, flag) =>
                     {
                         switch (flag)

--- a/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
@@ -213,7 +213,6 @@ namespace MongoDB.Bson.Serialization.Serializers
                     {
                         switch (flag)
                         {
-                            //TODO Why for ticks we use Int64Serializer instead of bsonReader.ReadInt64 like we do some lines after?
                             case Flags.DateTime: bsonReader.SkipValue(); break; // ignore value (use Ticks instead)
                             case Flags.Ticks: value = new DateTime(Int64Serializer.Instance.Deserialize(context), DateTimeKind.Utc); break;
                         }

--- a/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
@@ -15,6 +15,7 @@
 
 using System;
 using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization.Options;
 
 namespace MongoDB.Bson.Serialization.Serializers
 {
@@ -51,6 +52,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         private readonly SerializerHelper _helper;
         private readonly DateTimeKind _kind;
         private readonly BsonType _representation;
+        private readonly RepresentationConverter _converter;
 
         // constructors
         /// <summary>
@@ -126,6 +128,7 @@ namespace MongoDB.Bson.Serialization.Serializers
             _dateOnly = dateOnly;
             _kind = kind;
             _representation = representation;
+            _converter = new RepresentationConverter(false, false);
 
             _helper = new SerializerHelper
             (
@@ -202,10 +205,19 @@ namespace MongoDB.Bson.Serialization.Serializers
                     break;
 
                 case BsonType.Decimal128:
+                    value = DateTime.SpecifyKind(new DateTime(_converter.ToInt64(bsonReader.ReadDecimal128())), DateTimeKind.Utc);
+                    break;
+
                 case BsonType.Double:
+                    value = DateTime.SpecifyKind(new DateTime(_converter.ToInt64(bsonReader.ReadDouble())), DateTimeKind.Utc);
+                    break;
+
                 case BsonType.Int32:
+                    value = DateTime.SpecifyKind(new DateTime(bsonReader.ReadInt32()), DateTimeKind.Utc);
+                    break;
+
                 case BsonType.Int64:
-                    value = DateTime.SpecifyKind(new DateTime(Int64Serializer.Instance.Deserialize(context)), DateTimeKind.Utc);
+                    value = DateTime.SpecifyKind(new DateTime(bsonReader.ReadInt64()), DateTimeKind.Utc);
                     break;
 
                 case BsonType.String:

--- a/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DateTimeSerializer.cs
@@ -138,43 +138,28 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <summary>
         /// Gets an instance of DateTimeSerializer with DateOnly=true.
         /// </summary>
-        public static DateTimeSerializer DateOnlyInstance
-        {
-            get { return __dateOnlyInstance; }
-        }
+        public static DateTimeSerializer DateOnlyInstance => __dateOnlyInstance;
 
         /// <summary>
         /// Gets an instance of DateTimeSerializer with Kind=Local.
         /// </summary>
-        public static DateTimeSerializer LocalInstance
-        {
-            get { return __localInstance; }
-        }
+        public static DateTimeSerializer LocalInstance => __localInstance;
 
         /// <summary>
         /// Gets an instance of DateTimeSerializer with Kind=Utc.
         /// </summary>
-        public static DateTimeSerializer UtcInstance
-        {
-            get { return __utcInstance; }
-        }
+        public static DateTimeSerializer UtcInstance => __utcInstance;
 
         // public properties
         /// <summary>
         /// Gets whether this DateTime consists of a Date only.
         /// </summary>
-        public bool DateOnly
-        {
-            get { return _dateOnly; }
-        }
+        public bool DateOnly => _dateOnly;
 
         /// <summary>
         /// Gets the DateTimeKind (Local, Unspecified or Utc).
         /// </summary>
-        public DateTimeKind Kind
-        {
-            get { return _kind; }
-        }
+        public DateTimeKind Kind => _kind;
 
         /// <summary>
         /// Gets the external representation.
@@ -182,10 +167,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// <value>
         /// The representation.
         /// </value>
-        public BsonType Representation
-        {
-            get { return _representation; }
-        }
+        public BsonType Representation => _representation;
 
         // public methods
         /// <summary>
@@ -219,8 +201,11 @@ namespace MongoDB.Bson.Serialization.Serializers
                     });
                     break;
 
+                case BsonType.Decimal128:
+                case BsonType.Double:
+                case BsonType.Int32:
                 case BsonType.Int64:
-                    value = DateTime.SpecifyKind(new DateTime(bsonReader.ReadInt64()), DateTimeKind.Utc);
+                    value = DateTime.SpecifyKind(new DateTime(Int64Serializer.Instance.Deserialize(context)), DateTimeKind.Utc);
                     break;
 
                 case BsonType.String:

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -1,0 +1,84 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using Xunit;
+
+namespace MongoDB.Bson.Tests.Serialization.Serializers
+{
+    #if NET6_0_OR_GREATER
+    public class DateOnlySerializerTests
+    {
+        [Fact]
+        public void Equals_derived_should_return_false()
+        {
+            var x = new DateOnlySerializer();
+            var y = new DerivedFromDateOnlySerializer();
+
+            var result = x.Equals(y);
+
+            result.Should().Be(false);
+        }
+
+        [Fact]
+        public void Equals_null_should_return_false()
+        {
+            var x = new DateOnlySerializer();
+
+            var result = x.Equals(null);
+
+            result.Should().Be(false);
+        }
+
+        [Fact]
+        public void Equals_object_should_return_false()
+        {
+            var x = new DateOnlySerializer();
+            var y = new object();
+
+            var result = x.Equals(y);
+
+            result.Should().Be(false);
+        }
+
+        [Fact]
+        public void Equals_self_should_return_true()
+        {
+            var x = new DateOnlySerializer();
+
+            var result = x.Equals(x);
+
+            result.Should().Be(true);
+        }
+
+        [Fact]
+        public void Equals_with_equal_fields_should_return_true()
+        {
+            var x = new DateOnlySerializer();
+            var y = new DateOnlySerializer();
+
+            var result = x.Equals(y);
+
+            result.Should().Be(true);
+        }
+
+
+        public class DerivedFromDateOnlySerializer : DateOnlySerializer
+        {
+        }
+    }
+    #endif
+}

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -28,7 +28,7 @@ using Xunit;
 
 namespace MongoDB.Bson.Tests.Serialization.Serializers
 {
-    #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
     public class DateOnlySerializerTests
     {
         private class DerivedFromDateOnlySerializer : DateOnlySerializer
@@ -255,5 +255,5 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
             }
         }
     }
-    #endif
+#endif
 }

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -55,6 +55,27 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         [Theory]
+        [InlineData("""{ "x" : { "$numberDouble" : "638649792000000000" } }""","10/20/2024" )]
+        [InlineData("""{ "x" : { "$numberDecimal" : "638649792000000000" } }""","10/20/2024" )]
+        [InlineData("""{ "x" : { "$numberInt" : "0" } }""","01/01/0001" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberLong" : "638649792000000000" } } }""","10/20/2024" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberDecimal" : "638649792000000000" } } }""","10/20/2024" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberInt" : "0" } } }""","01/01/0001" )]
+        public void Deserialize_should_be_forgiving_of_actual_numeric_types(string json, string expectedResult)
+        {
+            var subject = new DateOnlySerializer();
+
+            using var reader = new JsonReader(json);
+            reader.ReadStartDocument();
+            reader.ReadName("x");
+            var context = BsonDeserializationContext.CreateRoot(reader);
+            var result = subject.Deserialize(context);
+            reader.ReadEndDocument();
+
+            result.Should().Be(DateOnly.Parse(expectedResult, CultureInfo.InvariantCulture));
+        }
+
+        [Theory]
         [InlineData("""{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""","10/20/2024" )]
         [InlineData("""{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""","01/01/0001" )]
         [InlineData("""{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""","12/31/9999" )]

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -14,14 +14,11 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
@@ -31,10 +28,6 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
 #if NET6_0_OR_GREATER
     public class DateOnlySerializerTests
     {
-        private class DerivedFromDateOnlySerializer : DateOnlySerializer
-        {
-        }
-
         [Fact]
         public void Constructor_with_no_arguments_should_return_expected_result()
         {
@@ -55,12 +48,12 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         [Theory]
-        [InlineData("""{ "x" : { "$numberDouble" : "638649792000000000" } }""","10/20/2024" )]
-        [InlineData("""{ "x" : { "$numberDecimal" : "638649792000000000" } }""","10/20/2024" )]
-        [InlineData("""{ "x" : { "$numberInt" : "0" } }""","01/01/0001" )]
-        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberLong" : "638649792000000000" } } }""","10/20/2024" )]
-        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberDecimal" : "638649792000000000" } } }""","10/20/2024" )]
-        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberInt" : "0" } } }""","01/01/0001" )]
+        [InlineData("""{ "x" : { "$numberDouble" : "638649792000000000" } }""","2024/10/20" )]
+        [InlineData("""{ "x" : { "$numberDecimal" : "638649792000000000" } }""","2024/10/20" )]
+        [InlineData("""{ "x" : { "$numberInt" : "0" } }""","0001/01/01" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberLong" : "638649792000000000" } } }""","2024/10/20" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberDecimal" : "638649792000000000" } } }""","2024/10/20" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberInt" : "0" } } }""","0001/01/01" )]
         public void Deserialize_should_be_forgiving_of_actual_numeric_types(string json, string expectedResult)
         {
             var subject = new DateOnlySerializer();
@@ -76,18 +69,18 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         [Theory]
-        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""","10/20/2024" )]
-        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""","01/01/0001" )]
-        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""","12/31/9999" )]
-        [InlineData("""{ "x" : "2024-10-20" }""","10/20/2024" )]
-        [InlineData("""{ "x" : "0001-01-01" }""","01/01/0001")]
-        [InlineData("""{ "x" : "9999-12-31" }""","12/31/9999" )]
-        [InlineData("""{ "x" : { "$numberLong" : "638649792000000000" } }""","10/20/2024" )]
-        [InlineData("""{ "x" : { "$numberLong" : "0" } }""","01/01/0001" )]
-        [InlineData("""{ "x" : { "$numberLong" : "3155378112000000000" } }""","12/31/9999" )]
-        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "1729382400000" } }, "Ticks" : { "$numberLong" : "638649792000000000" } } }""","10/20/2024" )]
-        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "-62135596800000" } }, "Ticks" : { "$numberLong" : "0" } } }""","01/01/0001" )]
-        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "253402214400000" } }, "Ticks" : { "$numberLong" : "3155378112000000000" } } }""","12/31/9999" )]
+        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""","2024/10/20" )]
+        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""","0001/01/01" )]
+        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""","9999/12/31" )]
+        [InlineData("""{ "x" : "2024-10-20" }""","2024/10/20" )]
+        [InlineData("""{ "x" : "0001-01-01" }""","0001/01/01")]
+        [InlineData("""{ "x" : "9999-12-31" }""","9999/12/31" )]
+        [InlineData("""{ "x" : { "$numberLong" : "638649792000000000" } }""","2024/10/20" )]
+        [InlineData("""{ "x" : { "$numberLong" : "0" } }""","0001/01/01" )]
+        [InlineData("""{ "x" : { "$numberLong" : "3155378112000000000" } }""","9999/12/31" )]
+        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "1729382400000" } }, "Ticks" : { "$numberLong" : "638649792000000000" } } }""","2024/10/20" )]
+        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "-62135596800000" } }, "Ticks" : { "$numberLong" : "0" } } }""","0001/01/01" )]
+        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "253402214400000" } }, "Ticks" : { "$numberLong" : "3155378112000000000" } } }""","9999/12/31" )]
         public void Deserialize_should_have_expected_result(string json, string expectedResult)
         {
             var subject = new DateOnlySerializer();
@@ -115,20 +108,9 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
             reader.ReadName("x");
             var context = BsonDeserializationContext.CreateRoot(reader);
 
-            Action action = () => subject.Deserialize(context);
-
-            action.ShouldThrow<FormatException>().WithMessage("Deserialized value has a non-zero time component.");
-        }
-
-        [Fact]
-        public void Equals_derived_should_return_false()
-        {
-            var x = new DateOnlySerializer();
-            var y = new DerivedFromDateOnlySerializer();
-
-            var result = x.Equals(y);
-
-            result.Should().Be(false);
+            var exception = Record.Exception(() => subject.Deserialize(context));
+            exception!.Should().BeOfType<FormatException>();
+            exception!.Message.Should().Be("Deserialized value has a non-zero time component.");
         }
 
         [Fact]
@@ -206,18 +188,18 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         [Theory]
-        [InlineData(BsonType.DateTime, "10/20/2024", """{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""")]
-        [InlineData(BsonType.DateTime, "01/01/0001", """{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""")]
-        [InlineData(BsonType.DateTime, "12/31/9999", """{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""")]
-        [InlineData(BsonType.String, "10/20/2024", """{ "x" : "2024-10-20" }""")]
-        [InlineData(BsonType.String, "01/01/0001", """{ "x" : "0001-01-01" }""")]
-        [InlineData(BsonType.String, "12/31/9999", """{ "x" : "9999-12-31" }""")]
-        [InlineData(BsonType.Int64, "10/20/2024", """{ "x" : { "$numberLong" : "638649792000000000" } }""")]
-        [InlineData(BsonType.Int64, "01/01/0001", """{ "x" : { "$numberLong" : "0" } }""")]
-        [InlineData(BsonType.Int64, "12/31/9999", """{ "x" : { "$numberLong" : "3155378112000000000" } }""")]
-        [InlineData(BsonType.Document, "10/20/2024", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "1729382400000" } }, "Ticks" : { "$numberLong" : "638649792000000000" } } }""")]
-        [InlineData(BsonType.Document, "01/01/0001", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "-62135596800000" } }, "Ticks" : { "$numberLong" : "0" } } }""")]
-        [InlineData(BsonType.Document, "12/31/9999", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "253402214400000" } }, "Ticks" : { "$numberLong" : "3155378112000000000" } } }""")]
+        [InlineData(BsonType.DateTime, "2024/10/20", """{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""")]
+        [InlineData(BsonType.DateTime, "0001/01/01", """{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""")]
+        [InlineData(BsonType.DateTime, "9999/12/31", """{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""")]
+        [InlineData(BsonType.String, "2024/10/20", """{ "x" : "2024-10-20" }""")]
+        [InlineData(BsonType.String, "0001/01/01", """{ "x" : "0001-01-01" }""")]
+        [InlineData(BsonType.String, "9999/12/31", """{ "x" : "9999-12-31" }""")]
+        [InlineData(BsonType.Int64, "2024/10/20", """{ "x" : { "$numberLong" : "638649792000000000" } }""")]
+        [InlineData(BsonType.Int64, "0001/01/01", """{ "x" : { "$numberLong" : "0" } }""")]
+        [InlineData(BsonType.Int64, "9999/12/31", """{ "x" : { "$numberLong" : "3155378112000000000" } }""")]
+        [InlineData(BsonType.Document, "2024/10/20", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "1729382400000" } }, "Ticks" : { "$numberLong" : "638649792000000000" } } }""")]
+        [InlineData(BsonType.Document, "0001/01/01", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "-62135596800000" } }, "Ticks" : { "$numberLong" : "0" } } }""")]
+        [InlineData(BsonType.Document, "9999/12/31", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "253402214400000" } }, "Ticks" : { "$numberLong" : "3155378112000000000" } } }""")]
         public void Serialize_should_have_expected_result(BsonType representation, string valueString,
             string expectedResult)
         {

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -48,12 +48,12 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         [Theory]
-        [InlineData("""{ "x" : { "$numberDouble" : "638649792000000000" } }""","2024/10/20" )]
-        [InlineData("""{ "x" : { "$numberDecimal" : "638649792000000000" } }""","2024/10/20" )]
-        [InlineData("""{ "x" : { "$numberInt" : "0" } }""","0001/01/01" )]
-        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberLong" : "638649792000000000" } } }""","2024/10/20" )]
-        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberDecimal" : "638649792000000000" } } }""","2024/10/20" )]
-        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberInt" : "0" } } }""","0001/01/01" )]
+        [InlineData("""{ "x" : { "$numberDouble" : "638649792000000000" } }""","2024-10-20" )]
+        [InlineData("""{ "x" : { "$numberDecimal" : "638649792000000000" } }""","2024-10-20" )]
+        [InlineData("""{ "x" : { "$numberInt" : "0" } }""","0001-01-01" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberLong" : "638649792000000000" } } }""","2024-10-20" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberDecimal" : "638649792000000000" } } }""","2024-10-20" )]
+        [InlineData("""{ "x" : { "DateTime" : "ignored", "Ticks" : { "$numberInt" : "0" } } }""","0001-01-01" )]
         public void Deserialize_should_be_forgiving_of_actual_numeric_types(string json, string expectedResult)
         {
             var subject = new DateOnlySerializer();
@@ -69,18 +69,18 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         [Theory]
-        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""","2024/10/20" )]
-        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""","0001/01/01" )]
-        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""","9999/12/31" )]
-        [InlineData("""{ "x" : "2024-10-20" }""","2024/10/20" )]
-        [InlineData("""{ "x" : "0001-01-01" }""","0001/01/01")]
-        [InlineData("""{ "x" : "9999-12-31" }""","9999/12/31" )]
-        [InlineData("""{ "x" : { "$numberLong" : "638649792000000000" } }""","2024/10/20" )]
-        [InlineData("""{ "x" : { "$numberLong" : "0" } }""","0001/01/01" )]
-        [InlineData("""{ "x" : { "$numberLong" : "3155378112000000000" } }""","9999/12/31" )]
-        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "1729382400000" } }, "Ticks" : { "$numberLong" : "638649792000000000" } } }""","2024/10/20" )]
-        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "-62135596800000" } }, "Ticks" : { "$numberLong" : "0" } } }""","0001/01/01" )]
-        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "253402214400000" } }, "Ticks" : { "$numberLong" : "3155378112000000000" } } }""","9999/12/31" )]
+        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""","2024-10-20" )]
+        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""","0001-01-01" )]
+        [InlineData("""{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""","9999-12-31" )]
+        [InlineData("""{ "x" : "2024-10-20" }""","2024-10-20" )]
+        [InlineData("""{ "x" : "0001-01-01" }""","0001-01-01")]
+        [InlineData("""{ "x" : "9999-12-31" }""","9999-12-31" )]
+        [InlineData("""{ "x" : { "$numberLong" : "638649792000000000" } }""","2024-10-20" )]
+        [InlineData("""{ "x" : { "$numberLong" : "0" } }""","0001-01-01" )]
+        [InlineData("""{ "x" : { "$numberLong" : "3155378112000000000" } }""","9999-12-31" )]
+        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "1729382400000" } }, "Ticks" : { "$numberLong" : "638649792000000000" } } }""","2024-10-20" )]
+        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "-62135596800000" } }, "Ticks" : { "$numberLong" : "0" } } }""","0001-01-01" )]
+        [InlineData("""{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "253402214400000" } }, "Ticks" : { "$numberLong" : "3155378112000000000" } } }""","9999-12-31" )]
         public void Deserialize_should_have_expected_result(string json, string expectedResult)
         {
             var subject = new DateOnlySerializer();
@@ -109,8 +109,8 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
             var context = BsonDeserializationContext.CreateRoot(reader);
 
             var exception = Record.Exception(() => subject.Deserialize(context));
-            exception!.Should().BeOfType<FormatException>();
-            exception!.Message.Should().Be("Deserialized value has a non-zero time component.");
+            exception.Should().BeOfType<FormatException>();
+            exception.Message.Should().Be("Deserialized value has a non-zero time component.");
         }
 
         [Fact]
@@ -188,18 +188,18 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         [Theory]
-        [InlineData(BsonType.DateTime, "2024/10/20", """{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""")]
-        [InlineData(BsonType.DateTime, "0001/01/01", """{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""")]
-        [InlineData(BsonType.DateTime, "9999/12/31", """{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""")]
-        [InlineData(BsonType.String, "2024/10/20", """{ "x" : "2024-10-20" }""")]
-        [InlineData(BsonType.String, "0001/01/01", """{ "x" : "0001-01-01" }""")]
-        [InlineData(BsonType.String, "9999/12/31", """{ "x" : "9999-12-31" }""")]
-        [InlineData(BsonType.Int64, "2024/10/20", """{ "x" : { "$numberLong" : "638649792000000000" } }""")]
-        [InlineData(BsonType.Int64, "0001/01/01", """{ "x" : { "$numberLong" : "0" } }""")]
-        [InlineData(BsonType.Int64, "9999/12/31", """{ "x" : { "$numberLong" : "3155378112000000000" } }""")]
-        [InlineData(BsonType.Document, "2024/10/20", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "1729382400000" } }, "Ticks" : { "$numberLong" : "638649792000000000" } } }""")]
-        [InlineData(BsonType.Document, "0001/01/01", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "-62135596800000" } }, "Ticks" : { "$numberLong" : "0" } } }""")]
-        [InlineData(BsonType.Document, "9999/12/31", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "253402214400000" } }, "Ticks" : { "$numberLong" : "3155378112000000000" } } }""")]
+        [InlineData(BsonType.DateTime, "2024-10-20", """{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""")]
+        [InlineData(BsonType.DateTime, "0001-01-01", """{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""")]
+        [InlineData(BsonType.DateTime, "9999-12-31", """{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""")]
+        [InlineData(BsonType.String, "2024-10-20", """{ "x" : "2024-10-20" }""")]
+        [InlineData(BsonType.String, "0001-01-01", """{ "x" : "0001-01-01" }""")]
+        [InlineData(BsonType.String, "9999-12-31", """{ "x" : "9999-12-31" }""")]
+        [InlineData(BsonType.Int64, "2024-10-20", """{ "x" : { "$numberLong" : "638649792000000000" } }""")]
+        [InlineData(BsonType.Int64, "0001-01-01", """{ "x" : { "$numberLong" : "0" } }""")]
+        [InlineData(BsonType.Int64, "9999-12-31", """{ "x" : { "$numberLong" : "3155378112000000000" } }""")]
+        [InlineData(BsonType.Document, "2024-10-20", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "1729382400000" } }, "Ticks" : { "$numberLong" : "638649792000000000" } } }""")]
+        [InlineData(BsonType.Document, "0001-01-01", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "-62135596800000" } }, "Ticks" : { "$numberLong" : "0" } } }""")]
+        [InlineData(BsonType.Document, "9999-12-31", """{ "x" : { "DateTime" : { "$date" : { "$numberLong" : "253402214400000" } }, "Ticks" : { "$numberLong" : "3155378112000000000" } } }""")]
         public void Serialize_should_have_expected_result(BsonType representation, string valueString,
             string expectedResult)
         {

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -220,6 +220,14 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
             result.Should().Be(expectedResult);
         }
 
+        [Fact]
+        public void Serializer_should_be_registered()
+        {
+            var serializer = BsonSerializer.LookupSerializer(typeof(DateOnly));
+
+            serializer.Should().Be(new DateOnlySerializer());
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void WithRepresentation_should_return_expected_result(

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -154,7 +154,7 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
 
             Action action = () => subject.Deserialize(context);
 
-            action.ShouldThrow<Exception>();
+            action.ShouldThrow<FormatException>().WithMessage("Deserialized value has a non-zero time component.");
         }
 
         [Fact]

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -35,64 +35,6 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         {
         }
 
-        private class TestClass
-        {
-            public DateOnly DefaultDate { get; set; }
-
-            [BsonRepresentation(BsonType.DateTime)]
-            public DateOnly DateTimeDate { get; set; }
-
-            [BsonRepresentation(BsonType.Int64)]
-            public DateOnly IntDate { get; set; }
-
-            [BsonRepresentation(BsonType.String)]
-            public DateOnly StringDate { get; set; }
-
-            [BsonRepresentation(BsonType.Document)]
-            public DateOnly DocumentDate { get; set; }
-
-            public override bool Equals(object obj)
-            {
-                return obj is TestClass to &&
-                       DefaultDate.Equals(to.DefaultDate) &&
-                       DateTimeDate.Equals(to.DateTimeDate) &&
-                       IntDate.Equals(to.IntDate) &&
-                       StringDate.Equals(to.StringDate) &&
-                       DocumentDate.Equals(to.DocumentDate);
-            }
-
-            public override int GetHashCode() => base.GetHashCode();
-        }
-
-        public static readonly IEnumerable<object[]> DateOnlyValues =
-        [
-            [DateOnly.MinValue],
-            [DateOnly.MaxValue],
-            [DateOnly.FromDateTime(DateTime.Today)],
-        ];
-
-        [Theory]
-        [MemberData(nameof(DateOnlyValues))]
-        public void BsonRepresentationAttribute_should_set_correct_representation(DateOnly testValue)
-        {
-            var testObj = new TestClass
-            {
-                DefaultDate = testValue,
-                DateTimeDate = testValue,
-                IntDate = testValue,
-                StringDate = testValue,
-                DocumentDate = testValue,
-            };
-
-            var bsonDocument = testObj.ToBsonDocument();
-
-            Assert.Equal(bsonDocument["DefaultDate"].BsonType, BsonType.DateTime);
-            Assert.Equal(bsonDocument["DateTimeDate"].BsonType, BsonType.DateTime);
-            Assert.Equal(bsonDocument["IntDate"].BsonType, BsonType.Int64);
-            Assert.Equal(bsonDocument["StringDate"].BsonType, BsonType.String);
-            Assert.Equal(bsonDocument["DocumentDate"].BsonType, BsonType.Document);
-        }
-
         [Fact]
         public void Constructor_with_no_arguments_should_return_expected_result()
         {
@@ -243,23 +185,6 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         }
 
         [Theory]
-        [ParameterAttributeData]
-        public void WithRepresentation_should_return_expected_result(
-            [Values(BsonType.Document, BsonType.DateTime, BsonType.Document, BsonType.String)] BsonType oldRepresentation,
-            [Values(BsonType.Document, BsonType.DateTime, BsonType.Document, BsonType.String)] BsonType newRepresentation)
-        {
-            var subject = new DateOnlySerializer(oldRepresentation);
-
-            var result = subject.WithRepresentation(newRepresentation);
-
-            result.Representation.Should().Be(newRepresentation);
-            if (newRepresentation == oldRepresentation)
-            {
-                result.Should().BeSameAs(subject);
-            }
-        }
-
-        [Theory]
         [InlineData(BsonType.DateTime, "10/20/2024", """{ "x" : { "$date" : { "$numberLong" : "1729382400000" } } }""")]
         [InlineData(BsonType.DateTime, "01/01/0001", """{ "x" : { "$date" : { "$numberLong" : "-62135596800000" } } }""")]
         [InlineData(BsonType.DateTime, "12/31/9999", """{ "x" : { "$date" : { "$numberLong" : "253402214400000" } } }""")]
@@ -290,6 +215,23 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
             var result = textWriter.ToString();
 
             result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void WithRepresentation_should_return_expected_result(
+            [Values(BsonType.Document, BsonType.DateTime, BsonType.Document, BsonType.String)] BsonType oldRepresentation,
+            [Values(BsonType.Document, BsonType.DateTime, BsonType.Document, BsonType.String)] BsonType newRepresentation)
+        {
+            var subject = new DateOnlySerializer(oldRepresentation);
+
+            var result = subject.WithRepresentation(newRepresentation);
+
+            result.Representation.Should().Be(newRepresentation);
+            if (newRepresentation == oldRepresentation)
+            {
+                result.Should().BeSameAs(subject);
+            }
         }
     }
     #endif

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateTimeOffsetSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateTimeOffsetSerializerTests.cs
@@ -70,8 +70,6 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         [InlineData("{ x : '1970-01-01T00:00:00-01:00' }", "1970-01-01T00:00:00-01:00")]
         public void Deserialize_should_return_expected_result(string json, string expectedResult)
         {
-            var x = DateTimeOffset.Parse(expectedResult);
-            var m = BsonUtils.ToMillisecondsSinceEpoch(x.UtcDateTime);
             var subject = new DateTimeOffsetSerializer();
 
             DateTimeOffset result;
@@ -98,8 +96,6 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         [InlineData("{ x : { DateTime : 'ignored', Ticks : { $numberDouble : '621355968000000000' }, Offset : { $numberDouble : '-60' } } }", "1970-01-01T00:00:00-01:00")]
         public void Deserialize_should_be_forgiving_of_actual_numeric_types(string json, string expectedResult)
         {
-            var x = DateTimeOffset.Parse(expectedResult);
-            var m = BsonUtils.ToMillisecondsSinceEpoch(x.UtcDateTime);
             var subject = new DateTimeOffsetSerializer();
 
             DateTimeOffset result;
@@ -151,6 +147,7 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
 
             result.Should().Be(expectedResult);
         }
+
         [Theory]
         [ParameterAttributeData]
         public void WithRepresentation_should_return_expected_result(

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateTimeSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateTimeSerializerTests.cs
@@ -17,7 +17,6 @@ using System;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;


### PR DESCRIPTION
This PR is still in draft because we need support for the .NET 6 target framework before merging. I have made the changes for .NET 6 locally, but I did not push them to avoid polluting the PR. 

The behaviour of `DateOnlySerializer` has taken mostly inspiration from `DateTimeSerializer` with `DateOnly = true`, including throwing an exception when deserializing a date time with a non-zero time component. 