### PR TITLE
CSHARP-4960: Add new type field support for search indexes

### DIFF
--- a/specifications/index-management/tests/createSearchIndex.json
+++ b/specifications/index-management/tests/createSearchIndex.json
@@ -28,7 +28,17 @@
   ],
   "runOnRequirements": [
     {
-      "minServerVersion": "7.0.0",
+      "minServerVersion": "7.0.5",
+      "maxServerVersion": "7.0.99",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    },
+    {
+      "minServerVersion": "7.2.0",
       "topologies": [
         "replicaset",
         "load-balanced",
@@ -50,54 +60,8 @@
                 "mappings": {
                   "dynamic": true
                 }
-              }
-            }
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndex",
-          "object": "collection0",
-          "arguments": {
-            "model": {
-              "definition": {
-                "mappings": {
-                  "dynamic": true
-                }
               },
-              "name": "test index"
+              "type": "search"
             }
           },
           "expectError": {
@@ -121,7 +85,117 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              },
+              "name": "test index",
+              "type": "search"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "fields": [
+                  {
+                    "type": "vector",
+                    "path": "plot_embedding",
+                    "numDimensions": 1536,
+                    "similarity": "euclidean"
+                  }
+                ]
+              },
+              "name": "test index",
+              "type": "vectorSearch"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
                     }
                   ],
                   "$db": "database0"

--- a/specifications/index-management/tests/createSearchIndex.yml
+++ b/specifications/index-management/tests/createSearchIndex.yml
@@ -16,7 +16,13 @@ createEntities:
       collectionName: *collection0
 
 runOnRequirements:
-  - minServerVersion: "7.0.0"
+  # Skip server versions without fix of SERVER-83107 to avoid error message "BSON field 'createSearchIndexes.indexes.type' is an unknown field."
+  # SERVER-83107 was not backported to 7.1.
+  - minServerVersion: "7.0.5"
+    maxServerVersion: "7.0.99"
+    topologies: [ replicaset, load-balanced, sharded ]
+    serverless: forbid
+  - minServerVersion: "7.2.0"
     topologies: [ replicaset, load-balanced, sharded ]
     serverless: forbid
 
@@ -26,7 +32,7 @@ tests:
       - name: createSearchIndex
         object: *collection0
         arguments:
-          model: { definition: &definition { mappings: { dynamic: true } } }
+          model: { definition: &definition { mappings: { dynamic: true } } , type: 'search' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -39,15 +45,15 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition } ]
+                indexes: [ { definition: *definition, type: 'search'} ]
                 $db: *database0
 
   - description: "name provided for an index definition"
     operations:
       - name: createSearchIndex
         object: *collection0
-        arguments: 
-          model: { definition: &definition { mappings: { dynamic: true } } , name: 'test index' }
+        arguments:
+          model: { definition: &definition { mappings: { dynamic: true } } , name: 'test index', type: 'search' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -60,5 +66,27 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition, name: 'test index' } ]
+                indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
+                $db: *database0
+
+  - description: "create a vector search index"
+    operations:
+      - name: createSearchIndex
+        object: *collection0
+        arguments:
+          model: { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ] }
+            , name: 'test index', type: 'vectorSearch' }
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createSearchIndexes: *collection0
+                indexes: [ { definition: *definition, name: 'test index', type: 'vectorSearch' } ]
                 $db: *database0

--- a/specifications/index-management/tests/createSearchIndexes.json
+++ b/specifications/index-management/tests/createSearchIndexes.json
@@ -28,7 +28,17 @@
   ],
   "runOnRequirements": [
     {
-      "minServerVersion": "7.0.0",
+      "minServerVersion": "7.0.5",
+      "maxServerVersion": "7.0.99",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    },
+    {
+      "minServerVersion": "7.2.0",
       "topologies": [
         "replicaset",
         "load-balanced",
@@ -83,56 +93,8 @@
                   "mappings": {
                     "dynamic": true
                   }
-                }
-              }
-            ]
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndexes",
-          "object": "collection0",
-          "arguments": {
-            "models": [
-              {
-                "definition": {
-                  "mappings": {
-                    "dynamic": true
-                  }
                 },
-                "name": "test index"
+                "type": "search"
               }
             ]
           },
