### PR TITLE
CSHARP-5381: Add valid-pass and valid-fail tests for $$matchAsRoot and $$matchAsDocument operators

### DIFF
--- a/specifications/unified-test-format/tests/valid-fail/operator-matchAsDocument.json
+++ b/specifications/unified-test-format/tests/valid-fail/operator-matchAsDocument.json
@@ -1,0 +1,205 @@
+{
+  "description": "operator-matchAsDocument",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "json": "{ \"x\": 1, \"y\": 2 }"
+        },
+        {
+          "_id": 2,
+          "json": "1"
+        },
+        {
+          "_id": 3,
+          "json": "[ \"foo\" ]"
+        },
+        {
+          "_id": 4,
+          "json": "{ \"x\" }"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsDocument with non-matching filter",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": "two"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument evaluates special operators",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument does not permit extra fields",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument expects JSON object but given scalar",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument expects JSON object but given array",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 3
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 3,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument fails to decode Extended JSON",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 4
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 4,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/unified-test-format/tests/valid-fail/operator-matchAsDocument.yml
+++ b/specifications/unified-test-format/tests/valid-fail/operator-matchAsDocument.yml
@@ -1,0 +1,88 @@
+description: operator-matchAsDocument
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, json: '{ "x": 1, "y": 2 }' }
+      # Documents with non-objects or invalid JSON
+      - { _id: 2, json: '1' }
+      - { _id: 3, json: '[ "foo" ]' }
+      - { _id: 4, json: '{ "x" }' }
+
+tests:
+  - description: matchAsDocument with non-matching filter
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1, y: "two" } } }
+  -
+    description: matchAsDocument evaluates special operators
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1, y: { $$exists: false } } } }
+  -
+    description: matchAsDocument does not permit extra fields
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1 } } }
+  -
+    description: matchAsDocument expects JSON object but given scalar
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 2 }
+          limit: 1
+        expectResult:
+          # The following $$matchAsRoot expression would match any document, so
+          # this ensures the failure is due to the actual value.
+          - { _id: 2, json: &match_any_document { $$matchAsDocument: { $$matchAsRoot: { } } } }
+  -
+    description: matchAsDocument expects JSON object but given array
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 3 }
+          limit: 1
+        expectResult:
+          - { _id: 3, json: *match_any_document }
+  -
+    description: matchAsDocument fails to decode Extended JSON
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 4 }
+          limit: 1
+        expectResult:
+          - { _id: 4, json: *match_any_document }

--- a/specifications/unified-test-format/tests/valid-fail/operator-matchAsRoot.json
+++ b/specifications/unified-test-format/tests/valid-fail/operator-matchAsRoot.json
@@ -1,0 +1,67 @@
+{
+  "description": "operator-matchAsRoot",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "x": {
+            "y": 2,
+            "z": 3
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsRoot with nested document does not match",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 3
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/unified-test-format/tests/valid-fail/operator-matchAsRoot.yml
+++ b/specifications/unified-test-format/tests/valid-fail/operator-matchAsRoot.yml
@@ -1,0 +1,33 @@
+description: operator-matchAsRoot
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: { y: 2, z: 3 } }
+
+tests:
+  -
+    description: matchAsRoot with nested document does not match
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 3 } } }

--- a/specifications/unified-test-format/tests/valid-pass/operator-lte.json
+++ b/specifications/unified-test-format/tests/valid-pass/operator-lte.json
@@ -1,0 +1,88 @@
+{
+  "description": "operator-lte",
+  "schemaVersion": "1.9",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0Name",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "special lte matching operator",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "x": 2,
+              "y": 3,
+              "z": 4
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$lte": 2
+                      },
+                      "x": {
+                        "$$lte": 2.1
+                      },
+                      "y": {
+                        "$$lte": {
+                          "$numberLong": "3"
+                        }
+                      },
+                      "z": {
+                        "$$lte": 4
+                      }
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "database0Name"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/unified-test-format/tests/valid-pass/operator-lte.yml
+++ b/specifications/unified-test-format/tests/valid-pass/operator-lte.yml
@@ -1,0 +1,41 @@
+description: operator-lte
+
+# Note: $$lte was introduced alongside schema changes for CSOT
+schemaVersion: "1.9"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: special lte matching operator
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id : 1, x: 2, y: 3, z: 4 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  # We can make exact assertions here but we use the $$lte operator to ensure drivers support it.
+                  - { _id: { $$lte: 2 }, x: { $$lte: 2.1 }, y: { $$lte: { $numberLong: "3"} }, z: { $$lte: 4 } }
+              commandName: insert
+              databaseName: *database0Name

