### PR TITLE
CSHARP-5585: Remove reliance on Evergreen instance profile credentials

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -310,6 +310,10 @@ functions:
   bootstrap-mongohoused:
     - command: shell.exec
       params:
+        include_expansions_in_env:
+          - "AWS_ACCESS_KEY_ID"
+          - "AWS_SECRET_ACCESS_KEY"
+          - "AWS_SESSION_TOKEN"
         script: |
           DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
     - command: shell.exec
@@ -1257,6 +1261,7 @@ tasks:
 
     - name: atlas-data-lake-test
       commands:
+        - func: assume-ec2-role
         - func: bootstrap-mongohoused
         - func: run-atlas-data-lake-test
 
@@ -2192,9 +2197,14 @@ task_groups:
     setup_group:
       - func: fetch-source
       - func: prepare-resources
+      - func: assume-ec2-role
       - command: subprocess.exec
         params:
           binary: bash
+          include_expansions_in_env:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
           env:
             LAMBDA_STACK_NAME: dbx-csharp-lambda
           args:


### PR DESCRIPTION
More fixes related to the profile credentials changes to fix following variants:

 [test-aws-lambda-deployed](https://spruce.mongodb.com/task/dot_net_driver_aws_lambda_tests_test_aws_lambda_deployed_patch_c2bec8127385cc76134e585d74454af35814ef07_683a1f8117c78c00072da11a_25_05_30_21_13_50?execution=0)
[atlas-data-lake-test](https://spruce.mongodb.com/task/dot_net_driver_atlas_data_lake_test_atlas_data_lake_test_patch_4ecb1797acf9f15b19a9b4dfa5f2ab5f40153ae9_683a1c781576680007a2671f_25_05_30_21_00_54?execution=0)