### PR TITLE
CSHARP-5419: Fix Single Node Replica Set Handling in the Driver

### DIFF
--- a/src/MongoDB.Driver/Core/Clusters/ClusterFactory.cs
+++ b/src/MongoDB.Driver/Core/Clusters/ClusterFactory.cs
@@ -52,7 +52,7 @@ namespace MongoDB.Driver.Core.Clusters
             {
                 return CreateLoadBalancedCluster(settings);
             }
-            else if (settings.DirectConnection)
+            else if (settings.DirectConnection || settings.EndPoints.Count == 1)
             {
                 return CreateSingleServerCluster(settings);
             }

--- a/src/MongoDB.Driver/Core/Clusters/SingleServerCluster.cs
+++ b/src/MongoDB.Driver/Core/Clusters/SingleServerCluster.cs
@@ -32,7 +32,7 @@ namespace MongoDB.Driver.Core.Clusters
         public SingleServerCluster(ClusterSettings settings, IClusterableServerFactory serverFactory, IEventSubscriber eventSubscriber, ILoggerFactory loggerFactory)
             : base(settings, serverFactory, eventSubscriber, loggerFactory)
         {
-            Ensure.That(settings.DirectConnection, $"DirectConnection mode is not supported for {nameof(SingleServerCluster)}.");
+            Ensure.That(!settings.DirectConnection, $"DirectConnection mode is not supported for {nameof(SingleServerCluster)}.");
             Ensure.That(settings.SrvMaxHosts == 0, "srvMaxHosts cannot be used with a single server cluster.");
             Ensure.IsEqualTo(settings.EndPoints.Count, 1, nameof(settings.EndPoints.Count));
 
@@ -121,7 +121,8 @@ namespace MongoDB.Driver.Core.Clusters
             }
 
             newClusterDescription = newClusterDescription.WithServerDescription(newServerDescription);
-
+            if(newClusterDescription.Type == ClusterType.Unknown)
+                newClusterDescription = newClusterDescription.WithType(newServerDescription.Type.ToClusterType());
             var shouldClusterDescriptionChangedEventBePublished = !args.OldServerDescription.SdamEquals(args.NewServerDescription);
             UpdateClusterDescription(newClusterDescription, shouldClusterDescriptionChangedEventBePublished);
         }


### PR DESCRIPTION
Fix For https://jira.mongodb.org/browse/CSHARP-5419

Steps to Reproduce:

Create a Single Node Replica Set for Testing Locally (Easiest for Repro: TestContainers)
Try to Connect to it for some Sort of Read/Write Operations without a Direct Connection From a C# Project i.e. the Attached Repro Project(Our Usecase, does not want Direct Connection, bcs we want to use transactions, and have integration Tests for those)
in our Repro Project, you will be prompted to input something or nothing, other than 'q'
Wait 30 seconds until the Connection Times out

Now i already spend the Debugging time to figure it out and a PR will follow shortly.

But here is what happened:
Step 1:

SingleNodeReplicaSet gets registered as MultiServerCluster in the Driver, this leads to issues, where the internal IpAddress, will be tried to be used for connecting (i.e. 127.0.0.1) instead of the host-side port/address. 

This Here we can find why, when comparing the ClusterFactory from i.e. 2.26.0 with 3.0.0. The Condition of assigning a SingleNodeCluster, in case Endpoints.Count == 1, is gone. 

Step2:

After we reinsert this condition, it will fail, because 'Direct Connection is not supported on SingleServerClusters') Strange... Here we have an Assertion, that is inverted, from what it's error Message sais (It Asserts, that DirectConnection Should be True in 3.0.0) - Invert this back to match, it's Description and move on.

Step 3:

We fail on a read... why you ask? our ClusterType == Unknown, so the ReadPreferenceServerSelector always returns an Empty Server List. So our server Selection endlessly loops.  Why? in 2.26 there was a statement in the ClusterDescription Update Handler of the SingleServerCluster, that would set the ClusterType based on the ServerType of it's Server. This was gone. 

So we reinsert this Tada. Now we can interact with a SingleNodeReplica again.




As i am completely new to this Codebase, i can't tell if any secrets are yet missing and will bite me/us again.
Yet i am sure many a team tried upgrading to the 3.0.0 Driver, saw all their integration Tests fail, and reverted their update. So i hope this will be patched in a public release soon.
