### PR TITLE
Convert LINQ tests to use Class Fixtures.

### DIFF
--- a/CSharpDriver.sln.DotSettings
+++ b/CSharpDriver.sln.DotSettings
@@ -91,6 +91,10 @@ namespace $NAMESPACE$
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=CLASS/Expression/@EntryValue">getAlphaNumericFileNameWithoutExtension()</s:String>
 	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=CLASS/InitialRange/@EntryValue">-1</s:Int64>
 	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=CLASS/Order/@EntryValue">0</s:Int64>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=CLASS2/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=CLASS2/Expression/@EntryValue">typeName()</s:String>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=CLASS2/InitialRange/@EntryValue">-1</s:Int64>
+	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=CLASS2/Order/@EntryValue">2</s:Int64>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=NAMESPACE/@KeyIndexDefined">True</s:Boolean>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=NAMESPACE/Expression/@EntryValue">fileDefaultNamespace()</s:String>
 	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=58D5EB70DF984241A0863E67D7E33F3D/Field/=NAMESPACE/InitialRange/@EntryValue">-1</s:Int64>
@@ -117,11 +121,12 @@ namespace $NAMESPACE$
 
 using System.Collections.Generic;
 using MongoDB.Driver.TestHelpers;
+using FluentAssertions;
 using Xunit;
 
 namespace $NAMESPACE$
 {
-    public class $CLASS$ : LinqIntegrationTest&lt;$CLASS$.ClassFixture&gt;
+    public class $CLASS$ : LinqIntegrationTest&lt;$CLASS2$.ClassFixture&gt;
     {
         public $CLASS$(ClassFixture fixture)
             : base(fixture)

--- a/tests/MongoDB.Driver.TestHelpers/MongoCollectionFixture.cs
+++ b/tests/MongoDB.Driver.TestHelpers/MongoCollectionFixture.cs
@@ -19,7 +19,11 @@ using MongoDB.Driver.Tests;
 
 namespace MongoDB.Driver.TestHelpers
 {
-    public abstract class MongoCollectionFixture<TDocument> : MongoDatabaseFixture
+    public abstract class MongoCollectionFixture<TDocument> : MongoCollectionFixture<TDocument, TDocument>
+    {
+    }
+
+    public abstract class MongoCollectionFixture<TSource, TDocument> : MongoDatabaseFixture
     {
         private readonly Lazy<IMongoCollection<TDocument>> _collection;
         private bool _dataInitialized;
@@ -31,7 +35,7 @@ namespace MongoDB.Driver.TestHelpers
 
         public IMongoCollection<TDocument> Collection => _collection.Value;
 
-        protected abstract IEnumerable<TDocument> InitialData { get; }
+        protected abstract IEnumerable<TSource> InitialData { get; }
 
         public virtual bool InitializeDataBeforeEachTestCase => false;
 
@@ -47,7 +51,8 @@ namespace MongoDB.Driver.TestHelpers
                 }
                 else
                 {
-                    Collection.InsertMany(InitialData);
+                    var collection = Database.GetCollection<TSource>(Collection.CollectionNamespace.CollectionName);
+                    collection.InsertMany(InitialData);
                 }
 
                 _dataInitialized = true;

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4116Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4116Tests.cs
@@ -13,26 +13,40 @@
 * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4116Tests : Linq3IntegrationTest
+    public class CSharp4116Tests : LinqIntegrationTest<CSharp4116Tests.ClassFixture>
     {
+        public CSharp4116Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [InlineData(false, "{ $match : { _id : { $type : -1 } } }")]
         [InlineData(true, "{ $match : { } }")]
         public void Optimize_match_with_expr(bool value, string expectedStage)
         {
-            var collection = GetCollection<BsonDocument>();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Where(x => value);
 
             var stages = Translate(collection, queryable);
 
             AssertStages(stages, expectedStage);
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<BsonDocument>
+        {
+            protected override IEnumerable<BsonDocument> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4118Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4118Tests.cs
@@ -13,19 +13,26 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4118Tests : Linq3IntegrationTest
+    public class CSharp4118Tests : LinqIntegrationTest<CSharp4118Tests.ClassFixture>
     {
+        public CSharp4118Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Known_serializers_should_not_propagate_past_anonymous_class()
         {
-            var collection = GetCollection<C>();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => new { S = "abc", HasId = x.Id != "000000000000000000000000" });
 
@@ -37,7 +44,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Known_serializers_should_not_propagate_past_class_with_member_initializers()
         {
-            var collection = GetCollection<C>();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => new R { S = "abc", HasId = x.Id != "000000000000000000000000" });
 
@@ -46,7 +53,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             AssertStages(stages, "{ $project : { S : 'abc', HasId : { $ne : ['$_id', ObjectId('000000000000000000000000')] }, _id : 0 } }");
         }
 
-        private class C
+        public class C
         {
             [BsonRepresentation(BsonType.ObjectId)] public string Id { get; set; }
         }
@@ -55,6 +62,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         {
             public string S { get; set; }
             public bool HasId { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4126Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4126Tests.cs
@@ -14,22 +14,26 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4126Tests : Linq3IntegrationTest
+    public class CSharp4126Tests : LinqIntegrationTest<CSharp4126Tests.ClassFixture>
     {
+        public CSharp4126Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Test()
         {
-            var collection = GetCollection<C>();
-            CreateCollection(
-                collection,
-                new C { Id = 1, A = new[] { 1, -2, -3 } });
-
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(_p0 => new { Id = _p0.Id, A = _p0.A.Select(_p1 => Math.Abs(_p1)) });
 
@@ -46,6 +50,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         {
             public int Id { get; set; }
             public int[] A { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, A = new[] { 1, -2, -3 } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4244Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4244Tests.cs
@@ -13,22 +13,28 @@
 * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4244Tests : Linq3IntegrationTest
+    public class CSharp4244Tests : LinqIntegrationTest<CSharp4244Tests.ClassFixture>
     {
+        public CSharp4244Tests(ClassFixture fixture)
+            : base(fixture, server => server.VersionGreaterThanOrEqualTo("6.0"))
+        {
+        }
+
         [Fact]
         public void Where_with_root_should_work()
         {
-            RequireServer.Check().VersionGreaterThanOrEqualTo("6.0");
-
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var person = new Person { Id = 2, Name = "Jane Doe" };
 
             var queryable = collection
@@ -42,22 +48,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Single().ShouldBeEquivalentTo(person);
         }
 
-        private IMongoCollection<Person> CreateCollection()
-        {
-            var collection = GetCollection<Person>("C");
-
-            CreateCollection(
-                collection,
-                new Person { Id = 1, Name = "John Doe" },
-                new Person { Id = 2, Name = "Jane Doe" });
-
-            return collection;
-        }
-
-        private class Person
+        public class Person
         {
             public int Id { get; set; }
             public string Name { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Person>
+        {
+            protected override IEnumerable<Person> InitialData =>
+            [
+                new Person { Id = 1, Name = "John Doe" },
+                new Person { Id = 2, Name = "Jane Doe" }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4289Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4289Tests.cs
@@ -13,21 +13,30 @@
 * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4289Tests : Linq3IntegrationTest
+    public class CSharp4289Tests : LinqIntegrationTest<CSharp4289Tests.ClassFixture>
     {
+        public CSharp4289Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Select_using_anonymous_class_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new { V = x.Id, W = x.Id });
@@ -43,7 +52,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_using_named_class_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new R(x.Id) { W = x.Id });
@@ -54,17 +63,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             var results = queryable.ToList();
             results.Select(r => r.V).Should().Equal("111111111111111111111111");
             results.Select(r => r.W).Should().Equal("111111111111111111111111");
-        }
-
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>();
-
-            CreateCollection(
-                collection,
-                new C { Id = "111111111111111111111111" });
-
-            return collection;
         }
 
         public class C
@@ -82,6 +80,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 
             [BsonElement("v")] public string V { get; set; }
             [BsonElement("w")] public string W { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = "111111111111111111111111" }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4317Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4317Tests.cs
@@ -18,17 +18,22 @@ using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Options;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4317Tests : Linq3IntegrationTest
+    public class CSharp4317Tests : LinqIntegrationTest<CSharp4317Tests.ClassFixture>
     {
+        public CSharp4317Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Projection_of_ArrayOfDocuments_dictionary_keys_and_values_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var projectStage = "{ $project : { Keys : '$Data.k', Values : '$Data.v', _id : 0 } }";
 
             var queryable = collection
@@ -46,23 +51,20 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Values.Should().Equal("v1", "v2");
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, Data = new Dictionary<int, string> { { 1, "v1" }, { 2, "v2" } } });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
 
             [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfDocuments)]
             public Dictionary<int, string> Data { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, Data = new Dictionary<int, string> { { 1, "v1" }, { 2, "v2" } } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4337Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4337Tests.cs
@@ -21,12 +21,14 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4337Tests : Linq3IntegrationTest
+    public class CSharp4337Tests : LinqIntegrationTest<CSharp4337Tests.ClassFixture>
     {
         private static (Expression<Func<C, R<bool>>> Projection, string ExpectedStage, bool[] ExpectedResults)[] __predicate_should_use_correct_representation_test_cases = new (Expression<Func<C, R<bool>>> Projection, string ExpectedStage, bool[] ExpectedResults)[]
         {
@@ -35,6 +37,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             (d => new R<bool> { N = d.Id, V = E.E1 == d.I1 ? true : false }, "{ $project : { N : '$_id', V : { $cond : { if : { $eq : [1, '$I1'] }, then : true, else : false } }, _id : 0 } }", new[] { true, false }),
             (d => new R<bool> { N = d.Id, V = E.E1 == d.S1 ? true : false }, "{ $project : { N : '$_id', V : { $cond : { if : { $eq : ['E1', '$S1'] }, then : true, else : false } }, _id : 0 } }", new[] { true, false })
         };
+
+        public CSharp4337Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
 
         public static IEnumerable<object[]> Predicate_should_use_correct_representation_member_data()
         {
@@ -49,7 +56,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [MemberData(nameof(Predicate_should_use_correct_representation_member_data))]
         public void Predicate_should_use_correct_representation(int i, string projectionAsString, string expectedStage, bool[] expectedResults)
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var projection = __predicate_should_use_correct_representation_test_cases[i].Projection;
 
             var aggregate = collection.Aggregate()
@@ -94,7 +101,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [MemberData(nameof(Result_should_use_correct_representation_member_data))]
         public void Result_should_use_correct_representation(int i, string projectionAsString, string expectedStage, E[] expectedResults)
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var projection = __result_should_use_correct_representation_test_cases[i].Projection;
 
             var aggregate = collection.Aggregate()
@@ -126,7 +133,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [MemberData(nameof(Result_with_mixed_representations_should_throw_member_data))]
         public void Result_with_mixed_representations_should_throw(int i, string projectionAsString)
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var projection = __result_with_mixed_representations_should_throw_test_cases[i];
 
             var aggregate = collection.Aggregate()
@@ -137,18 +144,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 
             var notSupportedException = exception.Should().BeOfType<ExpressionNotSupportedException>().Subject;
             notSupportedException.Message.Should().Contain("because IfTrue and IfFalse expressions have different serializers");
-        }
-
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>();
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, I1 = E.E1, I2 = E.E1, S1 = E.E1, S2 = E.E1 },
-                new C { Id = 2, I1 = E.E2, I2 = E.E2, S1 = E.E2, S2 = E.E2 });
-
-            return collection;
         }
 
         public class C
@@ -169,5 +164,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         }
 
         public enum E { E1 = 1, E2 }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, I1 = E.E1, I2 = E.E1, S1 = E.E1, S2 = E.E1 },
+                new C { Id = 2, I1 = E.E2, I2 = E.E2, S1 = E.E2, S2 = E.E2 }
+            ];
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4370Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4370Tests.cs
@@ -13,21 +13,27 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4370Tests : Linq3IntegrationTest
+    public class CSharp4370Tests : LinqIntegrationTest<CSharp4370Tests.ClassFixture>
     {
+        public CSharp4370Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Where_with_Id_represented_as_ObjectId_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.SomeId == "bbbbbbbbbbbbbbbbbbbbbbbb");
@@ -39,24 +45,20 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(r => r.Id).Should().Equal(2);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("products");
-            var database = collection.Database;
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, SomeId = "aaaaaaaaaaaaaaaaaaaaaaaa" },
-                new C { Id = 2, SomeId = "bbbbbbbbbbbbbbbbbbbbbbbb" });
-
-            return collection;
-        }
-
         public class C
         {
             public int Id { get; set; }
             [BsonRepresentation(BsonType.ObjectId)]
             public string SomeId { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, SomeId = "aaaaaaaaaaaaaaaaaaaaaaaa" },
+                new C { Id = 2, SomeId = "bbbbbbbbbbbbbbbbbbbbbbbb" }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4391Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4391Tests.cs
@@ -13,17 +13,23 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson;
 using Xunit;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver.TestHelpers;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4391Tests : Linq3IntegrationTest
+    public class CSharp4391Tests : LinqIntegrationTest<CSharp4391Tests.ClassFixture>
     {
+        public CSharp4391Tests(ClassFixture fixture) : base(fixture)
+        {
+        }
+
         [Fact]
         public void Serializing_struct_with_constructor_should_work()
         {
@@ -91,7 +97,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Queryable_with_struct_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable();
@@ -106,7 +112,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Queryable_with_projected_struct_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -119,19 +125,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Should().Equal(new S(1, 3, 4), new S(2, 4, 5));
         }
 
-        private IMongoCollection<S> CreateCollection()
-        {
-            var collection = GetCollection<S>("C");
-
-            CreateCollection(
-                collection,
-                new S(1, 2, 3),
-                new S(2, 3, 4));
-
-            return collection;
-        }
-
-        private struct S
+        public struct S
         {
             public S(int id, int x, int y)
             {
@@ -165,6 +159,15 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             public int Id { get; set; }
             public int X { get; set; }
             public int Y { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<S>
+        {
+            protected override IEnumerable<S> InitialData =>
+            [
+                new S(1, 2, 3),
+                new S(2, 3, 4)
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4401Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4401Tests.cs
@@ -21,11 +21,12 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4401Tests : Linq3IntegrationTest
+    public class CSharp4401Tests : LinqIntegrationTest<CSharp4401Tests.ClassFixture>
     {
         private static readonly WhereTestCase[] __whereTestCases;
 
@@ -35,6 +36,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             public string PredicateAsString { get; set; }
             public string ExpectedStage { get; set; }
             public int[] ExpectedResults { get; set; }
+        }
+
+        public CSharp4401Tests(ClassFixture fixture)
+            : base(fixture)
+        {
         }
 
         private static WhereTestCase CreateWhereTestCase(
@@ -173,7 +179,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [MemberData(nameof(Where_with_enum_comparison_should_work_member_data))]
         public void Where_with_enum_comparison_should_work(int i, string predicateAsString, string expectedMatchStage, int[] expectedResults)
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var predicate = __whereTestCases[i].Predicate;
             expectedResults ??= new int[0];
 
@@ -195,7 +201,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Comparison_of_enum_and_enum_with_mismatched_serializers_should_throw()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -210,7 +216,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Comparison_of_enum_and_nullable_enum_with_mismatched_serializers_should_throw()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -225,7 +231,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Comparison_of_nullable_enum_and_enum_with_mismatched_serializers_should_throw()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -240,7 +246,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Comparison_of_nullable_enum_and_nullable_enum_with_mismatched_serializers_should_throw()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -252,23 +258,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             exception.Message.Should().Contain("because the two arguments are serialized differently");
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>();
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, One = 1, E = E.A, F = E.A, NE = E.A, NF = E.A, S = E.A, T = E.A, NS = E.A, NT = E.A },
-                new C { Id = 2, One = 1, E = E.B, F = E.C, NE = E.B, NF = E.C, S = E.B, T = E.C, NS = E.B, NT = E.C },
-                new C { Id = 3, One = 1, E = E.C, F = E.B, NE = E.C, NF = E.B, S = E.C, T = E.B, NS = E.C, NT = E.B },
-                new C { Id = 4, One = 1, E = E.X, F = E.X, NE = E.X, NF = null, S = E.X, T = E.X, NS = E.X, NT = null },
-                new C { Id = 5, One = 1, E = E.Y, F = E.Z, NE = null, NF = E.Z, S = E.Y, T = E.Z, NS = null, NT = E.Z },
-                new C { Id = 6, One = 1, E = E.Z, F = E.Y, NE = null, NF = null, S = E.Z, T = E.Y, NS = null, NT = null });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int One { get; set; }
@@ -282,6 +272,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [BsonRepresentation(BsonType.String)] public E? NT { get; set; }
         }
 
-        private enum E { A = 1, B = 2, C = 3, X = 6, Y = 7, Z = 9 }
+        public enum E { A = 1, B = 2, C = 3, X = 6, Y = 7, Z = 9 }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, One = 1, E = E.A, F = E.A, NE = E.A, NF = E.A, S = E.A, T = E.A, NS = E.A, NT = E.A },
+                new C { Id = 2, One = 1, E = E.B, F = E.C, NE = E.B, NF = E.C, S = E.B, T = E.C, NS = E.B, NT = E.C },
+                new C { Id = 3, One = 1, E = E.C, F = E.B, NE = E.C, NF = E.B, S = E.C, T = E.B, NS = E.C, NT = E.B },
+                new C { Id = 4, One = 1, E = E.X, F = E.X, NE = E.X, NF = null, S = E.X, T = E.X, NS = E.X, NT = null },
+                new C { Id = 5, One = 1, E = E.Y, F = E.Z, NE = null, NF = E.Z, S = E.Y, T = E.Z, NS = null, NT = E.Z },
+                new C { Id = 6, One = 1, E = E.Z, F = E.Y, NE = null, NF = null, S = E.Z, T = E.Y, NS = null, NT = null }
+            ];
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4405Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4405Tests.cs
@@ -14,20 +14,27 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4405Tests : Linq3IntegrationTest
+    public class CSharp4405Tests : LinqIntegrationTest<CSharp4405Tests.ClassFixture>
     {
+        public CSharp4405Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Week_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -43,7 +50,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Week_with_timezone_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -56,23 +63,20 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Should().Equal(0, 52);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, D = DateTime.Parse("2022-01-01T00:00:00Z", null, DateTimeStyles.AdjustToUniversal), TZ = "UTC" },
-                new C { Id = 2, D = DateTime.Parse("2022-01-01T00:00:00Z", null, DateTimeStyles.AdjustToUniversal), TZ = "America/New_York" });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public DateTime D { get; set; }
             public string TZ { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, D = DateTime.Parse("2022-01-01T00:00:00Z", null, DateTimeStyles.AdjustToUniversal), TZ = "UTC" },
+                new C { Id = 2, D = DateTime.Parse("2022-01-01T00:00:00Z", null, DateTimeStyles.AdjustToUniversal), TZ = "America/New_York" }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4410Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4410Tests.cs
@@ -23,12 +23,13 @@ using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4410Tests : Linq3IntegrationTest
+    public class CSharp4410Tests : LinqIntegrationTest<CSharp4410Tests.ClassFixture>
     {
         private static readonly SelectTestCase[] __selectTestCases;
 
@@ -38,6 +39,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             public string ProjectionAsString { get; set; }
             public string ExpectedStage { get; set; }
             public int[] ExpectedResults { get; set; }
+        }
+
+        public CSharp4410Tests(ClassFixture fixture)
+            : base(fixture)
+        {
         }
 
         private static SelectTestCase CreateSelectTestCase(
@@ -158,7 +164,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [MemberData(nameof(Select_with_enum_comparison_should_work_member_data))]
         public void Select_with_enum_comparison_should_work(int i, string projectionAsString, string expectedProjectStage, int[] expectedResults)
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var projection = __selectTestCases[i].Projection;
             expectedResults ??= new int[0];
 
@@ -183,7 +189,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection
@@ -213,7 +219,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection
@@ -243,7 +249,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection
@@ -273,7 +279,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection
@@ -303,7 +309,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection
@@ -333,7 +339,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection
@@ -357,23 +363,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             }
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>();
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, One = 1, E = E.A, F = E.A, NE = E.A, NF = E.A, S = E.A, T = E.A, NS = E.A, NT = E.A },
-                new C { Id = 2, One = 1, E = E.B, F = E.C, NE = E.B, NF = E.C, S = E.B, T = E.C, NS = E.B, NT = E.C },
-                new C { Id = 3, One = 1, E = E.C, F = E.B, NE = E.C, NF = E.B, S = E.C, T = E.B, NS = E.C, NT = E.B },
-                new C { Id = 4, One = 1, E = E.X, F = E.X, NE = E.X, NF = null, S = E.X, T = E.X, NS = E.X, NT = null },
-                new C { Id = 5, One = 1, E = E.Y, F = E.Z, NE = null, NF = E.Z, S = E.Y, T = E.Z, NS = null, NT = E.Z },
-                new C { Id = 6, One = 1, E = E.Z, F = E.Y, NE = null, NF = null, S = E.Z, T = E.Y, NS = null, NT = null });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int One { get; set; }
@@ -387,6 +377,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [BsonRepresentation(BsonType.String)] public E? NT { get; set; }
         }
 
-        private enum E { A = 1, B = 2, C = 3, X = 6, Y = 7, Z = 9 }
+        public enum E { A = 1, B = 2, C = 3, X = 6, Y = 7, Z = 9 }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, One = 1, E = E.A, F = E.A, NE = E.A, NF = E.A, S = E.A, T = E.A, NS = E.A, NT = E.A },
+                new C { Id = 2, One = 1, E = E.B, F = E.C, NE = E.B, NF = E.C, S = E.B, T = E.C, NS = E.B, NT = E.C },
+                new C { Id = 3, One = 1, E = E.C, F = E.B, NE = E.C, NF = E.B, S = E.C, T = E.B, NS = E.C, NT = E.B },
+                new C { Id = 4, One = 1, E = E.X, F = E.X, NE = E.X, NF = null, S = E.X, T = E.X, NS = E.X, NT = null },
+                new C { Id = 5, One = 1, E = E.Y, F = E.Z, NE = null, NF = E.Z, S = E.Y, T = E.Z, NS = null, NT = E.Z },
+                new C { Id = 6, One = 1, E = E.Z, F = E.Y, NE = null, NF = null, S = E.Z, T = E.Y, NS = null, NT = null }
+            ];
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4415Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4415Tests.cs
@@ -14,20 +14,26 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4415Tests : Linq3IntegrationTest
+    public class CSharp4415Tests : LinqIntegrationTest<CSharp4415Tests.ClassFixture>
     {
+        public CSharp4415Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Year_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -44,22 +50,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Should().Equal(2021, 2022);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, D = DateTime.Parse("2021-01-01T01:01:01Z", null, DateTimeStyles.AdjustToUniversal) },
-                new C { Id = 2, D = DateTime.Parse("2022-02-02T02:02:02Z", null, DateTimeStyles.AdjustToUniversal) });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public DateTime D { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, D = DateTime.Parse("2021-01-01T01:01:01Z", null, DateTimeStyles.AdjustToUniversal) },
+                new C { Id = 2, D = DateTime.Parse("2022-02-02T02:02:02Z", null, DateTimeStyles.AdjustToUniversal) }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4445Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4445Tests.cs
@@ -13,20 +13,27 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4445Tests : Linq3IntegrationTest
+    public class CSharp4445Tests : LinqIntegrationTest<CSharp4445Tests.ClassFixture>
     {
+        public CSharp4445Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void AggregateFluent_Limit_with_int_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             int limit = 1;
 
             var aggregate =
@@ -45,7 +52,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void AggregateFluent_Limit_with_long_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             long limit = 1;
 
             var aggregate =
@@ -64,7 +71,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void AggregateFluent_Skip_with_int_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             int skip = 1;
 
             var aggregate =
@@ -83,7 +90,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void AggregateFluent_Skip_with_long_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             long limit = 1;
 
             var aggregate =
@@ -102,7 +109,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void PipelineDefinitionBuilder_Limit_with_int_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             int limit = 1;
 
             var pipeline =
@@ -121,7 +128,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void PipelineDefinitionBuilder_Limit_with_long_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             long limit = 1;
 
             var pipeline =
@@ -140,7 +147,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void PipelineDefinitionBuilder_Skip_with_int_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             int skip = 1;
 
             var pipeline =
@@ -159,7 +166,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void PipelineDefinitionBuilder_Skip_with_long_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             long skip = 1;
 
             var pipeline =
@@ -178,7 +185,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Queryable_Skip_with_int_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             int count = 1;
 
             var queryable =
@@ -197,7 +204,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Queryable_Skip_with_long_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             long count = 1;
 
             var queryable =
@@ -216,7 +223,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Queryable_Take_with_int_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             int count = 1;
 
             var queryable =
@@ -235,7 +242,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Queryable_Take_with_long_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             long count = 1;
 
             var queryable =
@@ -251,21 +258,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(1);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1 },
-                new C { Id = 2 });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1 },
+                new C { Id = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4457Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4457Tests.cs
@@ -13,21 +13,27 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4457Tests : Linq3IntegrationTest
+    public class CSharp4457Tests : LinqIntegrationTest<CSharp4457Tests.ClassFixture>
     {
+        public CSharp4457Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Filter_with_bool_field_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var builder = Builders<C>.Filter;
             var filter = builder.Where(x => x.BoolField);
 
@@ -41,7 +47,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Filter_with_bool_property_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var builder = Builders<C>.Filter;
             var filter = builder.Where(x => x.BoolProperty);
 
@@ -55,7 +61,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Filter_with_not_bool_field_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var builder = Builders<C>.Filter;
             var filter = builder.Where(x => !x.BoolField);
 
@@ -69,7 +75,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Filter_with_not_bool_property_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var builder = Builders<C>.Filter;
             var filter = builder.Where(x => !x.BoolProperty);
 
@@ -83,7 +89,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_bool_field_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable =
                 collection.AsQueryable()
@@ -99,7 +105,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_bool_property_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable =
                 collection.AsQueryable()
@@ -115,7 +121,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_not_bool_field_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable =
                 collection.AsQueryable()
@@ -131,7 +137,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_not_bool_property_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable =
                 collection.AsQueryable()
@@ -144,18 +150,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(2);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, BoolField = true, BoolProperty = true },
-                new C { Id = 2, BoolField = false, BoolProperty = false });
-
-            return collection;
-        }
-
         private BsonDocument RenderFilter<TDocument>(FilterDefinition<TDocument> filter)
         {
             var serializerRegistry = BsonSerializer.SerializerRegistry;
@@ -163,12 +157,21 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             return filter.Render(new(documentSerializer, serializerRegistry));
         }
 