--- a/specifications/unified-test-format/tests/valid-pass/operator-matchAsDocument.json
+++ b/specifications/unified-test-format/tests/valid-pass/operator-matchAsDocument.json
@@ -1,0 +1,124 @@
+{
+  "description": "operator-matchAsDocument",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "json": "{ \"x\": 1, \"y\": 2.0 }"
+        },
+        {
+          "_id": 2,
+          "json": "{ \"x\": { \"$oid\": \"57e193d7a9cc81b4027498b5\" } }"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsDocument performs flexible numeric comparisons",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": 2
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument evaluates special operators",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument decodes Extended JSON",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": {
+                    "$$type": "objectId"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/unified-test-format/tests/valid-pass/operator-matchAsDocument.yml
+++ b/specifications/unified-test-format/tests/valid-pass/operator-matchAsDocument.yml
@@ -1,0 +1,54 @@
+description: operator-matchAsDocument
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, json: '{ "x": 1, "y": 2.0 }' }
+      - { _id: 2, json: '{ "x": { "$oid": "57e193d7a9cc81b4027498b5" } }' }
+
+tests:
+  -
+    description: matchAsDocument performs flexible numeric comparisons
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1.0, y: 2 } } }
+  -
+    description: matchAsDocument evaluates special operators
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1, y: { $$exists: true } } } }
+  -
+    description: matchAsDocument decodes Extended JSON
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 2 }
+          limit: 1
+        expectResult:
+          - { _id: 2, json: { $$matchAsDocument: { x: { $$type: "objectId" } } } }

--- a/specifications/unified-test-format/tests/valid-pass/operator-matchAsRoot.json
+++ b/specifications/unified-test-format/tests/valid-pass/operator-matchAsRoot.json
@@ -1,0 +1,151 @@
+{
+  "description": "operator-matchAsRoot",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "x": {
+            "y": 2,
+            "z": 3
+          }
+        },
+        {
+          "_id": 2,
+          "json": "{ \"x\": 1, \"y\": 2 }"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsRoot with nested document",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 2
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsRoot performs flexible numeric comparisons",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 2
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsRoot evaluates special operators",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 2,
+                  "z": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsRoot with matchAsDocument",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/specifications/unified-test-format/tests/valid-pass/operator-matchAsRoot.yml
+++ b/specifications/unified-test-format/tests/valid-pass/operator-matchAsRoot.yml
@@ -1,0 +1,64 @@
+description: operator-matchAsRoot
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: { y: 2, z: 3 } }
+      - { _id: 2, json: '{ "x": 1, "y": 2 }' }
+
+tests:
+  -
+    description: matchAsRoot with nested document
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 2 } } }
+  -
+    description: matchAsRoot performs flexible numeric comparisons
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 2.0 } } }
+  -
+    description: matchAsRoot evaluates special operators
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 2, z: { $$exists: true } } } }
+  -
+    description: matchAsRoot with matchAsDocument
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 2 }
+          limit: 1
+        expectResult:
+          - { _id: 2, json: { $$matchAsDocument: { $$matchAsRoot: { x: 1 } } } }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedValueMatcher.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/Matchers/UnifiedValueMatcher.cs
@@ -19,8 +19,8 @@ using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
-using MongoDB.TestHelpers.XunitExtensions;
 using MongoDB.Driver;
+using MongoDB.TestHelpers.XunitExtensions;
 using Xunit.Sdk;
 
 namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
@@ -96,6 +96,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
                 {
                     var expectedName = expectedElement.Name;
                     var expectedValue = expectedElement.Value;
+                    var matchCurrentElementAsRoot = false;
 
                     if (expectedValue.IsBsonDocument &&
                         expectedValue.AsBsonDocument.ElementCount == 1 &&
@@ -104,6 +105,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
                         var specialOperatorDocument = expectedValue.AsBsonDocument;
                         var operatorName = specialOperatorDocument.GetElement(0).Name;
                         var operatorValue = specialOperatorDocument[0];
+
                         switch (operatorName)
                         {
                             case "$$exists":
@@ -120,10 +122,18 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
                                 actualDocument.Names.Should().Contain(expectedName);
                                 AssertExpectedType(actualDocument[expectedName], operatorValue);
                                 continue;
+                            case "$$lte":
+                                var actualElement = actualDocument[expectedName];
+                                actualElement.IsNumeric.Should().BeTrue();
+                                actualElement.ToDouble().Should().BeLessOrEqualTo(operatorValue.ToDouble());
+                                continue;
                             case "$$matchAsDocument":
                                 var parsedDocument = BsonDocument.Parse(actualDocument[expectedName].AsString);
                                 AssertValuesMatch(parsedDocument, operatorValue, false);
                                 continue;
+                            case "$$matchAsRoot":
+                                matchCurrentElementAsRoot = true;
+                                break;
                             case "$$matchesEntity":
                                 var resultId = operatorValue.AsString;
                                 expectedValue = _entityMap.Resutls[resultId];
@@ -148,7 +158,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations.Matchers
                     }
 
                     actualDocument.Names.Should().Contain(expectedName);
-                    AssertValuesMatch(actualDocument[expectedName], expectedValue, isRoot: false);
+                    AssertValuesMatch(actualDocument[expectedName], expectedValue, isRoot: matchCurrentElementAsRoot);
                 }
 
                 if (!isRoot)


### PR DESCRIPTION
Also addresses [CSHARP-5534](https://jira.mongodb.org/browse/CSHARP-5534)