### PR TITLE
CSHARP-5203: Benchmark Collection and Client bulkWrite

### DIFF
--- a/CSharpDriver.sln
+++ b/CSharpDriver.sln
@@ -60,6 +60,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDB.Driver.Encryption.T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDB.Driver.Authentication.AWS", "src\MongoDB.Driver.Authentication.AWS\MongoDB.Driver.Authentication.AWS.csproj", "{A0CAC199-457E-4862-AF9E-971C7A77CBF9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp2", "ConsoleApp2\ConsoleApp2.csproj", "{54EBC539-ABFB-45A0-A77F-1A294576212B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,10 @@ Global
 		{A0CAC199-457E-4862-AF9E-971C7A77CBF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0CAC199-457E-4862-AF9E-971C7A77CBF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A0CAC199-457E-4862-AF9E-971C7A77CBF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54EBC539-ABFB-45A0-A77F-1A294576212B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54EBC539-ABFB-45A0-A77F-1A294576212B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54EBC539-ABFB-45A0-A77F-1A294576212B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54EBC539-ABFB-45A0-A77F-1A294576212B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CSharpDriver.sln
+++ b/CSharpDriver.sln
@@ -60,8 +60,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDB.Driver.Encryption.T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDB.Driver.Authentication.AWS", "src\MongoDB.Driver.Authentication.AWS\MongoDB.Driver.Authentication.AWS.csproj", "{A0CAC199-457E-4862-AF9E-971C7A77CBF9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp2", "ConsoleApp2\ConsoleApp2.csproj", "{54EBC539-ABFB-45A0-A77F-1A294576212B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -132,10 +130,6 @@ Global
 		{A0CAC199-457E-4862-AF9E-971C7A77CBF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0CAC199-457E-4862-AF9E-971C7A77CBF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A0CAC199-457E-4862-AF9E-971C7A77CBF9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{54EBC539-ABFB-45A0-A77F-1A294576212B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{54EBC539-ABFB-45A0-A77F-1A294576212B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{54EBC539-ABFB-45A0-A77F-1A294576212B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{54EBC539-ABFB-45A0-A77F-1A294576212B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkResult.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkResult.cs
@@ -27,8 +27,10 @@ namespace MongoDB.Benchmarks
 
         public BenchmarkResult(BenchmarkReport benchmarkReport)
         {
+            Categories = new HashSet<string>(benchmarkReport.BenchmarkCase.Descriptor.Categories);
+
             int dataSetSize;
-            if (benchmarkReport.BenchmarkCase.Descriptor.HasCategory(DriverBenchmarkCategory.BsonBench))
+            if (Categories.Contains(DriverBenchmarkCategory.BsonBench))
             {
                 var bsonBenchmarkData = (BsonBenchmarkData)benchmarkReport.BenchmarkCase.Parameters["BenchmarkData"];
                 Name = bsonBenchmarkData.DataSetName + benchmarkReport.BenchmarkCase.Descriptor.Type.Name;
@@ -36,11 +38,12 @@ namespace MongoDB.Benchmarks
             }
             else
             {
-                Name = benchmarkReport.BenchmarkCase.Descriptor.Type.Name;
+                Name = Categories.Contains(DriverBenchmarkCategory.BulkWriteBench)
+                    ? benchmarkReport.BenchmarkCase.Descriptor.WorkloadMethod.Name
+                    : benchmarkReport.BenchmarkCase.Descriptor.Type.Name;
+                
                 dataSetSize = (int)benchmarkReport.BenchmarkCase.Parameters["BenchmarkDataSetSize"];
             }
-
-            Categories = new HashSet<string>(benchmarkReport.BenchmarkCase.Descriptor.Categories);
 
             // change the median from nanoseconds to seconds for calculating the score.
             // since dataSetSize is in bytes, divide the score to convert to MB/s

--- a/benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs
@@ -26,6 +26,9 @@ namespace MongoDB.Benchmarks
         public const string ReadBench = "ReadBench";
         public const string SingleBench = "SingleBench";
         public const string WriteBench = "WriteBench";
+        
+        // not included in AllCategories as it's not part of the benchmarking spec
+        public const string BulkWriteBench = "BulkWriteBench";
 
         public static readonly IEnumerable<string> AllCategories = new[] {BsonBench, ReadBench, WriteBench, MultiBench, SingleBench, ParallelBench, DriverBench};
     }

--- a/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
@@ -21,7 +21,7 @@ using static MongoDB.Benchmarks.BenchmarkHelper;
 
 namespace MongoDB.Benchmarks.MultiDoc
 {
-    [IterationCount(100)]
+    [IterationCount(15)]
     [BenchmarkCategory(DriverBenchmarkCategory.BulkWriteBench, DriverBenchmarkCategory.MultiBench, DriverBenchmarkCategory.WriteBench, DriverBenchmarkCategory.DriverBench)]
     public class BulkWriteMixedOpsBenchmark
     {

--- a/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
@@ -47,9 +47,11 @@ namespace MongoDB.Benchmarks.MultiDoc
             var smallDocument = ReadExtendedJson("single_and_multi_document/small_doc.json");
             for (var i = 0; i < 10000; i++)
             {
-                _clientBulkWriteMixedOpsModels.Add(new BulkWriteInsertOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Length], smallDocument.DeepClone().AsBsonDocument));
-                _clientBulkWriteMixedOpsModels.Add(new BulkWriteReplaceOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Length], FilterDefinition<BsonDocument>.Empty, smallDocument.DeepClone().AsBsonDocument));
-                _clientBulkWriteMixedOpsModels.Add(new BulkWriteDeleteOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Length], FilterDefinition<BsonDocument>.Empty));
+                var collectionName = __collectionNamespaces[i % __collectionNamespaces.Length];
+                
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteInsertOneModel<BsonDocument>(collectionName, smallDocument.DeepClone().AsBsonDocument));
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteReplaceOneModel<BsonDocument>(collectionName, FilterDefinition<BsonDocument>.Empty, smallDocument.DeepClone().AsBsonDocument));
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteDeleteOneModel<BsonDocument>(collectionName, FilterDefinition<BsonDocument>.Empty));
                 
                 _collectionBulkWriteMixedOpsModels.Add(new InsertOneModel<BsonDocument>(smallDocument.DeepClone().AsBsonDocument));
                 _collectionBulkWriteMixedOpsModels.Add(new ReplaceOneModel<BsonDocument>(FilterDefinition<BsonDocument>.Empty, smallDocument.DeepClone().AsBsonDocument));

--- a/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
@@ -64,13 +64,13 @@ namespace MongoDB.Benchmarks.MultiDoc
         }
 
         [Benchmark]
-        public void SmallDocCollectionBulkMixedOpsBenchmark()
+        public void SmallDocCollectionBulkWriteMixedOpsBenchmark()
         {
             _collection.BulkWrite(_collectionBulkWriteMixedOpsModels, new BulkWriteOptions());
         }
         
         [Benchmark]
-        public void SmallDocClientBulkMixedOpsBenchmark()
+        public void SmallDocClientBulkWriteMixedOpsBenchmark()
         {
             _client.BulkWrite(_clientBulkWriteMixedOpsModels, new ClientBulkWriteOptions());
         }

--- a/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
@@ -32,9 +32,9 @@ namespace MongoDB.Benchmarks.MultiDoc
         private readonly List<BulkWriteModel> _clientBulkWriteMixedOpsModels = [];
         private readonly List<WriteModel<BsonDocument>> _collectionBulkWriteMixedOpsModels = [];
 
-        private static readonly List<string> __collectionNamespaces = Enumerable.Range(0, 10)
+        private static readonly string[] __collectionNamespaces = Enumerable.Range(0, 10)
             .Select(i => $"{MongoConfiguration.PerfTestDatabaseName}.{MongoConfiguration.PerfTestCollectionName}_{i}")
-            .ToList();
+            .ToArray();
 
         [Params(5_500_000)]
         public int BenchmarkDataSetSize { get; set; } // used in BenchmarkResult.cs
@@ -47,9 +47,9 @@ namespace MongoDB.Benchmarks.MultiDoc
             var smallDocument = ReadExtendedJson("single_and_multi_document/small_doc.json");
             for (var i = 0; i < 10000; i++)
             {
-                _clientBulkWriteMixedOpsModels.Add(new BulkWriteInsertOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Count], smallDocument.DeepClone().AsBsonDocument));
-                _clientBulkWriteMixedOpsModels.Add(new BulkWriteReplaceOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Count], FilterDefinition<BsonDocument>.Empty, smallDocument.DeepClone().AsBsonDocument));
-                _clientBulkWriteMixedOpsModels.Add(new BulkWriteDeleteOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Count], FilterDefinition<BsonDocument>.Empty));
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteInsertOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Length], smallDocument.DeepClone().AsBsonDocument));
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteReplaceOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Length], FilterDefinition<BsonDocument>.Empty, smallDocument.DeepClone().AsBsonDocument));
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteDeleteOneModel<BsonDocument>(__collectionNamespaces[i % __collectionNamespaces.Length], FilterDefinition<BsonDocument>.Empty));
                 
                 _collectionBulkWriteMixedOpsModels.Add(new InsertOneModel<BsonDocument>(smallDocument.DeepClone().AsBsonDocument));
                 _collectionBulkWriteMixedOpsModels.Add(new ReplaceOneModel<BsonDocument>(FilterDefinition<BsonDocument>.Empty, smallDocument.DeepClone().AsBsonDocument));
