### PR TITLE
CSHARP-5559: Update Microsoft.NET.Test.Sdk to 17.13.0 for s390x compatibility

### DIFF
--- a/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
+++ b/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
+++ b/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
@@ -37,7 +37,7 @@
   
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MongoDB.Driver.Encryption.Tests/MongoDB.Driver.Encryption.Tests.csproj
+++ b/tests/MongoDB.Driver.Encryption.Tests/MongoDB.Driver.Encryption.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 

--- a/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
+++ b/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0'">

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/MongoDB.Driver.SmokeTests.Sdk.csproj
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/MongoDB.Driver.SmokeTests.Sdk.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />


### PR DESCRIPTION
## Problem
Tests were aborting with the following error on .NET 8 (especially on non-x86 platforms like s390x):

```
System.TypeInitializationException: The type initializer for 'Microsoft.VisualStudio.TestPlatform.ObjectModel.Constants' 
threw an exception. ---> System.NotSupportedException: Specified method is not supported. at 
Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformEnvironment.get_Architecture()
```


This is caused by an outdated version of `Microsoft.NET.Test.Sdk` (e.g., `15.8.0`), which uses `PlatformEnvironment.get_Architecture()` — not supported on some platforms.

---

##  Resolution

Upgraded `Microsoft.NET.Test.Sdk` to `17.13.0`, the latest stable release as of now, which includes:

- A fix for [`PlatformEnvironment.get_Architecture()` crash](https://github.com/microsoft/vstest/pull/4066)
- Improved cross-platform compatibility (including `s390x`)
- Improved platform abstraction and support

> The PR fixing this issue was merged on **October 12, 2022**, and first shipped in version **17.4.0**.

---

##  Related

- Fix PR in vstest repo: [microsoft/vstest#4066](https://github.com/microsoft/vstest/pull/4066)
- Observed error in MongoDB C# Driver tests (example failure: `LoadBalancingIntegrationTests`)

---