-        private class C
+        public class C
         {
             public bool BoolField;
 
             public int Id { get; set; }
             public bool BoolProperty { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, BoolField = true, BoolProperty = true },
+                new C { Id = 2, BoolField = false, BoolProperty = false }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4466Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4466Tests.cs
@@ -13,20 +13,27 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4466Tests : Linq3IntegrationTest
+    public class CSharp4466Tests : LinqIntegrationTest<CSharp4466Tests.ClassFixture>
     {
+        public CSharp4466Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void AppendStage_with_null_resultSerializer_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable =
                 collection.AsQueryable()
@@ -44,7 +51,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void AppendStage_with_resultSerializer_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var resultSerializer = BsonSerializer.LookupSerializer<D>();
 
             var queryable =
@@ -60,19 +67,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.X).Should().Equal(1, 2);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1 },
-                new C { Id = 2 });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
         }
@@ -80,6 +75,15 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         private class D
         {
             public int X { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1 },
+                new C { Id = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4468Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4468Tests.cs
@@ -14,18 +14,26 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4468Tests : Linq3IntegrationTest
+    public class CSharp4468Tests : LinqIntegrationTest<CSharp4468Tests.ClassFixture>
     {
+        public CSharp4468Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Query1_should_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable =
                 collection.AsQueryable()
@@ -52,7 +60,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Query2_should_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable =
                 collection.AsQueryable()
@@ -73,12 +81,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             AssertStages(stages, expectedStages);
         }
 
-        private IMongoCollection<OrderDao> CreateCollection()
-        {
-            var collection = GetCollection<OrderDao>();
-            return collection;
-        }
-
         public class OrderDao
         {
             public OrderLineDao[] Lines { get; set; }
@@ -97,6 +99,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         {
             public Guid Id { get; set; }
             public decimal TotalAmount { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<OrderDao>
+        {
+            protected override IEnumerable<OrderDao> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4486Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4486Tests.cs
@@ -14,22 +14,29 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4486Tests : Linq3IntegrationTest
+    public class CSharp4486Tests : LinqIntegrationTest<CSharp4486Tests.ClassFixture>
     {
+        public CSharp4486Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void And_with_two_arguments_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.P & x.Q);
@@ -44,7 +51,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void And_with_three_arguments_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.P & x.Q & x.R);
@@ -59,7 +66,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Not_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => !x.P);
@@ -74,7 +81,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Or_with_two_arguments_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.P | x.Q);
@@ -89,7 +96,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Or_with_three_arguments_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.P | x.Q | x.R);
@@ -107,7 +114,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -134,7 +141,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void BitAnd_with_two_arguments_should_work()
         {
             RequireServer.Check().Supports(Feature.BitwiseOperators);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.X & x.Z);
@@ -150,7 +157,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void BitAnd_with_three_arguments_should_work()
         {
             RequireServer.Check().Supports(Feature.BitwiseOperators);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.X & x.Y & x.Z);
@@ -168,7 +175,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void BitNot_should_work()
         {
             RequireServer.Check().Supports(Feature.BitwiseOperators);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ~x.X);
@@ -184,7 +191,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void BitOr_with_two_arguments_should_work()
         {
             RequireServer.Check().Supports(Feature.BitwiseOperators);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.X | x.Z);
@@ -200,7 +207,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void BitOr_with_three_arguments_should_work()
         {
             RequireServer.Check().Supports(Feature.BitwiseOperators);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.X | x.Y | x.Z);
@@ -216,7 +223,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void BitXor_with_two_arguments_should_work()
         {
             RequireServer.Check().Supports(Feature.BitwiseOperators);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.X ^ x.Z);
@@ -232,7 +239,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void BitXor_with_three_arguments_should_work()
         {
             RequireServer.Check().Supports(Feature.BitwiseOperators);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.X ^ x.Y ^ x.Z);
@@ -244,16 +251,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Should().Be(0);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, P = true, Q = true, R = false, X = 1, Y = 2, Z = 3 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public bool P { get; set; }
@@ -262,6 +260,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             public int X { get; set; }
             public int Y { get; set; }
             public int Z { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, P = true, Q = true, R = false, X = 1, Y = 2, Z = 3 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4493Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4493Tests.cs
@@ -18,16 +18,22 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4493Tests : Linq3IntegrationTest
+    public class CSharp4493Tests : LinqIntegrationTest<CSharp4493Tests.ClassFixture>
     {
+        public CSharp4493Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Find_with_predicate_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             string[] emails = { "email4@test.net" };
             string[] addresses = { "495 pacific street plymouth, ma 02360" };
             Expression<Func<Customer, bool>> filterByAddressAndEmails =
@@ -45,12 +51,27 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(2);
         }
 
-        private IMongoCollection<Customer> CreateCollection()
+        public class Customer
         {
-            var collection = GetCollection<Customer>("C");
+            public int Id { get; set; }
+            public AddressMetadata Address { get; set; }
+            public IList<EmailMetadata> Emails { get; set; }
+        }
 
-            CreateCollection(
-                collection,
+        public sealed record AddressMetadata
+        {
+            public string FullAddress { get; set; }
+        }
+
+        public sealed record EmailMetadata
+        {
+            public string Email { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Customer>
+        {
+            protected override IEnumerable<Customer> InitialData =>
+            [
                 new Customer {
                     Id = 1,
                     Address = new AddressMetadata
@@ -94,26 +115,8 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                             Email = "notEmail4@test.net"
                         }
                     }
-                });
-
-            return collection;
-        }
-
-        public class Customer
-        {
-            public int Id { get; set; }
-            public AddressMetadata Address { get; set; }
-            public IList<EmailMetadata> Emails { get; set; }
-        }
-
-        public sealed record AddressMetadata
-        {
-            public string FullAddress { get; set; }
-        }
-
-        public sealed record EmailMetadata
-        {
-            public string Email { get; set; }
+                }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4499Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4499Tests.cs
@@ -13,17 +13,24 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using MongoDB.Bson;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4499Tests : Linq3IntegrationTest
+    public class CSharp4499Tests : LinqIntegrationTest<CSharp4499Tests.ClassFixture>
     {
+        public CSharp4499Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void ExpressionFieldDefinition_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var fieldDefinition = new ExpressionFieldDefinition<ConcreteClass, object>(x => x.InternalId);
 
             var queryable = collection.Aggregate()
@@ -33,15 +40,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             AssertStages(stages, "{ $sort : { InternalId : 1 } }");
         }
 
-        private IMongoCollection<ConcreteClass> CreateCollection()
-        {
-            var collection = GetCollection<ConcreteClass>("C");
-            return collection;
-        }
-
-        private class ConcreteClass
+        public class ConcreteClass
         {
             public ObjectId InternalId { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<ConcreteClass>
+        {
+            protected override IEnumerable<ConcreteClass> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4500Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4500Tests.cs
@@ -16,17 +16,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4500Tests : Linq3IntegrationTest
+    public class CSharp4500Tests : LinqIntegrationTest<CSharp4500Tests.ClassFixture>
     {
+        public CSharp4500Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Where_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var input = "B";
 
             var queryable =
@@ -43,7 +48,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_inner_not_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var input = "B";
 
             var queryable =
@@ -60,7 +65,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_outer_not_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var input = "B";
 
             var queryable =
@@ -74,22 +79,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(2);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, List = new List<string> { "abc", "def" } },
-                new C { Id = 2, List = new List<string> { "ghi", "jkl" } });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public List<string> List { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, List = new List<string> { "abc", "def" } },
+                new C { Id = 2, List = new List<string> { "ghi", "jkl" } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4509Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4509Tests.cs
@@ -14,15 +14,21 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4509Tests : Linq3IntegrationTest
+    public class CSharp4509Tests : LinqIntegrationTest<CSharp4509Tests.ClassFixture>
     {
+        public CSharp4509Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [InlineData(JobSortColumn.DriverName, "DriverName")]
         [InlineData(JobSortColumn.JobNumber, "JobNumber")]
@@ -30,7 +36,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             JobSortColumn sortOrder,
             string expectedSortField)
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             Expression<Func<DbJob, object>> selector = sortOrder switch
             {
@@ -47,12 +53,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             AssertStages(stages, $"{{ $sort : {{ {expectedSortField} : -1 }} }}");
         }
 
-        private IMongoCollection<DbJob> CreateCollection()
-        {
-            var collection = GetCollection<DbJob>("jobs");
-            return collection;
-        }
-
         public class DbJob
         {
             public int JobNumber { get; set; }
@@ -60,5 +60,10 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         }
 
         public enum JobSortColumn { JobNumber, DriverName }
+
+        public sealed class ClassFixture : MongoCollectionFixture<DbJob>
+        {
+            protected override IEnumerable<DbJob> InitialData => null;
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4521Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4521Tests.cs
@@ -14,23 +14,29 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4512Tests : Linq3IntegrationTest
+    public class CSharp4512Tests : LinqIntegrationTest<CSharp4512Tests.ClassFixture>
     {
+        public CSharp4512Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [InlineData("x")]
         [InlineData("")]
         [InlineData(null)]
         public void Where_should_work(string paramName)
-        { 
-            var collection = CreateCollection();
+        {
+            var collection = Fixture.Collection;
             var param = Expression.Parameter(typeof(C), paramName);
             var body = Expression.MakeBinary(
                 ExpressionType.Equal,
@@ -47,21 +53,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(1);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1 },
-                new C { Id = 2 });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1 },
+                new C { Id = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4549Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4549Tests.cs
@@ -14,19 +14,25 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4549Tests : Linq3IntegrationTest
+    public class CSharp4549Tests : LinqIntegrationTest<CSharp4549Tests.ClassFixture>
     {
+        public CSharp4549Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_1_item_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int>(x.A));
@@ -41,7 +47,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_2_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int>(x.A, x.B));
@@ -56,7 +62,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_3_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int>(x.A, x.B, x.C));
@@ -71,7 +77,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_4_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int>(x.A, x.B, x.C, x.D));
@@ -86,7 +92,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_5_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int>(x.A, x.B, x.C, x.D, x.E));
@@ -101,7 +107,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_6_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int>(x.A, x.B, x.C, x.D, x.E, x.F));
@@ -116,7 +122,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_7_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int>(x.A, x.B, x.C, x.D, x.E, x.F, x.G));
@@ -131,7 +137,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_8_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int>(x.H)));
@@ -146,7 +152,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_9_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)));
@@ -161,7 +167,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_constructor_with_16_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -184,7 +190,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_create_with_1_item_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A));
@@ -199,7 +205,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_create_with_2_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B));
@@ -214,7 +220,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_create_with_3_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C));
@@ -229,7 +235,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_create_with_4_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D));
@@ -244,7 +250,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_create_with_5_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E));
@@ -259,7 +265,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_create_with_6_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F));
@@ -274,7 +280,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_create_with_7_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G));
@@ -289,7 +295,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_tuple_using_create_with_8_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H));
@@ -304,7 +310,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_1_item_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int>(x.A));
@@ -319,7 +325,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_2_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int>(x.A, x.B));
@@ -334,7 +340,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_3_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int>(x.A, x.B, x.C));
@@ -349,7 +355,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_4_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int>(x.A, x.B, x.C, x.D));
@@ -364,7 +370,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_5_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int>(x.A, x.B, x.C, x.D, x.E));
@@ -379,7 +385,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_6_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int>(x.A, x.B, x.C, x.D, x.E, x.F));
@@ -394,7 +400,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_7_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int>(x.A, x.B, x.C, x.D, x.E, x.F, x.G));
@@ -409,7 +415,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_8_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int>(x.H)));
@@ -424,7 +430,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_9_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)));
@@ -439,7 +445,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_constructor_with_16_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -458,7 +464,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_create_with_1_item_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A));
@@ -473,7 +479,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_create_with_2_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B));
@@ -488,7 +494,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_create_with_3_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C));
@@ -503,7 +509,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_create_with_4_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D));
@@ -518,7 +524,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_create_with_5_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E));
@@ -533,7 +539,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_create_with_6_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F));
@@ -548,7 +554,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_create_with_7_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G));
@@ -563,7 +569,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Projecting_a_value_tuple_using_create_with_8_items_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H));
@@ -578,7 +584,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple1_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A))
@@ -597,7 +603,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple2_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B))
@@ -616,7 +622,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple2_Item2_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B))
@@ -635,7 +641,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple7_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G))
@@ -654,7 +660,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple7_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G))
@@ -673,7 +679,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple8_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -692,7 +698,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple8_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -711,7 +717,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple8_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
                 .Select(x => x.Rest.Item1);