@@ -74,13 +74,13 @@ namespace MongoDB.Benchmarks.MultiDoc
         [Benchmark]
         public void SmallDocCollectionBulkWriteMixedOpsBenchmark()
         {
-            _collection.BulkWrite(_collectionBulkWriteMixedOpsModels, new BulkWriteOptions());
+            _collection.BulkWrite(_collectionBulkWriteMixedOpsModels, new());
         }
         
         [Benchmark]
         public void SmallDocClientBulkWriteMixedOpsBenchmark()
         {
-            _client.BulkWrite(_clientBulkWriteMixedOpsModels, new ClientBulkWriteOptions());
+            _client.BulkWrite(_clientBulkWriteMixedOpsModels, new());
         }
 
         [GlobalCleanup]

--- a/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/BulkWriteMixedOpsBenchmark.cs
@@ -1,0 +1,84 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using static MongoDB.Benchmarks.BenchmarkHelper;
+
+namespace MongoDB.Benchmarks.MultiDoc
+{
+    [IterationCount(100)]
+    [BenchmarkCategory(DriverBenchmarkCategory.BulkWriteBench, DriverBenchmarkCategory.MultiBench, DriverBenchmarkCategory.WriteBench, DriverBenchmarkCategory.DriverBench)]
+    public class BulkWriteMixedOpsBenchmark
+    {
+        private IMongoClient _client;
+        private IMongoCollection<BsonDocument> _collection;
+        private IMongoDatabase _database;
+        private readonly List<BulkWriteModel> _clientBulkWriteMixedOpsModels = [];
+        private readonly List<WriteModel<BsonDocument>> _collectionBulkWriteMixedOpsModels = [];
+
+        private static readonly CollectionNamespace __collectionNamespace =
+            CollectionNamespace.FromFullName($"{MongoConfiguration.PerfTestDatabaseName}.{MongoConfiguration.PerfTestCollectionName}");
+
+        [Params(5_500_000)]
+        public int BenchmarkDataSetSize { get; set; } // used in BenchmarkResult.cs
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _client = MongoConfiguration.CreateClient();
+            _database = _client.GetDatabase(MongoConfiguration.PerfTestDatabaseName);
+
+            var smallDocument = ReadExtendedJson("single_and_multi_document/small_doc.json");
+            for (var i = 0; i < 10000; i++)
+            {
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteInsertOneModel<BsonDocument>(__collectionNamespace, smallDocument.DeepClone().AsBsonDocument));
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteReplaceOneModel<BsonDocument>(__collectionNamespace, FilterDefinition<BsonDocument>.Empty, smallDocument.DeepClone().AsBsonDocument));
+                _clientBulkWriteMixedOpsModels.Add(new BulkWriteDeleteOneModel<BsonDocument>(__collectionNamespace, FilterDefinition<BsonDocument>.Empty));
+                
+                _collectionBulkWriteMixedOpsModels.Add(new InsertOneModel<BsonDocument>(smallDocument.DeepClone().AsBsonDocument));
+                _collectionBulkWriteMixedOpsModels.Add(new ReplaceOneModel<BsonDocument>(FilterDefinition<BsonDocument>.Empty, smallDocument.DeepClone().AsBsonDocument));
+                _collectionBulkWriteMixedOpsModels.Add(new DeleteOneModel<BsonDocument>(FilterDefinition<BsonDocument>.Empty));
+            }
+        }
+
+        [IterationSetup]
+        public void BeforeTask()
+        {
+            _database.DropCollection(MongoConfiguration.PerfTestCollectionName);
+            _collection = _database.GetCollection<BsonDocument>(MongoConfiguration.PerfTestCollectionName);
+        }
+
+        [Benchmark]
+        public void SmallDocCollectionBulkMixedOpsBenchmark()
+        {
+            _collection.BulkWrite(_collectionBulkWriteMixedOpsModels, new BulkWriteOptions());
+        }
+        
+        [Benchmark]
+        public void SmallDocClientBulkMixedOpsBenchmark()
+        {
+            _client.BulkWrite(_clientBulkWriteMixedOpsModels, new ClientBulkWriteOptions());
+        }
+
+        [GlobalCleanup]
+        public void Teardown()
+        {
+            _client.Dispose();
+        }
+    }
+}

