### PR TITLE
CSHARP-4535: Support queries after casting IQueryable<Derived> to IQueryable<Base>.

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Misc/Symbol.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Misc/Symbol.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Linq.Expressions;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Core.Misc;
@@ -37,6 +38,11 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
             _ast = Ensure.IsNotNull(ast, nameof(ast));
             _serializer = Ensure.IsNotNull(serializer, nameof(serializer));
             _isCurrent = isCurrent;
+
+            if (_serializer.ValueType != _parameter.Type)
+            {
+                throw new ArgumentException($"Value type {_serializer.ValueType} of serializer type {_serializer.GetType()} does not match parameter type {_parameter.Type}.");
+            }
         }
 
         // public properties

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionToFilterTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToFilterTranslators/ExpressionToFilterTranslator.cs
@@ -13,10 +13,10 @@
 * limitations under the License.
 */
 
-using System;
 using System.Linq;
 using System.Linq.Expressions;
 using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Linq.Linq3Implementation.Ast.Filters;
 using MongoDB.Driver.Linq.Linq3Implementation.Misc;
 using MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggregationExpressionTranslators;
@@ -56,9 +56,10 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToFilter
             bool asRoot = false)
         {
             var parameterExpression = lambdaExpression.Parameters.Single();
-            if (parameterSerializer.ValueType != parameterExpression.Type)
+
+            if (parameterSerializer.ValueType != parameterExpression.Type && parameterExpression.Type.IsAssignableFrom(parameterSerializer.ValueType))
             {
-                throw new ArgumentException($"ValueType '{parameterSerializer.ValueType.FullName}' of parameterSerializer does not match parameter type '{parameterExpression.Type.FullName}'.", nameof(parameterSerializer));
+                parameterSerializer = DowncastingSerializer.Create(parameterExpression.Type, parameterSerializer.ValueType, parameterSerializer);
             }
 
             var parameterSymbol =

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4535Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp4535Tests.cs
@@ -1,0 +1,71 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using MongoDB.Driver.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira;
+
+public class CSharp4535Tests : LinqIntegrationTest<CSharp4535Tests.ClassFixture>
+{
+    public CSharp4535Tests(ClassFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void Empty_query_should_work()
+    {
+        var mongoEntityCollection = Fixture.Collection;
+        var entityQueryable = (IQueryable<Entity>)mongoEntityCollection.AsQueryable();
+
+        var results = entityQueryable.ToArray();
+
+        results.Select(x => x.Id).Should().Equal(1);
+    }
+
+    [Fact]
+    public void Where_should_work()
+    {
+        var mongoEntityCollection = Fixture.Collection;
+        var entityQueryable = (IQueryable<Entity>)mongoEntityCollection.AsQueryable();
+
+        var queryable = entityQueryable.Where(x => x.Id == 1);
+
+        var results = queryable.ToArray();
+
+        results.Select(x => x.Id).Should().Equal(1);
+    }
+
+    public class Entity
+    {
+        public int Id { get; set; }
+    }
+
+    public class MongoEntity : Entity
+    {
+    }
+
+    public sealed class ClassFixture : MongoCollectionFixture<MongoEntity>
+    {
+        protected override IEnumerable<MongoEntity> InitialData =>
+        [
+            new MongoEntity { Id = 1 }
+        ];
+    }
+}


### PR DESCRIPTION
If this approach looks good then I should still look for all places where a new `Symbol` is created and see if any other places need to wrap a `DowncastingSerializer` around a serializer for a derived type.