### PR TITLE
CSHARP-5894: Prevent deadlock during multi-theaded BsonClassMap serializer resolution

### DIFF
--- a/src/MongoDB.Bson/Serialization/Serializers/DictionarySerializerBase.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/DictionarySerializerBase.cs
@@ -420,8 +420,8 @@ namespace MongoDB.Bson.Serialization.Serializers
         public DictionarySerializerBase(DictionaryRepresentation dictionaryRepresentation, IBsonSerializerRegistry serializerRegistry)
             : this(
                 dictionaryRepresentation,
-                new Lazy<IBsonSerializer<TKey>>(() => serializerRegistry.GetSerializer<TKey>()),
-                new Lazy<IBsonSerializer<TValue>>(() => serializerRegistry.GetSerializer<TValue>()))
+                Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TKey>()),
+                Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TValue>()))
         {
             if (serializerRegistry == null)
             {

--- a/src/MongoDB.Bson/Serialization/Serializers/EnumerableSerializerBase.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/EnumerableSerializerBase.cs
@@ -64,7 +64,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("serializerRegistry");
             }
 
-            _lazyItemSerializer = new Lazy<IBsonSerializer>(() => serializerRegistry.GetSerializer(typeof(object)));
+            _lazyItemSerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer(typeof(object)));
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("serializerRegistry");
             }
 
-            _lazyItemSerializer = new Lazy<IBsonSerializer<TItem>>(() => serializerRegistry.GetSerializer<TItem>());
+            _lazyItemSerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TItem>());
         }
 
         // public properties

--- a/src/MongoDB.Bson/Serialization/Serializers/IEnumerableDeserializingAsCollectionSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/IEnumerableDeserializingAsCollectionSerializer.cs
@@ -81,7 +81,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException(nameof(serializerRegistry));
             }
 
-            _lazyItemSerializer = new Lazy<IBsonSerializer<TItem>>(serializerRegistry.GetSerializer<TItem>);
+            _lazyItemSerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TItem>());
         }
 
         // public properties

--- a/src/MongoDB.Bson/Serialization/Serializers/ImpliedImplementationInterfaceSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ImpliedImplementationInterfaceSerializer.cs
@@ -74,7 +74,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         /// </summary>
         /// <param name="serializerRegistry">The serializer registry.</param>
         public ImpliedImplementationInterfaceSerializer(IBsonSerializerRegistry serializerRegistry)
-            : this(new Lazy<IBsonSerializer<TImplementation>>(() => serializerRegistry.GetSerializer<TImplementation>()))
+            : this(Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TImplementation>()))
         {
             if (serializerRegistry == null)
             {

--- a/src/MongoDB.Bson/Serialization/Serializers/KeyValuePairSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/KeyValuePairSerializer.cs
@@ -124,8 +124,8 @@ namespace MongoDB.Bson.Serialization.Serializers
         public KeyValuePairSerializer(BsonType representation, IBsonSerializerRegistry serializerRegistry)
             : this(
                 representation,
-                new Lazy<IBsonSerializer<TKey>>(() => serializerRegistry.GetSerializer<TKey>()),
-                new Lazy<IBsonSerializer<TValue>>(() => serializerRegistry.GetSerializer<TValue>()))
+                Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TKey>()),
+                Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TValue>()))
         {
             if (serializerRegistry == null)
             {

--- a/src/MongoDB.Bson/Serialization/Serializers/Lazy.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/Lazy.cs
@@ -1,0 +1,33 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Threading;
+
+namespace MongoDB.Bson.Serialization.Serializers;
+
+internal static class Lazy
+{
+    /// <summary>
+    /// Creates a <see cref="Lazy{T}"/> with <see cref="LazyThreadSafetyMode.PublicationOnly"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the lazily initialized value.</typeparam>
+    /// <param name="valueFactory">The factory delegate that produces the value.</param>
+    /// <returns>A <see cref="Lazy{T}"/> configured with <see cref="LazyThreadSafetyMode.PublicationOnly"/>.</returns>
+    public static Lazy<T> CreatePublicationOnly<T>(Func<T> valueFactory)
+    {
+        return new Lazy<T>(valueFactory, LazyThreadSafetyMode.PublicationOnly);
+    }
+}

--- a/src/MongoDB.Bson/Serialization/Serializers/NullableSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/NullableSerializer.cs
@@ -160,7 +160,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("serializerRegistry");
             }
 
-            _lazySerializer = new Lazy<IBsonSerializer<T>>(() => serializerRegistry.GetSerializer<T>());
+            _lazySerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T>());
         }
 
         // public properties

--- a/src/MongoDB.Bson/Serialization/Serializers/SerializeAsNominalTypeSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/SerializeAsNominalTypeSerializer.cs
@@ -47,7 +47,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("nominalTypeSerializer");
             }
 
