### PR TITLE
CSHARP-5370: Test driver-generated '_id' fields are first in documents

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/crud/prose-tests/CrudProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/prose-tests/CrudProseTests.cs
@@ -624,7 +624,7 @@ namespace MongoDB.Driver.Tests.Specifications.crud.prose_tests
         public async Task Ensure_generated_ids_are_first_fields_in_document_using_insertOne([Values(true, false)] bool async)
         {
             var eventCapturer = new EventCapturer().Capture<CommandStartedEvent>();
-            var client = CreateMongoClient(eventCapturer);
+            using var client = CreateMongoClient(eventCapturer);
             var testCollection = client.GetDatabase("test").GetCollection<BsonDocument>("test");
 
             var document = new BsonDocument("x", 1);
@@ -648,7 +648,7 @@ namespace MongoDB.Driver.Tests.Specifications.crud.prose_tests
         public async Task Ensure_generated_ids_are_first_fields_in_document_using_collection_bulkWrite([Values(true, false)] bool async)
         {
             var eventCapturer = new EventCapturer().Capture<CommandStartedEvent>();
-            var client = CreateMongoClient(eventCapturer);
+            using var client = CreateMongoClient(eventCapturer);
             var testCollection = client.GetDatabase("test").GetCollection<BsonDocument>("test");
 
             var document = new BsonDocument("x", 1);
@@ -674,7 +674,7 @@ namespace MongoDB.Driver.Tests.Specifications.crud.prose_tests
             RequireServer.Check().Supports(Feature.ClientBulkWrite).Serverless(false);
 
             var eventCapturer = new EventCapturer().Capture<CommandStartedEvent>();
-            var client = CreateMongoClient(eventCapturer);
+            using var client = CreateMongoClient(eventCapturer);
 
             var document = new BsonDocument("x", 1);
             if (async)

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/prose-tests/CrudProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/prose-tests/CrudProseTests.cs
@@ -637,9 +637,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud.prose_tests
                 testCollection.InsertOne(document);
             }
 
-            eventCapturer.Next(); // skip the hello command that is captured.
-            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>()
-                .Subject.Command["documents"][0].AsBsonDocument.Names.First().Should().Be("_id");
+            var insertEvents = eventCapturer.Events.OfType<CommandStartedEvent>().Where(e => e.CommandName == "insert").ToArray();
+            insertEvents.Length.Should().Be(1);
+            insertEvents[0].Command["documents"][0].AsBsonDocument.Names.First().Should().Be("_id");
             document.Names.Should().Contain("_id");
         }
 
@@ -661,9 +661,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud.prose_tests
                 testCollection.BulkWrite([new InsertOneModel<BsonDocument>(document)]);
             }
 
-            eventCapturer.Next(); // skip the hello command that is captured.
-            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>()
-                .Subject.Command["documents"][0].AsBsonDocument.Names.First().Should().Be("_id");
+            var insertEvents = eventCapturer.Events.OfType<CommandStartedEvent>().Where(e => e.CommandName == "insert").ToArray();
+            insertEvents.Length.Should().Be(1);
+            insertEvents[0].Command["documents"][0].AsBsonDocument.Names.First().Should().Be("_id");
             document.Names.Should().Contain("_id");
         }
 
@@ -686,9 +686,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud.prose_tests
                 client.BulkWrite([new BulkWriteInsertOneModel<BsonDocument>("test.test", document)]);
             }
 
-            eventCapturer.Next(); // skip the hello command that is captured.
-            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>()
-                .Subject.Command["ops"][0]["document"].AsBsonDocument.Names.First().Should().Be("_id");
+            var bulkEvents = eventCapturer.Events.OfType<CommandStartedEvent>().Where(e => e.CommandName == "bulkWrite").ToArray();
+            bulkEvents.Length.Should().Be(1);
+            bulkEvents[0].Command["ops"][0]["document"].AsBsonDocument.Names.First().Should().Be("_id");
             document.Names.Should().Contain("_id");
         }
 


### PR DESCRIPTION
Add new prose test from spec: https://specifications.readthedocs.io/en/latest/crud/tests/#16-generated-document-identifiers-are-the-first-field-in-their-document