### PR TITLE
DEVPROD-13302: template authenticode key name

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -926,6 +926,7 @@ functions:
           PACKAGE_VERSION: "$PACKAGE_VERSION"
           GRS_USERNAME: ${GRS_USERNAME}
           GRS_PASSWORD: ${GRS_PASSWORD}
+          AUTHENTICODE_KEY_NAME: ${AUTHENTICODE_KEY_NAME}
         script: |
           ${PREPARE_SHELL}
           . ./evergreen/sign-packages.sh

--- a/evergreen/sign-packages.sh
+++ b/evergreen/sign-packages.sh
@@ -15,4 +15,4 @@ echo "GRS_CONFIG_USER1_PASSWORD=${GRS_PASSWORD}" >> "signing-envfile"
 
 docker run --platform="linux/amd64" --env-file=signing-envfile --rm -v $(pwd):/workdir -w /workdir \
   artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-jsign \
-  /bin/bash -c "jsign --tsaurl "http://timestamp.digicert.com" -a mongo-authenticode-2021 "./artifacts/nuget/*.$PACKAGE_VERSION.nupkg""
+  /bin/bash -c "jsign --tsaurl "http://timestamp.digicert.com" -a ${AUTHENTICODE_KEY_NAME} "./artifacts/nuget/*.$PACKAGE_VERSION.nupkg""


### PR DESCRIPTION
This commit templates our authenticode key name in preparation for the authenticode 2021 deprecation. The variable will be added to our Evergreen project as mongo-authenticode-2021, and later updated to 2024 when that certificate is ready.