### PR TITLE
CSHARP-5026: Add Kubernetes Support for OIDC

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1042,6 +1042,26 @@ functions:
           fi
           ./evergreen/upload-apidocs.sh
 
+  run_oidc_k8s_tests:
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: mongo-csharp-driver
+        include_expansions_in_env:
+          - "AWS_ACCESS_KEY_ID"
+          - "AWS_SECRET_ACCESS_KEY"
+          - "AWS_SESSION_TOKEN"
+        script: |
+          ${PREPARE_SHELL}
+
+          export K8S_VARIANT=${K8S_VARIANT}
+          export K8S_DRIVERS_TAR_FILE=/tmp/mongo-csharp-driver.tgz
+          export K8S_TEST_CMD="OIDC_ENV=k8s ./evergreen/run-mongodb-oidc-env-tests.sh"
+
+          bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/setup-pod.sh
+          bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-driver-test.sh
+          bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/teardown-pod.sh
+
 pre:
   - func: fetch-source
   - func: prepare-resources
@@ -1288,6 +1308,27 @@ tasks:
               export GCPOIDC_DRIVERS_TAR_FILE=/tmp/mongo-csharp-driver.tgz
               export GCPOIDC_TEST_CMD="OIDC_ENV=gcp ./evergreen/run-mongodb-oidc-env-tests.sh"
               bash $DRIVERS_TOOLS/.evergreen/auth_oidc/gcp/run-driver-test.sh
