### PR TITLE
CSHARP-5514: Revert skip to non-lb-connection-establishment

### DIFF
--- a/specifications/load-balancers/tests/non-lb-connection-establishment.json
+++ b/specifications/load-balancers/tests/non-lb-connection-establishment.json
@@ -57,19 +57,6 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "8.0.99",
-          "topologies": [
-            "single"
-          ]
-        },
-        {
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "runCommand",

--- a/specifications/load-balancers/tests/non-lb-connection-establishment.yml
+++ b/specifications/load-balancers/tests/non-lb-connection-establishment.yml
@@ -42,11 +42,6 @@ tests:
   # If the server is not configured to be behind a load balancer and the URI contains loadBalanced=true, the driver
   # should error during the connection handshake because the server's hello response does not contain a serviceId field.
   - description: operations against non-load balanced clusters fail if URI contains loadBalanced=true
-    runOnRequirements:
-      - maxServerVersion: 8.0.99 # DRIVERS-3108: Skip test on >=8.1 mongod. SERVER-85804 changes a non-LB mongod to close connection.
-        topologies: [ single ]
-      - topologies: [ sharded ]
-
     operations:
       - name: runCommand
         object: *lbTrueDatabase


### PR DESCRIPTION
Revert test skip from https://github.com/mongodb/mongo-csharp-driver/pull/1618

The server problem that initiated the test skip has been resolved so we can revert the skip and run the test on the latest server build.