### PR TITLE
CSHARP-5531: Optimize the conversion from an array index to UTF-8 byte arrays

### DIFF
--- a/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryWriter.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
 
@@ -29,6 +30,7 @@ namespace MongoDB.Bson.IO
         private readonly Stream _baseStream;
 #pragma warning restore CA2213 // Disposable never disposed
         private readonly BsonStream _bsonStream;
+        private readonly byte[] _temp10Bytes = new byte[10];
         private BsonBinaryWriterContext _context;
 
         // constructors
@@ -719,8 +721,8 @@ namespace MongoDB.Bson.IO
             if (_context.ContextType == ContextType.Array)
             {
                 var index = _context.Index++;
-                var nameBytes = ArrayElementNameAccelerator.Default.GetElementNameBytes(index);
-                _bsonStream.WriteCStringBytes(nameBytes);
+                Utf8Formatter.TryFormat(index, _temp10Bytes.AsSpan(), out var bytesWritten);
+                _bsonStream.WriteCStringBytes(new ArraySegment<byte>(_temp10Bytes, 0, bytesWritten));
             }
             else
             {

--- a/src/MongoDB.Bson/IO/BsonStream.cs
+++ b/src/MongoDB.Bson/IO/BsonStream.cs
@@ -101,6 +101,12 @@ namespace MongoDB.Bson.IO
         public abstract void WriteCStringBytes(byte[] value);
 
         /// <summary>
+        /// Writes the CString bytes to the stream.
+        /// </summary>
+        /// <param name="value"></param>
+        public abstract void WriteCStringBytes(ArraySegment<byte> value);
+
+        /// <summary>
         /// Writes a BSON Decimal128 to the stream.
         /// </summary>
         /// <param name="value">The value.</param>

--- a/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
+++ b/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
@@ -484,6 +484,15 @@ namespace MongoDB.Bson.IO
         }
 
         /// <inheritdoc/>
+        public override void WriteCStringBytes(ArraySegment<byte> value)
+        {
+            ThrowIfDisposed();
+
+            this.WriteBytes(value.Array, value.Offset, value.Count);
+            WriteByte(0);
+        }
+
+        /// <inheritdoc/>
         public override void WriteDecimal128(Decimal128 value)
         {
             ThrowIfDisposed();

--- a/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
+++ b/src/MongoDB.Bson/IO/BsonStreamAdapter.cs
@@ -495,9 +495,8 @@ namespace MongoDB.Bson.IO
         public override void WriteDouble(double value)
         {
             ThrowIfDisposed();
-            var bytes = new byte[8];
-            BinaryPrimitivesCompat.WriteDoubleLittleEndian(bytes, value);
-            _stream.Write(bytes, 0, 8);
+            BinaryPrimitivesCompat.WriteDoubleLittleEndian(_temp, value);
+            _stream.Write(_temp, 0, 8);
         }
 
         /// <inheritdoc/>
@@ -515,9 +514,8 @@ namespace MongoDB.Bson.IO
         public override void WriteInt64(long value)
         {
             ThrowIfDisposed();
-            var bytes = new byte[8];
-            BinaryPrimitives.WriteInt64LittleEndian(bytes, value);
-            _stream.Write(bytes, 0, 8);
+            BinaryPrimitives.WriteInt64LittleEndian(_temp, value);
+            _stream.Write(_temp, 0, 8);
         }
 
         /// <inheritdoc/>

--- a/src/MongoDB.Bson/IO/ByteBufferStream.cs
+++ b/src/MongoDB.Bson/IO/ByteBufferStream.cs
@@ -572,7 +572,7 @@ namespace MongoDB.Bson.IO
             {
                 // Compare to 128 to preserve original behavior
                 const int maxLengthToUseCStringUtf8EncodingWith = 128;
-          
+
                 if (maxLength <= maxLengthToUseCStringUtf8EncodingWith)
                 {
                     using var rentedBuffer = ThreadStaticBuffer.RentBuffer(maxLengthToUseCStringUtf8EncodingWith);
@@ -618,6 +618,21 @@ namespace MongoDB.Bson.IO
             PrepareToWrite(length + 1);
 
             _buffer.SetBytes(_position, value, 0, length);
+            _buffer.SetByte(_position + length, 0);
+
+            SetPositionAfterWrite(_position + length + 1);
+        }
+
+        /// <inheritdoc/>
+        public override void WriteCStringBytes(ArraySegment<byte> value)
+        {
+            ThrowIfDisposed();
+
+            var length = value.Count;
+
+            PrepareToWrite(length + 1);
+
+            _buffer.SetBytes(_position, value.Array, value.Offset, length);
             _buffer.SetByte(_position + length, 0);
 
             SetPositionAfterWrite(_position + length + 1);

--- a/tests/MongoDB.Bson.TestHelpers/IO/NullBsonStream.cs
+++ b/tests/MongoDB.Bson.TestHelpers/IO/NullBsonStream.cs
@@ -158,6 +158,11 @@ namespace MongoDB.Bson.TestHelpers.IO
             Position += value.Length + 1;
         }
 
+        public override void WriteCStringBytes(ArraySegment<byte> value)
+        {
+            Position += value.Count + 1;
+        }
+
         public override void WriteDecimal128(Decimal128 value)
         {
             Position += 16;


### PR DESCRIPTION
1. Use Utf8Formatter.TryFormat API to avoid string allocations and write directly to a reused byte[]
2. Define a byte[] member in BsonBinaryWriter class and reuse it to avoid byte[] allocations

see[CSHARP-5531](https://jira.mongodb.org/browse/CSHARP-5531?focusedCommentId=7168898&focusedId=7168898&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-7168898) for more details