-            _lazyNominalTypeSerializer = new Lazy<IBsonSerializer<TNominalType>>(() => nominalTypeSerializer);
+            _lazyNominalTypeSerializer = Lazy.CreatePublicationOnly(() => nominalTypeSerializer);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("serializerRegistry");
             }
 
-            _lazyNominalTypeSerializer = new Lazy<IBsonSerializer<TNominalType>>(() => serializerRegistry.GetSerializer<TNominalType>());
+            _lazyNominalTypeSerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TNominalType>());
         }
 
         // public methods

--- a/src/MongoDB.Bson/Serialization/Serializers/SerializeAsNominalTypeSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/SerializeAsNominalTypeSerializer.cs
@@ -47,7 +47,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("nominalTypeSerializer");
             }
 
-            _lazyNominalTypeSerializer = Lazy.CreatePublicationOnly(() => nominalTypeSerializer);
+            _lazyNominalTypeSerializer = new Lazy<IBsonSerializer<TNominalType>>(() => nominalTypeSerializer);
         }
 
         /// <summary>

--- a/src/MongoDB.Bson/Serialization/Serializers/ThreeDimensionalArraySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ThreeDimensionalArraySerializer.cs
@@ -63,7 +63,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("serializerRegistry");
             }
 
-            _lazyItemSerializer = new Lazy<IBsonSerializer<TItem>>(() => serializerRegistry.GetSerializer<TItem>());
+            _lazyItemSerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TItem>());
         }
 
         // public properties

--- a/src/MongoDB.Bson/Serialization/Serializers/TupleSerializers.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/TupleSerializers.cs
@@ -138,7 +138,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
         }
 
         // public properties
@@ -236,8 +236,8 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException("serializerRegistry"); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
         }
 
         // public properties
@@ -350,9 +350,9 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
         }
 
         // public properties
@@ -479,10 +479,10 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
         }
 
         // public properties
@@ -625,11 +625,11 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
-            _lazyItem5Serializer = new Lazy<IBsonSerializer<T5>>(() => serializerRegistry.GetSerializer<T5>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem5Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T5>());
         }
 
         // public properties
@@ -787,12 +787,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException("serializerRegistry"); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
-            _lazyItem5Serializer = new Lazy<IBsonSerializer<T5>>(() => serializerRegistry.GetSerializer<T5>());
-            _lazyItem6Serializer = new Lazy<IBsonSerializer<T6>>(() => serializerRegistry.GetSerializer<T6>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem5Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T5>());
+            _lazyItem6Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T6>());
         }
 
         // public properties
@@ -965,13 +965,13 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
-            _lazyItem5Serializer = new Lazy<IBsonSerializer<T5>>(() => serializerRegistry.GetSerializer<T5>());
-            _lazyItem6Serializer = new Lazy<IBsonSerializer<T6>>(() => serializerRegistry.GetSerializer<T6>());
-            _lazyItem7Serializer = new Lazy<IBsonSerializer<T7>>(() => serializerRegistry.GetSerializer<T7>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem5Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T5>());
+            _lazyItem6Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T6>());
+            _lazyItem7Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T7>());
         }
 
         // public properties
@@ -1159,14 +1159,14 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
-            _lazyItem5Serializer = new Lazy<IBsonSerializer<T5>>(() => serializerRegistry.GetSerializer<T5>());
-            _lazyItem6Serializer = new Lazy<IBsonSerializer<T6>>(() => serializerRegistry.GetSerializer<T6>());
-            _lazyItem7Serializer = new Lazy<IBsonSerializer<T7>>(() => serializerRegistry.GetSerializer<T7>());
-            _lazyRestSerializer = new Lazy<IBsonSerializer<TRest>>(() => serializerRegistry.GetSerializer<TRest>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem5Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T5>());
+            _lazyItem6Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T6>());
+            _lazyItem7Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T7>());
+            _lazyRestSerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TRest>());
         }
 
         // public properties

--- a/src/MongoDB.Bson/Serialization/Serializers/TwoDimensionalArraySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/TwoDimensionalArraySerializer.cs
@@ -49,7 +49,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("itemSerializer");
             }
 
-            _lazyItemSerializer = new Lazy<IBsonSerializer<TItem>>(() => itemSerializer);
+            _lazyItemSerializer = Lazy.CreatePublicationOnly(() => itemSerializer);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("serializerRegistry");
             }
 
-            _lazyItemSerializer = new Lazy<IBsonSerializer<TItem>>(() => serializerRegistry.GetSerializer<TItem>());
+            _lazyItemSerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TItem>());
         }
 
         // public properties

--- a/src/MongoDB.Bson/Serialization/Serializers/TwoDimensionalArraySerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/TwoDimensionalArraySerializer.cs
@@ -49,7 +49,7 @@ namespace MongoDB.Bson.Serialization.Serializers
                 throw new ArgumentNullException("itemSerializer");
             }
 