--- a/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/LargeDocBulkInsertBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/LargeDocBulkInsertBenchmark.cs
@@ -29,9 +29,9 @@ namespace MongoDB.Benchmarks.MultiDoc
         private IMongoClient _client;
         private IMongoCollection<BsonDocument> _collection;
         private IMongoDatabase _database;
-        private IEnumerable<BsonDocument> _largeDocuments;
-        private List<InsertOneModel<BsonDocument>> _collectionBulkWriteInsertModels;
-        private List<BulkWriteInsertOneModel<BsonDocument>> _clientBulkWriteInsertModels;
+        private BsonDocument[] _largeDocuments;
+        private InsertOneModel<BsonDocument>[] _collectionBulkWriteInsertModels;
+        private BulkWriteInsertOneModel<BsonDocument>[] _clientBulkWriteInsertModels;
         
         private static readonly CollectionNamespace __collectionNamespace =
             CollectionNamespace.FromFullName($"{MongoConfiguration.PerfTestDatabaseName}.{MongoConfiguration.PerfTestCollectionName}");
@@ -46,9 +46,9 @@ namespace MongoDB.Benchmarks.MultiDoc
             _database = _client.GetDatabase(MongoConfiguration.PerfTestDatabaseName);
 
             var largeDocument = ReadExtendedJson("single_and_multi_document/large_doc.json");
