### PR TITLE
CSHARP-5303: Change MongoClient StartImplicitSession to protected virtual

### DIFF
--- a/src/MongoDB.Driver/MongoClient.cs
+++ b/src/MongoDB.Driver/MongoClient.cs
@@ -534,7 +534,11 @@ namespace MongoDB.Driver
             return messageEncoderSettings;
         }
 
-        private IClientSessionHandle StartImplicitSession()
+        /// <summary>
+        /// Starts an implicit Core Session.
+        /// </summary>
+        /// <returns>A handle to an underlying reference counted <see cref="IClientSession"/>.</returns>
+        protected virtual IClientSessionHandle StartImplicitSession()
         {
             var options = new ClientSessionOptions { CausalConsistency = false, Snapshot = false };
             ICoreSessionHandle coreSession = _cluster.StartSession(options.ToCore(isImplicit: true));


### PR DESCRIPTION
This PR Sub-Task Ticket: [CSHARP-5303](https://jira.mongodb.org/browse/CSHARP-5303)
Parent Ticket: [CSHARP-5302](https://jira.mongodb.org/browse/CSHARP-5302)

**Background**:

Since there's hasn't been any activity on [CSHARP-2890](https://jira.mongodb.org/browse/CSHARP-2890) for about five years now, I would like to propose a way to allow people who require C# `TransactionScope` an easier interface to implement it themselves by making `MongoClient` open to extension.

**Propose Changes**:
Make `StartImplicitSession` from `private` method to `protected virtual`, allowing an easy management of session with `TransactionScope` if someone choose to extend `MongoClient` with that functionality.

Motive:
To illustrate the need for this I would like to present [SwissLife-OSS/mongo-extensions: Extensions libraries for MongoDB. (github.com)](https://github.com/SwissLife-OSS/mongo-extensions) package which achieves this support by extending the Client's each transaction related method, this is a well maintained package with over 138.8K downloads on Nuget, so there's clearly a need for this.

**Objections**:
To address some common questions about this proposal:

1. Why can't you just use that extension library?
  A. Unfortunately due to our internal policies we are unable to use it.
2. Why not extend the Client in similar manner as the extension library?
  A. It's requires much more maintainability, we would prefer a least intrusive solution as possible.

3. Isn't Sessions API provided by MongoDb C# Drive provide essentially the similar functionality?
   A. Yes, but we require `TransactionScope` functionality (though limited in implementation in the end due to fundamentally different architecture) to have a uniform API across different DBs we gonna use.

