### PR TITLE
CSHARP-5348: Avoid allocations for Bson*Context

### DIFF
--- a/benchmarks/MongoDB.Driver.Benchmarks/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/README.md
@@ -13,7 +13,7 @@ This suite implements the benchmarks described in this [spec](https://github.com
    (e.g `dotnet run -c Release -- --driverBenchmarks --envVars MONGODB_URI:"ConnectionString"`)
 
 You can also select the benchmarks to run directly on the command for running the benchmarks as such
-`dotnet run -c Release -- --driverBenchmarks --fitler "*BenchmarkClassName*"`. The benchmarks are also grouped into categories namely: BSONBench, WriteBench
+`dotnet run -c Release -- --driverBenchmarks --filter "*BenchmarkClassName*"`. The benchmarks are also grouped into categories namely: BSONBench, WriteBench
 ReadBench, ParallelBench, SingleBench, MultiBench and DriverBench. So if you wanted to only run the WriteBench benchmarks, you can do so
 as follows: `dotnet run -c Release -- --driverBenchmarks --anyCategories "WriteBench"`.
 

--- a/benchmarks/MongoDB.Driver.Benchmarks/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/README.md
@@ -1,6 +1,6 @@
 # C# Driver Benchmark Suite
 
-This suite implements the benchmarks described in this [spec](https://github.com/mongodb/specifications/blob/master/source/benchmarking/benchmarking.rst).
+This suite implements the benchmarks described in this [spec](https://github.com/mongodb/specifications/blob/master/source/benchmarking/benchmarking.md).
 
 ## Running the Driver Benchmarks
 

--- a/src/MongoDB.Bson/IO/BsonBinaryReader.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryReader.cs
@@ -432,7 +432,7 @@ namespace MongoDB.Bson.IO
 
             var startPosition = _bsonStream.Position; // position of size field
             var size = ReadSize();
-            _context = new BsonBinaryReaderContext(_context, ContextType.JavaScriptWithScope, startPosition, size);
+            _context = _context.PushContext(ContextType.JavaScriptWithScope, startPosition, size);
             var code = _bsonStream.ReadString(Settings.Encoding);
 
             State = BsonReaderState.ScopeDocument;
@@ -590,7 +590,7 @@ namespace MongoDB.Bson.IO
 
             var startPosition = _bsonStream.Position; // position of size field
             var size = ReadSize();
-            _context = new BsonBinaryReaderContext(_context, ContextType.Array, startPosition, size);
+            _context = _context.PushContext(ContextType.Array, startPosition, size);
             State = BsonReaderState.Type;
         }
 
@@ -605,7 +605,7 @@ namespace MongoDB.Bson.IO
             var contextType = (State == BsonReaderState.ScopeDocument) ? ContextType.ScopeDocument : ContextType.Document;
             var startPosition = _bsonStream.Position; // position of size field
             var size = ReadSize();
-            _context = new BsonBinaryReaderContext(_context, contextType, startPosition, size);
+            _context = _context.PushContext(contextType, startPosition, size);
             State = BsonReaderState.Type;
         }
 

--- a/src/MongoDB.Bson/IO/BsonBinaryReaderContext.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryReaderContext.cs
@@ -83,5 +83,10 @@ namespace MongoDB.Bson.IO
             }
             return _parentContext;
         }
+
+        internal BsonBinaryReaderContext PushContext(ContextType contextType, long startPosition, long size)
+        {
+            return new BsonBinaryReaderContext(this, contextType, startPosition, size);
+        }
     }
 }

--- a/src/MongoDB.Bson/IO/BsonBinaryReaderContext.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryReaderContext.cs
@@ -21,9 +21,10 @@ namespace MongoDB.Bson.IO
     {
         // private fields
         private readonly BsonBinaryReaderContext _parentContext;
-        private readonly ContextType _contextType;
-        private readonly long _startPosition;
-        private readonly long _size;
+        private BsonBinaryReaderContext _cachedPushContext;
+        private ContextType _contextType;
+        private long _startPosition;
+        private long _size;
         private string _currentElementName;
         private int _currentArrayIndex = -1;
 
@@ -86,7 +87,17 @@ namespace MongoDB.Bson.IO
 
         internal BsonBinaryReaderContext PushContext(ContextType contextType, long startPosition, long size)
         {
-            return new BsonBinaryReaderContext(this, contextType, startPosition, size);
+            if (_cachedPushContext == null)
+                _cachedPushContext = new BsonBinaryReaderContext(this, contextType, startPosition, size);
+            else
+            {
+                _cachedPushContext._contextType = contextType;
+                _cachedPushContext._startPosition = startPosition;
+                _cachedPushContext._size = size;
+                _cachedPushContext._currentArrayIndex = -1;
+                _cachedPushContext._currentElementName = null;
+            }
+            return _cachedPushContext;
         }
     }
 }