@@ -157,7 +119,121 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "mappings": {
+                    "dynamic": true
+                  }
+                },
+                "name": "test index",
+                "type": "search"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "fields": [
+                    {
+                      "type": "vector",
+                      "path": "plot_embedding",
+                      "numDimensions": 1536,
+                      "similarity": "euclidean"
+                    }
+                  ]
+                },
+                "name": "test index",
+                "type": "vectorSearch"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
                     }
                   ],
                   "$db": "database0"

--- a/specifications/index-management/tests/createSearchIndexes.yml
+++ b/specifications/index-management/tests/createSearchIndexes.yml
@@ -16,7 +16,13 @@ createEntities:
       collectionName: *collection0
 
 runOnRequirements:
-  - minServerVersion: "7.0.0"
+  # Skip server versions without fix of SERVER-83107 to avoid error message "BSON field 'createSearchIndexes.indexes.type' is an unknown field."
+  # SERVER-83107 was not backported to 7.1.
+  - minServerVersion: "7.0.5"
+    maxServerVersion: "7.0.99"
+    topologies: [ replicaset, load-balanced, sharded ]
+    serverless: forbid
+  - minServerVersion: "7.2.0"
     topologies: [ replicaset, load-balanced, sharded ]
     serverless: forbid
 
@@ -25,7 +31,7 @@ tests:
     operations:
       - name: createSearchIndexes
         object: *collection0
-        arguments: 
+        arguments:
           models: []
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
@@ -48,7 +54,7 @@ tests:
       - name: createSearchIndexes
         object: *collection0
         arguments:
-          models: [ { definition: &definition { mappings: { dynamic: true } } } ]
+          models: [ { definition: &definition { mappings: { dynamic: true } } , type: 'search' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -61,15 +67,15 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition } ]
+                indexes: [ { definition: *definition, type: 'search'} ]
                 $db: *database0
 
   - description: "name provided for an index definition"
     operations:
       - name: createSearchIndexes
         object: *collection0
-        arguments: 
-          models: [ { definition: &definition { mappings: { dynamic: true } } , name: 'test index' } ]
+        arguments:
+          models: [ { definition: &definition { mappings: { dynamic: true } } , name: 'test index' , type: 'search' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -82,5 +88,27 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition, name: 'test index' } ]
+                indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
+                $db: *database0
+
+  - description: "create a vector search index"
+    operations:
+      - name: createSearchIndexes
+        object: *collection0
+        arguments:
+          models: [ { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ] },
+                      name: 'test index' , type: 'vectorSearch' } ]
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createSearchIndexes: *collection0
+                indexes: [ { definition: *definition, name: 'test index', type: 'vectorSearch' } ]
                 $db: *database0

--- a/src/MongoDB.Driver/Core/Operations/CreateSearchIndexRequest.cs
+++ b/src/MongoDB.Driver/Core/Operations/CreateSearchIndexRequest.cs
@@ -21,11 +21,13 @@ namespace MongoDB.Driver.Core.Operations
     internal sealed class CreateSearchIndexRequest
     {
         public string Name { get; }
+        public SearchIndexType? Type { get; }
         public BsonDocument Definition { get; }
 
-        public CreateSearchIndexRequest(string name, BsonDocument definition)
+        public CreateSearchIndexRequest(string name, SearchIndexType? type, BsonDocument definition)
         {
             Name = name;
+            Type = type;
             Definition = Ensure.IsNotNull(definition, nameof(definition));
         }
 
@@ -34,6 +36,7 @@ namespace MongoDB.Driver.Core.Operations
             new()
             {
                 { "name", Name, Name != null },
+                { "type", Type == SearchIndexType.VectorSearch ? "vectorSearch" : "search", Type != null },
                 { "definition", Definition }
             };
     }

--- a/src/MongoDB.Driver/CreateSearchIndexModel.cs
+++ b/src/MongoDB.Driver/CreateSearchIndexModel.cs
@@ -26,6 +26,10 @@ namespace MongoDB.Driver
         /// <value>The index name.</value>
         public string Name { get; }
 
+        /// <summary>Gets the index type.</summary>
+        /// <value>The index type.</value>
+        public SearchIndexType? Type { get; }
+
         /// <summary>Gets the index definition.</summary>
         /// <value>The definition.</value>
         public BsonDocument Definition { get; }
@@ -35,9 +39,18 @@ namespace MongoDB.Driver
         /// </summary>
         /// <param name="name">The name.</param>
         /// <param name="definition">The definition.</param>