@@ -729,7 +735,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple8_Rest_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
                 .Select(x => x.Rest);
@@ -747,7 +753,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple9_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
@@ -766,7 +772,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple9_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
@@ -785,7 +791,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple9_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
@@ -804,7 +810,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple9_Item9_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
                 .Select(x => x.Rest.Item2);
@@ -822,7 +828,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple9_Rest_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
                 .Select(x => x.Rest);
@@ -840,7 +846,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple16_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -863,7 +869,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple16_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -886,7 +892,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple16_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -909,7 +915,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple16_Item14_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -932,7 +938,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple16_Item15_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -955,7 +961,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple16_Item16_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -978,7 +984,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple16_Rest_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -1001,7 +1007,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Tuple16_Rest_Rest_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -1024,7 +1030,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple1_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A))
@@ -1043,7 +1049,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple2_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B))
@@ -1062,7 +1068,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple2_Item2_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B))
@@ -1081,7 +1087,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple7_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G))
@@ -1100,7 +1106,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple7_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G))
@@ -1119,7 +1125,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple8_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -1138,7 +1144,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple8_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -1157,7 +1163,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple8_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
                 .Select(x => x.Item8);
@@ -1175,7 +1181,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple8_Rest_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
                 .Select(x => x.Rest);
@@ -1193,7 +1199,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple9_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
@@ -1212,7 +1218,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple9_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
@@ -1231,7 +1237,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple9_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
@@ -1250,7 +1256,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple9_Item9_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
                 .Select(x => x.Item9);
@@ -1268,7 +1274,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple9_Rest_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
                 .Select(x => x.Rest);
@@ -1286,7 +1292,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple16_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -1309,7 +1315,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple16_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -1332,7 +1338,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple16_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -1355,7 +1361,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple16_Item14_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -1378,7 +1384,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple16_Item15_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -1401,7 +1407,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple16_Item16_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -1424,7 +1430,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple16_Rest_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -1447,7 +1453,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ValueTuple16_Rest_Rest_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -1470,7 +1476,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple1_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A))
@@ -1489,7 +1495,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple2_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B))
@@ -1508,7 +1514,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple2_Item2_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B))
@@ -1527,7 +1533,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple7_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G))
@@ -1546,7 +1552,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple7_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G))
@@ -1565,7 +1571,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple8_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -1584,7 +1590,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple8_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -1603,7 +1609,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple8_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => Tuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -1622,7 +1628,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple9_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
@@ -1641,7 +1647,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple9_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
@@ -1660,7 +1666,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple9_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
@@ -1679,7 +1685,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple9_Item9_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new Tuple<int, int>(x.H, x.I)))
@@ -1698,7 +1704,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple16_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -1725,7 +1731,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple16_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -1752,7 +1758,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple16_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -1779,7 +1785,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple16_Item14_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -1806,7 +1812,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple16_Item15_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -1833,7 +1839,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Tuple16_Item16_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new Tuple<int, int, int, int, int, int, int, Tuple<int, int, int, int, int, int, int, Tuple<int, int>>>(
@@ -1860,7 +1866,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple1_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A))
@@ -1879,7 +1885,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple2_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B))
@@ -1898,7 +1904,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple2_Item2_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B))
@@ -1917,7 +1923,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple7_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G))
@@ -1936,7 +1942,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple7_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G))
@@ -1955,7 +1961,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple8_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -1974,7 +1980,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple8_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -1993,7 +1999,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple8_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => ValueTuple.Create(x.A, x.B, x.C, x.D, x.E, x.F, x.G, x.H))
@@ -2012,7 +2018,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple9_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
@@ -2031,7 +2037,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple9_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
@@ -2050,7 +2056,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple9_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
@@ -2069,7 +2075,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple9_Item9_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>(x.A, x.B, x.C, x.D, x.E, x.F, x.G, new ValueTuple<int, int>(x.H, x.I)))
@@ -2088,7 +2094,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple16_Item1_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -2111,7 +2117,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple16_Item7_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -2134,7 +2140,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple16_Item8_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -2157,7 +2163,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple16_Item14_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -2180,7 +2186,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple16_Item15_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -2203,7 +2209,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ValueTuple16_Item16_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => new ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int>>>(
@@ -2223,18 +2229,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Should().Equal((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16));
         }
 