--- a/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
@@ -400,7 +400,7 @@ namespace MongoDB.Bson.IO
 
             _bsonStream.WriteBsonType(BsonType.JavaScriptWithScope);
             WriteNameHelper();
-            _context = new BsonBinaryWriterContext(_context, ContextType.JavaScriptWithScope, _bsonStream.Position);
+            _context = _context.PushContext(ContextType.JavaScriptWithScope, _bsonStream.Position);
             _bsonStream.WriteInt32(0); // reserve space for size of JavaScript with scope value
             _bsonStream.WriteString(code, Settings.Encoding);
 
@@ -564,7 +564,7 @@ namespace MongoDB.Bson.IO
             base.WriteStartArray();
             _bsonStream.WriteBsonType(BsonType.Array);
             WriteNameHelper();
-            _context = new BsonBinaryWriterContext(_context, ContextType.Array, _bsonStream.Position);
+            _context = _context.PushContext(ContextType.Array, _bsonStream.Position);
             _bsonStream.WriteInt32(0); // reserve space for size
 
             State = BsonWriterState.Value;
@@ -588,7 +588,10 @@ namespace MongoDB.Bson.IO
                 WriteNameHelper();
             }
             var contextType = (State == BsonWriterState.ScopeDocument) ? ContextType.ScopeDocument : ContextType.Document;
-            _context = new BsonBinaryWriterContext(_context, contextType, _bsonStream.Position);
+            if (_context == null)
+                _context = new BsonBinaryWriterContext(null, contextType, _bsonStream.Position);
+            else
+                _context = _context.PushContext(contextType, _bsonStream.Position);
             _bsonStream.WriteInt32(0); // reserve space for size
 
             State = BsonWriterState.Name;

--- a/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
@@ -290,7 +290,7 @@ namespace MongoDB.Bson.IO
             _bsonStream.WriteByte(0);
             BackpatchSize(); // size of document
 
-            _context = _context.ParentContext;
+            _context = _context.PopContext();
             State = GetNextState();
         }
 
@@ -313,7 +313,7 @@ namespace MongoDB.Bson.IO
             _bsonStream.WriteByte(0);
             BackpatchSize(); // size of document
 
-            _context = _context.ParentContext;
+            _context = _context.PopContext();
             if (_context == null)
             {
                 State = BsonWriterState.Done;
@@ -323,7 +323,7 @@ namespace MongoDB.Bson.IO
                 if (_context.ContextType == ContextType.JavaScriptWithScope)
                 {
                     BackpatchSize(); // size of the JavaScript with scope value
-                    _context = _context.ParentContext;
+                    _context = _context.PopContext();
                 }
                 State = GetNextState();
             }

--- a/src/MongoDB.Bson/IO/BsonBinaryWriterContext.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriterContext.cs
@@ -18,7 +18,8 @@ namespace MongoDB.Bson.IO
     internal class BsonBinaryWriterContext
     {
         // private fields
-        private BsonBinaryWriterContext _parentContext;
+        private readonly BsonBinaryWriterContext _parentContext;
+        private BsonBinaryWriterContext _cachedPushContext;
         private ContextType _contextType;
         private long _startPosition;
         private int _index; // used when contextType is Array
@@ -63,7 +64,15 @@ namespace MongoDB.Bson.IO
 
         internal BsonBinaryWriterContext PushContext(ContextType contextType, long startPosition)
         {
-            return new BsonBinaryWriterContext(this, contextType, startPosition);
+            if (_cachedPushContext == null)
+                _cachedPushContext = new BsonBinaryWriterContext(this, contextType, startPosition);
+            else
+            {
+                _cachedPushContext._contextType = contextType;
+                _cachedPushContext._startPosition = startPosition;
+                _cachedPushContext._index = 0;
+            }
+            return _cachedPushContext;
         }
     }
 }

--- a/src/MongoDB.Bson/IO/BsonBinaryWriterContext.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriterContext.cs
@@ -60,5 +60,10 @@ namespace MongoDB.Bson.IO
         {
             return _parentContext;
         }
