### PR TITLE
CSHARP-5702: Fix AWS Lambda Tests failed variant

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -2028,6 +2028,7 @@ task_groups:
             - "AWS_SESSION_TOKEN"
           env:
             LAMBDA_STACK_NAME: dbx-csharp-lambda
+            MONGODB_VERSION: "7.0"
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update


### PR DESCRIPTION
This PR fixes the used MongoDB version, however the variant is still not green because of another issue:
https://jira.mongodb.org/browse/DRIVERS-3250