### PR TITLE
CSHARP-5621 Fix BinaryConnectionTests.ReceiveMessage_should_throw_a_FormatException fails with TimeoutException

### DIFF
--- a/tests/MongoDB.Driver.Tests/Core/Connections/BinaryConnectionTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Connections/BinaryConnectionTests.cs
@@ -374,6 +374,10 @@ namespace MongoDB.Driver.Core.Connections
             using (var stream = new BlockingMemoryStream())
             {
                 var bytes = BitConverter.GetBytes(length);
+                if (!BitConerter.IsLittleEndian)
+                {
+                    Array.Reverse(bytes);
+                }
                 stream.Write(bytes, 0, bytes.Length);
                 stream.Seek(0, SeekOrigin.Begin);
                 var encoderSelector = new ReplyMessageEncoderSelector<BsonDocument>(BsonDocumentSerializer.Instance);


### PR DESCRIPTION
[Jira Ticket](https://jira.mongodb.org/projects/CSHARP/issues/CSHARP-5621)

This PR fixes a test case failure in BinaryConnectionTests.ReceiveMessage_should_throw_a_FormatException_when_message_is_an_invalid_size when run on Big Endian systems like s390x.

Root Cause:
The test uses BitConverter.GetBytes(length) which encodes the integer in system-native endianness. MongoDB’s wire protocol, however, requires that all integer fields be little-endian. When the test runs on a Big Endian system, the message size is encoded incorrectly, leading the driver to misinterpret the message size and wait for more data, resulting in a TimeoutException.


Fix:
fix the test by reversing the byte array explicitly if BitConverter.IsLittleEndian == false. This ensures consistent little-endian encoding regardless of the platform.


Alternative:
Instead of using BitConverter and reversing bytes manually, we could replace the logic with BinaryPrimitives.WriteInt32LittleEndian, which guarantees correct little-endian encoding

```
Span<byte> bytes = stackalloc byte[4];
BinaryPrimitives.WriteInt32LittleEndian(bytes, length);
stream.Write(bytes);
```
cc: @giritrivedi