+
+        internal BsonBinaryWriterContext PushContext(ContextType contextType, long startPosition)
+        {
+            return new BsonBinaryWriterContext(this, contextType, startPosition);
+        }
     }
 }

--- a/src/MongoDB.Bson/IO/BsonBinaryWriterContext.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriterContext.cs
@@ -55,5 +55,10 @@ namespace MongoDB.Bson.IO
             get { return _index; }
             set { _index = value; }
         }
+
+        internal BsonBinaryWriterContext PopContext()
+        {
+            return _parentContext;
+        }
     }
 }

--- a/src/MongoDB.Bson/IO/BsonDocumentReader.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentReader.cs
@@ -413,7 +413,7 @@ namespace MongoDB.Bson.IO
             VerifyBsonType("ReadStartArray", BsonType.Array);
 
             var array = _currentValue.AsBsonArray;
-            _context = new BsonDocumentReaderContext(_context, ContextType.Array, array);
+            _context = _context.PushContext(ContextType.Array, array);
             State = BsonReaderState.Type;
         }
 
@@ -435,7 +435,7 @@ namespace MongoDB.Bson.IO
             {
                 document = _currentValue.AsBsonDocument;
             }
-            _context = new BsonDocumentReaderContext(_context, ContextType.Document, document);
+            _context = _context.PushContext(ContextType.Document, document);
             State = BsonReaderState.Type;
         }
 

--- a/src/MongoDB.Bson/IO/BsonDocumentReaderContext.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentReaderContext.cs
@@ -124,5 +124,15 @@ namespace MongoDB.Bson.IO
         {
             return _parentContext;
         }
+
+        internal BsonDocumentReaderContext PushContext(ContextType contextType, BsonArray array)
+        {
+            return new BsonDocumentReaderContext(this, contextType, array);
+        }
+
+        internal BsonDocumentReaderContext PushContext(ContextType contextType, BsonDocument document)
+        {
+            return new BsonDocumentReaderContext(this, contextType, document);
+        }
     }
 }

--- a/src/MongoDB.Bson/IO/BsonDocumentWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentWriter.cs
@@ -195,7 +195,7 @@ namespace MongoDB.Bson.IO
 
             base.WriteEndArray();
             var array = _context.Array;
-            _context = _context.ParentContext;
+            _context = _context.PopContext();
             WriteValue(array);
             State = GetNextState();
         }
@@ -219,15 +219,15 @@ namespace MongoDB.Bson.IO
             if (_context.ContextType == ContextType.ScopeDocument)
             {
                 var scope = _context.Document;
-                _context = _context.ParentContext;
+                _context = _context.PopContext();
                 var code = _context.Code;
-                _context = _context.ParentContext;
+                _context = _context.PopContext();
                 WriteValue(new BsonJavaScriptWithScope(code, scope));
             }
             else
             {
                 var document = _context.Document;
-                _context = _context.ParentContext;
+                _context = _context.PopContext();
                 if (_context != null)
                 {
                     WriteValue(document);

--- a/src/MongoDB.Bson/IO/BsonDocumentWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentWriter.cs
@@ -304,7 +304,7 @@ namespace MongoDB.Bson.IO
                 ThrowInvalidState("WriteJavaScriptWithScope", BsonWriterState.Value);
             }
 
-            _context = new BsonDocumentWriterContext(_context, ContextType.JavaScriptWithScope, code);
+            _context = _context.PushContext(ContextType.JavaScriptWithScope, code);
             State = BsonWriterState.ScopeDocument;
         }
 
@@ -407,7 +407,7 @@ namespace MongoDB.Bson.IO
             }
 
             base.WriteStartArray();
-            _context = new BsonDocumentWriterContext(_context, ContextType.Array, new BsonArray());
+            _context = _context.PushContext(ContextType.Array, new BsonArray());
             State = BsonWriterState.Value;
         }
 
@@ -430,10 +430,10 @@ namespace MongoDB.Bson.IO
                     _context = new BsonDocumentWriterContext(null, ContextType.Document, _document);
                     break;
                 case BsonWriterState.Value:
-                    _context = new BsonDocumentWriterContext(_context, ContextType.Document, new BsonDocument());
+                    _context = _context.PushContext(ContextType.Document, new BsonDocument());
                     break;
                 case BsonWriterState.ScopeDocument:
-                    _context = new BsonDocumentWriterContext(_context, ContextType.ScopeDocument, new BsonDocument());
+                    _context = _context.PushContext(ContextType.ScopeDocument, new BsonDocument());
                     break;
                 default:
                     throw new BsonInternalException("Unexpected state.");