-            _largeDocuments = Enumerable.Range(0, 10).Select(_ => largeDocument.DeepClone().AsBsonDocument).ToList();
-            _collectionBulkWriteInsertModels = _largeDocuments.Select(x => new InsertOneModel<BsonDocument>(x.DeepClone().AsBsonDocument)).ToList();
-            _clientBulkWriteInsertModels = _largeDocuments.Select(x => new BulkWriteInsertOneModel<BsonDocument>(__collectionNamespace, x.DeepClone().AsBsonDocument)).ToList();
+            _largeDocuments = Enumerable.Range(0, 10).Select(_ => largeDocument.DeepClone().AsBsonDocument).ToArray();
+            _collectionBulkWriteInsertModels = _largeDocuments.Select(x => new InsertOneModel<BsonDocument>(x.DeepClone().AsBsonDocument)).ToArray();
+            _clientBulkWriteInsertModels = _largeDocuments.Select(x => new BulkWriteInsertOneModel<BsonDocument>(__collectionNamespace, x.DeepClone().AsBsonDocument)).ToArray();
         }
 
         [IterationSetup]
@@ -61,19 +61,19 @@ namespace MongoDB.Benchmarks.MultiDoc
         [Benchmark]
         public void InsertManyLargeBenchmark()
         {
-            _collection.InsertMany(_largeDocuments, new InsertManyOptions());
+            _collection.InsertMany(_largeDocuments, new());
         }
         
         [Benchmark]
         public void LargeDocCollectionBulkWriteInsertBenchmark()
         {
-            _collection.BulkWrite(_collectionBulkWriteInsertModels, new BulkWriteOptions());
+            _collection.BulkWrite(_collectionBulkWriteInsertModels, new());
         }
         
         [Benchmark]
         public void LargeDocClientBulkWriteInsertBenchmark()
         {
-            _client.BulkWrite(_clientBulkWriteInsertModels, new ClientBulkWriteOptions());
+            _client.BulkWrite(_clientBulkWriteInsertModels, new());
         }
 
         [GlobalCleanup]