-        private IMongoCollection<T> CreateCollection()
-        {
-            var collection = GetCollection<T>("test");
-
-            CreateCollection(
-                collection,
-                new T { Id = 1, A = 1, B = 2, C = 3, D = 4, E = 5, F = 6, G = 7, H = 8, I = 9, J = 10, K = 11, L = 12, M = 13, N = 14, O = 15, P = 16 });
-
-            return collection;
-        }
-
-        private class T
+        public class T
         {
             public int Id { get; set; }
             public int A { get; set; }
@@ -2253,6 +2248,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             public int N { get; set; }
             public int O { get; set; }
             public int P { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<T>
+        {
+            protected override IEnumerable<T> InitialData =>
+            [
+                new T { Id = 1, A = 1, B = 2, C = 3, D = 4, E = 5, F = 6, G = 7, H = 8, I = 9, J = 10, K = 11, L = 12, M = 13, N = 14, O = 15, P = 16 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4557Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4557Tests.cs
@@ -16,17 +16,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4557Tests : Linq3IntegrationTest
+    public class CSharp4557Tests : LinqIntegrationTest<CSharp4557Tests.ClassFixture>
     {
+        public CSharp4557Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Where_with_ContainsKey_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -42,7 +47,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_with_ContainsKey_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -55,22 +60,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Should().Equal(false, true);
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("C");
-
-            CreateCollection(
-                collection,
-                new C { Id = 1, Foo = new Dictionary<string, int> { { "foo", 100 } } },
-                new C { Id = 2, Foo = new Dictionary<string, int> { { "bar", 100 } } });
-
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public Dictionary<string, int> Foo { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, Foo = new Dictionary<string, int> { { "foo", 100 } } },
+                new C { Id = 2, Foo = new Dictionary<string, int> { { "bar", 100 } } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4562Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4562Tests.cs
@@ -14,16 +14,22 @@
 */
 
 using System.Collections.Generic;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4562Tests : Linq3IntegrationTest
+    public class CSharp4562Tests : LinqIntegrationTest<CSharp4562Tests.ClassFixture>
     {
+        public CSharp4562Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void SortBy_using_constant_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = GetTranslationsSortedByEnglish(collection);
 
@@ -34,7 +40,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void SortBy_using_parameter_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             var language = "sp";
 
             var aggregate = GetSortedTranslations(collection, language);
@@ -43,13 +49,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             AssertStages(stages, "{ $sort : { 'Text.sp' : 1 } }");
         }
 
-        private IMongoCollection<Translation> CreateCollection()
-        {
-            var collection = GetCollection<Translation>("test");
-            return collection;
-        }
-
-        private class Translation
+        public class Translation
         {
             public int Id { get; set; }
             public Dictionary<string, string> Text { get; set; }
@@ -65,6 +65,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         {
             return collection.Aggregate()
                 .SortBy(c => c.Text["en"]);
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Translation>
+        {
+            protected override IEnumerable<Translation> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4567Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4567Tests.cs
@@ -14,21 +14,28 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using FluentAssertions;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4567Tests : Linq3IntegrationTest
+    public class CSharp4567Tests : LinqIntegrationTest<CSharp4567Tests.ClassFixture>
     {
+        public CSharp4567Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Projection_to_derived_type_should_work()
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             Expression<Func<C, object>> projection = x => new R { X = x.Id };
 
             var find = collection.Find("{}").Project(projection);
@@ -40,16 +47,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.X.Should().Be(1);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
         }
@@ -57,6 +55,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         private class R
         {
             public int X { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4592Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4592Tests.cs
@@ -16,17 +16,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4592Tests : Linq3IntegrationTest
+    public class CSharp4592Tests : LinqIntegrationTest<CSharp4592Tests.ClassFixture>
     {
+        public CSharp4592Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Project_dictionary_value_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.Dict["test"]);
@@ -38,20 +43,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Should().Equal(3, 0); // missing values deserialize as 0
         }
 
-        private IMongoCollection<ExampleClass> CreateCollection()
-        {
-            var collection = GetCollection<ExampleClass>("test");
-            CreateCollection(
-                collection,
-                new ExampleClass { Id = 1, Dict = new Dictionary<string, int> { ["test"] = 3 } },
-                new ExampleClass { Id = 2, Dict = new Dictionary<string, int> { ["a"] = 4 } });
-            return collection;
-        }
-
-        private class ExampleClass
+        public class ExampleClass
         {
             public int Id { get; set; }
             public IDictionary<string, int> Dict { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<ExampleClass>
+        {
+            protected override IEnumerable<ExampleClass> InitialData =>
+            [
+                new ExampleClass { Id = 1, Dict = new Dictionary<string, int> { ["test"] = 3 } },
+                new ExampleClass { Id = 2, Dict = new Dictionary<string, int> { ["a"] = 4 } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4607Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4607Tests.cs
@@ -16,16 +16,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4607Tests : Linq3IntegrationTest
+    public class CSharp4607Tests : LinqIntegrationTest<CSharp4607Tests.ClassFixture>
     {
+        public CSharp4607Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Constant_All_Enumerable_Contains_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             IList<int> values = new int[] { 1, 2, 3 };
 
             var filter = Builders<C>.Filter.Where(c => values.All(e => c.A.Contains(e)));
@@ -37,7 +43,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Constant_All_IList_Contains_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             IList<int> values = new int[] { 1, 2, 3 };
 
             var filter = Builders<C>.Filter.Where(c => values.All(e => c.L.Contains(e)));
@@ -46,21 +52,16 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             translatedFilter.Should().Be("{ L : { $all : [1, 2, 3] } }");
         }
 
-        private IMongoCollection<C> CreateCollection()
-        {
-            var collection = GetCollection<C>("test");
-            //CreateCollection(
-            //    collection,
-            //    new SimpleContact { Id = 1, Dict = new Dictionary<string, int> { ["test"] = 3 } },
-            //    new SimpleContact { Id = 2, Dict = new Dictionary<string, int> { ["a"] = 4 } });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int[] A { get; set; }
             public IList<int> L { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4609Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4609Tests.cs
@@ -14,20 +14,26 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4609Tests : Linq3IntegrationTest
+    public class CSharp4609Tests : LinqIntegrationTest<CSharp4609Tests.ClassFixture>
     {
+        public CSharp4609Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Project_dictionary_value_should_work()
         {
-            var collection = CreateCollection();
+            var collection = Fixture.Collection;
             Expression<Func<MeasurementDetails, object>> field = x => x.CreationDate;
             var myValue = "2023-04-13T01:02:03Z";
             var filter = Builders<MeasurementDetails>.Filter.Lt(field, myValue);
@@ -41,20 +47,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(r => r.Id).Should().Equal(1);
         }
 
-        private IMongoCollection<MeasurementDetails> CreateCollection()
-        {
-            var collection = GetCollection<MeasurementDetails>("test");
-            CreateCollection(
-                collection,
-                new MeasurementDetails { Id = 1, CreationDate = new DateTime(2023, 04, 13, 1, 2, 2, DateTimeKind.Utc) },
-                new MeasurementDetails { Id = 2, CreationDate = new DateTime(2023, 04, 13, 1, 2, 3, DateTimeKind.Utc) });
-            return collection;
-        }
-
-        private class MeasurementDetails
+        public class MeasurementDetails
         {
             public int Id { get; set; }
             public DateTime CreationDate { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<MeasurementDetails>
+        {
+            protected override IEnumerable<MeasurementDetails> InitialData =>
+            [
+                new MeasurementDetails { Id = 1, CreationDate = new DateTime(2023, 04, 13, 1, 2, 2, DateTimeKind.Utc) },
+                new MeasurementDetails { Id = 2, CreationDate = new DateTime(2023, 04, 13, 1, 2, 3, DateTimeKind.Utc) }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4622Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4622Tests.cs
@@ -13,36 +13,41 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4622Tests : Linq3IntegrationTest
+    public class CSharp4622Tests : LinqIntegrationTest<CSharp4622Tests.ClassFixture>
     {
+        public CSharp4622Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void ReplaceOne()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var options = new ReplaceOptions { IsUpsert = true };
-            var data = new Data { Id = 8, Text = "updated" };
+            var data = new C { Id = 8, Text = "updated" };
 
             var result = collection.ReplaceOne(d => true, data, options);
 
             result.UpsertedId.Should().Be(8);
         }
 
-        private IMongoCollection<Data> GetCollection()
-        {
-            var collection = GetCollection<Data>("test");
-            CreateCollection(collection);
-            return collection;
-        }
-
-        private class Data
+        public class C
         {
             public int Id { get; set; }
             public string Text { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4651Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4651Tests.cs
@@ -14,20 +14,26 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4651Tests : Linq3IntegrationTest
+    public class CSharp4651Tests : LinqIntegrationTest<CSharp4651Tests.ClassFixture>
     {
+        public CSharp4651Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void First_custom_projection_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(c => c.VehicleType == VehicleType.Car)
@@ -48,7 +54,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Second_custom_projection_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(c => c.VehicleType == VehicleType.Truck)
@@ -64,28 +70,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             var result = results.Single();
             result.Id.Should().Be("6666YYY");
             result.Description.Should().Be("No description available for trucks");
-        }
-
-        private IMongoCollection<Car> GetCollection()
-        {
-            var collection = GetCollection<Car>("test");
-            var carLicensePlate = "5555XXX";
-            var truckLicensePlate = "6666YYY";
-            CreateCollection(
-                collection,
-                new Car
-                {
-                    Id = carLicensePlate,
-                    Description = $"Description for license: {carLicensePlate}",
-                    VehicleType = VehicleType.Car
-                },
-                new Car
-                {
-                    Id = truckLicensePlate,
-                    Description = $"Description for license: {truckLicensePlate}",
-                    VehicleType = VehicleType.Truck
-                });
-            return collection;
         }
 
         private static Expression<Func<Car, CarDto>> ToCustomProjection_Works(VehicleType vehicleType)
@@ -107,23 +91,42 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             };
         }
 
-        private enum VehicleType
+        public enum VehicleType
         {
             Car = 0,
             Truck = 1
         }
 
-        private class Car
+        public class Car
         {
             public string Id { get; set; }
             public string Description { get; set; }
             public VehicleType VehicleType { get; set; }
         }
 
-        private class CarDto
+        public class CarDto
         {
             public string Id { get; set; }
             public string Description { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Car>
+        {
+            protected override IEnumerable<Car> InitialData =>
+            [
+                new Car
+                {
+                    Id = "5555XXX",
+                    Description = $"Description for license: 5555XXX",
+                    VehicleType = VehicleType.Car
+                },
+                new Car
+                {
+                    Id = "6666YYY",
+                    Description = $"Description for license: 6666YYY",
+                    VehicleType = VehicleType.Truck
+                }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4658Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4658Tests.cs
@@ -13,23 +13,29 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4658Tests : Linq3IntegrationTest
+    public class CSharp4658Tests : LinqIntegrationTest<CSharp4658Tests.ClassFixture>
     {
+        public CSharp4658Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Select_new_Model_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .GroupBy(x => x.Name)
                 .Select(x =>
-                    new Model
+                    new C
                     {
                         NotId = string.Empty,
                         Name = x.Key
@@ -45,7 +51,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Project_new_ModelAggregated_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Group(
@@ -53,7 +59,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                     g => new { Count = g.Count()}
                 )
                 .Project(
-                    x => new ModelAggregated
+                    x => new CAggregated
                     {
                         NotId = string.Empty,
                         Count = x.Count
@@ -67,22 +73,21 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 "{ $project : { NotId : '', Count : '$Count', _id : 0 } }");
         }
 
-        private IMongoCollection<Model> GetCollection()
-        {
-            var collection = GetCollection<Model>("test");
-            return collection;
-        }
-
-        private class Model
+        public class C
         {
             public string NotId { get; set; }
             public string Name { get; set; }
         }
 
-        private class ModelAggregated
+        public class CAggregated
         {
             public string NotId { get; set; }
             public int Count { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4666Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4666Tests.cs
@@ -13,17 +13,24 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4666Tests : Linq3IntegrationTest
+    public class CSharp4666Tests : LinqIntegrationTest<CSharp4666Tests.ClassFixture>
     {
+        public CSharp4666Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Find_project_id_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var find = collection
                 .Find(_ => true)
@@ -39,7 +46,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Find_project_field_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var find = collection
                 .Find(_ => true)
@@ -52,19 +59,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Should().Be(2);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 2 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int X { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4681Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4681Tests.cs
@@ -13,18 +13,25 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using FluentAssertions;
 using MongoDB.Bson.Serialization;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4681Tests : Linq3IntegrationTest
+    public class CSharp4681Tests : LinqIntegrationTest<CSharp4681Tests.ClassFixture>
     {
+        public CSharp4681Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Find_projection_render_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var fluentFind = collection.Find(a => a.Id == "1").Project(a => a.Id);
 
@@ -36,19 +43,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Should().Be("1");
         }
 
-        private IMongoCollection<A> GetCollection()
-        {
-            var collection = GetCollection<A>("test");
-            CreateCollection(
-                collection,
-                new A { Id = "1" },
-                new A { Id = "2" });
-            return collection;
-        }
-
-        private class A
+        public class C
         {
             public string Id { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = "1" },
+                new C { Id = "2" }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4684Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4684Tests.cs
@@ -13,24 +13,30 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Driver.Linq;
-using MongoDB.Driver.Tests.Linq.Linq3Implementation;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
-namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4684Tests : Linq3IntegrationTest
+    public class CSharp4684Tests : LinqIntegrationTest<CSharp4684Tests.ClassFixture>
     {
+        public CSharp4684Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [ParameterAttributeData]
         public async Task Multiple_result_query_logged_stages_can_be_retrieved_using_IQueryable_GetLoggedStages_method(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable().Where(x => x.X == 1);
 
             var results = async ? await queryable.ToListAsync() : queryable.ToList();
@@ -44,7 +50,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
         public async Task Single_result_query_logged_stages_can_be_retrieved_using_IQueryable_GetLoggedStages_method(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable().Where(x => x.X == 1);
 
             // cast to IQueryable so First below resolves to Queryable.First instead of IAsyncCursorSource.First
@@ -62,7 +68,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
         public async Task Multiple_result_query_logged_stages_can_be_retrieved_using_IMongoQueryProvider_LoggedStages_property(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable().Where(x => x.X == 1);
 
             var results = async ? await queryable.ToListAsync() : queryable.ToList();
@@ -76,7 +82,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
         public async Task Single_result_query_logged_stages_can_be_retrieved_using_IMongoQueryProvider_LoggedStages_property(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable().Where(x => x.X == 1);
 
             // cast to IQueryable so First below resolves to Queryable.First instead of IAsyncCursorSource.First
@@ -89,20 +95,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationTests.Jira
             result.Id.Should().Be(1);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>();
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 1 },
-                new C { Id = 2, X = 2 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int X { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 1 },
+                new C { Id = 2, X = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4688Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4688Tests.cs
@@ -13,23 +13,30 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4688Tests : Linq3IntegrationTest
+    public class CSharp4688Tests : LinqIntegrationTest<CSharp4688Tests.ClassFixture>
     {
+        public CSharp4688Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [ParameterAttributeData]
         public async Task IQueryable_Any_should_add_expected_stages(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable();
 
             var result = async ? await queryable.AnyAsync() : queryable.Any();
@@ -46,7 +53,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public async Task IQueryable_First_should_add_expected_stages(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable();
 
             var result = async ? await queryable.FirstAsync() : queryable.First();
@@ -60,7 +67,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public async Task IQueryable_FirstOrDefault_should_add_expected_stages(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable();
 
             var result = async ? await queryable.FirstOrDefaultAsync() : queryable.FirstOrDefault();
@@ -74,7 +81,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public async Task IQueryable_Single_should_add_expected_stages(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable().Where(x => x.X == 1);
 
             var result = async ? await queryable.SingleAsync() : queryable.Single();
@@ -91,7 +98,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public async Task IQueryable_SingleOrDefault_should_add_expected_stages(
             [Values(false, true)] bool async)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var queryable = collection.AsQueryable().Where(x => x.X == 1);
 
             var result = async ? await queryable.SingleOrDefaultAsync() : queryable.SingleOrDefault();
@@ -103,20 +110,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Id.Should().Be(1);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>();
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 1 },
-                new C { Id = 2, X = 2 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int X { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 1 },
+                new C { Id = 2, X = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4700Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4700Tests.cs
@@ -13,19 +13,25 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4700Tests : Linq3IntegrationTest
+    public class CSharp4700Tests : LinqIntegrationTest<CSharp4700Tests.ClassFixture>
     {
+        public CSharp4700Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void OrderBy_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .GroupBy(x => x.Name)
@@ -48,22 +54,20 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results[1].Count().Should().Be(2);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, Name = "John" },
-                new C { Id = 2, Name = "John" },
-                new C { Id = 6, Name = "Jane" });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public string Name { get; set; }
         }
 
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, Name = "John" },
+                new C { Id = 2, Name = "John" },
+                new C { Id = 6, Name = "Jane" }
+            ];
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4702Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4702Tests.cs
@@ -17,17 +17,22 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp702Tests : Linq3IntegrationTest
+    public class CSharp4702Tests : LinqIntegrationTest<CSharp4702Tests.ClassFixture>
     {
+        public CSharp4702Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Query1_using_list_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var lookingFor = new List<string> { "value1", "value2" };
 
             var queryable = collection.AsQueryable()
@@ -43,7 +48,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Query2_using_list_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var lookingFor = new List<string> { "value1", "value2" };
 
             var queryable = collection.AsQueryable()
@@ -59,7 +64,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Query1_using_hashset_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var lookingFor = new List<string> { "value1", "value2" };
 
             var queryable = collection.AsQueryable()
@@ -75,7 +80,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Query2_using_hashset_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var lookingFor = new List<string> { "value1", "value2" };
 
             var queryable = collection.AsQueryable()
@@ -88,27 +93,25 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(model => model.Id).Should().BeEquivalentTo(4, 5);
         }
 
-        private IMongoCollection<Model> GetCollection()
+        public class C
         {
-            var collection = GetCollection<Model>("test");
-            var documentsCollection = GetCollection<BsonDocument>("test");
-            CreateCollection(
-                documentsCollection,
+            public int Id { get; set; }
+            public List<string> List { get; set; }
+            public HashSet<string> HashSet { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<BsonDocument, C>
+        {
+            protected override IEnumerable<BsonDocument> InitialData =>
+            [
                 BsonDocument.Parse("{ _id : 1 }"),
                 BsonDocument.Parse("{ _id : 2, List : null, HashSet : null }"),
                 BsonDocument.Parse("{ _id : 3, List : [], HashSet : [] }"),
                 BsonDocument.Parse("{ _id : 4, List : ['value1'], HashSet : ['value1'] }"),
                 BsonDocument.Parse("{ _id : 5, List : ['value1', 'value2'], HashSet : ['value1', 'value2'] }"),
                 BsonDocument.Parse("{ _id : 6, List : ['value3'], HashSet : ['value3'] }"),
-                BsonDocument.Parse("{ _id : 7, List : ['value3', 'value4'], HashSet : ['value3', 'value4'] }"));
-            return collection;
-        }
-
-        private class Model
-        {
-            public int Id { get; set; }
-            public List<string> List { get; set; }
-            public HashSet<string> HashSet { get; set; }
+                BsonDocument.Parse("{ _id : 7, List : ['value3', 'value4'], HashSet : ['value3', 'value4'] }")
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4708Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4708Tests.cs
@@ -19,17 +19,22 @@ using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions;
 using MongoDB.Bson;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4708Tests : Linq3IntegrationTest
+    public class CSharp4708Tests : LinqIntegrationTest<CSharp4708Tests.ClassFixture>
     {
+        public CSharp4708Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Select_Dictionary_item_with_string_using_compiler_generated_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.Dictionary["a"]);
@@ -44,7 +49,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Dictionary_item_with_string_using_call_to_get_item_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Call(
                 Expression.Property(x, typeof(C).GetProperty("Dictionary")),
@@ -66,7 +71,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Dictionary_item_with_string_using_MakeIndex_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.MakeIndex(
                 Expression.Property(x, typeof(C).GetProperty("Dictionary")),
@@ -88,7 +93,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Document_item_with_int_using_compiler_generated_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.Document[0]);
@@ -103,7 +108,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Document_item_with_int_using_call_to_get_item_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Call(
                 Expression.Property(x, typeof(C).GetProperty("Document")),
@@ -125,7 +130,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Document_item_with_int_using_MakeIndex_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.MakeIndex(
                 Expression.Property(x, typeof(C).GetProperty("Document")),
@@ -147,7 +152,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Document_item_with_string_using_compiler_generated_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.Document["a"]);
@@ -162,7 +167,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Document_item_with_string_using_call_to_get_item_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Call(
                 Expression.Property(x, typeof(C).GetProperty("Document")),
@@ -184,7 +189,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Document_item_with_string_using_MakeIndex_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.MakeIndex(
                 Expression.Property(x, typeof(C).GetProperty("Document")),
@@ -206,7 +211,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_List_item_with_int_using_compiler_generated_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.List[0]);
@@ -221,7 +226,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_List_item_with_int_using_call_to_get_item_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Call(
                 Expression.Property(x, typeof(C).GetProperty("List")),
@@ -243,7 +248,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_List_item_with_int_using_MakeIndex_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.MakeIndex(
                 Expression.Property(x, typeof(C).GetProperty("List")),
@@ -265,7 +270,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Dictionary_item_with_string_using_compiler_generated_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.Dictionary["a"] == 1);
@@ -280,7 +285,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Dictionary_item_with_string_using_call_to_get_item_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Equal(
                 Expression.Call(
@@ -304,7 +309,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Dictionary_item_with_string_using_MakeIndex_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Equal(
                 Expression.MakeIndex(
@@ -328,7 +333,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Document_item_with_int_using_compiler_generated_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.Document[0] == 1);
@@ -343,7 +348,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Document_item_with_int_using_call_to_get_item_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Equal(
                 Expression.Call(
@@ -367,7 +372,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Document_item_with_int_using_MakeIndex_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Equal(
                 Expression.MakeIndex(
@@ -391,7 +396,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Document_item_with_string_using_compiler_generated_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.Document["a"] == 1);
@@ -406,7 +411,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Document_item_with_string_using_call_to_get_item_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Equal(
                 Expression.Call(
@@ -430,7 +435,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Document_item_with_string_using_MakeIndex_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Equal(
                 Expression.MakeIndex(
@@ -454,7 +459,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_List_item_with_int_using_compiler_generated_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.List[0] == 1);
@@ -469,7 +474,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_List_item_with_int_using_call_to_get_item_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Equal(
                 Expression.Call(
@@ -493,7 +498,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_List_item_with_int_using_MakeIndex_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var x = Expression.Parameter(typeof(C), "x");
             var body = Expression.Equal(
                 Expression.MakeIndex(
@@ -514,22 +519,21 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(1);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, Dictionary = new Dictionary<string, int> { ["a"] = 1 }, Document = new BsonDocument("a", 1), List = new List<int> { 1 } },
-                new C { Id = 2, Dictionary = new Dictionary<string, int> { ["b"] = 2 }, Document = new BsonDocument("b", 2), List = new List<int> { 2 } });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public IDictionary<string, int> Dictionary { get; set; }
             public BsonDocument Document { get; set; }
             public IList<int> List { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, Dictionary = new Dictionary<string, int> { ["a"] = 1 }, Document = new BsonDocument("a", 1), List = new List<int> { 1 } },
+                new C { Id = 2, Dictionary = new Dictionary<string, int> { ["b"] = 2 }, Document = new BsonDocument("b", 2), List = new List<int> { 2 } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4723Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4723Tests.cs
@@ -13,25 +13,32 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4723Tests : Linq3IntegrationTest
+    public class CSharp4723Tests : LinqIntegrationTest<CSharp4723Tests.ClassFixture>
     {
+        public CSharp4723Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Find_projection_in_findoneandupdate_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
-            var update = Builders<A>.Update.Set("Value", "updated");
-            var options = new FindOneAndUpdateOptions<A>
+            var update = Builders<C>.Update.Set("Value", "updated");
+            var options = new FindOneAndUpdateOptions<C>
             {
-                Projection = Builders<A>.Projection.Expression(x => x)
+                Projection = Builders<C>.Projection.Expression(x => x)
             };
 
-            var result = collection.FindOneAndUpdate<A, A>(x => x.Id == 1, update, options);
+            var result = collection.FindOneAndUpdate<C, C>(x => x.Id == 1, update, options);
 
             result.Id.Should().Be(1);
             result.Value.Should().Be("1");
@@ -40,13 +47,13 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Find_projection_in_findoneandreplace_should_work()
         {
-            var collection = GetCollection();
-            var options = new FindOneAndReplaceOptions<A, A>
+            var collection = Fixture.Collection;
+            var options = new FindOneAndReplaceOptions<C, C>
             {
-                Projection = Builders<A>.Projection.Expression(x => x)
+                Projection = Builders<C>.Projection.Expression(x => x)
             };
 
-            var result = collection.FindOneAndReplace<A, A>(x => x.Id == 1, new A { Id = 1, Value = "updated" }, options);
+            var result = collection.FindOneAndReplace<C, C>(x => x.Id == 1, new C { Id = 1, Value = "updated" }, options);
 
             result.Id.Should().Be(1);
             result.Value.Should().Be("1");
@@ -55,33 +62,34 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Find_projection_in_findoneanddelete_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
-            var options = new FindOneAndDeleteOptions<A>
+            var options = new FindOneAndDeleteOptions<C>
             {
-                Projection = Builders<A>.Projection.Expression(x => x),
+                Projection = Builders<C>.Projection.Expression(x => x),
             };
 
-            var result = collection.FindOneAndDelete<A, A>(x => x.Id == 1, options);
+            var result = collection.FindOneAndDelete<C, C>(x => x.Id == 1, options);
 
             result.Id.Should().Be(1);
             result.Value.Should().Be("1");
         }
 
-        private IMongoCollection<A> GetCollection()
-        {
-            var collection = GetCollection<A>("test");
-            CreateCollection(
-                collection,
-                new A { Id = 1, Value = "1"});
-            return collection;
-        }
-
-        private class A
+        public class C
         {
             public int Id { get; set; }
 
             public string Value { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            public override bool InitializeDataBeforeEachTestCase => true;
+
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, Value = "1" }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4731Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4731Tests.cs
@@ -13,23 +13,27 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4731Tests : Linq3IntegrationTest
+    public class CSharp4731Tests : LinqIntegrationTest<CSharp4731Tests.ClassFixture>
     {
+        public CSharp4731Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Select_setting_IList_from_List_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -49,7 +53,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_setting_IReadOnlyList_from_List_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection
                 .AsQueryable()
@@ -66,33 +70,32 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.IReadOnlyList.Should().Equal(E.A, E.B);
         }
 
-        private IMongoCollection<Test> GetCollection()
-        {
-            var collection = GetCollection<Test>("test");
-            CreateCollection(
-                collection,
-                new Test { Id = 1, List = new List<E> { E.A, E.B } },
-                new Test { Id = 2, List = new List<E> { E.C, E.D } });
-            return collection;
-        }
-
-        private class Test
+        public class Test
         {
             public int Id { get; set; }
             [BsonRepresentation(BsonType.String)]
             public List<E> List { get; set; }
         }
 
-        private class P
+        public class P
         {
             public IList<E> IList { get; set; }
         }
 
-        private class Q
+        public class Q
         {
             public IReadOnlyList<E> IReadOnlyList { get; set; }
         }
 
-        private enum E { A, B, C, D };
+        public enum E { A, B, C, D }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Test>
+        {
+            protected override IEnumerable<Test> InitialData =>
+            [
+                new Test { Id = 1, List = new List<E> { E.A, E.B } },
+                new Test { Id = 2, List = new List<E> { E.C, E.D } }
+            ];
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4742Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4742Tests.cs
@@ -13,19 +13,26 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using FluentAssertions;
 using MongoDB.Bson.Serialization;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4742Tests : Linq3IntegrationTest
+    public class CSharp4742Tests : LinqIntegrationTest<CSharp4742Tests.ClassFixture>
     {
+        public CSharp4742Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Find_with_identity_projection_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Expression(x => x);
 
             var find = collection
@@ -43,7 +50,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Aggregate_Project_with_identity_projection_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Expression(x => x);
 
             var aggregate = collection
@@ -63,7 +70,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void ExpressionProjectionDefinition_with_identity_projection_Render_should_work(
             [Values(true, false)] bool renderForFind)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = new ExpressionProjectionDefinition<C, C>(x => x);
             var sourceSerializer = collection.DocumentSerializer;
             var serializerRegistry = BsonSerializer.SerializerRegistry;
@@ -79,7 +86,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void FindExpressionProjectionDefinition_with_identity_projection_Render_should_work(
             [Values(true, false)] bool renderForFind)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = new FindExpressionProjectionDefinition<C, C>(x => x);
             var sourceSerializer = collection.DocumentSerializer;
             var serializerRegistry = BsonSerializer.SerializerRegistry;
@@ -90,19 +97,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             renderedProjection.ProjectionSerializer.Should().BeSameAs(sourceSerializer);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 2 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int X { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4743Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4743Tests.cs
@@ -14,22 +14,28 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4743Tests : Linq3IntegrationTest
+    public class CSharp4743Tests : LinqIntegrationTest<CSharp4743Tests.ClassFixture>
     {
+        public CSharp4743Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Where_using_DateTime_Date_should_work()
         {
             RequireServer.Check().Supports(Feature.DateOperatorsNewIn50);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var memberId = 1;
             var startDateTime = new DateTime(2023, 08, 07, 1, 2, 3, DateTimeKind.Utc);
 
@@ -49,7 +55,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Where_using_DateTime_TimeOfDay_should_work()
         {
             RequireServer.Check().Supports(Feature.DateOperatorsNewIn50);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var memberId = 1;
             var startTimeOfDay = TimeSpan.FromHours(1);
 
@@ -68,7 +74,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_using_DateTime_Year_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var memberId = 1;
             var startDateTime = new DateTime(2023, 08, 07, 0, 0, 0, DateTimeKind.Utc);
 
@@ -84,20 +90,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Id.Should().Be(1);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, MemberId = 1, InteractionDate = new DateTime(2023, 08, 07, 1, 2, 3, DateTimeKind.Utc) });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int MemberId { get; set; }
             public DateTime? InteractionDate { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, MemberId = 1, InteractionDate = new DateTime(2023, 08, 07, 1, 2, 3, DateTimeKind.Utc) }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4744Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4744Tests.cs
@@ -13,20 +13,26 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4744Tests : Linq3IntegrationTest
+    public class CSharp4744Tests : LinqIntegrationTest<CSharp4744Tests.ClassFixture>
     {
+        public CSharp4744Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void ReplaceOne()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .GroupBy(x => x.FooName, (x, y) => new Summary()
@@ -40,13 +46,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 stages,
                 "{ $group: { _id : '$FooName', __agg0 : { $sum : { $cond : { if : { $eq : ['$State', 'Running'] }, then : 1, else : 0 } } } } }",
                 "{ $project : { FooName : '$_id', Count : '$__agg0', _id : 0 } }");
-        }
-
-        private IMongoCollection<Foo> GetCollection()
-        {
-            var collection = GetCollection<Foo>("test");
-            CreateCollection(collection);
-            return collection;
         }
 
         public enum State
@@ -67,6 +66,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         {
             public string FooName;
             public int Count;
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Foo>
+        {
+            protected override IEnumerable<Foo> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4747Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4747Tests.cs
@@ -13,23 +13,30 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4747Tests : Linq3IntegrationTest
+    public class CSharp4747Tests : LinqIntegrationTest<CSharp4747Tests.ClassFixture>
     {
+        public CSharp4747Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Builder_Set_with_one_int_field_name_and_constant_with_int_representation_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set("X", 2);
 
@@ -47,7 +54,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_one_int_field_name_and_constant_with_string_representation_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set("Y", 2);
 
@@ -65,7 +72,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_one_enum_field_name_and_constant_with_int_representation_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set("E", E.B);
 
@@ -83,7 +90,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_one_enum_field_name_and_constant_with_string_representation_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set("F", E.B);
 
@@ -101,7 +108,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_multiple_int_field_names_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set("X", 2)
                 .Set("Y", 3)
@@ -123,7 +130,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_multiple_enum_field_names_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set("E", E.B)
                 .Set("F", E.B)
@@ -145,7 +152,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_duplicate_int_field_names_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set("X", 2)
                 .Set("X", 3); // last one wins
@@ -164,7 +171,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_one_int_field_expression_and_constant_with_int_representation_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set(x => x.X, 2);
 
@@ -182,7 +189,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_one_int_field_expression_and_constant_with_string_representation_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set(x => x.Y, 2);
 
@@ -200,7 +207,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_one_enum_field_expression_and_constant_with_int_representation_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set(x => x.E, E.B);
 
@@ -218,7 +225,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_one_enum_field_expression_and_constant_with_string_representation_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set(x => x.F, E.B);
 
@@ -236,7 +243,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_multiple_int_field_expressions_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set(x => x.X, 2)
                 .Set(x => x.Y, 3)
@@ -258,7 +265,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_multiple_enum_field_expressions_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set(x => x.E, E.B)
                 .Set(x => x.F, E.B)
@@ -280,7 +287,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Builder_Set_with_duplicate_int_field_expressions_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fields = Builders<C>.SetFields
                 .Set(x => x.X, 2)
                 .Set(x => x.X, 3); // last one wins
@@ -299,7 +306,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_with_new_anonymous_class_with_empty_members_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new { });
@@ -315,7 +322,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_with_new_anonymous_class_with_members_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new { X = 2, E = E.B, F = x.F, G = E.B, Z = 4 });
@@ -335,7 +342,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_with_new_default_constructor_and_no_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new C());
@@ -351,7 +358,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_with_new_default_constructor_and_empty_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new C { });
@@ -367,7 +374,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_with_new_default_constructor_and_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new C { X = 2, E = E.B, F = x.F });
@@ -385,7 +392,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_with_new_copy_constructor_and_no_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new C(x));
@@ -401,7 +408,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_with_new_copy_constructor_and_empty_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new C(x) { });
@@ -417,7 +424,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_with_new_copy_constructor_and_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new C(x) { X = 2, E = E.B, F = x.F });
@@ -435,7 +442,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_struct_with_new_default_constructor_and_no_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new S());
@@ -451,7 +458,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_struct_with_new_default_constructor_and_empty_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new S { });
@@ -467,7 +474,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Set_struct_with_new_default_constructor_and_member_initializers_should_work()
         {
             RequireServer.Check().Supports(Feature.SetStage);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var aggregate = collection.Aggregate()
                 .Set(x => new S { X = 2 });
@@ -479,16 +486,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.X.Should().Be(2);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 1, Y = 1, E = E.A, F = E.A });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public C()
             {
@@ -508,7 +506,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [BsonRepresentation(BsonType.String)] public E F { get; set; }
         }
 
-        private struct S
+        public struct S
         {
             // struct has an implicit default constructor
 
@@ -522,6 +520,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             public int X { get; set; }
         }
 
-        private enum E { A = 1, B = 2 };
+        public enum E { A = 1, B = 2 };
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 1, Y = 1, E = E.A, F = E.A }
+            ];
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4748Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4748Tests.cs
@@ -20,12 +20,12 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Options;
 using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4748Tests : Linq3IntegrationTest
+    public class CSharp4748Tests : LinqIntegrationTest<CSharp4748Tests.ClassFixture>
     {
         static CSharp4748Tests()
         {
@@ -42,10 +42,15 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             });
         }
 
+        public CSharp4748Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Where_with_ContainsKey_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var language = LanguageEnum.en;
 
             var queryable = collection.AsQueryable()
@@ -61,7 +66,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_with_ContainsKey_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var language = LanguageEnum.en;
 
             var queryable = collection.AsQueryable()
@@ -72,16 +77,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 
             var results = queryable.ToList();
             results.Should().Equal(true, false);
-        }
-
-        private IMongoCollection<Translation> GetCollection()
-        {
-            var collection = GetCollection<Translation>("test");
-            CreateCollection(
-                collection,
-                new Translation { Id = 1, Languages = new Dictionary<LanguageEnum, string> { { LanguageEnum.en, "English" } } },
-                new Translation { Id = 2, Languages = new Dictionary<LanguageEnum, string> { { LanguageEnum.fr, "French" } } });
-            return collection;
         }
 
         public class Translation
@@ -97,6 +92,15 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             fr,
             de,
             pl,
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Translation>
+        {
+            protected override IEnumerable<Translation> InitialData =>
+            [
+                new Translation { Id = 1, Languages = new Dictionary<LanguageEnum, string> { { LanguageEnum.en, "English" } } },
+                new Translation { Id = 2, Languages = new Dictionary<LanguageEnum, string> { { LanguageEnum.fr, "French" } } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4757Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4757Tests.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
@@ -20,13 +21,18 @@ using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4757Tests : Linq3IntegrationTest
+    public class CSharp4757Tests : LinqIntegrationTest<CSharp4757Tests.ClassFixture>
     {
+        public CSharp4757Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Deserialize_should_ungroup_members()
         {
@@ -52,7 +58,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_with_grouped_member_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.OrderId);
@@ -67,7 +73,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_with_ungrouped_member_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.Quantity);
@@ -82,7 +88,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_grouped_member_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.OrderId == 1);
@@ -97,7 +103,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_ungrouped_member_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.Quantity == 3);
@@ -109,18 +115,8 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.OrderId.Should().Be(1);
         }
 
-        private IMongoCollection<OrderItem> GetCollection()
-        {
-            var collection = GetCollection<OrderItem>("test");
-            CreateCollection(
-                collection,
-                new OrderItem { OrderId = 1, ProductId = 2, Quantity = 3 },
-                new OrderItem { OrderId = 4, ProductId = 5, Quantity = 6 });
-            return collection;
-        }
-
         [BsonSerializer(typeof(OrderItemsSerializer))]
-        private class OrderItem
+        public class OrderItem
         {
             public int OrderId { get; set; }
             public int ProductId { get; set; }
@@ -204,6 +200,15 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 writer.WriteInt32(value.Quantity);
                 writer.WriteEndDocument();
             }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<OrderItem>
+        {
+            protected override IEnumerable<OrderItem> InitialData =>
+            [
+                new OrderItem { OrderId = 1, ProductId = 2, Quantity = 3 },
+                new OrderItem { OrderId = 4, ProductId = 5, Quantity = 6 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4763Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4763Tests.cs
@@ -14,16 +14,23 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4763Tests : Linq3IntegrationTest
+    public class CSharp4763Tests : LinqIntegrationTest<CSharp4763Tests.ClassFixture>
     {
+        public CSharp4763Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [InlineData(false, false, null)]
         [InlineData(true, false, null)]
@@ -35,7 +42,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var findOptions = GetFindOptions(useFindOptions, useTranslationOptions, enableClientSideProjections);
 
             var find = collection
@@ -77,7 +84,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var findOptions = GetFindOptions(useFindOptions, useFindOptions, enableClientSideProjections);
 
             var find = collection
@@ -119,7 +126,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var findOptions = GetFindOptions(useFindOptions, useFindOptions, enableClientSideProjections);
 
             var find = collection
@@ -161,7 +168,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var aggregate = collection.Aggregate(aggregateOptions)
@@ -195,7 +202,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var aggregate = collection.Aggregate(aggregateOptions)
@@ -229,7 +236,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var aggregate = collection.Aggregate(aggregateOptions)
@@ -260,7 +267,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var queryable = collection.AsQueryable(aggregateOptions)
@@ -294,7 +301,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var queryable = collection.AsQueryable(aggregateOptions)
@@ -328,7 +335,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var queryable = collection.AsQueryable(aggregateOptions)
@@ -358,7 +365,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var queryable = collection.AsQueryable(aggregateOptions)
@@ -392,7 +399,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var queryable = collection.AsQueryable(aggregateOptions)
@@ -422,7 +429,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var queryable = collection.AsQueryable(aggregateOptions)
@@ -453,7 +460,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             bool useTranslationOptions,
             bool? enableClientSideProjections)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var aggregateOptions = GetAggregateOptions(useAggregateOptions, useTranslationOptions, enableClientSideProjections);
 
             var queryable = collection.AsQueryable(aggregateOptions)
@@ -481,15 +488,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 (true, true) => new AggregateOptions { TranslationOptions = GetTranslationOptions(enableClientSideProjections) },
             };
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 1 });
-            return collection;
-        }
-
         private FindOptions GetFindOptions(bool useFindOptions, bool useTranslationOptions, bool? enableClientSideProjections)
         {
             return (useFindOptions, useTranslationOptions) switch
@@ -513,10 +511,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 
         private int MyFunction(int x) => 2 * x;
 
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int X { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 1 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4772Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4772Tests.cs
@@ -17,17 +17,22 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4772Tests : Linq3IntegrationTest
+    public class CSharp4772Tests : LinqIntegrationTest<CSharp4772Tests.ClassFixture>
     {
+        public CSharp4772Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Select_with_Any_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var organizationId = 1;
 
             var queryable = collection.AsQueryable()
@@ -45,7 +50,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_with_Array_Exists_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var organizationId = 1;
 
             var queryable = collection.AsQueryable()
@@ -63,7 +68,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_with_List_Exists_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var organizationId = 1;
 
             var queryable = collection.AsQueryable()
@@ -81,7 +86,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Any_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var organizationId = 1;
 
             var queryable = collection.AsQueryable()
@@ -99,7 +104,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Array_Exists_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var organizationId = 1;
 
             var queryable = collection.AsQueryable()
@@ -117,7 +122,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_List_Exists_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var organizationId = 1;
 
             var queryable = collection.AsQueryable()
@@ -132,49 +137,48 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(1);
         }
 
-        private IMongoCollection<Account> GetCollection()
+        public class Account
         {
-            var collection = GetCollection<Account>("test");
-            CreateCollection(
-                collection,
+            public int Id { get; set; }
+            public ProfileDto[] ProfilesArray { get; set; }
+            public List<ProfileDto> ProfilesList { get; set; }
+        }
+
+        public class ProfileDto
+        {
+            public int[] OrganizationIdsArray { get; set; }
+            public List<int> OrganizationIdsList { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Account>
+        {
+            protected override IEnumerable<Account> InitialData =>
+            [
                 new Account
                 {
                     Id = 1,
-                    ProfilesArray = new Profile[] { new Profile { OrganizationIdsArray = new int[] { 1 } } },
-                    ProfilesList = new List<Profile> { new Profile { OrganizationIdsList = new List<int> { 1 } } }
+                    ProfilesArray = new ProfileDto[] { new ProfileDto { OrganizationIdsArray = new int[] { 1 } } },
+                    ProfilesList = new List<ProfileDto> { new ProfileDto { OrganizationIdsList = new List<int> { 1 } } }
                 },
                 new Account
                 {
                     Id = 2,
-                    ProfilesArray = new Profile[] { new Profile { OrganizationIdsArray = new int[] { 2 } } },
-                    ProfilesList = new List<Profile> { new Profile { OrganizationIdsList = new List<int> { 2 } } }
+                    ProfilesArray = new ProfileDto[] { new ProfileDto { OrganizationIdsArray = new int[] { 2 } } },
+                    ProfilesList = new List<ProfileDto> { new ProfileDto { OrganizationIdsList = new List<int> { 2 } } }
                 },
                 new Account
                 {
                     Id = 3,
-                    ProfilesArray = new Profile[0],
-                    ProfilesList = new List<Profile>()
+                    ProfilesArray = new ProfileDto[0],
+                    ProfilesList = new List<ProfileDto>()
                 },
                 new Account
                 {
                     Id = 4,
-                    ProfilesArray = new Profile[] { new Profile { OrganizationIdsArray = new int[0] } },
-                    ProfilesList = new List<Profile> { new Profile { OrganizationIdsList = new List<int>() } }
-                });
-            return collection;
-        }
-
-        private class Account
-        {
-            public int Id { get; set; }
-            public Profile[] ProfilesArray { get; set; }
-            public List<Profile> ProfilesList { get; set; }
-        }
-
-        private class Profile
-        {
-            public int[] OrganizationIdsArray { get; set; }
-            public List<int> OrganizationIdsList { get; set; }
+                    ProfilesArray = new ProfileDto[] { new ProfileDto { OrganizationIdsArray = new int[0] } },
+                    ProfilesList = new List<ProfileDto> { new ProfileDto { OrganizationIdsList = new List<int>() } }
+                }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4776Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4776Tests.cs
@@ -16,17 +16,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4776Tests : Linq3IntegrationTest
+    public class CSharp4776Tests : LinqIntegrationTest<CSharp4776Tests.ClassFixture>
     {
+        public CSharp4776Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Where_with_Count_method_equal_to_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Count() == 2);
@@ -41,7 +46,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_method_greater_than_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Count() > 2);
@@ -56,7 +61,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_method_greater_than_or_equal_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Count() >= 2);
@@ -71,7 +76,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_method_less_than_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Count() < 2);
@@ -86,7 +91,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_method_less_than_or_equal_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Count() <= 2);
@@ -101,7 +106,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_method_not_equal_to_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Count() != 2);
@@ -116,7 +121,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_property_method_equal_to_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.Count == 2);
@@ -131,7 +136,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_property_greater_than_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.Count > 2);
@@ -146,7 +151,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_property_greater_than_or_equal_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.Count >= 2);
@@ -161,7 +166,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_property_less_than_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.Count < 2);
@@ -176,7 +181,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_property_less_than_or_equal_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.Count <= 2);
@@ -191,7 +196,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Count_property_method_not_equal_to_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.Count != 2);
@@ -206,7 +211,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Length_property_equal_to_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Length == 2);
@@ -221,7 +226,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Length_property_greater_than_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Length > 2);
@@ -236,7 +241,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Length_property_greater_than_or_equal_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Length >= 2);
@@ -251,7 +256,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Length_property_less_than_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Length < 2);
@@ -266,7 +271,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Length_property_less_than_or_equal_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Length <= 2);
@@ -281,7 +286,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_Length_property_not_equal_to_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.A.Length != 2);
@@ -296,7 +301,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_LongCount_method_method_equal_to_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.LongCount() == 2);
@@ -311,7 +316,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_LongCount_method_greater_than_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.LongCount() > 2);
@@ -326,7 +331,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_LongCount_method_greater_than_or_equal_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.LongCount() >= 2);
@@ -341,7 +346,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_LongCount_method_less_than_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.LongCount() < 2);
@@ -356,7 +361,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_LongCount_method_less_than_or_equal_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.LongCount() <= 2);
@@ -371,7 +376,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_LongCount_method_method_not_equal_to_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.L.LongCount() != 2);
@@ -383,25 +388,23 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(1, 2, 3, 5);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, A = null, L = null },
-                new C { Id = 2, A = new int[0], L = new List<int>() },
-                new C { Id = 3, A = new[] { 1 }, L = new List<int> { 1 } },
-                new C { Id = 4, A = new[] { 1, 2 }, L = new List<int> { 1, 2 } },
-                new C { Id = 5, A = new[] { 1, 2, 3 }, L = new List<int> { 1, 2, 3 } });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int[] A { get; set; }
             public IList<int> L { get; set; }
         }
 
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, A = null, L = null },
+                new C { Id = 2, A = new int[0], L = new List<int>() },
+                new C { Id = 3, A = new[] { 1 }, L = new List<int> { 1 } },
+                new C { Id = 4, A = new[] { 1, 2 }, L = new List<int> { 1, 2 } },
+                new C { Id = 5, A = new[] { 1, 2, 3 }, L = new List<int> { 1, 2, 3 } }
+            ];
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4781Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4781Tests.cs
@@ -13,15 +13,21 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4781Tests : Linq3IntegrationTest
+    public class CSharp4781Tests : LinqIntegrationTest<CSharp4781Tests.ClassFixture>
     {
+        public CSharp4781Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Enumerable_DefaultIfEmpty_should_return_default_int()
         {
@@ -45,7 +51,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_with_DefaultIfEmpty_should_return_default_int()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.IntArray.DefaultIfEmpty());
@@ -62,7 +68,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_with_DefaultIfEmpty_should_return_default_string()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.StringArray.DefaultIfEmpty());
@@ -76,21 +82,20 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results[1].Should().Equal(new string[] { null });
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, IntArray = new int[] { 1 }, StringArray = new string[] { "abc" } },
-                new C { Id = 2, IntArray = new int[] { }, StringArray = new string[] { } });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int[] IntArray { get; set; }
             public string[] StringArray { get; set; } // note that string is suitable for this test since it does not have a default constructor
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, IntArray = new int[] { 1 }, StringArray = new string[] { "abc" } },
+                new C { Id = 2, IntArray = new int[] { }, StringArray = new string[] { } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4802Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4802Tests.cs
@@ -13,17 +13,24 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4802Tests : Linq3IntegrationTest
+    public class CSharp4802Tests : LinqIntegrationTest<CSharp4802Tests.ClassFixture>
     {
+        public CSharp4802Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Find_with_projection_of_subfield_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var find = collection.Find(d => d.Status == "a").Project(d => d.SubDocument.Id);
 
@@ -34,17 +41,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Should().Be(11);
         }
 
-        private IMongoCollection<Document> GetCollection()
-        {
-            var collection = GetCollection<Document>("test");
-            CreateCollection(
-                collection,
-                new Document { Id = 1, Status = "a", SubDocument = new SubDocument { Id = 11 } },
-                new Document { Id = 2, Status = "b", SubDocument = new SubDocument { Id = 22 } });
-            return collection;
-        }
-
-        private class Document
+        public class Document
         {
             public int Id { get; set; }
             public string Status { get; set; }
@@ -54,6 +51,15 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public class SubDocument
         {
             public int Id { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Document>
+        {
+            protected override IEnumerable<Document> InitialData =>
+            [
+                new Document { Id = 1, Status = "a", SubDocument = new SubDocument { Id = 11 } },
+                new Document { Id = 2, Status = "b", SubDocument = new SubDocument { Id = 22 } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4803Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4803Tests.cs
@@ -14,18 +14,25 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4803Tests : Linq3IntegrationTest
+    public class CSharp4803Tests : LinqIntegrationTest<CSharp4803Tests.ClassFixture>
     {
+        public CSharp4803Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Find_filter_with_nonnullable_date_fields_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fromDate = new DateTime(2023, 9, 27, 0, 0, 0, DateTimeKind.Utc);
             Expression<Func<C, bool>> filter = ft => ft.Date >= fromDate;
 
@@ -38,7 +45,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Find_filter_with_nullable_date_fields_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var fromDate = new DateTime(2023, 9, 27, 0, 0, 0, DateTimeKind.Utc);
             Expression<Func<C, bool>> filter = ft => ft.NullableDate >= fromDate;
 
@@ -48,17 +55,16 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             renderedFilter.Should().Be("{ NullableDate : { $gte : ISODate('2023-09-27T00:00:00Z') } }");
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public DateTime Date { get; set; }
             public DateTime? NullableDate { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData => null;
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4804Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4804Tests.cs
@@ -13,19 +13,25 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4804Tests : Linq3IntegrationTest
+    public class CSharp4804Tests : LinqIntegrationTest<CSharp4804Tests.ClassFixture>
     {
+        public CSharp4804Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Find_Slice_with_field_name_and_limit_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Slice("A", 3);
 
             var find = collection.Find("{}").Project(projection);
@@ -40,7 +46,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Find_Slice_with_field_expression_and_limit_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Slice(x => x.A, 3);
 
             var find = collection.Find("{}").Project(projection);
@@ -55,7 +61,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Find_Slice_with_field_name_and_skip_and_limit_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Slice("A", 1, 3);
 
             var find = collection.Find("{}").Project(projection);
@@ -70,7 +76,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Find_Slice_with_field_expression_and_skip_and_limit_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Slice(x => x.A, 1, 3);
 
             var find = collection.Find("{}").Project(projection);
@@ -85,7 +91,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Aggregate_Slice_with_field_name_and_limit_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Slice("A", 3);
 
             var aggregate = collection.Aggregate()
@@ -101,7 +107,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Aggregate_Slice_with_field_expression_and_limit_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Slice(x => x.A, 3);
 
             var aggregate = collection.Aggregate()
@@ -117,7 +123,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void AggregateSlice_with_field_name_and_skip_and_limit_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Slice("A", 1, 3);
 
             var aggregate = collection.Aggregate()
@@ -133,7 +139,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Aggregate_Slice_with_field_expression_and_skip_and_limit_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var projection = Builders<C>.Projection.Slice(x => x.A, 1, 3);
 
             var aggregate = collection.Aggregate()
@@ -146,19 +152,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result["A"].AsBsonArray.Select(i => i.AsInt32).Should().Equal(2, 3, 4);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, A = new[] { 1, 2, 3, 4, 5 } });
-            return collection;
-        }
-
         public class C
         {
             public int Id { get; set; }
             public int[] A { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, A = new[] { 1, 2, 3, 4, 5 } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4809Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4809Tests.cs
@@ -14,21 +14,28 @@
 */
 
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4809Tests : Linq3IntegrationTest
+    public class CSharp4809Tests : LinqIntegrationTest<CSharp4809Tests.ClassFixture>
     {
+        public CSharp4809Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Filter_by_Id_with_custom_serializer_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var id = "111111111111111111111111";
 
             var filter = Builders<RootDocument>.Filter.Where(x => x.Id == id);
@@ -40,17 +47,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.X.Should().Be(1);
         }
 
-        private IMongoCollection<RootDocument> GetCollection()
-        {
-            var collection = GetCollection<RootDocument>("test");
-            CreateCollection(
-                collection,
-                new RootDocument { Id = "111111111111111111111111", X = 1 },
-                new RootDocument { Id = "222222222222222222222222", X = 2 });
-            return collection;
-        }
-
-        private class RootDocument
+        public class RootDocument
         {
             [BsonSerializer(typeof(CustomStringRepresentedAsObjectIdSerializer))]
             public string Id { get; set; }
@@ -90,6 +87,15 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                     return ObjectId.Empty;
                 }
             }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<RootDocument>
+        {
+            protected override IEnumerable<RootDocument> InitialData =>
+            [
+                new RootDocument { Id = "111111111111111111111111", X = 1 },
+                new RootDocument { Id = "222222222222222222222222", X = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4813Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4813Tests.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,17 +22,23 @@ using MongoDB.Bson.Serialization.Options;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4813Tests : Linq3IntegrationTest
+    public class CSharp4813Tests : LinqIntegrationTest<CSharp4813Tests.ClassFixture>
     {
+        public CSharp4813Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Where_BitArray_Count_should_throw()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.BitArray.Count == 1);
@@ -45,7 +50,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.Count == 1);
@@ -60,7 +65,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Dictionary_Count_should_throw()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.Dictionary.Count == 1);
@@ -72,7 +77,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_DictionaryAsArrayOfArrays_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.DictionaryAsArrayOfArrays.Count == 1);
@@ -87,7 +92,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_DictionaryAsArrayOfDocuments_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.DictionaryAsArrayOfDocuments.Count == 1);
@@ -102,7 +107,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_DictionaryInterface_Count_should_throw()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.DictionaryInterface.Count == 1);
@@ -114,7 +119,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_DictionaryInterfaceArrayOfArrays_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.DictionaryInterfaceAsArrayOfArrays.Count == 1);
@@ -129,7 +134,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_DictionaryInterfaceArrayOfDocuments_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.DictionaryInterfaceAsArrayOfDocuments.Count == 1);
@@ -144,7 +149,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_List_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.List.Count == 1);
@@ -159,7 +164,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_ListInterface_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.ListInterface.Count == 1);
@@ -177,7 +182,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -203,7 +208,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.Count);
@@ -221,7 +226,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -247,7 +252,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_DictionaryAsArrayOfArrays_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.DictionaryAsArrayOfArrays.Count);
@@ -262,7 +267,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_DictionaryAsArrayOfDocuments_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.DictionaryAsArrayOfDocuments.Count);
@@ -280,7 +285,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -306,7 +311,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_DictionaryInterfaceAsArrayOfArrays_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.DictionaryInterfaceAsArrayOfArrays.Count);
@@ -321,7 +326,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_DictionaryInterfaceAsArrayOfDocuments_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.DictionaryInterfaceAsArrayOfDocuments.Count);
@@ -336,7 +341,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_List_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.List.Count);
@@ -351,7 +356,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_ListInterface_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.ListInterface.Count);
@@ -363,11 +368,25 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Should().Equal(1, 2);
         }
 
-        private IMongoCollection<C> GetCollection()
+        public class C
         {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
+            public int Id { get; set; }
+            public BitArray BitArray { get; set; }
+            public int Count { get; set; }
+            public Dictionary<string, int> Dictionary { get; set; }
+            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfArrays)] public Dictionary<string, int> DictionaryAsArrayOfArrays { get; set; }
+            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfDocuments)] public Dictionary<string, int> DictionaryAsArrayOfDocuments { get; set; }
+            public IDictionary<string, int> DictionaryInterface { get; set; }
+            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfArrays)] public IDictionary<string, int> DictionaryInterfaceAsArrayOfArrays { get; set; }
+            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfDocuments)] public IDictionary<string, int> DictionaryInterfaceAsArrayOfDocuments { get; set; }
+            public List<int> List { get; set; }
+            public IList<int> ListInterface { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
                 new C
                 {
                     Id = 1,
@@ -395,23 +414,8 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                     DictionaryInterfaceAsArrayOfDocuments = new Dictionary<string, int> { { "A", 1 }, { "B", 2 } },
                     List = new() { 1, 2 },
                     ListInterface = new List<int> { 1, 2 }
-                }); ;
-            return collection;
-        }
-
-        private class C
-        {
-            public int Id { get; set; }
-            public BitArray BitArray { get; set; }
-            public int Count { get; set; }
-            public Dictionary<string, int> Dictionary { get; set; }
-            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfArrays)] public Dictionary<string, int> DictionaryAsArrayOfArrays { get; set; }
-            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfDocuments)] public Dictionary<string, int> DictionaryAsArrayOfDocuments { get; set; }
-            public IDictionary<string, int> DictionaryInterface { get; set; }
-            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfArrays)] public IDictionary<string, int> DictionaryInterfaceAsArrayOfArrays { get; set; }
-            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfDocuments)] public IDictionary<string, int> DictionaryInterfaceAsArrayOfDocuments { get; set; }
-            public List<int> List { get; set; }
-            public IList<int> ListInterface { get; set; }
+                }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4861Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4861Tests.cs
@@ -16,17 +16,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4861Tests : Linq3IntegrationTest
+    public class CSharp4861Tests : LinqIntegrationTest<CSharp4861Tests.ClassFixture>
     {
+        public CSharp4861Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void One_less_than_Count_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => 1 < x.Set.Count);
@@ -41,7 +46,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void One_less_than_Length_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => 1 < x.Array.Length);
@@ -56,7 +61,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Count_greater_than_one_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.Set.Count > 1);
@@ -71,7 +76,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Length_greater_than_one_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => x.Array.Length > 1);
@@ -83,22 +88,21 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(2, 3);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, Array = new[] { 1 }, Set = new HashSet<int> { 1 } },
-                new C { Id = 2, Array = new[] { 1, 2 }, Set = new HashSet<int> { 1, 2 } },
-                new C { Id = 3, Array = new[] { 1, 2, 3 }, Set = new HashSet<int> { 1, 2, 3 } });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int[] Array { get; set; }
             public HashSet<int> Set { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, Array = new[] { 1 }, Set = new HashSet<int> { 1 } },
+                new C { Id = 2, Array = new[] { 1, 2 }, Set = new HashSet<int> { 1, 2 } },
+                new C { Id = 3, Array = new[] { 1, 2, 3 }, Set = new HashSet<int> { 1, 2, 3 } }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4872Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4872Tests.cs
@@ -13,21 +13,28 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4872Tests : Linq3IntegrationTest
+    public class CSharp4872Tests : LinqIntegrationTest<CSharp4872Tests.ClassFixture>
     {
+        public CSharp4872Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void Append_constant_should_work(
             [Values(false, true)] bool withNestedAsQueryable)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = withNestedAsQueryable ?
                 collection.AsQueryable().Select(x => x.A.AsQueryable().Append(4).ToList()) :
@@ -45,7 +52,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Append_expression_should_work(
             [Values(false, true)] bool withNestedAsQueryable)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = withNestedAsQueryable ?
                 collection.AsQueryable().Select(x => x.A.AsQueryable().Append(x.B).ToList()) :
@@ -63,7 +70,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Prepend_constant_should_work(
             [Values(false, true)] bool withNestedAsQueryable)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = withNestedAsQueryable ?
                 collection.AsQueryable().Select(x => x.A.AsQueryable().Prepend(4).ToList()) :
@@ -81,7 +88,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Prepend_expression_should_work(
             [Values(false, true)] bool withNestedAsQueryable)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = withNestedAsQueryable ?
                 collection.AsQueryable().Select(x => x.A.AsQueryable().Prepend(x.B).ToList()) :
@@ -94,20 +101,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Should().Equal(4, 1, 2, 3);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, A = [1, 2, 3], B = 4 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int[] A { get; set; }
             public int B { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, A = [1, 2, 3], B = 4 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4876Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4876Tests.cs
@@ -13,22 +13,29 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4876Tests : Linq3IntegrationTest
+    public class CSharp4876Tests : LinqIntegrationTest<CSharp4876Tests.ClassFixture>
     {
+        public CSharp4876Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void OfType_should_work(
             [Values(false, true)] bool withNestedAsQueryable)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = withNestedAsQueryable ?
                 collection.AsQueryable().Select(x => x.A.AsQueryable().OfType<B2>().ToArray()) :
@@ -41,23 +48,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Select(x => x.Id).Should().Equal(2);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C
-                {
-                    Id = 1, A =
-                        [
-                            new B1 { Id = 1 },
-                            new B2 { Id = 2 }
-                        ]
-                });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public B[] A { get; set; }
@@ -75,6 +66,21 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 
         public class B2 : B
         {
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C
+                {
+                    Id = 1, A =
+                    [
+                        new B1 { Id = 1 },
+                        new B2 { Id = 2 }
+                    ]
+                }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4878Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4878Tests.cs
@@ -13,18 +13,25 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4878Tests : Linq3IntegrationTest
+    public class CSharp4878Tests : LinqIntegrationTest<CSharp4878Tests.ClassFixture>
     {
+        public CSharp4878Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Repeat_with_constant_and_constant_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Select(x => Enumerable.Repeat(2, 3));
 
@@ -38,7 +45,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Repeat_with_constant_and_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Select(x => Enumerable.Repeat(2, x.Y));
 
@@ -52,7 +59,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Repeat_with_expression_and_constant_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Select(x => Enumerable.Repeat(x.X, 3));
 
@@ -66,7 +73,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Repeat_with_expression_and_expression_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Select(x => Enumerable.Repeat(x.X, x.Y));
 
@@ -77,20 +84,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Should().Equal(2, 2, 2);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 2, Y = 3 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int X { get; set; }
             public int Y { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 2, Y = 3 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4880Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4880Tests.cs
@@ -13,22 +13,29 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4880Tests : Linq3IntegrationTest
+    public class CSharp4880Tests : LinqIntegrationTest<CSharp4880Tests.ClassFixture>
     {
+        public CSharp4880Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void Select_SequenceEqual_should_work(
             [Values(false, true)] bool withNestedAsQueryable)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = withNestedAsQueryable ?
                 collection.AsQueryable().Select(x => x.A.AsQueryable().SequenceEqual(x.B)) :
@@ -41,26 +48,25 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Should().Equal(false, false, false, false, true, false, false);
         }
 
-        private IMongoCollection<C> GetCollection()
+        public class C
         {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection.Database.GetCollection<BsonDocument>(collection.CollectionNamespace.CollectionName),
+            public int Id { get; set; }
+            public int[] A { get; set; }
+            public int[] B { get; set; }
+        }
+
+        public sealed class ClassFixture :  MongoCollectionFixture<BsonDocument, C>
+        {
+            protected override IEnumerable<BsonDocument> InitialData =>
+            [
                 BsonDocument.Parse("{ _id : 1, A : null, B : null }"),
                 BsonDocument.Parse("{ _id : 2, A : null, B : [1, 2, 3] }"),
                 BsonDocument.Parse("{ _id : 3, A : [1, 2, 3], B : null }"),
                 BsonDocument.Parse("{ _id : 4, A : [1, 2, 3], B : [1, 2] }"),
                 BsonDocument.Parse("{ _id : 5, A : [1, 2, 3], B : [1, 2, 3] }"),
                 BsonDocument.Parse("{ _id : 6, A : [1, 2, 3], B : [4, 5, 6] }"),
-                BsonDocument.Parse("{ _id : 7, A : [1, 2, 3], B : [1, 2, 3, 4] }"));
-            return collection;
-        }
-
-        private class C
-        {
-            public int Id { get; set; }
-            public int[] A { get; set; }
-            public int[] B { get; set; }
+                BsonDocument.Parse("{ _id : 7, A : [1, 2, 3], B : [1, 2, 3, 4] }")
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4888Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4888Tests.cs
@@ -13,21 +13,27 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4888Tests : Linq3IntegrationTest
+    public class CSharp4888Tests : LinqIntegrationTest<CSharp4888Tests.ClassFixture>
     {
+        public CSharp4888Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void GroupBy_Select_with_int_enum_representation_in_conditional_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .GroupBy(c => 0)
@@ -51,7 +57,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void GroupBy_Select_with_string_enum_representation_in_conditional_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .GroupBy(c => 0)
@@ -72,16 +78,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.SuvCarCount.Should().Be(0);
         }
 
-        private IMongoCollection<Car> GetCollection()
-        {
-            var collection = GetCollection<Car>("test");
-            CreateCollection(
-                collection,
-                new Car { Id = 1, LicensePlate = "abcdef", CarType = CarType.Sport, CarTypeString = CarType.Sport });
-            return collection;
-        }
-
-        private class Car
+        public class Car
         {
             public int Id { get; set; }
             public string LicensePlate { get; set; }
@@ -89,11 +86,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [BsonRepresentation(BsonType.String)] public CarType CarTypeString { get; set; }
         }
 
-        private enum CarType
+        public enum CarType
         {
             Undefined = 0,
             Sport = 1,
             Suv = 2
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Car>
+        {
+            protected override IEnumerable<Car> InitialData =>
+            [
+                new Car { Id = 1, LicensePlate = "abcdef", CarType = CarType.Sport, CarTypeString = CarType.Sport }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4937Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4937Tests.cs
@@ -14,16 +14,22 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4937Tests : Linq3IntegrationTest
+    public class CSharp4937Tests : LinqIntegrationTest<CSharp4937Tests.ClassFixture>
     {
+        public CSharp4937Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [InlineData(2, "<" , 0, "{ _id : { $lt : 2 } }", new int[] { 1 })]
         [InlineData(2, "<=", 0, "{ _id : { $lte : 2 } }", new int[] { 1, 2 })]
@@ -38,7 +44,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             string expectedFilter,
             int[] expectedIds)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             Expression<Func<C, bool>> predicate = comparisonOperator switch
             {
@@ -83,7 +89,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             string expectedProjection,
             bool[] expectedResults)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             Expression<Func<C, bool>> selector = comparisonOperator switch
             {
@@ -113,25 +119,24 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             }
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1 },
-                new C { Id = 2 },
-                new C { Id = 3 });
-            return collection;
-        }
-
         public interface IIdentity<TId>
         {
             public TId Id { get; set; }
         }
 
-        private class C : IIdentity<int>
+        public class C : IIdentity<int>
         {
             public int Id { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1 },
+                new C { Id = 2 },
+                new C { Id = 3 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4957Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4957Tests.cs
@@ -13,7 +13,7 @@
 * limitations under the License.
 */
 
-using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
@@ -21,17 +21,23 @@ using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4957Tests : Linq3IntegrationTest
+    public class CSharp4957Tests : LinqIntegrationTest<CSharp4957Tests.ClassFixture>
     {
+        public CSharp4957Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void New_array_with_zero_items_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (new int[] { }));
@@ -47,7 +53,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void New_array_with_one_items_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (new[] { x.X }));
@@ -63,7 +69,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void New_array_with_two_items_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (new[] { x.X, x.X + 1 }));
@@ -82,7 +88,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -105,20 +111,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             }
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 1, Y = 2 });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int X { get; set; }
             [BsonRepresentation(BsonType.String)] public int Y { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 1, Y = 2 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4993Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4993Tests.cs
@@ -13,21 +13,27 @@
 * limitations under the License.
 */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp4993Tests : Linq3IntegrationTest
+    public class CSharp4993Tests : LinqIntegrationTest<CSharp4993Tests.ClassFixture>
     {
+        public CSharp4993Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Select_decimal_divide_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.D / 1.3M);
@@ -39,19 +45,18 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             result.Should().Be(769.23076923076923076923076923M);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, D = 1000.0M });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             [BsonRepresentation(BsonType.Decimal128)] public decimal D { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, D = 1000.0M }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5043Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5043Tests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
@@ -21,17 +22,23 @@ using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp5043Tests : Linq3IntegrationTest
+    public class CSharp5043Tests : LinqIntegrationTest<CSharp5043Tests.ClassFixture>
     {
+        public CSharp5043Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Convert_E1_to_E1_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E1)x.E1);
@@ -46,7 +53,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_E1_to_E2_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E2)x.E1);
@@ -61,7 +68,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_E1_to_nullable_E1_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E1?)x.E1);
@@ -76,7 +83,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_E1_to_nullable_E2_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E2?)x.E1);
@@ -91,7 +98,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_nullable_E1_to_E1_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E1)x.NE1);
@@ -107,7 +114,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_nullable_E1_to_E2_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E2)x.NE1);
@@ -123,7 +130,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_nullable_E1_to_nullable_E1_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E1?)x.NE1);
@@ -138,7 +145,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_nullable_E1_to_nullable_E2_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E2?)x.NE1);
@@ -153,7 +160,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_ES1_to_E1_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E1)x.ES1);
@@ -171,7 +178,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -197,7 +204,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Convert_ES1_to_nullable_E1_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => (E1?)x.ES1);
@@ -215,7 +222,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [Values(false, true)] bool enableClientSideProjections)
         {
             RequireServer.Check().Supports(Feature.FindProjectionExpressions);
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = new ExpressionTranslationOptions { EnableClientSideProjections = enableClientSideProjections };
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -238,17 +245,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             }
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, E1 = E1.A, NE1 = E1.A, ES1 = E1.A, NES1 = E1.A },
-                new C { Id = 2, E1 = E1.B, NE1 = null, ES1 = E1.B, NES1 = null });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public E1 E1 { get; set; }
@@ -257,7 +254,16 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             [BsonRepresentation(BsonType.String)] public E1? NES1 { get; set; }
         }
 
