### PR TITLE
CSHARP-5061: Enable tests that require failCommand with appName on initial handshake before 4.9

### DIFF
--- a/specifications/load-balancers/tests/sdam-error-handling.json
+++ b/specifications/load-balancers/tests/sdam-error-handling.json
@@ -263,7 +263,7 @@
       "description": "errors during the initial connection hello are ignored",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.9"
+          "minServerVersion": "4.4.7"
         }
       ],
       "operations": [

--- a/specifications/load-balancers/tests/sdam-error-handling.yml
+++ b/specifications/load-balancers/tests/sdam-error-handling.yml
@@ -141,9 +141,8 @@ tests:
   # to the same mongos on which the failpoint is set.
   - description: errors during the initial connection hello are ignored
     runOnRequirements:
-      # Server version 4.9+ is needed to set a fail point on the initial
-      # connection handshake with the appName filter due to SERVER-49336.
-      - minServerVersion: '4.9'
+      # Require SERVER-49336 for failCommand + appName on the initial handshake.
+      - minServerVersion: '4.4.7'
     operations:
       - name: failPoint
         object: testRunner

--- a/specifications/server-discovery-and-monitoring/tests/unified/hello-command-error.json
+++ b/specifications/server-discovery-and-monitoring/tests/unified/hello-command-error.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.10",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9",
+      "minServerVersion": "4.4.7",
       "serverless": "forbid",
       "topologies": [
         "single",

--- a/specifications/server-discovery-and-monitoring/tests/unified/hello-command-error.yml
+++ b/specifications/server-discovery-and-monitoring/tests/unified/hello-command-error.yml
@@ -4,8 +4,8 @@ description: hello-command-error
 schemaVersion: "1.10"
 
 runOnRequirements:
-    # failCommand appName requirements
-  - minServerVersion: "4.9"
+  # Require SERVER-49336 for failCommand + appName on the initial handshake.
+  - minServerVersion: "4.4.7"
     serverless: forbid
     topologies: [ single, replicaset, sharded ]
 

--- a/specifications/server-discovery-and-monitoring/tests/unified/hello-network-error.json
+++ b/specifications/server-discovery-and-monitoring/tests/unified/hello-network-error.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.10",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9",
+      "minServerVersion": "4.4.7",
       "serverless": "forbid",
       "topologies": [
         "single",

--- a/specifications/server-discovery-and-monitoring/tests/unified/hello-network-error.yml
+++ b/specifications/server-discovery-and-monitoring/tests/unified/hello-network-error.yml
@@ -4,8 +4,8 @@ description: hello-network-error
 schemaVersion: "1.10"
 
 runOnRequirements:
-    # failCommand appName requirements
-  - minServerVersion: "4.9"
+  # Require SERVER-49336 for failCommand + appName on the initial handshake.
+  - minServerVersion: "4.4.7"
     serverless: forbid
     topologies: [ single, replicaset, sharded ]
 

--- a/specifications/server-discovery-and-monitoring/tests/unified/interruptInUse-pool-clear.json
+++ b/specifications/server-discovery-and-monitoring/tests/unified/interruptInUse-pool-clear.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.11",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9",
+      "minServerVersion": "4.4",
       "serverless": "forbid",
       "topologies": [
         "replicaset",

--- a/specifications/server-discovery-and-monitoring/tests/unified/interruptInUse-pool-clear.yml
+++ b/specifications/server-discovery-and-monitoring/tests/unified/interruptInUse-pool-clear.yml
@@ -5,7 +5,7 @@ schemaVersion: "1.11"
 
 runOnRequirements:
   # failCommand appName requirements
-  - minServerVersion: "4.9"
+  - minServerVersion: "4.4"
     serverless: forbid
     topologies: [ replicaset, sharded ]
 

--- a/specifications/server-discovery-and-monitoring/tests/unified/minPoolSize-error.json
+++ b/specifications/server-discovery-and-monitoring/tests/unified/minPoolSize-error.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.10",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9",
+      "minServerVersion": "4.4.7",
       "serverless": "forbid",
       "topologies": [
         "single"

--- a/specifications/server-discovery-and-monitoring/tests/unified/minPoolSize-error.yml
+++ b/specifications/server-discovery-and-monitoring/tests/unified/minPoolSize-error.yml
@@ -4,8 +4,8 @@ description: minPoolSize-error
 schemaVersion: "1.10"
 
 runOnRequirements:
-    # failCommand appName requirements
-  - minServerVersion: "4.9"
+  # Require SERVER-49336 for failCommand + appName on the initial handshake.
+  - minServerVersion: "4.4.7"
     serverless: forbid
     topologies:
       - single


### PR DESCRIPTION
Sample previously skipped tests are now running and passing: https://spruce.mongodb.com/task/dot_net_driver_secure_tests_windows__version~4.4_os~windows_64_topology~sharded_cluster_auth~auth_ssl~ssl_test_net472_patch_8b465a2fb7c8b3cadf05729e38af910a659655df_67257c93ea33b9000738c24c_24_11_02_01_12_52?execution=0&page=0&sortBy=STATUS&sortDir=ASC&testname=hello-comman