--- a/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/SmallDocBulkInsertBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MultiDoc/SmallDocBulkInsertBenchmark.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using MongoDB.Bson;
@@ -29,9 +28,9 @@ namespace MongoDB.Benchmarks.MultiDoc
         private IMongoClient _client;
         private IMongoCollection<BsonDocument> _collection;
         private IMongoDatabase _database;
-        private List<BsonDocument> _smallDocuments;
-        private List<InsertOneModel<BsonDocument>> _collectionBulkWriteInsertModels;
-        private List<BulkWriteInsertOneModel<BsonDocument>> _clientBulkWriteInsertModels;
+        private BsonDocument[] _smallDocuments;
+        private InsertOneModel<BsonDocument>[] _collectionBulkWriteInsertModels;
+        private BulkWriteInsertOneModel<BsonDocument>[] _clientBulkWriteInsertModels;
 
         private static readonly CollectionNamespace __collectionNamespace =
             CollectionNamespace.FromFullName($"{MongoConfiguration.PerfTestDatabaseName}.{MongoConfiguration.PerfTestCollectionName}");
@@ -46,9 +45,9 @@ namespace MongoDB.Benchmarks.MultiDoc
             _database = _client.GetDatabase(MongoConfiguration.PerfTestDatabaseName);
 
             var smallDocument = ReadExtendedJson("single_and_multi_document/small_doc.json");
-            _smallDocuments = Enumerable.Range(0, 10000).Select(_ => smallDocument.DeepClone().AsBsonDocument).ToList();
-            _collectionBulkWriteInsertModels = _smallDocuments.Select(x => new InsertOneModel<BsonDocument>(x.DeepClone().AsBsonDocument)).ToList();
-            _clientBulkWriteInsertModels = _smallDocuments.Select(x => new BulkWriteInsertOneModel<BsonDocument>(__collectionNamespace, x.DeepClone().AsBsonDocument)).ToList();
+            _smallDocuments = Enumerable.Range(0, 10000).Select(_ => smallDocument.DeepClone().AsBsonDocument).ToArray();
+            _collectionBulkWriteInsertModels = _smallDocuments.Select(x => new InsertOneModel<BsonDocument>(x.DeepClone().AsBsonDocument)).ToArray();
+            _clientBulkWriteInsertModels = _smallDocuments.Select(x => new BulkWriteInsertOneModel<BsonDocument>(__collectionNamespace, x.DeepClone().AsBsonDocument)).ToArray();
         }
 
         [IterationSetup]
@@ -61,19 +60,19 @@ namespace MongoDB.Benchmarks.MultiDoc
         [Benchmark]
         public void InsertManySmallBenchmark()
         {
-            _collection.InsertMany(_smallDocuments, new InsertManyOptions());
+            _collection.InsertMany(_smallDocuments, new());
         }
         
         [Benchmark]
         public void SmallDocCollectionBulkWriteInsertBenchmark()
         {
-            _collection.BulkWrite(_collectionBulkWriteInsertModels, new BulkWriteOptions());
+            _collection.BulkWrite(_collectionBulkWriteInsertModels, new());
         }
         
         [Benchmark]
         public void SmallDocClientBulkWriteInsertBenchmark()
         {
-            _client.BulkWrite(_clientBulkWriteInsertModels, new ClientBulkWriteOptions());
+            _client.BulkWrite(_clientBulkWriteInsertModels, new());
         }
 
         [GlobalCleanup]