-        private enum E1 { A, B }
-        private enum E2 { C, D }
+        public enum E1 { A, B }
+        public enum E2 { C, D }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, E1 = E1.A, NE1 = E1.A, ES1 = E1.A, NES1 = E1.A },
+                new C { Id = 2, E1 = E1.B, NE1 = null, ES1 = E1.B, NES1 = null }
+            ];
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5067Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5067Tests.cs
@@ -14,24 +14,30 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp5067Tests : Linq3IntegrationTest
+    public class CSharp5067Tests : LinqIntegrationTest<CSharp5067Tests.ClassFixture>
     {
+        public CSharp5067Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void Where_with_bool_field_represented_as_boolean_should_work(
             [Values(false, true)] bool justField)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = justField ?
                 collection.AsQueryable().Where(x => x.BoolFieldRepresentedAsBoolean) :
@@ -49,7 +55,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Where_with_bool_field_represented_as_int32_should_work(
             [Values(false, true)] bool justField)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = justField ?
                 collection.AsQueryable().Where(x => x.BoolFieldRepresentedAsInt32) :
@@ -67,7 +73,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Where_with_bool_field_represented_as_string_should_work(
             [Values(false, true)] bool justField)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = justField ?
                 collection.AsQueryable().Where(x => x.BoolFieldRepresentedAsString) :
@@ -83,7 +89,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_bool_array_field_represented_as_booleans_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Where(x => x.BoolArrayFieldRepresentedAsBoolean.Any(p => p));
 
@@ -97,7 +103,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_bool_array_field_represented_as_int32s_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Where(x => x.BoolArrayFieldRepresentedAsInt32.Any(p => p));
 
@@ -111,7 +117,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_bool_array_field_represented_as_strings_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Where(x => x.BoolArrayFieldRepresentedAsString.Any(p => p));
 
@@ -127,7 +133,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Where_with_bool_property_represented_as_boolean_should_work(
             [Values(false, true)] bool justProperty)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = justProperty ?
                 collection.AsQueryable().Where(x => x.BoolPropertyRepresentedAsBoolean) :
@@ -145,7 +151,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Where_with_bool_property_represented_as_int32_should_work(
             [Values(false, true)] bool justProperty)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = justProperty ?
                 collection.AsQueryable().Where(x => x.BoolPropertyRepresentedAsInt32) :
@@ -163,7 +169,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         public void Where_with_bool_property_represented_as_string_should_work(
             [Values(false, true)] bool justProperty)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = justProperty ?
                 collection.AsQueryable().Where(x => x.BoolPropertyRepresentedAsString) :
@@ -179,7 +185,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_bool_array_property_represented_as_booleans_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Where(x => x.BoolArrayPropertyRepresentedAsBoolean.Any(p => p));
 
@@ -193,7 +199,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_bool_array_property_represented_as_int32s_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Where(x => x.BoolArrayPropertyRepresentedAsInt32.Any(p => p));
 
@@ -207,7 +213,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_with_bool_array_property_represented_as_strings_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable().Where(x => x.BoolArrayPropertyRepresentedAsString.Any(p => p));
 
@@ -230,7 +236,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             string expectedStage,
             int[] expectedResults)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = expression switch
             {
@@ -262,7 +268,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             string expectedStage,
             int[] expectedResults)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = expression switch
             {
@@ -294,7 +300,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             string expectedStage,
             int[] expectedResults)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = expression switch
             {
@@ -314,11 +320,27 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(expectedResults);
         }
 
