### PR TITLE
CSHARP-5716: Update cake version to support newer Ubuntu versions

### DIFF
--- a/build.config
+++ b/build.config
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-CAKE_VERSION=2.2.0
+CAKE_VERSION=2.3.0
 DOTNET_VERSION=8.0.204


### PR DESCRIPTION
Older cake version fail to load on newer Ubuntu version, due to https://github.com/cake-build/cake/issues/3931