### PR TITLE
CSHARP-5204: Test Heartbeats don't gossip cluster time

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/SessionsProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/SessionsProseTests.cs
@@ -337,15 +337,11 @@ namespace MongoDB.Driver.Tests.Specifications.sessions
             eventCapturer.Clear();
 
             eventCapturer.WaitForOrThrowIfTimeout(
-                events =>
+                capturedEvents =>
                 {
-                    var capturedEvents = events.ToArray();
-                    return capturedEvents.Count(e => e is ServerHeartbeatSucceededEvent) > 1 &&
-                           capturedEvents
-                               .Where((e, i) =>
-                                   e is ServerHeartbeatStartedEvent &&
-                                   capturedEvents[i + 1] is ServerHeartbeatSucceededEvent)
-                               .Any();
+                    return capturedEvents
+                        .SkipWhile(e => e is not ServerHeartbeatStartedEvent)
+                        .Any(e => e is ServerHeartbeatSucceededEvent);
                 }, TimeSpan.FromSeconds(1), "Didn't get any server heartbeat pairs");
 
             c1.GetDatabase("admin").RunCommand<BsonDocument>(pingCommand);

--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/SessionsProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/SessionsProseTests.cs
@@ -318,7 +318,7 @@ namespace MongoDB.Driver.Tests.Specifications.sessions
                 {
                     settings.ClusterConfigurator = c => c.Subscribe(eventCapturer);
                     settings.DirectConnection = true;
-                    settings.HeartbeatInterval = TimeSpan.FromSeconds(2000);
+                    settings.HeartbeatInterval = TimeSpan.FromMilliseconds(10);
                 });
 
             var pingCommand = new BsonDocument("ping", 1);

--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/SessionsProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/SessionsProseTests.cs
@@ -303,6 +303,7 @@ namespace MongoDB.Driver.Tests.Specifications.sessions
             await eventsTask.WithTimeout(1000);
         }
 
+        // https://specifications.readthedocs.io/en/latest/sessions/tests/#20-drivers-do-not-gossip-clustertime-on-sdam-commands
         [Fact]
         public void Ensure_cluster_times_are_not_gossiped_on_SDAM_commands()
         {
@@ -319,6 +320,10 @@ namespace MongoDB.Driver.Tests.Specifications.sessions
                     settings.ClusterConfigurator = c => c.Subscribe(eventCapturer);
                     settings.DirectConnection = true;
                     settings.HeartbeatInterval = TimeSpan.FromMilliseconds(10);
+                    if (settings.Servers.Count() > 1)
+                    {
+                        settings.Servers = settings.Servers.Take(1);
+                    }
                 });
 
             var pingCommand = new BsonDocument("ping", 1);


### PR DESCRIPTION
It turns out we were already not gossiping cluster times in our monitoring connections. Our monitors send hello requests  which use a `NoCoreSession` instance when the wire protocol command is created for a hello request. A `NoCoreSession` instance has a null `ClusterTime` which cannot be changed and calling `session.AdvanceClusterTime` is also a no-op for a `NoCoreSession`. So this PR just adds the new prose test described in the Drivers spec update: https://github.com/mongodb/specifications/commit/b76cbf96807d96aa8ae4337a3f2b3c9be39d3487