### PR TITLE
CSHARP-5464: Fix EFCore tests

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1869,7 +1869,7 @@ tasks:
             LOCAL_PATH: ${workdir}/efcore
             SCRIPT: |
               ${PREPARE_SHELL}
-              DRIVER_VERSION="${PACKAGE_VERSION}" bash ./evergreen/run-tests.sh
+              CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" DRIVER_VERSION="${PACKAGE_VERSION}" bash ./evergreen/run-tests.sh
 
 axes:
   - id: version


### PR DESCRIPTION
CRYPT_SHARED_LIB_PATH mandatory environment variable was recently added to EFCore test script. Have to mirror the changes here to make **test-efcore** task green in Driver's repo.