+
+    - name: test-oidc-k8s
+      commands:
+        - command: shell.exec
+          params:
+            shell: bash
+            working_dir: mongo-csharp-driver
+            script: |-
+              ${PREPARE_SHELL}
+              dotnet build
+              tar czf /tmp/mongo-csharp-driver.tgz tests/*.Tests/bin/Debug/net6.0/ ./evergreen/run-mongodb-oidc-env-tests.sh
+        - func: assume-ec2-role
+        - func: run_oidc_k8s_tests
+          vars:
+            K8S_VARIANT: eks
+        - func: run_oidc_k8s_tests
+          vars:
+            K8S_VARIANT: gke
+        - func: run_oidc_k8s_tests
+          vars:
+            K8S_VARIANT: aks
 
     - name: test-serverless
       exec_timeout_secs: 2700 # 45 minutes: 15 for setup + 30 for tests
@@ -2251,6 +2292,34 @@ task_groups:
     tasks:
       - test-oidc-gcp
 
+  - name: oidc-auth-k8s-task-group
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800 # 30 minutes
+    setup_group:
+      - func: fetch-source
+      - func: prepare-resources
+      - func: fix-absolute-paths
+      - func: make-files-executable
+      - func: install-dotnet
+      - func: assume-ec2-role
+      - command: subprocess.exec
+        params:
+          binary: bash
+          include_expansions_in_env:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
+    teardown_group:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/teardown.sh
+    tasks:
+      - test-oidc-k8s
+
   - name: serverless-task-group
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800 # 30 minutes
@@ -2447,6 +2516,13 @@ buildvariants:
   batchtime: 20160 # 14 days
   tasks:
     - name: oidc-auth-gcp-task-group
+
+- matrix_name: mongodb-oidc-k8s-tests
+  matrix_spec: { os: [ "ubuntu-2004" ] }
+  display_name: "MongoDB-OIDC Auth (k8s) - ${os}"
+  batchtime: 20160 # 14 days
+  tasks:
+    - name: oidc-auth-k8s-task-group
 
 - matrix_name: "ocsp-tests"
   matrix_spec: { version: ["4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"], auth: "noauth", ssl: "ssl", topology: "standalone", os: "windows-64" }

--- a/evergreen/run-mongodb-oidc-env-tests.sh
+++ b/evergreen/run-mongodb-oidc-env-tests.sh
@@ -5,12 +5,9 @@ set -o errexit # Exit the script with error if any of the commands fail
 
 DOTNET_SDK_PATH="$(pwd)/.dotnet"
 
-## check if curl exists and install, needed for k8s environment
-which curl &> /dev/null || apt install curl
-
 echo "Downloading .NET SDK installer into $DOTNET_SDK_PATH folder..."
 curl -Lfo ./dotnet-install.sh https://dot.net/v1/dotnet-install.sh
-echo "Installing .NET LTS SDK..."
+echo "Installing .NET 6.0 SDK..."
 bash ./dotnet-install.sh --channel 6.0 --install-dir "$DOTNET_SDK_PATH" --no-path
 export PATH=$DOTNET_SDK_PATH:$PATH
 

--- a/specifications/auth/tests/legacy/connection-string.json
+++ b/specifications/auth/tests/legacy/connection-string.json
@@ -626,6 +626,26 @@
       "uri": "mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:gcp",
       "valid": false,
       "credential": null
+    },
+    {
+      "description": "should recognise the mechanism with k8s provider (MONGODB-OIDC)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-OIDC",
+        "mechanism_properties": {
+          "ENVIRONMENT": "k8s"
+        }
+      }
+    },
+    {
+      "description": "should throw an error for a username and password with k8s provider (MONGODB-OIDC)",
+      "uri": "mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s",
+      "valid": false,
+      "credential": null
     }
   ]
 }

--- a/specifications/auth/tests/legacy/connection-string.yml
+++ b/specifications/auth/tests/legacy/connection-string.yml
@@ -454,3 +454,18 @@ tests:
   uri: mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:gcp
   valid: false
   credential: null
+- description: should recognise the mechanism with k8s provider (MONGODB-OIDC)
+  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s
+  valid: true
+  credential:
+    username: null
+    password: null
+    source: $external
+    mechanism: MONGODB-OIDC
+    mechanism_properties:
+      ENVIRONMENT: k8s
+- description: should throw an error for a username and password with k8s provider
+    (MONGODB-OIDC)
+  uri: mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s
+  valid: false
+  credential: null

--- a/src/MongoDB.Driver/Authentication/Oidc/FileOidcCallback.cs
+++ b/src/MongoDB.Driver/Authentication/Oidc/FileOidcCallback.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-using System.IO;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver.Core.Misc;
@@ -22,35 +22,53 @@ namespace MongoDB.Driver.Authentication.Oidc
 {
     internal sealed class FileOidcCallback : IOidcCallback
     {
+        private readonly IFileSystemProvider _fileSystemProvider;
+
         #region static
-        public static FileOidcCallback CreateFromEnvironmentVariable(string environmentVariableName, IEnvironmentVariableProvider environmentVariableProvider)
+        public static FileOidcCallback CreateFromEnvironmentVariable(
+            IEnvironmentVariableProvider environmentVariableProvider,
+            IFileSystemProvider fileSystemProvider,
+            string[] environmentVariableNames,
+            string defaultPath = null)
         {
-            var tokenPath = Ensure.IsNotNull(environmentVariableProvider, nameof(environmentVariableProvider)).GetEnvironmentVariable(environmentVariableName);
-            return new FileOidcCallback(tokenPath);
+            Ensure.IsNotNull(environmentVariableProvider, nameof(environmentVariableProvider));
+            Ensure.IsNotNull(fileSystemProvider, nameof(fileSystemProvider));
+
+            string filePath = null;
+            if (environmentVariableNames != null)
+            {
+                foreach (var variableName in environmentVariableNames)
+                {
+                    filePath = environmentVariableProvider.GetEnvironmentVariable(variableName);
+                    if (!string.IsNullOrEmpty(filePath))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            filePath ??= defaultPath;
+            return new FileOidcCallback(fileSystemProvider, filePath);
         }
         #endregion
 
-        private readonly string _path;
-
-        public FileOidcCallback(string path)
+        public FileOidcCallback(IFileSystemProvider fileSystemProvider, string filePath)
         {
-            _path = Ensure.IsNotNullOrEmpty(path, nameof(path));
+            _fileSystemProvider = Ensure.IsNotNull(fileSystemProvider, nameof(fileSystemProvider));
+            FilePath = Ensure.IsNotNullOrEmpty(filePath, nameof(filePath));
         }
+
+        public string FilePath { get; }
 
         public OidcAccessToken GetOidcAccessToken(OidcCallbackParameters parameters, CancellationToken cancellationToken)
         {
-            var accessToken = File.ReadAllText(_path);
+            var accessToken = _fileSystemProvider.File.ReadAllText(FilePath);
             return new(accessToken, expiresIn: null);
         }
 
         public async Task<OidcAccessToken> GetOidcAccessTokenAsync(OidcCallbackParameters parameters, CancellationToken cancellationToken)
         {
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-            var accessToken = await File.ReadAllTextAsync(_path, cancellationToken).ConfigureAwait(false);
-#else
-            using var streamReader = new StreamReader(_path, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
-            var accessToken = await streamReader.ReadToEndAsync().ConfigureAwait(false); // no support for cancellationToken
-#endif
+            var accessToken = await _fileSystemProvider.File.ReadAllTextAsync(FilePath).ConfigureAwait(false);
             return new(accessToken, expiresIn: null);
         }
     }

--- a/src/MongoDB.Driver/Authentication/Oidc/FileOidcCallback.cs
+++ b/src/MongoDB.Driver/Authentication/Oidc/FileOidcCallback.cs
@@ -33,17 +33,15 @@ namespace MongoDB.Driver.Authentication.Oidc
         {
             Ensure.IsNotNull(environmentVariableProvider, nameof(environmentVariableProvider));
             Ensure.IsNotNull(fileSystemProvider, nameof(fileSystemProvider));
+            Ensure.IsNotNullOrEmpty(environmentVariableNames, nameof(environmentVariableNames));
 
             string filePath = null;
-            if (environmentVariableNames != null)
+            foreach (var variableName in environmentVariableNames)
             {
-                foreach (var variableName in environmentVariableNames)
+                filePath = environmentVariableProvider.GetEnvironmentVariable(variableName);
+                if (!string.IsNullOrEmpty(filePath))
                 {
-                    filePath = environmentVariableProvider.GetEnvironmentVariable(variableName);
-                    if (!string.IsNullOrEmpty(filePath))
-                    {
-                        break;
-                    }
+                    break;
                 }
             }
 

--- a/src/MongoDB.Driver/Authentication/Oidc/OidcConfiguration.cs
+++ b/src/MongoDB.Driver/Authentication/Oidc/OidcConfiguration.cs
@@ -27,7 +27,7 @@ namespace MongoDB.Driver.Authentication.Oidc
         public const string EnvironmentMechanismPropertyName = "ENVIRONMENT";
         public const string TokenResourceMechanismPropertyName = "TOKEN_RESOURCE";
 
-        private static readonly ISet<string> __supportedEnvironments = new HashSet<string> { "test", "azure", "gcp" };
+        private static readonly ISet<string> __supportedEnvironments = new HashSet<string> { "test", "azure", "gcp", "k8s" };
         private readonly int _hashCode;
 
         public OidcConfiguration(

--- a/src/MongoDB.Driver/Authentication/Oidc/OidcSaslMechanism.cs
+++ b/src/MongoDB.Driver/Authentication/Oidc/OidcSaslMechanism.cs
@@ -25,21 +25,7 @@ namespace MongoDB.Driver.Authentication.Oidc
         public const string MechanismName = "MONGODB-OIDC";
 
         public static OidcSaslMechanism Create(SaslContext context)
-            => Create(context, SystemClock.Instance, EnvironmentVariableProvider.Instance);
-
-        public static OidcSaslMechanism Create(SaslContext context, IClock clock, IEnvironmentVariableProvider environmentVariableProvider)
-        {
-            Ensure.IsNotNull(clock, nameof(clock));
-            Ensure.IsNotNull(environmentVariableProvider, nameof(environmentVariableProvider));
-
-            var callbackAdapterFactory = OidcCallbackAdapterCachingFactory.Instance;
-            if (clock != SystemClock.Instance || environmentVariableProvider != EnvironmentVariableProvider.Instance)
-            {
-                callbackAdapterFactory = new OidcCallbackAdapterCachingFactory(clock, environmentVariableProvider);
-            }
-
-            return Create(context, callbackAdapterFactory);
-        }
+            => Create(context, OidcCallbackAdapterCachingFactory.Instance);
 
         public static OidcSaslMechanism Create(
             SaslContext context,

--- a/src/MongoDB.Driver/Core/Misc/FileWrapper.cs
+++ b/src/MongoDB.Driver/Core/Misc/FileWrapper.cs
@@ -14,6 +14,7 @@
  */
 
 using System.IO;