-        public CreateSearchIndexModel(string name, BsonDocument definition)
+        public CreateSearchIndexModel(string name, BsonDocument definition) : this(name, null, definition) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateSearchIndexModel"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="type">The type.</param>
+        /// <param name="definition">The definition.</param>
+        public CreateSearchIndexModel(string name, SearchIndexType? type, BsonDocument definition)
         {
             Name = name;
+            Type = type;
             Definition = definition;
         }
     }

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -1856,6 +1856,9 @@ namespace MongoDB.Driver
             public string CreateOne(BsonDocument definition, string name = null, CancellationToken cancellationToken = default) =>
                 CreateOne(new CreateSearchIndexModel(name, definition), cancellationToken);
 
+            public string CreateOne(BsonDocument definition, SearchIndexType type, string name = null, CancellationToken cancellationToken = default) =>
+                CreateOne(new CreateSearchIndexModel(name, type, definition), cancellationToken);
+
             public string CreateOne(CreateSearchIndexModel model, CancellationToken cancellationToken = default)
             {
                 var result = CreateMany(new[] { model }, cancellationToken);
@@ -1864,6 +1867,9 @@ namespace MongoDB.Driver
 
             public Task<string> CreateOneAsync(BsonDocument definition, string name = null, CancellationToken cancellationToken = default) =>
                 CreateOneAsync(new CreateSearchIndexModel(name, definition), cancellationToken);
+
+            public Task<string> CreateOneAsync(BsonDocument definition, SearchIndexType type, string name = null, CancellationToken cancellationToken = default) =>
+                CreateOneAsync(new CreateSearchIndexModel(name, type, definition), cancellationToken);
 
             public async Task<string> CreateOneAsync(CreateSearchIndexModel model, CancellationToken cancellationToken = default)
             {
@@ -1917,7 +1923,7 @@ namespace MongoDB.Driver
 
             private CreateSearchIndexesOperation CreateCreateIndexesOperation(IEnumerable<CreateSearchIndexModel> models) =>
                 new(_collection._collectionNamespace,
-                    models.Select(m => new CreateSearchIndexRequest(m.Name, m.Definition)),
+                    models.Select(m => new CreateSearchIndexRequest(m.Name, m.Type, m.Definition)),
                     _collection._messageEncoderSettings);
 
             private string[] GetIndexNames(BsonDocument createSearchIndexesResponse) =>

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -1856,9 +1856,6 @@ namespace MongoDB.Driver
             public string CreateOne(BsonDocument definition, string name = null, CancellationToken cancellationToken = default) =>
                 CreateOne(new CreateSearchIndexModel(name, definition), cancellationToken);
 
-            public string CreateOne(BsonDocument definition, SearchIndexType type, string name = null, CancellationToken cancellationToken = default) =>
-                CreateOne(new CreateSearchIndexModel(name, type, definition), cancellationToken);
-
             public string CreateOne(CreateSearchIndexModel model, CancellationToken cancellationToken = default)
             {
                 var result = CreateMany(new[] { model }, cancellationToken);
@@ -1867,9 +1864,6 @@ namespace MongoDB.Driver
 
             public Task<string> CreateOneAsync(BsonDocument definition, string name = null, CancellationToken cancellationToken = default) =>
                 CreateOneAsync(new CreateSearchIndexModel(name, definition), cancellationToken);
-
-            public Task<string> CreateOneAsync(BsonDocument definition, SearchIndexType type, string name = null, CancellationToken cancellationToken = default) =>
-                CreateOneAsync(new CreateSearchIndexModel(name, type, definition), cancellationToken);
 
             public async Task<string> CreateOneAsync(CreateSearchIndexModel model, CancellationToken cancellationToken = default)
             {

--- a/src/MongoDB.Driver/Search/IMongoSearchIndexManager.cs
+++ b/src/MongoDB.Driver/Search/IMongoSearchIndexManager.cs
@@ -59,18 +59,6 @@ namespace MongoDB.Driver.Search
         /// <summary>
         /// Creates a search index.
         /// </summary>
-        /// <param name="definition">The index definition.</param>
-        /// <param name="type">The index type.</param>
-        /// <param name="name">The index name.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>
-        /// The name of the index that was created.
-        /// </returns>
-        string CreateOne(BsonDocument definition, SearchIndexType type, string name = null, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a search index.
-        /// </summary>
         /// <param name="model">The model defining the index.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
@@ -88,18 +76,6 @@ namespace MongoDB.Driver.Search
         /// The name of the index that was created.
         /// </returns>
         Task<string> CreateOneAsync(BsonDocument definition, string name = null, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a search index.
-        /// </summary>
-        /// <param name="definition">The index definition.</param>
-        /// <param name="type">The index type.</param>
-        /// <param name="name">The index name.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>
-        /// The name of the index that was created.
-        /// </returns>
-        Task<string> CreateOneAsync(BsonDocument definition, SearchIndexType type, string name = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a search index.

--- a/src/MongoDB.Driver/Search/IMongoSearchIndexManager.cs
+++ b/src/MongoDB.Driver/Search/IMongoSearchIndexManager.cs
@@ -59,6 +59,18 @@ namespace MongoDB.Driver.Search
         /// <summary>
         /// Creates a search index.
         /// </summary>
+        /// <param name="definition">The index definition.</param>
+        /// <param name="type">The index type.</param>
+        /// <param name="name">The index name.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The name of the index that was created.
+        /// </returns>
+        string CreateOne(BsonDocument definition, SearchIndexType type, string name = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a search index.
+        /// </summary>
         /// <param name="model">The model defining the index.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>
@@ -76,6 +88,18 @@ namespace MongoDB.Driver.Search
         /// The name of the index that was created.
         /// </returns>
         Task<string> CreateOneAsync(BsonDocument definition, string name = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a search index.
+        /// </summary>
+        /// <param name="definition">The index definition.</param>
+        /// <param name="type">The index type.</param>
+        /// <param name="name">The index name.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The name of the index that was created.
+        /// </returns>
+        Task<string> CreateOneAsync(BsonDocument definition, SearchIndexType type, string name = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a search index.

--- a/src/MongoDB.Driver/SearchIndexType.cs
+++ b/src/MongoDB.Driver/SearchIndexType.cs
@@ -1,0 +1,32 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.Driver
+{
+    /// <summary>
+    /// Represents an Atlas search index type.
+    /// </summary>
+    public enum SearchIndexType
+    {
+        /// <summary>
+        /// A search index type.
+        /// </summary>
+        Search,
+        /// <summary>
+        /// A vector search index type.
+        /// </summary>
+        VectorSearch
+    }
+}

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateSearchIndexOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateSearchIndexOperation.cs
@@ -84,6 +84,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
 
             BsonDocument definition = null;
             string name = null;
+            SearchIndexType? type = null;
 
             foreach (var argument in model)
             {
@@ -91,6 +92,14 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 {
                     case "name":
                         name = argument.Value.AsString;
+                        break;
+                    case "type":
+                        type = argument.Value.AsString switch
+                        {
+                            "search" => SearchIndexType.Search,
+                            "vectorSearch" => SearchIndexType.VectorSearch,
+                            _ => throw new FormatException($"Unexpected search index type '{argument.Value}'.")
+                        };
                         break;
                     case "definition":
                         definition = argument.Value.AsBsonDocument;
@@ -100,7 +109,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 }
             }
 
-            var createSearchIndexModel = new CreateSearchIndexModel(name, definition);
+            var createSearchIndexModel = new CreateSearchIndexModel(name, type, definition);
 
             return new(collection, createSearchIndexModel);
         }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateSearchIndexesOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedCreateSearchIndexesOperation.cs
@@ -89,6 +89,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             {
                 BsonDocument definition = null;
                 string name = null;
+                SearchIndexType? type = null;
 
                 foreach (var argument in model.AsBsonDocument)
                 {
@@ -96,6 +97,14 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     {
                         case "name":
                             name = argument.Value.AsString;
+                            break;
+                        case "type":
+                            type = argument.Value.AsString switch
+                            {
+                                "search" => SearchIndexType.Search,
+                                "vectorSearch" => SearchIndexType.VectorSearch,
+                                _ => throw new FormatException($"Unexpected search index type '{argument.Value}'.")
+                            };
                             break;
                         case "definition":
                             definition = argument.Value.AsBsonDocument;
@@ -105,7 +114,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     }
                 }
 
-                parsedModels.Add(new(name, definition));
+                parsedModels.Add(new(name, type, definition));
             }
 
 


### PR DESCRIPTION
Add support for the `type` field when creating search indexes. Also syncs the unified search index tests and adds two new search index prose tests, as added in [jira.mongodb.org/browse/DRIVERS-2768](https://jira.mongodb.org/browse/DRIVERS-2768).