--- a/src/MongoDB.Bson/IO/BsonDocumentWriterContext.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentWriterContext.cs
@@ -87,5 +87,10 @@ namespace MongoDB.Bson.IO
         {
             get { return _code; }
         }
+
+        internal BsonDocumentWriterContext PopContext()
+        {
+            return _parentContext;
+        }
     }
 }

--- a/src/MongoDB.Bson/IO/BsonDocumentWriterContext.cs
+++ b/src/MongoDB.Bson/IO/BsonDocumentWriterContext.cs
@@ -36,7 +36,7 @@ namespace MongoDB.Bson.IO
             _document = document;
         }
 
-        internal BsonDocumentWriterContext(
+        private BsonDocumentWriterContext(
             BsonDocumentWriterContext parentContext,
             ContextType contextType,
             BsonArray array)
@@ -46,7 +46,7 @@ namespace MongoDB.Bson.IO
             _array = array;
         }
 
-        internal BsonDocumentWriterContext(
+        private BsonDocumentWriterContext(
             BsonDocumentWriterContext parentContext,
             ContextType contextType,
             string code)
@@ -91,6 +91,21 @@ namespace MongoDB.Bson.IO
         internal BsonDocumentWriterContext PopContext()
         {
             return _parentContext;
+        }
+
+        internal BsonDocumentWriterContext PushContext(ContextType contextType, BsonDocument document)
+        {
+            return new BsonDocumentWriterContext(this, contextType, document);
+        }
+
+        internal BsonDocumentWriterContext PushContext(ContextType contextType, BsonArray array)
+        {
+            return new BsonDocumentWriterContext(this, contextType, array);
+        }
+
+        internal BsonDocumentWriterContext PushContext(ContextType contextType, string code)
+        {
+            return new BsonDocumentWriterContext(this, contextType, code);
         }
     }
 }

--- a/src/MongoDB.Bson/IO/JsonReader.cs
+++ b/src/MongoDB.Bson/IO/JsonReader.cs
@@ -627,7 +627,7 @@ namespace MongoDB.Bson.IO
         {
             if (Disposed) { ThrowObjectDisposedException(); }
             VerifyBsonType("ReadJavaScriptWithScope", BsonType.JavaScriptWithScope);
-            _context = new JsonReaderContext(_context, ContextType.JavaScriptWithScope);
+            _context = _context.PushContext(ContextType.JavaScriptWithScope);
             State = BsonReaderState.ScopeDocument;
             return _currentValue.AsString;
         }
@@ -723,7 +723,7 @@ namespace MongoDB.Bson.IO
             if (Disposed) { ThrowObjectDisposedException(); }
             VerifyBsonType("ReadStartArray", BsonType.Array);
 
-            _context = new JsonReaderContext(_context, ContextType.Array);
+            _context = _context.PushContext(ContextType.Array);
             State = BsonReaderState.Type;
         }
 
@@ -735,7 +735,7 @@ namespace MongoDB.Bson.IO
             if (Disposed) { ThrowObjectDisposedException(); }
             VerifyBsonType("ReadStartDocument", BsonType.Document);
 
-            _context = new JsonReaderContext(_context, ContextType.Document);
+            _context = _context.PushContext(ContextType.Document);
             State = BsonReaderState.Type;
         }
 

--- a/src/MongoDB.Bson/IO/JsonReaderContext.cs
+++ b/src/MongoDB.Bson/IO/JsonReaderContext.cs
@@ -53,5 +53,10 @@ namespace MongoDB.Bson.IO
         {
             return _parentContext;
         }
+
+        internal JsonReaderContext PushContext(ContextType contextType)
+        {
+            return new JsonReaderContext(this, contextType);
+        }
     }
 }

--- a/src/MongoDB.Bson/IO/JsonReaderContext.cs
+++ b/src/MongoDB.Bson/IO/JsonReaderContext.cs
@@ -18,7 +18,8 @@ namespace MongoDB.Bson.IO
     internal class JsonReaderContext
     {
         // private fields
-        private JsonReaderContext _parentContext;
+        private readonly JsonReaderContext _parentContext;
+        private JsonReaderContext _cachedPushContext;
         private ContextType _contextType;
 
         // constructors
@@ -56,7 +57,11 @@ namespace MongoDB.Bson.IO
 
         internal JsonReaderContext PushContext(ContextType contextType)
         {
-            return new JsonReaderContext(this, contextType);
+            if (_cachedPushContext == null)
+                _cachedPushContext = new JsonReaderContext(this, contextType);
+            else
+                _cachedPushContext._contextType = contextType;
+            return _cachedPushContext;
         }
     }
 }

