### PR TITLE
Upgraded Snappier to 1.2.0 to let license compliance checks find its license

### DIFF
--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="DnsClient" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
-    <PackageReference Include="Snappier" Version="1.0.0" />
+    <PackageReference Include="Snappier" Version="1.2.0" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>


### PR DESCRIPTION
At the moment, the driver depends on [Snappier 1.0.0](https://www.nuget.org/packages/Snappier/1.0.0) which is probably badly annotated and doesn't provide a license identifier (though it provides a link to the license text)

This upgrade is to support automated license checks, which are required to ensure legal compliance.