### PR TITLE
CSHARP-5675: Where possible, return null for average over the empty set

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToExecutableQueryTranslators/AverageMethodToExecutableQueryTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToExecutableQueryTranslators/AverageMethodToExecutableQueryTranslator.cs
@@ -161,7 +161,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecut
                 return ExecutableQuery.Create(
                     provider,
                     pipeline,
-                    !returnType.IsValueType || returnType.IsNullable()
+                    returnType.IsNullable() // Note: numeric types are never reference types
                         ? __singleOrDefaultFinalizer
                         : __singleFinalizer);
             }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationWithLinq2Tests/IntegrationTestBase.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationWithLinq2Tests/IntegrationTestBase.cs
@@ -253,7 +253,11 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationWithLinq2Tests
                 O = new List<long> { 100, 200, 300 },
                 P = 1.1,
                 U = -1.234565723762724332233489m,
-                Z = 10
+                Z = 10,
+                NullableW = 8,
+                NullableX = 9,
+                NullableY = 10,
+                NullableZ = 11
             };
             __collection.InsertOne(root);
         }
@@ -333,6 +337,14 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationWithLinq2Tests
             public int Y { get; set; }
 
             public decimal Z { get; set; }
+
+            public double? NullableW { get; set; }
+
+            public long? NullableX { get; set; }
+
+            public int? NullableY { get; set; }
+
+            public decimal? NullableZ { get; set; }
         }
 
         public class RootDescended : Root

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationWithLinq2Tests/MongoQueryableTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3ImplementationWithLinq2Tests/MongoQueryableTests.cs
@@ -136,6 +136,106 @@ namespace MongoDB.Driver.Tests.Linq.Linq3ImplementationWithLinq2Tests
         }
 
         [Fact]
+        public void Average_on_empty_set()
+        {
+            Action action = () => CreateQuery().Where(x => x.A == "__dummy__").Select(x => x.W).Average();
+
+            action.ShouldThrow<InvalidOperationException>().WithMessage("Sequence contains no elements");
+        }
+
+        [Fact]
+        public void Average_on_empty_set_with_selector()
+        {
+            Action action = () => CreateQuery().Where(x => x.A == "__dummy__").Average(x => x.X);
+
+            action.ShouldThrow<InvalidOperationException>().WithMessage("Sequence contains no elements");
+        }
+
+        [Fact]
+        public void AverageAsync_on_empty_set()
+        {
+            var subject = CreateQuery().Where(x => x.A == "__dummy__").Select(x => x.Y).AverageAsync();
+
+            subject.Awaiting(async q => await q)
+                .ShouldThrow<InvalidOperationException>()
+                .WithMessage("Sequence contains no elements");
+        }
+
+        [Fact]
+        public void AverageAsync_on_empty_set_with_selector()
+        {
+            var subject = CreateQuery().Where(x => x.A == "__dummy__").AverageAsync(x => x.Z);
+
+            subject.Awaiting(async q => await q)
+                .ShouldThrow<InvalidOperationException>()
+                .WithMessage("Sequence contains no elements");
+        }
+
+        [Fact]
+        public void Average_on_nullable_empty_set()
+        {
+            var result = CreateQuery().Where(x => x.A == "__dummy__").Select(x => x.NullableW).Average();
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public void Average_on_nullable_empty_set_with_selector()
+        {
+            var result = CreateQuery().Where(x => x.A == "__dummy__").Average(x => x.NullableX);
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public async Task AverageAsync_on_nullable_empty_set()
+        {
+            var result = await CreateQuery().Where(x => x.A == "__dummy__").Select(x => x.NullableY).AverageAsync();
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public async Task AverageAsync_on_nullable_empty_set_with_selector()
+        {
+            var result = await CreateQuery().Where(x => x.A == "__dummy__").AverageAsync(x => x.NullableZ);
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public void Average_on_empty_set_cast_to_nullable()
+        {
+            var result = CreateQuery().Where(x => x.A == "__dummy__").Select(x => (double?)x.W).Average();
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public void Average_on_empty_set_cast_to_nullable_with_selector()
+        {
+            var result = CreateQuery().Where(x => x.A == "__dummy__").Average(x => (long?)x.X);
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public async Task AverageAsync_on_empty_set_cast_to_nullable()
+        {
+            var result = await CreateQuery().Where(x => x.A == "__dummy__").Select(x => (int?)x.Y).AverageAsync();
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public async Task AverageAsync_on_empty_set_cast_to_nullable_with_selector()
+        {
+            var result = await CreateQuery().Where(x => x.A == "__dummy__").AverageAsync(x => (decimal?)x.Z);
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
         public void GroupBy_combined_with_a_previous_embedded_pipeline()
         {
             var bs = new List<string>


### PR DESCRIPTION
Fixes [CSHARP-5675: Average over empty collection of nullable types throws](https://jira.mongodb.org/browse/CSHARP-5675)

For the terminating operator, the fix is to use the SingleOrDefault finalizer when the type is nullable.