### PR TITLE
CSHARP-5710: Fix RangeExplicitEncryptionTest definition

### DIFF
--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/DateOnlySerializerTests.cs
@@ -342,8 +342,8 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
         [Theory]
         [ParameterAttributeData]
         public void WithRepresentation_should_return_expected_result(
-            [Values(BsonType.Document, BsonType.DateTime, BsonType.Document, BsonType.String)] BsonType oldRepresentation,
-            [Values(BsonType.Document, BsonType.DateTime, BsonType.Document, BsonType.String)] BsonType newRepresentation)
+            [Values(BsonType.Document, BsonType.DateTime, BsonType.String)] BsonType oldRepresentation,
+            [Values(BsonType.Document, BsonType.DateTime, BsonType.String)] BsonType newRepresentation)
         {
             var subject = new DateOnlySerializer(oldRepresentation);
 

--- a/tests/MongoDB.Bson.Tests/Serialization/Serializers/TimeOnlySerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/Serializers/TimeOnlySerializerTests.cs
@@ -72,7 +72,7 @@ namespace MongoDB.Bson.Tests.Serialization.Serializers
             [Values(BsonType.String, BsonType.Int64, BsonType.Int32, BsonType.Double)]
             BsonType representation,
             [Values(TimeOnlyUnits.Ticks, TimeOnlyUnits.Hours, TimeOnlyUnits.Minutes, TimeOnlyUnits.Seconds,
-                TimeOnlyUnits.Milliseconds, TimeOnlyUnits.Microseconds, TimeOnlyUnits.Ticks, TimeOnlyUnits.Nanoseconds)]
+                TimeOnlyUnits.Milliseconds, TimeOnlyUnits.Microseconds, TimeOnlyUnits.Nanoseconds)]
             TimeOnlyUnits units)
         {
             var subject = new TimeOnlySerializer(representation, units);

--- a/tests/MongoDB.Driver.Tests/Core/Operations/DistinctOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/DistinctOperationTests.cs
@@ -153,7 +153,7 @@ namespace MongoDB.Driver.Core.Operations
         [Theory]
         [ParameterAttributeData]
         public void ReadConcern_get_and_set_should_work(
-            [Values(null, ReadConcernLevel.Local, ReadConcernLevel.Local)]
+            [Values(null, ReadConcernLevel.Local)]
             ReadConcernLevel? level)
         {
             var subject = new DistinctOperation<int>(_collectionNamespace, _valueSerializer, _fieldName, _messageEncoderSettings);

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -2184,7 +2184,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             [Range(1, 8)] int testCase,
             // test case rangeType values correspond to keys used in test configuration files
             [Values("DecimalNoPrecision", "DecimalPrecision", "DoubleNoPrecision", "DoublePrecision", "Date", "Int", "Long")] string rangeType,
-            [Values(false, false)] bool async)
+            [Values(true, false)] bool async)
         {
             // CSHARP-4606: Skip all fle2v2 tests on Mac until https://jira.mongodb.org/browse/SERVER-69563 propagates to EG Macs.
             RequirePlatform.Check().SkipWhen(SupportedOperatingSystem.MacOS);

--- a/tests/MongoDB.TestHelpers/XunitExtensions/ValuesAttribute.cs
+++ b/tests/MongoDB.TestHelpers/XunitExtensions/ValuesAttribute.cs
@@ -25,14 +25,14 @@ namespace MongoDB.TestHelpers.XunitExtensions
 
         public ValuesAttribute(params object[] values)
         {
-            _values =  values;
+            _values = values;
         }
 
         public object[] GenerateValues()
         {
             if (_values.Distinct().Count() != _values.Length)
             {
-                throw new ArgumentException();
+                throw new InvalidOperationException();
             }
 
             return _values;

--- a/tests/MongoDB.TestHelpers/XunitExtensions/ValuesAttribute.cs
+++ b/tests/MongoDB.TestHelpers/XunitExtensions/ValuesAttribute.cs
@@ -25,11 +25,16 @@ namespace MongoDB.TestHelpers.XunitExtensions
 
         public ValuesAttribute(params object[] values)
         {
-            _values = values;
+            _values =  values;
         }
 
         public object[] GenerateValues()
         {
+            if (_values.Distinct().Count() != _values.Length)
+            {
+                throw new ArgumentException();
+            }
+
             return _values;
         }
     }


### PR DESCRIPTION
Some tests have duplicated values in the Theory arguments. This leads to the warning like this:
```
[xUnit.net 00:00:11.08] MongoDB.Driver.Tests: Skipping test case with duplicate ID '2fb9bd387351a3fdf140e2605db341578e10eb73' ('MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests.ClientEncryptionProseTests.RangeExplicitEncryptionTest(testCase: 1, rangeType: "DecimalNoPrecision", async: False)' and 'MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests.ClientEncryptionProseTests.RangeExplicitEncryptionTest(testCase: 1, rangeType: "DecimalNoPrecision", async: False)')
```