--- a/benchmarks/MongoDB.Driver.Benchmarks/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/README.md
@@ -13,7 +13,7 @@ This suite implements the benchmarks described in this [spec](https://github.com
    (e.g `dotnet run -c Release -- --driverBenchmarks --envVars MONGODB_URI:"ConnectionString"`)
 
 You can also select the benchmarks to run directly on the command for running the benchmarks as such
-`dotnet run -c Release -- --driverBenchmarks --fitler "*BenchmarkClassName*"`. The benchmarks are also grouped into categories namely: BSONBench, WriteBench
+`dotnet run -c Release -- --driverBenchmarks --filter "*BenchmarkClassName*"`. The benchmarks are also grouped into categories namely: BSONBench, WriteBench
 ReadBench, ParallelBench, SingleBench, MultiBench and DriverBench. So if you wanted to only run the WriteBench benchmarks, you can do so
 as follows: `dotnet run -c Release -- --driverBenchmarks --anyCategories "WriteBench"`.
 

--- a/benchmarks/MongoDB.Driver.Benchmarks/scripts/download-data.sh
+++ b/benchmarks/MongoDB.Driver.Benchmarks/scripts/download-data.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright 2010 MongoDB, Inc.
 #

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1473,6 +1473,18 @@ tasks:
         - func: install-dotnet
         - func: run-performance-tests
 
+    - name: performance-tests-net80-server-v8.0
+      commands:
+        - func: bootstrap-mongo-orchestration
+          vars:
+            VERSION: "v8.0-perf"
+            TOPOLOGY: "server"
+            SSL: "nossl"
+            AUTH: "noauth"
+            SKIP_LEGACY_SHELL: "true"
+        - func: install-dotnet
+        - func: run-performance-tests
+          
     - name: test-aws-lambda-deployed
       commands:
         - command: ec2.assume_role
@@ -2528,6 +2540,7 @@ buildvariants:
     - rhel90-dbx-perf-large
   tasks:
     - name: performance-tests-net80-server-v6.0
+    - name: performance-tests-net80-server-v8.0
 
 # AWS Lambda tests
 - name: aws-lambda-tests

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1461,19 +1461,7 @@ tasks:
         - func: bootstrap-mongo-orchestration
         - func: run-smoke-tests
 
-    - name: performance-tests-net80-server-v6.0
-      commands:
-        - func: bootstrap-mongo-orchestration
-          vars:
-            VERSION: "v6.0-perf"
-            TOPOLOGY: "server"
-            SSL: "nossl"
-            AUTH: "noauth"
-            SKIP_LEGACY_SHELL: "true"
-        - func: install-dotnet
-        - func: run-performance-tests
-
-    - name: performance-tests-net80-server-v8.0
+    - name: test-csharp-spec-benchmarks
       commands:
         - func: bootstrap-mongo-orchestration
           vars:
@@ -2539,8 +2527,7 @@ buildvariants:
   run_on:
     - rhel90-dbx-perf-large
   tasks:
-    - name: performance-tests-net80-server-v6.0
-    - name: performance-tests-net80-server-v8.0
+    - name: test-csharp-spec-benchmarks
 
 # AWS Lambda tests
 - name: aws-lambda-tests

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1472,7 +1472,7 @@ tasks:
             SKIP_LEGACY_SHELL: "true"
         - func: install-dotnet
         - func: run-performance-tests
-          
+
     - name: test-aws-lambda-deployed
       commands:
         - command: ec2.assume_role


### PR DESCRIPTION
Here are results of the new benchmarks:
<markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Name | MB/sec
-- | --
SmallDocClientBulkWriteMixedOps | 1.9320055323
SmallDocCollectionBulkWriteMixedOps | 0.7543254574
LargeDocClientBulkWriteInsert | 94.103463269
LargeDocCollectionBulkWriteInsert | 96.6259091508
SmallDocClientBulkWriteInsert | 36.7585335938
SmallDocCollectionBulkWriteInsert | 40.8752903883

</markdown-accessiblity-table><br class="Apple-interchange-newline">

(Updated with latest EG run found [here](https://spruce.mongodb.com/task/dot_net_driver_driver_performance_tests_test_csharp_spec_benchmarks_patch_1a43b7138e2675ac0837e1ab3d8daa48645e75b0_6765d56f567cab000723c1bf_24_12_20_20_37_13/trend-charts?execution=0))