--- a/src/MongoDB.Bson/IO/JsonWriter.cs
+++ b/src/MongoDB.Bson/IO/JsonWriter.cs
@@ -312,7 +312,7 @@ namespace MongoDB.Bson.IO
             base.WriteEndArray();
             _textWriter.Write("]");
 
-            _context = _context.ParentContext;
+            _context = _context.PopContext();
             State = GetNextState();
         }
 
@@ -344,12 +344,12 @@ namespace MongoDB.Bson.IO
 
             if (_context.ContextType == ContextType.ScopeDocument)
             {
-                _context = _context.ParentContext;
+                _context = _context.PopContext();
                 WriteEndDocument();
             }
             else
             {
-                _context = _context.ParentContext;
+                _context = _context.PopContext();
             }
 
             if (_context == null)

--- a/src/MongoDB.Bson/IO/JsonWriter.cs
+++ b/src/MongoDB.Bson/IO/JsonWriter.cs
@@ -641,7 +641,7 @@ namespace MongoDB.Bson.IO
             WriteNameHelper(Name);
             _textWriter.Write("[");
 
-            _context = new JsonWriterContext(_context, ContextType.Array, Settings.IndentChars);
+            _context = _context.PushContext(ContextType.Array, Settings.IndentChars);
             State = BsonWriterState.Value;
         }
 
@@ -664,7 +664,7 @@ namespace MongoDB.Bson.IO
             _textWriter.Write("{");
 
             var contextType = (State == BsonWriterState.ScopeDocument) ? ContextType.ScopeDocument : ContextType.Document;
-            _context = new JsonWriterContext(_context, contextType, Settings.IndentChars);
+            _context = _context.PushContext(contextType, Settings.IndentChars);
             State = BsonWriterState.Name;
         }
 

--- a/src/MongoDB.Bson/IO/JsonWriterContext.cs
+++ b/src/MongoDB.Bson/IO/JsonWriterContext.cs
@@ -52,5 +52,10 @@ namespace MongoDB.Bson.IO
             get { return _hasElements; }
             set { _hasElements = value; }
         }
+
+        internal JsonWriterContext PopContext()
+        {
+            return _parentContext;
+        }
     }
 }

--- a/src/MongoDB.Bson/IO/JsonWriterContext.cs
+++ b/src/MongoDB.Bson/IO/JsonWriterContext.cs
@@ -18,7 +18,8 @@ namespace MongoDB.Bson.IO
     internal class JsonWriterContext
     {
         // private fields
-        private JsonWriterContext _parentContext;
+        private readonly JsonWriterContext _parentContext;
+        private JsonWriterContext _cachedPushContext;
         private ContextType _contextType;
         private string _indentation;
         private bool _hasElements = false;
@@ -60,7 +61,14 @@ namespace MongoDB.Bson.IO
 
         internal JsonWriterContext PushContext(ContextType contextType, string indentChars)
         {
-            return new JsonWriterContext(this, contextType, indentChars);
+            if (_cachedPushContext == null)
+                _cachedPushContext = new JsonWriterContext(this, contextType, indentChars);
+            else
+            {
+                _cachedPushContext._contextType = contextType;
+                _cachedPushContext._hasElements = false;
+            }
+            return _cachedPushContext;
         }
     }
 }

--- a/src/MongoDB.Bson/IO/JsonWriterContext.cs
+++ b/src/MongoDB.Bson/IO/JsonWriterContext.cs
@@ -57,5 +57,10 @@ namespace MongoDB.Bson.IO
         {
             return _parentContext;
         }
+
+        internal JsonWriterContext PushContext(ContextType contextType, string indentChars)
+        {
+            return new JsonWriterContext(this, contextType, indentChars);
+        }
     }
 }


### PR DESCRIPTION
See [CSHARP-5348](https://jira.mongodb.org/browse/CSHARP-5348) for details.

This PR is split into three commits
- First, adds PopContext if it is missing from Bson*Context (no logic change)
- Second, adds a PushContext method (no logic change)
- The third adds the caching logic to Bson*Context.

If the first and second commits should be separated, I can reduce the PR to just the caching logic. For our environment, the `BsonBinaryReader`/`BsonBinaryWriter` are also the most important ones.