+using System.Threading.Tasks;
 
 namespace MongoDB.Driver.Core.Misc
 {
@@ -22,14 +23,27 @@ namespace MongoDB.Driver.Core.Misc
     /// </summary>
     internal interface IFile
     {
-        bool Exists(string name);
+        bool Exists(string path);
+
+        string ReadAllText(string path);
+
+        Task<string> ReadAllTextAsync(string path);
     }
 
     internal sealed class FileWrapper : IFile
     {
-        public bool Exists(string name)
+        public bool Exists(string path) => File.Exists(path);
+
+        public string ReadAllText(string path)
         {
-            return File.Exists(name);
+            using var streamReader = new StreamReader(path, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return streamReader.ReadToEnd();
+        }
+
+        public async Task<string> ReadAllTextAsync(string path)
+        {
+            using var streamReader = new StreamReader(path, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return await streamReader.ReadToEndAsync().ConfigureAwait(false);
         }
     }
 }

--- a/tests/MongoDB.Driver.TestHelpers/Core/EnvironmentVariableProviderMock.cs
+++ b/tests/MongoDB.Driver.TestHelpers/Core/EnvironmentVariableProviderMock.cs
@@ -1,0 +1,41 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Driver.Core.Misc;
+using Moq;
+
+namespace MongoDB.Driver.TestHelpers.Core;
+
+internal static class EnvironmentVariableProviderMock
+{
+    public static Mock<IEnvironmentVariableProvider> Create(params string[] env)
+    {
+        var environmentVariableProviderMock = new Mock<IEnvironmentVariableProvider>();
+        if (env != null)
+        {
+            foreach (var variable in env)
+            {
+                var parts = variable.Split('=');
+                var variableName = parts[0];
+                var variableValue = parts.Length == 1 ? "1" : parts[1];
+                environmentVariableProviderMock
+                    .Setup(e => e.GetEnvironmentVariable(variableName))
+                    .Returns(variableValue);
+            }
+        }
+
+        return environmentVariableProviderMock;
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Authentication/Oidc/FileOidcCallbackTests.cs
+++ b/tests/MongoDB.Driver.Tests/Authentication/Oidc/FileOidcCallbackTests.cs
@@ -78,7 +78,7 @@ public class FileOidcCallbackTests
     {
         var exception = Record.Exception(() =>
         {
-            FileOidcCallback.CreateFromEnvironmentVariable(null, Mock.Of<IFileSystemProvider>(), [], "defaultPath");
+            FileOidcCallback.CreateFromEnvironmentVariable(null, Mock.Of<IFileSystemProvider>(), ["env"], "defaultPath");
         });
 
         exception.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("environmentVariableProvider");
@@ -89,10 +89,32 @@ public class FileOidcCallbackTests
     {
         var exception = Record.Exception(() =>
         {
-            FileOidcCallback.CreateFromEnvironmentVariable(Mock.Of<IEnvironmentVariableProvider>(), null, [], "defaultPath");
+            FileOidcCallback.CreateFromEnvironmentVariable(Mock.Of<IEnvironmentVariableProvider>(), null, ["env"], "defaultPath");
         });
 
         exception.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("fileSystemProvider");
+    }
+
+    [Fact]
+    public void CreateFromEnvironmentVariable_throws_on_null_environmentVariableNames()
+    {
+        var exception = Record.Exception(() =>
+        {
+            FileOidcCallback.CreateFromEnvironmentVariable(Mock.Of<IEnvironmentVariableProvider>(), Mock.Of<IFileSystemProvider>(), null, "defaultPath");
+        });
+
+        exception.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("environmentVariableNames");
+    }
+
+    [Fact]
+    public void CreateFromEnvironmentVariable_throws_on_empty_environmentVariableNames()
+    {
+        var exception = Record.Exception(() =>
+        {
+            FileOidcCallback.CreateFromEnvironmentVariable(Mock.Of<IEnvironmentVariableProvider>(), Mock.Of<IFileSystemProvider>(), [], "defaultPath");
+        });
+
+        exception.Should().BeOfType<ArgumentException>().Subject.ParamName.Should().Be("environmentVariableNames");
     }
 
     [Theory]
@@ -121,19 +143,7 @@ public class FileOidcCallbackTests
     [
         [
             null,
-            null,
-            "defaultPath",
-            "defaultPath"
-        ],
-        [
-            null,
             new[] { "env1", "env2" },
-            "defaultPath",
-            "defaultPath"
-        ],
-        [
-            new[] { "env1=path1", "env2=path2" },
-            null,
             "defaultPath",
             "defaultPath"
         ],
@@ -155,15 +165,7 @@ public class FileOidcCallbackTests
     [
         [
             null,
-            null
-        ],
-        [
-            new[] { "env1=path1", "env2=path2" },
-            null
-        ],
-        [
-            null,
-            new[] { "env3", "env4" }
+            new[] { "env1", "env2" }
         ],
         [
             new[] { "env1=path1", "env2=path2" },

--- a/tests/MongoDB.Driver.Tests/Authentication/Oidc/FileOidcCallbackTests.cs
+++ b/tests/MongoDB.Driver.Tests/Authentication/Oidc/FileOidcCallbackTests.cs
@@ -1,0 +1,173 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Driver.Authentication.Oidc;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.TestHelpers.Core;
+using MongoDB.TestHelpers.XunitExtensions;
+using Moq;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Authentication.Oidc;
+
+public class FileOidcCallbackTests
+{
+    [Fact]
+    public void FileOidcCallback_ctor_throws_on_empty_fileSystemProvider()
+    {
+        var exception = Record.Exception(() => new FileOidcCallback(null, "filePath"));
+        exception.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("fileSystemProvider");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void FileOidcCallback_ctor_throws_on_empty_filePath(string filePath)
+    {
+        var exception = Record.Exception(() => new FileOidcCallback(Mock.Of<IFileSystemProvider>(), filePath));
+        exception.Should().BeAssignableTo<ArgumentException>().Subject.ParamName.Should().Be("filePath");
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public async Task GetOidcAccessToken_calls_fileSystemProvider([Values(true, false)]bool async)
+    {
+        var filePath = "some-file-path";
+        var fileContent = "some-content";
+        var fileSystemProviderMock = new Mock<IFileSystemProvider>();
+        var fileMock = new Mock<IFile>();
+        fileMock.Setup(f => f.ReadAllText(filePath)).Returns(fileContent);
+        fileMock.Setup(f => f.ReadAllTextAsync(filePath)).Returns(Task.FromResult(fileContent));
+        fileSystemProviderMock.Setup(f => f.File).Returns(fileMock.Object);
+        var oidcParameters = new OidcCallbackParameters(1, "userName");
+
+        var oidcCallback = new FileOidcCallback(fileSystemProviderMock.Object, filePath);
+        var result = async ?
+            await oidcCallback.GetOidcAccessTokenAsync(oidcParameters, default):
+            oidcCallback.GetOidcAccessToken(oidcParameters, default);
+
+        result.AccessToken.Should().Be(fileContent);
+        if (async)
+        {
+            fileMock.Verify(f => f.ReadAllTextAsync(filePath), Times.Once);
+        }
+        else
+        {
+            fileMock.Verify(f => f.ReadAllText(filePath), Times.Once);
+        }
+    }
+
+    [Fact]
+    public void CreateFromEnvironmentVariable_throws_on_null_environmentVariableProvider()
+    {
+        var exception = Record.Exception(() =>
+        {
+            FileOidcCallback.CreateFromEnvironmentVariable(null, Mock.Of<IFileSystemProvider>(), [], "defaultPath");
+        });
+
+        exception.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("environmentVariableProvider");
+    }
+
+    [Fact]
+    public void CreateFromEnvironmentVariable_throws_on_null_fileSystemProvider()
+    {
+        var exception = Record.Exception(() =>
+        {
+            FileOidcCallback.CreateFromEnvironmentVariable(Mock.Of<IEnvironmentVariableProvider>(), null, [], "defaultPath");
+        });
+
+        exception.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("fileSystemProvider");
+    }
+
+    [Theory]
+    [MemberData(nameof(CreateFromEnvironmentVariable_ValidTestCases))]
+    public void CreateFromEnvironmentVariable_should_resolve_filePath(string[] env, string[] variablesToCheck, string defaultPath, string expectedFilePath)
+    {
+        var environmentVariableProviderMock = EnvironmentVariableProviderMock.Create(env);
+
+        var fileOidcCallback = FileOidcCallback.CreateFromEnvironmentVariable(environmentVariableProviderMock.Object, Mock.Of<IFileSystemProvider>(), variablesToCheck, defaultPath);
+
+        fileOidcCallback.FilePath.Should().Be(expectedFilePath);
+    }
+
+    [Theory]
+    [MemberData(nameof(CreateFromEnvironmentVariable_InvalidTestCases))]
+    public void CreateFromEnvironmentVariable_should_throw_on_unresolvable_filePath(string[] env, string[] variablesToCheck)
+    {
+        var environmentVariableProviderMock = EnvironmentVariableProviderMock.Create(env);
+
+        var exception = Record.Exception(() => FileOidcCallback.CreateFromEnvironmentVariable(environmentVariableProviderMock.Object, Mock.Of<IFileSystemProvider>(), variablesToCheck));
+
+        exception.Should().BeAssignableTo<ArgumentException>().Subject.ParamName.Should().Be("filePath");
+    }
+
+    public static IEnumerable<object[]> CreateFromEnvironmentVariable_ValidTestCases =
+    [
+        [
+            null,
+            null,
+            "defaultPath",
+            "defaultPath"
+        ],
+        [
+            null,
+            new[] { "env1", "env2" },
+            "defaultPath",
+            "defaultPath"
+        ],
+        [
+            new[] { "env1=path1", "env2=path2" },
+            null,
+            "defaultPath",
+            "defaultPath"
+        ],
+        [
+            new[] { "env1=path1", "env2=path2" },
+            new[] { "env3", "env4" },
+            "defaultPath",
+            "defaultPath"
+        ],
+        [
+            new[] { "env1=path1", "env2=path2" },
+            new[] { "env3", "env1" },
+            "defaultPath",
+            "path1"
+        ]
+    ];
+
+    public static IEnumerable<object[]> CreateFromEnvironmentVariable_InvalidTestCases =
+    [
+        [
+            null,
+            null
+        ],
+        [
+            new[] { "env1=path1", "env2=path2" },
+            null
+        ],
+        [
+            null,
+            new[] { "env3", "env4" }
+        ],
+        [
+            new[] { "env1=path1", "env2=path2" },
+            new[] { "env3", "env4" }
+        ]
+    ];
+}

--- a/tests/MongoDB.Driver.Tests/ClientDocumentHelperTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClientDocumentHelperTests.cs
@@ -24,6 +24,7 @@ using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.TestHelpers.Core;
 using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;
@@ -32,26 +33,28 @@ namespace MongoDB.Driver.Tests
 {
     public class ClientDocumentHelperTests
     {
+        private static readonly string __longAString = new string('a', 512);
+
         [Theory]
         [ParameterAttributeData]
         public async Task Handhake_should_handle_faas_env_variables(
             [Values(
             // Valid AWS
-            "{ 'AWS_EXECUTION_ENV' : 'AWS_Lambda_java8', 'AWS_REGION' : 'us-east-2', 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE' : '1024', expected : { 'name' : 'aws.lambda', 'memory_mb' : 1024, 'region' : 'us-east-2' } }",
+            "{ 'env' : ['AWS_EXECUTION_ENV=AWS_Lambda_java8', 'AWS_REGION=us-east-2', 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE=1024'], expected : { 'name' : 'aws.lambda', 'memory_mb' : 1024, 'region' : 'us-east-2' } }",
             // Invalid - AWS_EXECUTION_ENV should start with AWS_Lambda_
-            "{ 'AWS_EXECUTION_ENV' : 'EC2', 'AWS_REGION' : 'us-east-2', expected : null }",
+            "{ 'env' : ['AWS_EXECUTION_ENV=EC2', 'AWS_REGION=us-east-2'], expected : null }",
             // Valid Azure
-            "{ 'FUNCTIONS_WORKER_RUNTIME' : 'node', expected: { 'name' : 'azure.func' } }",
+            "{ 'env' : ['FUNCTIONS_WORKER_RUNTIME=node'], expected: { 'name' : 'azure.func' } }",
             // Valid GCP
-            "{ 'K_SERVICE' : 'servicename', 'FUNCTION_MEMORY_MB' : '1024', 'FUNCTION_TIMEOUT_SEC' : '60', 'FUNCTION_REGION' : 'us-central1', expected: { 'name' : 'gcp.func', 'timeout_sec' : 60, 'memory_mb' : 1024, 'region' : 'us-central1' } }",
+            "{ 'env' : ['K_SERVICE=servicename', 'FUNCTION_MEMORY_MB=1024', 'FUNCTION_TIMEOUT_SEC=60', 'FUNCTION_REGION=us-central1'], expected: { 'name' : 'gcp.func', 'timeout_sec' : 60, 'memory_mb' : 1024, 'region' : 'us-central1' } }",
             // Valid VERCEL
-            "{ 'VERCEL' : '1', 'VERCEL_REGION' : 'cdg1', expected: { 'name' : 'vercel', 'region' : 'cdg1' } }",
+            "{ 'env' : ['VERCEL=1', 'VERCEL_REGION=cdg1'], expected: { 'name' : 'vercel', 'region' : 'cdg1' } }",
             // Invalid - multiple providers
-            "{ 'AWS_EXECUTION_ENV' : 'AWS_Lambda_java8', 'FUNCTIONS_WORKER_RUNTIME' : 'node', expected: null }",
+            "{ 'env' : ['AWS_EXECUTION_ENV=AWS_Lambda_java8', 'FUNCTIONS_WORKER_RUNTIME=node'], expected: null }",
             // Invalid - long string
-            "{ 'AWS_EXECUTION_ENV' : 'AWS_Lambda_java8', 'AWS_REGION' : '#longA#', expected: { 'name' : 'aws.lambda' } }",
+            "{ 'env' : ['AWS_EXECUTION_ENV=AWS_Lambda_java8', 'AWS_REGION=#longA#'], expected: { 'name' : 'aws.lambda' } }",
             // Invalid - wrong types
-            "{ 'AWS_EXECUTION_ENV' : 'AWS_Lambda_java8', 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE' : 'big', expected: { 'name' : 'aws.lambda' } }")]
+            "{ 'env' : ['AWS_EXECUTION_ENV=AWS_Lambda_java8', 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE=big'], expected: { 'name' : 'aws.lambda' } }")]
             string environmentVariableDescription,
             [Values(false, true)] bool async)
         {
@@ -61,15 +64,8 @@ namespace MongoDB.Driver.Tests
 
             var environmentVariableDescriptionDocument = BsonDocument.Parse(environmentVariableDescription);
             var expectedValue = environmentVariableDescriptionDocument["expected"];
-            environmentVariableDescriptionDocument.Remove("expected");
-            var descriptionElements = environmentVariableDescriptionDocument
-                .Elements
-                .ToList();
-
-            var environmentVariableProviderMock = new Mock<IEnvironmentVariableProvider>();
-
-            descriptionElements.ForEach(e =>
-                environmentVariableProviderMock.Setup(env => env.GetEnvironmentVariable(e.Name)).Returns(GetValue(e.Value.ToString())));
+            var env = environmentVariableDescriptionDocument["env"].AsBsonArray.Values.Select(v => v.AsString.Replace("#longA#", __longAString)).ToArray();
+            var environmentVariableProviderMock = EnvironmentVariableProviderMock.Create(env);
 
             using var __ = new ClientDocumentHelperProvidersSetter(environmentVariableProviderMock.Object);
 
@@ -100,8 +96,6 @@ namespace MongoDB.Driver.Tests
                     command["env"].AsBsonDocument.Should().Be(expectedDocument);
                 }
             }
-
-            string GetValue(string input) => input == "#longA#" ? new string('a', 512) : input;
         }
     }
 

--- a/tests/MongoDB.Driver.Tests/Core/Servers/ServerMonitorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Servers/ServerMonitorTests.cs
@@ -31,6 +31,7 @@ using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.TestHelpers.Logging;
 using MongoDB.Driver.Core.WireProtocol;
 using MongoDB.Driver.Core.WireProtocol.Messages;
+using MongoDB.Driver.TestHelpers.Core;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -509,12 +510,7 @@ namespace MongoDB.Driver.Core.Servers
         [InlineData("VERCEL")]
         public void Should_use_polling_protocol_if_running_in_FaaS_platform(string environmentVariable)
         {
-            var environmentVariableParts = environmentVariable.Split('=');
-
-            var environmentVariableProviderMock = new Mock<IEnvironmentVariableProvider>();
-            environmentVariableProviderMock
-                .Setup(env => env.GetEnvironmentVariable(environmentVariableParts[0]))
-                .Returns(environmentVariableParts.Length > 1 ? environmentVariableParts[1] : "dummy");
+            var environmentVariableProviderMock = EnvironmentVariableProviderMock.Create(environmentVariable);
 
             var capturedEvents = new EventCapturer()
                 .Capture<ServerHeartbeatStartedEvent>()

--- a/tests/MongoDB.Driver.Tests/Specifications/auth/AuthTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/auth/AuthTestRunner.cs
@@ -24,6 +24,7 @@ using MongoDB.Driver.Authentication;
 using MongoDB.Driver.Authentication.Gssapi;
 using MongoDB.Driver.Authentication.Oidc;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.TestHelpers.Core;
 using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;
@@ -81,10 +82,10 @@ namespace MongoDB.Driver.Tests.Specifications.auth
 
                         if (mongoCredential.Mechanism?.ToUpper() == OidcSaslMechanism.MechanismName)
                         {
-                            var environmentVariablesProviderMock = new Mock<IEnvironmentVariableProvider>();
-                            environmentVariablesProviderMock
-                                .Setup(p => p.GetEnvironmentVariable("OIDC_TOKEN_FILE")).Returns("dummy_file_path");
-                            var mechanism = OidcSaslMechanism.Create(saslContext, SystemClock.Instance, environmentVariablesProviderMock.Object);
+                            var environmentVariablesProviderMock = EnvironmentVariableProviderMock.Create("OIDC_TOKEN_FILE=dummy_file_path");
+
+                            var callbackFactory = new OidcCallbackAdapterCachingFactory(SystemClock.Instance, environmentVariablesProviderMock.Object, FileSystemProvider.Instance);
+                            var mechanism = OidcSaslMechanism.Create(saslContext, callbackFactory);
                             authenticator = new SaslAuthenticator(mechanism, null);
                             return;
                         }


### PR DESCRIPTION
There are 2 separate commits that could be reviewed separately:
1) Implement EnvironmentVariableProviderMock - minor refactoring in tests for easier mocking of IEnvironmentVariableProvider
2) CSHARP-5026: Add Kubernetes Support for OIDC - implementation of the functionality itself.