### PR TITLE
Scalar discriminator as in EF Core POC.

### DIFF
--- a/src/MongoDB.Bson/Serialization/Conventions/IDiscriminatorConvention.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/IDiscriminatorConvention.cs
@@ -44,4 +44,17 @@ namespace MongoDB.Bson.Serialization.Conventions
         /// <returns>The discriminator value.</returns>
         BsonValue GetDiscriminator(Type nominalType, Type actualType);
     }
+
+    /// <summary>
+    /// Represents a discriminator convention where the discriminator for each type in a polymorphic hierarchy is a scalar.
+    /// </summary>
+    public interface IPolymorphicScalarDiscriminatorConvention : IDiscriminatorConvention
+    {
+        /// <summary>
+        /// Returns all the discriminators for a type and all of its known subtypes.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The discriminators.</returns>
+        BsonValue[] GetAllDiscriminatorsForType(Type type);
+    }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/OfTypeWithScalarDiscriminatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/OfTypeWithScalarDiscriminatorTests.cs
@@ -1,0 +1,184 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+using MongoDB.Bson.Serialization.Serializers;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
+{
+    public class OfTypeWithScalarDiscriminatorTests : Linq3IntegrationTest
+    {
+        static OfTypeWithScalarDiscriminatorTests()
+        {
+            var animalTypes = new Type[]
+            {
+                typeof(Animal),
+                typeof(Mammal),
+                typeof(Cat),
+                typeof(Dog),
+                typeof(Reptile),
+                typeof(Snake)
+            };
+
+            // register the same discriminator convention for every class in the hierarchy
+            var animalDiscriminatorConvention = new AnimalDiscriminatorConvention();
+            foreach (var type in animalTypes)
+            {
+                BsonSerializer.RegisterDiscriminatorConvention(type, animalDiscriminatorConvention);
+            }
+        }
+
+        [Fact]
+        public void OfType_Mammal_should_work()
+        {
+            var collection = GetCollection();
+
+            var queryable = collection.AsQueryable()
+                .OfType<Mammal>();
+
+            var stages = Translate(collection, queryable);
+            AssertStages(stages, "{ $match : { _t : { $in : ['Cat', 'Dog'] } } }");
+
+            var results = queryable.ToList();
+            results.Select(x => x.Id).Should().Equal(1, 2);
+            results.Select(x => x.GetType().Name).Should().Equal("Cat", "Dog");
+        }
+
+        [Fact]
+        public void OfType_Dog_should_work()
+        {
+            var collection = GetCollection();
+
+            var queryable = collection.AsQueryable()
+                .OfType<Dog>();
+
+            var stages = Translate(collection, queryable);
+            AssertStages(stages, "{ $match : { _t : 'Dog' } }");
+
+            var results = queryable.ToList();
+            results.Select(x => x.Id).Should().Equal(2);
+            results.Select(x => x.GetType().Name).Should().Equal("Dog");
+        }
+
+        [Fact]
+        public void OfType_Reptile_should_work()
+        {
+            var collection = GetCollection();
+
+            var queryable = collection.AsQueryable()
+                .OfType<Snake>();
+
+            var stages = Translate(collection, queryable);
+            AssertStages(stages, "{ $match : { _t : 'Snake' } }");
+
+            var results = queryable.ToList();
+            results.Select(x => x.Id).Should().Equal(3);
+            results.Select(x => x.GetType().Name).Should().Equal("Snake");
+        }
+        private IMongoCollection<Animal> GetCollection()
+        {
+            var collection = GetCollection<Animal>("test");
+            CreateCollection(
+                collection,
+                new Cat { Id = 1 },
+                new Dog { Id = 2 },
+                new Snake { Id = 3 });
+            return collection;
+        }
+
+        private abstract class Animal
+        {
+            public int Id { get; set; }
+        }
+
+        private abstract class Mammal : Animal
+        {
+        }
+
+        private class Cat : Mammal
+        {
+        }
+
+        private class Dog : Mammal
+        {
+        }
+
+        private class Reptile : Animal
+        {
+        }
+
+        private class Snake : Reptile
+        {
+        }
+
+        private class AnimalDiscriminatorConvention : IPolymorphicScalarDiscriminatorConvention
+        {
+            public string ElementName => "_t";
+
+            public Type GetActualType(IBsonReader bsonReader, Type nominalType)
+            {
+                var discriminator = ReadDiscriminator(bsonReader);
+                return discriminator.AsString switch
+                {
+                    // abstract types can be omitted because the can't be any documents of that type
+                    "Cat" => typeof(Cat),
+                    "Dog" => typeof(Dog),
+                    "Snake" => typeof(Snake),
+                    _ => throw new InvalidOperationException($"Unknown discriminator: {discriminator}")
+                };
+            }
+
+            public BsonValue GetDiscriminator(Type nominalType, Type actualType) => actualType.Name;
+
+            public BsonValue[] GetAllDiscriminatorsForType(Type type)
+            {
+                // note that we are omitting abstract classes from the results because they can't exist
+                return type.Name switch
+                {
+                    "Animal" => new BsonValue[] { "Cat", "Dog", "Snake" },
+                    "Mammal" => new BsonValue[] { "Cat", "Dog" },
+                    "Cat" => new BsonValue[] { "Cat" },
+                    "Dog" => new BsonValue[] { "Dog", },
+                    "Reptile" => new BsonValue[] { "Snake" },
+                    "Snake" => new BsonValue[] { "Snake" },
+                    _ => throw new InvalidOperationException($"Unknown type: {type}")
+                };
+            }
+
+            private BsonValue ReadDiscriminator(IBsonReader bsonReader)
+            {
+                // this code peeks ahead to read the _t value
+                // the actual serializer needs to know to skip the _t value
+                var bookmark = bsonReader.GetBookmark();
+                bsonReader.ReadStartDocument();
+                BsonValue discriminator = null;
+                if (bsonReader.FindElement("_t"))
+                {
+                    var context = BsonDeserializationContext.CreateRoot(bsonReader);
+                    discriminator = BsonValueSerializer.Instance.Deserialize(context);
+                }
+                bsonReader.ReturnToBookmark(bookmark);
+                return discriminator;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a relatively complete (but not fully complete) POC of how the driver could be modified to handle polymorphic hierarchies with scalar discriminator values the way EF does.

I will add some more comments to the changed files.