-            _lazyItemSerializer = Lazy.CreatePublicationOnly(() => itemSerializer);
+            _lazyItemSerializer = new Lazy<IBsonSerializer<TItem>>(() => itemSerializer);
         }
 
         /// <summary>

--- a/src/MongoDB.Bson/Serialization/Serializers/ValueTupleSerializers.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/ValueTupleSerializers.cs
@@ -99,7 +99,7 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
         }
 
         // public properties
@@ -221,8 +221,8 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
         }
 
         // public properties
@@ -361,9 +361,9 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
         }
 
         // public properties
@@ -519,10 +519,10 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
         }
 
         // public properties
@@ -695,11 +695,11 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
-            _lazyItem5Serializer = new Lazy<IBsonSerializer<T5>>(() => serializerRegistry.GetSerializer<T5>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem5Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T5>());
         }
 
         // public properties
@@ -889,12 +889,12 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
-            _lazyItem5Serializer = new Lazy<IBsonSerializer<T5>>(() => serializerRegistry.GetSerializer<T5>());
-            _lazyItem6Serializer = new Lazy<IBsonSerializer<T6>>(() => serializerRegistry.GetSerializer<T6>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem5Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T5>());
+            _lazyItem6Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T6>());
         }
 
         // public properties
@@ -1101,13 +1101,13 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
-            _lazyItem5Serializer = new Lazy<IBsonSerializer<T5>>(() => serializerRegistry.GetSerializer<T5>());
-            _lazyItem6Serializer = new Lazy<IBsonSerializer<T6>>(() => serializerRegistry.GetSerializer<T6>());
-            _lazyItem7Serializer = new Lazy<IBsonSerializer<T7>>(() => serializerRegistry.GetSerializer<T7>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem5Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T5>());
+            _lazyItem6Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T6>());
+            _lazyItem7Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T7>());
         }
 
         // public properties
