### PR TITLE
CSHARP-5412: Performance: Avoid allocations of BsonDeserializationContext when deserialising a batch

### DIFF
--- a/src/MongoDB.Driver/Core/Operations/CursorBatchDeserializationHelper.cs
+++ b/src/MongoDB.Driver/Core/Operations/CursorBatchDeserializationHelper.cs
@@ -49,12 +49,13 @@ namespace MongoDB.Driver.Core.Operations
             using (var stream = new ByteBufferStream(batch.Slice, ownsBuffer: false))
             using (var reader = new BsonBinaryReader(stream, readerSettings))
             {
+                var context = BsonDeserializationContext.CreateRoot(reader);
+
                 // BSON requires that the top level object be a document, but an array looks close enough to a document that we can pretend it is one
                 reader.ReadStartDocument();
                 while (reader.ReadBsonType() != 0)
                 {
                     reader.SkipName(); // skip over the index pseudo names
-                    var context = BsonDeserializationContext.CreateRoot(reader);
                     var document = documentSerializer.Deserialize<TDocument>(context);
                     documents.Add(document);
                 }


### PR DESCRIPTION
See [CSHARP-5412](https://jira.mongodb.org/browse/CSHARP-5412) for details.

This PR reuses a `BsonDeserializationContext` so that only one object needs to be allocated for a batch instead of one object per document in the batch.