### PR TITLE
CSHARP-5354: Add IsExpired check on the cached credential on SaslStep Initialize

### DIFF
--- a/src/MongoDB.Driver/Authentication/Oidc/OidcSaslMechanism.cs
+++ b/src/MongoDB.Driver/Authentication/Oidc/OidcSaslMechanism.cs
@@ -104,7 +104,7 @@ namespace MongoDB.Driver.Authentication.Oidc
         {
             var cachedCredentials = _oidcCallback.CachedCredentials;
 
-            if (cachedCredentials != null)
+            if (cachedCredentials != null && !cachedCredentials.IsExpired)
             {
                 return new OidcCachedCredentialsSaslStep(cachedCredentials);
             }


### PR DESCRIPTION
[CSHARP-5354](https://jira.mongodb.org/browse/CSHARP-5354): Add IsExpired check on SaslStep Initialize so we invoke the OidcObtainCredentialsSaslStep instead of the OidcCachedCredentialsSaslStep to renew the credentials through the callback.