-        private IMongoCollection<C> GetCollection()
+        public class C
         {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
+            public int Id { get; set; }
+            public bool[] BoolArrayFieldRepresentedAsBoolean;
+            [BsonRepresentation(BsonType.Int32)] public bool[] BoolArrayFieldRepresentedAsInt32;
+            [BsonRepresentation(BsonType.String)] public bool[] BoolArrayFieldRepresentedAsString;
+            public bool[] BoolArrayPropertyRepresentedAsBoolean;
+            [BsonRepresentation(BsonType.Int32)] public bool[] BoolArrayPropertyRepresentedAsInt32;
+            [BsonRepresentation(BsonType.String)] public bool[] BoolArrayPropertyRepresentedAsString;
+            public bool BoolFieldRepresentedAsBoolean;
+            [BsonRepresentation(BsonType.Int32)] public bool BoolFieldRepresentedAsInt32;
+            [BsonRepresentation(BsonType.String)] public bool BoolFieldRepresentedAsString;
+            public bool BoolPropertyRepresentedAsBoolean { get; set; }
+            [BsonRepresentation(BsonType.Int32)] public bool BoolPropertyRepresentedAsInt32 { get; set; }
+            [BsonRepresentation(BsonType.String)] public bool BoolPropertyRepresentedAsString { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
                 new C
                 {
                     Id = 1,
@@ -349,25 +371,8 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                     BoolPropertyRepresentedAsBoolean = true,
                     BoolPropertyRepresentedAsInt32 = true,
                     BoolPropertyRepresentedAsString = true
-                });
-            return collection;
-        }
-
-        private class C
-        {
-            public int Id { get; set; }
-            public bool[] BoolArrayFieldRepresentedAsBoolean;
-            [BsonRepresentation(BsonType.Int32)] public bool[] BoolArrayFieldRepresentedAsInt32;
-            [BsonRepresentation(BsonType.String)] public bool[] BoolArrayFieldRepresentedAsString;
-            public bool[] BoolArrayPropertyRepresentedAsBoolean;
-            [BsonRepresentation(BsonType.Int32)] public bool[] BoolArrayPropertyRepresentedAsInt32;
-            [BsonRepresentation(BsonType.String)] public bool[] BoolArrayPropertyRepresentedAsString;
-            public bool BoolFieldRepresentedAsBoolean;
-            [BsonRepresentation(BsonType.Int32)] public bool BoolFieldRepresentedAsInt32;
-            [BsonRepresentation(BsonType.String)] public bool BoolFieldRepresentedAsString;
-            public bool BoolPropertyRepresentedAsBoolean { get; set; }
-            [BsonRepresentation(BsonType.Int32)] public bool BoolPropertyRepresentedAsInt32 { get; set; }
-            [BsonRepresentation(BsonType.String)] public bool BoolPropertyRepresentedAsString { get; set; }
+                }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5071Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5071Tests.cs
@@ -14,17 +14,23 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
-using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp5071Tests : Linq3IntegrationTest
+    public class CSharp5071Tests : LinqIntegrationTest<CSharp5071Tests.ClassFixture>
     {
+        public CSharp5071Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Theory]
         [InlineData("intconstant+stringproperty", "{ $project : { _v : { $concat : ['1', '$B'] }, _id : 0 } }", "1B")]
         [InlineData("intproperty+stringproperty", "{ $project : { _v : { $concat : [{ $toString : '$I' }, '$B'] }, _id : 0 } }", "1B")]
