### PR TITLE
CSHARP-5591: Configure MongoDB.Driver.Encryption.Tests to run on net472 target

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -117,12 +117,6 @@ Task("Test")
         items: GetFiles("./**/*.Tests.csproj").Where(name => !name.ToString().Contains("Atlas")),
         action: (BuildConfig buildConfig, Path testProject) =>
     {
-        if (Environment.GetEnvironmentVariable("MONGODB_API_VERSION") != null &&
-            testProject.ToString().Contains("Legacy"))
-        {
-            return; // Legacy tests are exempt from Version API testing
-        }
-
         var mongoX509ClientCertificatePath = Environment.GetEnvironmentVariable("MONGO_X509_CLIENT_CERTIFICATE_PATH");
         if (mongoX509ClientCertificatePath != null)
         {

--- a/build.ps1
+++ b/build.ps1
@@ -89,17 +89,16 @@ if($FoundDotNetCliVersion -ne $DotNetVersion) {
         New-Item -Path $InstallPath -ItemType Directory -Force | Out-Null;
     }
 
-    # N.B. We explicitly install .NET Core 2.1 and 3.1 because .NET 5.0 SDK can build those TFMs
+    # N.B. We explicitly install .NET Core 3.1 because .NET 5.0 SDK can build those TFMs
     #      but will silently upgrade to a more recent runtime to execute tests if the desired runtime
     #      isn't available. For example, `dotnet run --framework netcoreapp3.0` will silently run
     #      on .NET 5.0 if .NET Core 3.0 and 3.1 aren't installed.
-    #      This solution is admittedly hacky as .NET Core 2.1 and 3.1 won't be installed if
+    #      This solution is admittedly hacky as .NET Core 3.1 won't be installed if
     #      $DOTNET_VERSION matches $DOTNET_INSTALLED_VERSION, but it minimizes the changes required
     #      to install required dependencies on Evergreen.
     if ($IsMacOS -or $IsLinux) {
         $ScriptPath = Join-Path $InstallPath 'dotnet-install.sh'
         (New-Object System.Net.WebClient).DownloadFile($DotNetUnixInstallerUri, $ScriptPath);
-        & bash $ScriptPath --install-dir "$InstallPath" --channel 2.1 --no-path
         & bash $ScriptPath --install-dir "$InstallPath" --channel 3.1 --no-path
         & bash $ScriptPath --install-dir "$InstallPath" --channel 5.0 --no-path
         & bash $ScriptPath --install-dir "$InstallPath" --channel 6.0 --no-path
@@ -111,7 +110,6 @@ if($FoundDotNetCliVersion -ne $DotNetVersion) {
     else {
         $ScriptPath = Join-Path $InstallPath 'dotnet-install.ps1'
         (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, $ScriptPath);
-        & $ScriptPath -Channel 2.1 -InstallDir $InstallPath;
         & $ScriptPath -Channel 3.1 -InstallDir $InstallPath;
         & $ScriptPath -Channel 5.0 -InstallDir $InstallPath;
         & $ScriptPath -Channel 6.0 -InstallDir $InstallPath;

--- a/build.sh
+++ b/build.sh
@@ -33,18 +33,17 @@ if [ "$DOTNET_VERSION" != "$DOTNET_INSTALLED_VERSION" ]; then
       mkdir "$SCRIPT_DIR/.dotnet"
     fi
     curl -Lfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh
-    # N.B. We explicitly install .NET Core 2.1 and 3.1 because .NET 6.0 SDK can build those TFMs
+    # N.B. We explicitly install .NET Core 3.1 because .NET 6.0 SDK can build those TFMs
     #      but will silently upgrade to a more recent runtime to execute tests if the desired runtime
     #      isn't available. For example, `dotnet run --framework netcoreapp3.0` will silently run
     #      on .NET 6.0 if .NET Core 3.0 and 3.1 aren't installed.
-    #      This solution is admittedly hacky as .NET Core 2.1 and 3.1 won't be installed if
+    #      This solution is admittedly hacky as .NET Core 3.1 won't be installed if
     #      $DOTNET_VERSION matches $DOTNET_INSTALLED_VERSION, but it minimizes the changes required
     #      to install required dependencies on Evergreen.
     #      Since ARM64 support was first added in .NET 6.0, the following commands will install:
     #      | CPU   | 2.1 | 3.1 | Latest |
     #      | x64   | x64 | x64 |    x64 |
     #      | arm64 | x64 | x64 |  arm64 |
-    bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --channel 2.1 --architecture x64 --install-dir .dotnet --no-path
     bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --channel 3.1 --architecture x64 --install-dir .dotnet --no-path
     bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --channel 5.0 --architecture x64 --install-dir .dotnet --no-path
     bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --channel 6.0 --install-dir .dotnet --no-path

--- a/tests/AstrolabeWorkloadExecutor/AstrolabeWorkloadExecutor.csproj
+++ b/tests/AstrolabeWorkloadExecutor/AstrolabeWorkloadExecutor.csproj
@@ -18,10 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
+++ b/tests/AtlasConnectivity.Tests/AtlasConnectivity.Tests.csproj
@@ -11,10 +11,6 @@
     <Description>Atlas connectivity tests.</Description>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
-  </ItemGroup>
-
   <PropertyGroup>
     <NoWarn>
       1701;1702; <!--https://github.com/dotnet/roslyn/issues/19640-->

--- a/tests/BuildProps/Tests.Build.props
+++ b/tests/BuildProps/Tests.Build.props
@@ -43,6 +43,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />

--- a/tests/MongoDB.Bson.TestHelpers/MongoDB.Bson.TestHelpers.csproj
+++ b/tests/MongoDB.Bson.TestHelpers/MongoDB.Bson.TestHelpers.csproj
@@ -12,10 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\MongoDB.Bson\MongoDB.Bson.csproj" />
     <ProjectReference Include="..\MongoDB.TestHelpers\MongoDB.TestHelpers.csproj" />
   </ItemGroup>

--- a/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
+++ b/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
@@ -11,10 +11,6 @@
     <Description>MongoDB.Bson tests.</Description>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
-  </ItemGroup>
-
   <PropertyGroup>
     <NoWarn>
       1701;1702; <!--https://github.com/dotnet/roslyn/issues/19640-->
@@ -31,10 +27,10 @@
     </NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/tests/MongoDB.Driver.Encryption.Tests/MongoDB.Driver.Encryption.Tests.csproj
+++ b/tests/MongoDB.Driver.Encryption.Tests/MongoDB.Driver.Encryption.Tests.csproj
@@ -8,14 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/tests/MongoDB.Driver.Encryption.Tests/MongoDB.Driver.Encryption.Tests.csproj
+++ b/tests/MongoDB.Driver.Encryption.Tests/MongoDB.Driver.Encryption.Tests.csproj
@@ -1,15 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\BuildProps\Tests.Build.props" />
+  <Import Project="..\BuildProps\Tests.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net6.0</TargetFrameworks>
-
-    <Platforms>AnyCPU</Platforms>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MongoDB.Driver.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
@@ -21,8 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(CMakeCurrentSourceDir)/xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tests/MongoDB.Driver.Encryption.Tests/xunit.runner.json
+++ b/tests/MongoDB.Driver.Encryption.Tests/xunit.runner.json
@@ -1,6 +1,6 @@
 ﻿{
-  "$schema": "https://xunit.github.io/schema/current/xunit.runner.schema.json",
-
-  "appDomain": "denied",
-  "shadowCopy": false
+    "longRunningTestSeconds": 10,
+    "parallelizeAssembly": false,
+    "parallelizeTestCollections": false,
+    "shadowCopy": false
 }

--- a/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
+++ b/tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj
@@ -12,10 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>

--- a/tests/MongoDB.Driver.TestHelpers/MongoDB.Driver.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.TestHelpers/MongoDB.Driver.TestHelpers.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -29,10 +29,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
PR contains fixes for:
- run MongoDB.Driver.Encryption.Tests to run on net472 target (filter by test name to MongoDB.Driver.Encryption.Tests to see new tests run on net472 variants)
- remove installation of netcore 2.1 as we dropped support of netstandard2.0
- remove some leftovers in cake for Legacy Driver
- fix for Warning MSB3243 : No way to resolve conflict between "Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "Microsoft.CSharp".