@@ -1332,14 +1332,14 @@ namespace MongoDB.Bson.Serialization.Serializers
         {
             if (serializerRegistry == null) { throw new ArgumentNullException(nameof(serializerRegistry)); }
 
-            _lazyItem1Serializer = new Lazy<IBsonSerializer<T1>>(() => serializerRegistry.GetSerializer<T1>());
-            _lazyItem2Serializer = new Lazy<IBsonSerializer<T2>>(() => serializerRegistry.GetSerializer<T2>());
-            _lazyItem3Serializer = new Lazy<IBsonSerializer<T3>>(() => serializerRegistry.GetSerializer<T3>());
-            _lazyItem4Serializer = new Lazy<IBsonSerializer<T4>>(() => serializerRegistry.GetSerializer<T4>());
-            _lazyItem5Serializer = new Lazy<IBsonSerializer<T5>>(() => serializerRegistry.GetSerializer<T5>());
-            _lazyItem6Serializer = new Lazy<IBsonSerializer<T6>>(() => serializerRegistry.GetSerializer<T6>());
-            _lazyItem7Serializer = new Lazy<IBsonSerializer<T7>>(() => serializerRegistry.GetSerializer<T7>());
-            _lazyRestSerializer = new Lazy<IBsonSerializer<TRest>>(() => serializerRegistry.GetSerializer<TRest>());
+            _lazyItem1Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T1>());
+            _lazyItem2Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T2>());
+            _lazyItem3Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T3>());
+            _lazyItem4Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T4>());
+            _lazyItem5Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T5>());
+            _lazyItem6Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T6>());
+            _lazyItem7Serializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<T7>());
+            _lazyRestSerializer = Lazy.CreatePublicationOnly(() => serializerRegistry.GetSerializer<TRest>());
         }
 
         // public properties

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonClassMapConcurrencyTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonClassMapConcurrencyTests.cs
@@ -1,0 +1,89 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Options;
+using Xunit;
+
+namespace MongoDB.Bson.Tests.Serialization
+{
+    public class BsonClassMapConcurrencyTests
+    {
+        [Fact]
+        public void LookupClassMap_should_not_deadlock_when_serializer_resolution_triggers_nested_class_map_lookup()
+        {
+            var mre1 = new ManualResetEventSlim(false);
+            var mre2 = new ManualResetEventSlim(false);
+
+            DeadlockTriggeringOptionsAttribute.__mre1 = mre1;
+            DeadlockTriggeringOptionsAttribute.__mre2 = mre2;
+
+            var taskB = Task.Run(() => BsonClassMap.LookupClassMap(typeof(ClassB)));
+
+            mre1.Wait(); // Wait until taskB acquires the lock on Lazy<IBsonSerializer<ClassA>>._state
+
+            var taskA = Task.Run(() => BsonClassMap.LookupClassMap(typeof(ClassC)));
+
+            Thread.Sleep(2000); // Wait until taskA acquires write-lock on BsonSerializer.ConfigLock
+
+            mre2.Set(); // Release taskB
+
+            var completed = Task.WhenAll(taskA, taskB).Wait(TimeSpan.FromSeconds(10));
+
+            completed.Should().BeTrue("LookupClassMap has deadlocked");
+        }
+
+        // nested types
+        private class ClassA
+        {
+            [DeadlockTriggeringOptions]
+            public int X { get; set; }
+        }
+
+        private class ClassB
+        {
+            [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfDocuments)]
+            public Dictionary<string, ClassA> Dictionary { get; set; } = new();
+        }
+
+        private class ClassC : ClassB
+        {
+        }
+
+        private class DeadlockTriggeringOptionsAttribute : BsonSerializationOptionsAttribute
+        {
+            internal static ManualResetEventSlim __mre1;
+            internal static ManualResetEventSlim __mre2;
+
+            protected override IBsonSerializer Apply(IBsonSerializer serializer)
+            {
+                var mre1 = Interlocked.Exchange(ref __mre1, null);
+                var mre2 = Interlocked.Exchange(ref __mre2, null);
+
+                mre1?.Set(); // Signal that taskB has acquired the lock on Lazy<IBsonSerializer<ClassA>>._state
+
+                mre2?.Wait(); // Wait until taskA acquires write-lock on BsonSerializer.ConfigLock
+
+                return serializer;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes [CSHARP-5894](https://jira.mongodb.org/browse/CSHARP-5894)

v3.x introduces a deadlock when deadlock occurs when two threads concurrently call `BsonClassMap.LookupClassMap` for related types involving two independent locks:

- **Thread A**: holds `ConfigLock` WRITE (inside `Freeze`) -> accesses a `Lazy<IBsonSerializer>.Value` on a cached `DictionarySerializer` -> blocks on the Lazy's internal lock
- **Thread B**: holds that Lazy's internal lock (factory still executing) -> needs `ConfigLock` WRITE to complete `LookupClassMap` for a nested type -> blocks

The shared `Lazy` instance comes from the serializer registry's `ConcurrentDictionary` cache - both threads resolve the same `Dictionary<string, T>` type and get back the same serializer object with the same Lazy fields.

## Regression from v2.x

This was not happening in 2.x as `AutoMap()` ran **inside** the `ConfigLock` WRITE lock which forced all resolution onto the same thread.

https://github.com/mongodb/mongo-csharp-driver/blob/v2.x/src/MongoDB.Bson/Serialization/BsonClassMap.cs#L350

    BsonSerializer.ConfigLock.EnterWriteLock();
    try
    {
        classMap.AutoMap();       // under WRITE lock
        RegisterClassMap(classMap);
        return classMap.Freeze();
    }

`ConfigLock` is a `ReaderWriterLockSlim` with `SupportsRecursion`, which allows recursive lock acquisition **on the same thread** to succeed without contention. No second thread could interleave because it would be blocked on `ConfigLock`.

v3.x moved `AutoMap()` outside the lock to solve a [different deadlock problem[(https://github.com/mongodb/mongo-csharp-driver/pull/1436/files).

    // current
    newClassMap.AutoMap();            // no lock held
    BsonSerializer.ConfigLock.EnterWriteLock();
    try
    {
        RegisterClassMap(newClassMap);
        return classMap.Freeze();
    }

This allows threads to do expensive `AutoMap` work in parallel, but it opened a window where Thread B can be mid-`AutoMap` (holding a Lazy internal lock, no `ConfigLock`) while Thread A acquires `ConfigLock` and reaches the same Lazy through a different path (`Freeze` -> `LookupClassMap(baseType)` -> `AutoMap` -> same cached serializer -> same Lazy).

## The fix

Changing `Lazy` instances on serializers whose factories call `serializerRegistry.GetSerializer` to use `LazyThreadSafetyMode.PublicationOnly` instead of the default `ExecutionAndPublication`.

The default mode acquires an internal lock so that only one thread executes the factory -- all other threads block on `.Value` until the first thread completes. This blocking is what creates the deadlock cycle.

`PublicationOnly` removes that internal lock entirely. Multiple threads can execute the factory concurrently, and the first result to complete is published as the value. The rest are discarded. This is safe here because `serializerRegistry.GetSerializer` is idempotent and the serializer instances are functionally equivalent.

Lazy instances wrapping already-resolved serializers (e.g. `new Lazy<T>(() => itemSerializer)`) are unchanged -- their factories return immediately and can never participate in a lock cycle.

This is achieved with a new "Lazy" helper that not only provides the PublicationOnly but uses the generic method resolution to avoid having to specify the type args to "new".

A test to cover it is included but it does not cover ALL possible factory resolvers.