@@ -40,7 +46,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 RequireServer.Check().Supports(Feature.AggregateToString);
             }
 
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = scenario switch
             {
@@ -84,7 +90,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 RequireServer.Check().Supports(Feature.AggregateToString);
             }
 
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = scenario switch
             {
@@ -123,7 +129,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 RequireServer.Check().Supports(Feature.AggregateToString);
             }
 
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = scenario switch
             {
@@ -150,7 +156,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 RequireServer.Check().Supports(Feature.AggregateToString);
             }
 
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = scenario switch
             {
@@ -194,7 +200,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 RequireServer.Check().Supports(Feature.AggregateToString);
             }
 
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = scenario switch
             {
@@ -259,7 +265,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
                 RequireServer.Check().Supports(Feature.AggregateToString);
             }
 
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = scenario switch
             {
@@ -309,7 +315,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [InlineData("stringproperty+stringproperty+stringproperty", "{ $project : { _v : { $concat : ['$A', '$B', '$C'] }, _id : 0 } }", "ABC")]
         public void Concat_with_array_of_string_argument_should_work(string scenario, string expectedStage, string expectedResult)
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = scenario switch
             {
@@ -355,25 +361,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             }
         }
 
-        private IMongoCollection<Document> GetCollection()
-        {
-            var collection = GetCollection<Document>("test");
-            CreateCollection(
-                collection,
-                new Document
-                {
-                    Id = 1,
-                    A = "A",
-                    B = "B",
-                    C = "C",
-                    I = 1,
-                    J = 2,
-                    K = 3
-                });
-            return collection;
-        }
-
-        private class Document
+        public class Document
         {
             public int Id { get; set; }
             public string A { get; set; }
@@ -382,6 +370,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             public int I { get; set; }
             public int J { get; set; }
             public int K { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<Document>
+        {
+            protected override IEnumerable<Document> InitialData =>
+            [
+                new Document { Id = 1, A = "A", B = "B", C = "C", I = 1, J = 2, K = 3 }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5258Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5258Tests.cs
@@ -13,18 +13,25 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp5258Tests : Linq3IntegrationTest
+    public class CSharp5258Tests : LinqIntegrationTest<CSharp5258Tests.ClassFixture>
     {
+        public CSharp5258Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Select_First_with_predicate_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(_x => _x.List.First(_y => _y > 2));
@@ -39,7 +46,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Select_Where_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(_x => _x.List.Where(_y => _y % 2 == 0));
@@ -53,20 +60,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results[1].Should().Equal(2, 4, 6);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, List = [1, 3, 5] },
-                new C { Id = 2, List = [2, 4, 6] });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int[] List { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, List = [1, 3, 5] },
+                new C { Id = 2, List = [2, 4, 6] }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5286Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5286Tests.cs
@@ -24,7 +24,6 @@ using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.TestHelpers;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5295Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5295Tests.cs
@@ -13,21 +13,28 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver.Linq;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp5295Tests : Linq3IntegrationTest
+    public class CSharp5295Tests : LinqIntegrationTest<CSharp5295Tests.ClassFixture>
     {
+        public CSharp5295Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Subtract_two_decimals_with_decimal_representation_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.D2 - x.D1);
@@ -42,7 +49,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Subtract_two_decimals_with_left_string_representation_should_throw()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.DS2 - x.D1);
@@ -55,7 +62,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Subtract_two_decimals_with_right_string_representation_should_throw()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Select(x => x.D2 - x.DS1);
@@ -65,22 +72,21 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             exception.Message.Should().Be("Expression not supported: (x.D2 - x.DS1) because x.DS1 uses a non-numeric representation: String.");
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, D1 = 1.0M, D2 = 2.0M, DS1 = 3.0M, DS2 = 4.0M });
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             [BsonRepresentation(BsonType.Decimal128)] public decimal D1 { get; set; }
             [BsonRepresentation(BsonType.Decimal128)] public decimal D2 { get; set; }
             [BsonRepresentation(BsonType.String)] public decimal DS1 { get; set; }
             [BsonRepresentation(BsonType.String)] public decimal DS2 { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, D1 = 1.0M, D2 = 2.0M, DS1 = 3.0M, DS2 = 4.0M }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5321Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5321Tests.cs
