### PR TITLE
CSHARP-5633: BsonSerializer.IsTypeDiscriminated is not thread-safe

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -321,7 +321,7 @@ namespace MongoDB.Bson.Serialization
         /// <returns>True if the type is discriminated.</returns>
         public static bool IsTypeDiscriminated(Type type)
         {
-            return type.GetTypeInfo().IsInterface || __discriminatedTypes.ContainsKey(type);
+            return type.IsInterface || __discriminatedTypes.ContainsKey(type);
         }
 
         /// <summary>
@@ -586,6 +586,7 @@ namespace MongoDB.Bson.Serialization
                     // mark all base types as discriminated (so we know that it's worth reading a discriminator)
                     for (var baseType = typeInfo.BaseType; baseType != null; baseType = baseType.GetTypeInfo().BaseType)
                     {
+                        // We expect that TryAdd will always return true, so no need to check the return value.
                         __discriminatedTypes.TryAdd(baseType, true);
                     }
                 }

--- a/src/MongoDB.Bson/Serialization/BsonSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializer.cs
@@ -321,8 +321,20 @@ namespace MongoDB.Bson.Serialization
         /// <returns>True if the type is discriminated.</returns>
         public static bool IsTypeDiscriminated(Type type)
         {
-            var typeInfo = type.GetTypeInfo();
-            return typeInfo.IsInterface || __discriminatedTypes.Contains(type);
+            if (type.GetTypeInfo().IsInterface)
+            {
+                return true;
+            }
+
+            __configLock.EnterReadLock();
+            try
+            {
+                return __discriminatedTypes.Contains(type);
+            }
+            finally
+            {
+                __configLock.ExitReadLock();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
[CSHARP-5633](https://jira.mongodb.org/browse/CSHARP-5633)