### PR TITLE
CSHARP-5368: Eliminiate allocations in Bson.Decimal128 to decimal conversion

### DIFF
--- a/src/MongoDB.Bson/ObjectModel/Decimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/Decimal128.cs
@@ -1909,7 +1909,7 @@ namespace MongoDB.Bson
             {
                 var xType = GetDecimal128Type(x);
                 var yType = GetDecimal128Type(y);
-// .NET Framework lacks some optimizations for enums that would result in boxing and lookup overhead for the default comparer
+				// .NET Framework lacks some optimizations for enums that would result in boxing and lookup overhead for the default comparer
 #if NET6_0_OR_GREATER
                 var result = Comparer<Decimal128Type>.Default.Compare(xType, yType);
 #else

--- a/src/MongoDB.Bson/ObjectModel/Decimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/Decimal128.cs
@@ -1465,7 +1465,12 @@ namespace MongoDB.Bson
         /// <param name="value">The value.</param>
         public Decimal128(decimal value)
         {
+#if NET6_0_OR_GREATER
+            Span<int> bits = stackalloc int[4];
+            _ = decimal.GetBits(value, bits);
+#else
             var bits = decimal.GetBits(value);
+#endif
             var isNegative = (bits[3] & 0x80000000) != 0;
             var scale = (short)((bits[3] & 0x00FF0000) >> 16);
             var exponent = (short)-scale;
@@ -1904,7 +1909,11 @@ namespace MongoDB.Bson
             {
                 var xType = GetDecimal128Type(x);
                 var yType = GetDecimal128Type(y);
-                var result = xType.CompareTo(yType);
+#if NET6_0_OR_GREATER
+                var result = Comparer<Decimal128Type>.Default.Compare(xType, yType);
+#else
+                var result = ((int)xType).CompareTo((int)yType);
+#endif
                 if (result == 0 && xType == Decimal128Type.Number)
                 {
                     return CompareNumbers(x, y);
@@ -1928,7 +1937,11 @@ namespace MongoDB.Bson
             {
                 var xClass = GetNumberClass(x);
                 var yClass = GetNumberClass(y);
-                var result = xClass.CompareTo(yClass);
+#if NET6_0_OR_GREATER
+                var result = Comparer<NumberClass>.Default.Compare(xClass, yClass);
+#else
+                var result = ((int)xClass).CompareTo((int)yClass);
+#endif
                 if (result == 0)
                 {
                     if (xClass == NumberClass.Negative)

--- a/src/MongoDB.Bson/ObjectModel/Decimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/Decimal128.cs
@@ -1938,7 +1938,7 @@ namespace MongoDB.Bson
             {
                 var xClass = GetNumberClass(x);
                 var yClass = GetNumberClass(y);
-// .NET Framework lacks some optimizations for enums that would result in boxing and lookup overhead for the default comparer
+				// .NET Framework lacks some optimizations for enums that would result in boxing and lookup overhead for the default comparer
 #if NET6_0_OR_GREATER
                 var result = Comparer<NumberClass>.Default.Compare(xClass, yClass);
 #else

--- a/src/MongoDB.Bson/ObjectModel/Decimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/Decimal128.cs
@@ -1909,6 +1909,7 @@ namespace MongoDB.Bson
             {
                 var xType = GetDecimal128Type(x);
                 var yType = GetDecimal128Type(y);
+// .NET Framework lacks some optimizations for enums that would result in boxing and lookup overhead for the default comparer
 #if NET6_0_OR_GREATER
                 var result = Comparer<Decimal128Type>.Default.Compare(xType, yType);
 #else
@@ -1937,6 +1938,7 @@ namespace MongoDB.Bson
             {
                 var xClass = GetNumberClass(x);
                 var yClass = GetNumberClass(y);
+// .NET Framework lacks some optimizations for enums that would result in boxing and lookup overhead for the default comparer
 #if NET6_0_OR_GREATER
                 var result = Comparer<NumberClass>.Default.Compare(xClass, yClass);
 #else


### PR DESCRIPTION
See [CSHARP-5368](https://jira.mongodb.org/browse/CSHARP-5368) for details.

This PR removes allocations that happens for

- [`Enum.CompareTo(object? enum)`](https://learn.microsoft.com/de-de/dotnet/api/system.enum.compareto?view=net-8.0), because this results in boxing of both enums.
The alternative is `Comparer<T>.Default.Compar` for .NET 6.0 and manual int-casts for .NET 4.x.
- [`decimal.GetBits(decimal d)`](https://learn.microsoft.com/en-us/dotnet/api/system.decimal.getbits?view=net-8.0#system-decimal-getbits(system-decimal)) allocates an `int[4]` array on every call.
The alternative is [`decimal.GetBits(decimal d, Span<int> destination)`](https://learn.microsoft.com/en-us/dotnet/api/system.decimal.getbits?view=net-8.0#system-decimal-getbits(system-decimal-system-span((system-int32)))), which allows you to pass a [stack allocated](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/stackalloc) int-array. This method is not available in .NET 4.x.