### PR TITLE
CSHARP-5593: Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# Provide the set of commits to always ignore when using `git blame` on the cmd line.
+# git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Additional useful options to set on your local git config:
+
+# Mark with a `?` any lines that have had a commit ignored.
+# git config --global blame.markIgnoredLines true
+
+# Mark with a `*` any lines that were added in an ignored commit and can not be blamed.
+# git config --global blame.markUnblamableLines true


### PR DESCRIPTION
This is adding a file in which we can list the commit hashes of commits we want git blame to ignore. This file is picked up by Github and used when looking at the Blame tab on the Github web UI.