@@ -13,20 +13,26 @@
  * limitations under the License.
  */
 
-using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp5321Tests : Linq3IntegrationTest
+    public class CSharp5321Tests : LinqIntegrationTest<CSharp5321Tests.ClassFixture>
     {
+        public CSharp5321Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Client_side_projection_should_fetch_only_needed_fields()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = GetTranslationOptions();
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -42,7 +48,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Client_side_projection_should_compute_sum_server_side()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
             var translationOptions = GetTranslationOptions();
 
             var queryable = collection.AsQueryable(translationOptions)
@@ -53,15 +59,6 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 
             var result = queryable.Single();
             result.Should().Be(10);
-        }
-
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection,
-                new C { Id = 1, X = 1, A = [1, 2, 3] });
-            return collection;
         }
 
         private ExpressionTranslationOptions GetTranslationOptions()
@@ -77,11 +74,19 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 
         private static int Add(int x, int y) => x + y;
 
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int X { get; set; }
             public int[] A { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<C>
+        {
+            protected override IEnumerable<C> InitialData =>
+            [
+                new C { Id = 1, X = 1, A = [1, 2, 3] }
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5403Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5403Tests.cs
@@ -13,19 +13,26 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.GridFS;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp5403Tests : Linq3IntegrationTest
+    public class CSharp5403Tests : LinqIntegrationTest<CSharp5403Tests.ClassFixture>
     {
+        public CSharp5403Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Project_Id_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var find = collection
                 .Find(Builders<GridFSFileInfo>.Filter.Where(x => x.Id == ObjectId.Parse("111111111111111111111111")))
@@ -45,7 +52,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Project_IdAsBsonValue_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var find = collection
                 .Find(Builders<GridFSFileInfo>.Filter.Where(x => x.IdAsBsonValue == new BsonObjectId(ObjectId.Parse("111111111111111111111111"))))
@@ -62,14 +69,13 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        private IMongoCollection<GridFSFileInfo> GetCollection()
+        public sealed class ClassFixture : MongoCollectionFixture<BsonDocument, GridFSFileInfo>
         {
-            var collection = GetCollection<GridFSFileInfo>("test");
-            CreateCollection(
-                collection.Database.GetCollection<BsonDocument>(collection.CollectionNamespace.CollectionName),
+            protected override IEnumerable<BsonDocument> InitialData =>
+            [
                 BsonDocument.Parse("{ _id : { $oid : '111111111111111111111111' }, filename : 'One' }"),
-                BsonDocument.Parse("{ _id : { $oid : '222222222222222222222222' }, filename : 'Two' }"));
-            return collection;
+                BsonDocument.Parse("{ _id : { $oid : '222222222222222222222222' }, filename : 'Two' }")
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5427Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp5427Tests.cs
@@ -13,20 +13,27 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
 {
-    public class CSharp5427Tests : Linq3IntegrationTest
+    public class CSharp5427Tests : LinqIntegrationTest<CSharp5427Tests.ClassFixture>
     {
+        public CSharp5427Tests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
         [Fact]
         public void Where_Mql_Exists_with_property_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => Mql.Exists(x.X));
@@ -41,7 +48,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Mql_Exists_with_shadow_property_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => Mql.Exists(Mql.Field(x, "X", new NullableSerializer<int>(Int32Serializer.Instance))));
@@ -56,7 +63,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Mql_IsMissing_with_property_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => Mql.IsMissing(x.X));
@@ -71,7 +78,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Mql_IsMissing_with_shadow_property_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => Mql.IsMissing(Mql.Field(x, "X", new NullableSerializer<int>(Int32Serializer.Instance))));
@@ -86,7 +93,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Mql_IsNullOrMissing_with_property_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => Mql.IsNullOrMissing(x.X));
@@ -101,7 +108,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
         [Fact]
         public void Where_Mql_IsNullOrMissing_with_shadow_property_should_work()
         {
-            var collection = GetCollection();
+            var collection = Fixture.Collection;
 
             var queryable = collection.AsQueryable()
                 .Where(x => Mql.IsNullOrMissing(Mql.Field(x, "X", new NullableSerializer<int>(Int32Serializer.Instance))));
@@ -113,21 +120,20 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira
             results.Select(x => x.Id).Should().Equal(1, 2);
         }
 
-        private IMongoCollection<C> GetCollection()
-        {
-            var collection = GetCollection<C>("test");
-            CreateCollection(
-                collection.Database.GetCollection<BsonDocument>("test"),
-                BsonDocument.Parse("{ _id : 1 }"),
-                BsonDocument.Parse("{ _id : 2, X : null }"),
-                BsonDocument.Parse("{ _id : 3, X : 3 }"));
-            return collection;
-        }
-
-        private class C
+        public class C
         {
             public int Id { get; set; }
             public int? X { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoCollectionFixture<BsonDocument, C>
+        {
+            protected override IEnumerable<BsonDocument> InitialData =>
+            [
+                BsonDocument.Parse("{ _id : 1 }"),
+                BsonDocument.Parse("{ _id : 2, X : null }"),
+                BsonDocument.Parse("{ _id : 3, X : 3 }")
+            ];
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/server-selection/InWindowTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-selection/InWindowTestRunner.cs
@@ -47,7 +47,7 @@ namespace MongoDB.Driver.Tests.Specifications.server_selection
             public IDictionary<string, double> expected_frequencies  { get; set; }
         }
 
-        private sealed class TestData
+        private sealed class TestC
         {
             public string _path { get; set; }
             public BsonDocument topology_description { get; set; }
@@ -68,7 +68,7 @@ namespace MongoDB.Driver.Tests.Specifications.server_selection
         public void RunTestDefinition(JsonDrivenTestCase testCase)
         {
             var testDefinition = testCase.Test;
-            var testData = BsonSerializer.Deserialize<TestData>(testDefinition);
+            var testData = BsonSerializer.Deserialize<TestC>(testDefinition);
             var clusterDescription = ServerSelectionTestHelper.BuildClusterDescription(testData.topology_description);
 
             using var cluster = CreateAndSetupCluster(clusterDescription, testData.mocked_topology_state);

--- a/tests/MongoDB.Driver.Tests/Specifications/server-selection/InWindowTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-selection/InWindowTestRunner.cs
@@ -47,7 +47,7 @@ namespace MongoDB.Driver.Tests.Specifications.server_selection
             public IDictionary<string, double> expected_frequencies  { get; set; }
         }
 
-        private sealed class TestC
+        private sealed class TestData
         {
             public string _path { get; set; }
             public BsonDocument topology_description { get; set; }
@@ -68,7 +68,7 @@ namespace MongoDB.Driver.Tests.Specifications.server_selection
         public void RunTestDefinition(JsonDrivenTestCase testCase)
         {
             var testDefinition = testCase.Test;
-            var testData = BsonSerializer.Deserialize<TestC>(testDefinition);
+            var testData = BsonSerializer.Deserialize<TestData>(testDefinition);
             var clusterDescription = ServerSelectionTestHelper.BuildClusterDescription(testData.topology_description);
 
             using var cluster = CreateAndSetupCluster(clusterDescription, testData.mocked_topology_state);
@@ -125,7 +125,7 @@ namespace MongoDB.Driver.Tests.Specifications.server_selection
                         serverDescriptionDisconnected = serverDescriptionDisconnected.With(replicaSetConfig: replicaSetConfig);
                     }
                     var serverDescriptionConnected = serverDescriptionDisconnected.With(state: ServerState.Connected);
-                    
+
 
                     var operationsCount = operationsCounts.Single(o => endpoint.ToString().EndsWith(o.address));
 


### PR DESCRIPTION
This PR contains number of test classes from Linq/Jira folder converted to use Class Fixture. Not all of them though: need a little more time to finish the conversion + some of test classes were skipped intentionally as I want to start with converting trivial cases, when more complex tests that might need more careful review will be included into separate smaller PR.