### PR TITLE
CSHARP-5935: Command activities may be skipped when using pooled connection

### DIFF
--- a/src/MongoDB.Driver/Core/Connections/BinaryConnection.cs
+++ b/src/MongoDB.Driver/Core/Connections/BinaryConnection.cs
@@ -155,7 +155,11 @@ namespace MongoDB.Driver.Core.Connections
             {
                 _failedEventHasBeenRaised = true;
                 _eventLogger.LogAndPublish(new ConnectionFailedEvent(_connectionId, exception));
-                _commandEventHelper.ConnectionFailed(_connectionId, _description?.ServiceId, exception, IsInitializing);
+
+                if (_commandEventHelper.ShouldCallConnectionFailed)
+                {
+                    _commandEventHelper.ConnectionFailed(_connectionId, _description?.ServiceId, exception, IsInitializing);
+                }
             }
         }
 

--- a/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
@@ -78,6 +78,8 @@ namespace MongoDB.Driver.Core.Connections
 
         public bool ShouldCallErrorReceiving => _eventsNeedState || ShouldTraceWithActivityListener();
 
+        public bool ShouldCallConnectionFailed => (_shouldTrackFailed || ShouldTraceWithActivityListener()) && _state != null;
+
         private bool ShouldTraceWithActivityListener()
             => !_tracingDisabled && MongoTelemetry.ActivitySource.HasListeners();
 
@@ -227,16 +229,6 @@ namespace MongoDB.Driver.Core.Connections
 
         public void ConnectionFailed(ConnectionId connectionId, ObjectId? serviceId, Exception exception, bool skipLogging)
         {
-            if (!_shouldTrackFailed && !ShouldTraceWithActivityListener())
-            {
-                return;
-            }
-
-            if (_state == null)
-            {
-                return;
-            }
-
             CompleteFailedCommandActivity(exception);
 
             var requestIds = _state.Keys;

--- a/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
@@ -36,9 +36,9 @@ namespace MongoDB.Driver.Core.Connections
         private readonly EventLogger<LogCategories.Command> _eventLogger;
         private ConcurrentDictionary<int, CommandState> _state;
 
-        private readonly bool _shouldProcessRequestMessages;
+        private readonly bool _eventsNeedBeforeSending;
         private readonly bool _shouldTrackStarted;
-        private readonly bool _shouldTrackState;
+        private readonly bool _eventsNeedState;
         private readonly bool _shouldTrackFailed;
         private readonly bool _shouldTrackSucceeded;
         private readonly bool _tracingDisabled;
@@ -57,10 +57,10 @@ namespace MongoDB.Driver.Core.Connections
             _tracingDisabled = tracingOptions?.Disabled == true;
             _queryTextMaxLength = tracingOptions?.QueryTextMaxLength ?? 0;
 
-            _shouldTrackState = _shouldTrackSucceeded || _shouldTrackFailed;
-            _shouldProcessRequestMessages = _shouldTrackStarted || _shouldTrackState;
+            _eventsNeedState = _shouldTrackSucceeded || _shouldTrackFailed;
+            _eventsNeedBeforeSending = _shouldTrackStarted || _eventsNeedState;
 
-            if (_shouldTrackState)
+            if (_eventsNeedState)
             {
                 // we only need to track state if we have to raise
                 // a succeeded or failed event or for tracing
@@ -68,15 +68,15 @@ namespace MongoDB.Driver.Core.Connections
             }
         }
 
-        public bool ShouldCallBeforeSending => _shouldProcessRequestMessages || ShouldTraceWithActivityListener();
+        public bool ShouldCallBeforeSending => _eventsNeedBeforeSending || ShouldTraceWithActivityListener();
 
-        public bool ShouldCallAfterSending => _shouldTrackState || ShouldTraceWithActivityListener();
+        public bool ShouldCallAfterSending => _eventsNeedState || ShouldTraceWithActivityListener();
 
-        public bool ShouldCallErrorSending => _shouldTrackState || ShouldTraceWithActivityListener();
+        public bool ShouldCallErrorSending => _eventsNeedState || ShouldTraceWithActivityListener();
 
-        public bool ShouldCallAfterReceiving => _shouldTrackState || ShouldTraceWithActivityListener();
+        public bool ShouldCallAfterReceiving => _eventsNeedState || ShouldTraceWithActivityListener();
 
-        public bool ShouldCallErrorReceiving => _shouldTrackState || ShouldTraceWithActivityListener();
+        public bool ShouldCallErrorReceiving => _eventsNeedState || ShouldTraceWithActivityListener();
 
         private bool ShouldTraceWithActivityListener()
             => !_tracingDisabled && MongoTelemetry.ActivitySource.HasListeners();
@@ -742,16 +742,12 @@ namespace MongoDB.Driver.Core.Connections
         {
             var shouldTraceCommand = ShouldTraceWithActivityListener() && !shouldRedactCommand && !skipLogging;
 
-            if (!_shouldTrackState && !shouldTraceCommand)
+            if (!_eventsNeedState && !shouldTraceCommand)
             {
                 return;
             }
 
-            if (!_shouldTrackState && shouldTraceCommand)
-            {
-                // Lazy initialize state dictionary when tracing is needed but event tracking is not
-                _state ??= new ConcurrentDictionary<int, CommandState>();
-            }
+            _state ??= new ConcurrentDictionary<int, CommandState>();
 
             var commandState = new CommandState
             {

--- a/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
@@ -41,7 +41,7 @@ namespace MongoDB.Driver.Core.Connections
         private readonly bool _shouldTrackState;
         private readonly bool _shouldTrackFailed;
         private readonly bool _shouldTrackSucceeded;
-        private readonly bool _shouldTrace;
+        private readonly bool _tracingDisabled;
         private readonly int _queryTextMaxLength;
 
         private Activity _currentCommandActivity;
@@ -54,10 +54,10 @@ namespace MongoDB.Driver.Core.Connections
             _shouldTrackFailed = _eventLogger.IsEventTracked<CommandFailedEvent>();
             _shouldTrackStarted = _eventLogger.IsEventTracked<CommandStartedEvent>();
 
-            _shouldTrace = tracingOptions?.Disabled != true && MongoTelemetry.ActivitySource.HasListeners();
+            _tracingDisabled = tracingOptions?.Disabled == true;
             _queryTextMaxLength = tracingOptions?.QueryTextMaxLength ?? 0;
 
-            _shouldTrackState = _shouldTrackSucceeded || _shouldTrackFailed || _shouldTrace;
+            _shouldTrackState = _shouldTrackSucceeded || _shouldTrackFailed || !_tracingDisabled;
             _shouldProcessRequestMessages = _shouldTrackStarted || _shouldTrackState;
 
             if (_shouldTrackState)
@@ -223,7 +223,7 @@ namespace MongoDB.Driver.Core.Connections
 
         public void ConnectionFailed(ConnectionId connectionId, ObjectId? serviceId, Exception exception, bool skipLogging)
         {
-            if (!_shouldTrackFailed && !_shouldTrace)
+            if (!_shouldTrackFailed && _tracingDisabled)
             {
                 return;
             }
@@ -746,7 +746,7 @@ namespace MongoDB.Driver.Core.Connections
                 ShouldRedactReply = shouldRedactCommand
             };
 
-            if (_shouldTrace && !shouldRedactCommand && !skipLogging)
+            if (!_tracingDisabled && MongoTelemetry.ActivitySource.HasListeners() && !shouldRedactCommand && !skipLogging)
             {
                 _currentCommandActivity = MongoTelemetry.StartCommandActivity(
                     commandName,

--- a/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
@@ -34,7 +34,7 @@ namespace MongoDB.Driver.Core.Connections
     internal class CommandEventHelper
     {
         private readonly EventLogger<LogCategories.Command> _eventLogger;
-        private readonly ConcurrentDictionary<int, CommandState> _state;
+        private ConcurrentDictionary<int, CommandState> _state;
 
         private readonly bool _shouldProcessRequestMessages;
         private readonly bool _shouldTrackStarted;
@@ -57,7 +57,7 @@ namespace MongoDB.Driver.Core.Connections
             _tracingDisabled = tracingOptions?.Disabled == true;
             _queryTextMaxLength = tracingOptions?.QueryTextMaxLength ?? 0;
 
-            _shouldTrackState = _shouldTrackSucceeded || _shouldTrackFailed || !_tracingDisabled;
+            _shouldTrackState = _shouldTrackSucceeded || _shouldTrackFailed;
             _shouldProcessRequestMessages = _shouldTrackStarted || _shouldTrackState;
 
             if (_shouldTrackState)
@@ -68,30 +68,18 @@ namespace MongoDB.Driver.Core.Connections
             }
         }
 
-        public bool ShouldCallBeforeSending
-        {
-            get { return _shouldProcessRequestMessages; }
-        }
+        public bool ShouldCallBeforeSending => _shouldProcessRequestMessages || ShouldTraceWithActivityListener();
 
-        public bool ShouldCallAfterSending
-        {
-            get { return _shouldTrackState; }
-        }
+        public bool ShouldCallAfterSending => _shouldTrackState || ShouldTraceWithActivityListener();
 
-        public bool ShouldCallErrorSending
-        {
-            get { return _shouldTrackState; }
-        }
+        public bool ShouldCallErrorSending => _shouldTrackState || ShouldTraceWithActivityListener();
 
-        public bool ShouldCallAfterReceiving
-        {
-            get { return _shouldTrackState; }
-        }
+        public bool ShouldCallAfterReceiving => _shouldTrackState || ShouldTraceWithActivityListener();
 
-        public bool ShouldCallErrorReceiving
-        {
-            get { return _shouldTrackState; }
-        }
+        public bool ShouldCallErrorReceiving => _shouldTrackState || ShouldTraceWithActivityListener();
+
+        private bool ShouldTraceWithActivityListener()
+            => !_tracingDisabled && MongoTelemetry.ActivitySource.HasListeners();
 
         public void CompleteFailedCommandActivity(Exception exception)
         {
@@ -129,8 +117,12 @@ namespace MongoDB.Driver.Core.Connections
 
         public void AfterSending(RequestMessage message, ConnectionId connectionId, ObjectId? serviceId, bool skipLogging)
         {
-            CommandState state;
-            if (_state.TryGetValue(message.RequestId, out state) &&
+            if (_state == null)
+            {
+                return;
+            }
+
+            if (_state.TryGetValue(message.RequestId, out var state) &&
                 state.ExpectedResponseType == ExpectedResponseType.None)
             {
                 state.Stopwatch.Stop();
@@ -157,12 +149,16 @@ namespace MongoDB.Driver.Core.Connections
 
         public void ErrorSending(RequestMessage message, ConnectionId connectionId, ObjectId? serviceId, Exception exception, bool skipLogging)
         {
-            CommandState state;
-            if (_state.TryRemove(message.RequestId, out state))
+            CompleteCommandActivityWithException(exception);
+
+            if (_state == null)
+            {
+                return;
+            }
+
+            if (_state.TryRemove(message.RequestId, out var state))
             {
                 state.Stopwatch.Stop();
-
-                CompleteCommandActivityWithException(exception);
 
                 _eventLogger.LogAndPublish(new CommandFailedEvent(
                         state.CommandName,
@@ -179,8 +175,12 @@ namespace MongoDB.Driver.Core.Connections
 
         public void AfterReceiving(ResponseMessage message, IByteBuffer buffer, ConnectionId connectionId, ObjectId? serviceId, MessageEncoderSettings encoderSettings, bool skipLogging)
         {
-            CommandState state;
-            if (!_state.TryRemove(message.ResponseTo, out state))
+            if (_state == null)
+            {
+                return;
+            }
+
+            if (!_state.TryRemove(message.ResponseTo, out var state))
             {
                 // this indicates a bug in the sending portion...
                 return;
@@ -198,16 +198,20 @@ namespace MongoDB.Driver.Core.Connections
 
         public void ErrorReceiving(int responseTo, ConnectionId connectionId, ObjectId? serviceId, Exception exception, bool skipLogging)
         {
-            CommandState state;
-            if (!_state.TryRemove(responseTo, out state))
+            CompleteCommandActivityWithException(exception);
+
+            if (_state == null)
+            {
+                return;
+            }
+
+            if (!_state.TryRemove(responseTo, out var state))
             {
                 // this indicates a bug in the sending portion...
                 return;
             }
 
             state.Stopwatch.Stop();
-
-            CompleteCommandActivityWithException(exception);
 
             _eventLogger.LogAndPublish(new CommandFailedEvent(
                 state.CommandName,
@@ -223,12 +227,17 @@ namespace MongoDB.Driver.Core.Connections
 
         public void ConnectionFailed(ConnectionId connectionId, ObjectId? serviceId, Exception exception, bool skipLogging)
         {
-            if (!_shouldTrackFailed && (_tracingDisabled || !MongoTelemetry.ActivitySource.HasListeners()))
+            if (!_shouldTrackFailed && !ShouldTraceWithActivityListener())
             {
                 return;
             }
 
             CompleteCommandActivityWithException(exception);
+
+            if (_state == null)
+            {
+                return;
+            }
 
             var requestIds = _state.Keys;
             foreach (var requestId in requestIds)
@@ -731,9 +740,17 @@ namespace MongoDB.Driver.Core.Connections
             BsonDocument sessionId,
             long? transactionNumber)
         {
-            if (!_shouldTrackState)
+            var shouldTraceCommand = ShouldTraceWithActivityListener() && !shouldRedactCommand && !skipLogging;
+
+            if (!_shouldTrackState && !shouldTraceCommand)
             {
                 return;
+            }
+
+            if (!_shouldTrackState && shouldTraceCommand)
+            {
+                // Lazy initialize state dictionary when tracing is needed but event tracking is not
+                _state ??= new ConcurrentDictionary<int, CommandState>();
             }
 
             var commandState = new CommandState
@@ -746,7 +763,7 @@ namespace MongoDB.Driver.Core.Connections
                 ShouldRedactReply = shouldRedactCommand
             };
 
-            if (!_tracingDisabled && MongoTelemetry.ActivitySource.HasListeners() && !shouldRedactCommand && !skipLogging)
+            if (shouldTraceCommand)
             {
                 _currentCommandActivity = MongoTelemetry.StartCommandActivity(
                     commandName,

--- a/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
@@ -223,7 +223,7 @@ namespace MongoDB.Driver.Core.Connections
 
         public void ConnectionFailed(ConnectionId connectionId, ObjectId? serviceId, Exception exception, bool skipLogging)
         {
-            if (!_shouldTrackFailed && _tracingDisabled)
+            if (!_shouldTrackFailed && (_tracingDisabled || !MongoTelemetry.ActivitySource.HasListeners()))
             {
                 return;
             }

--- a/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver/Core/Connections/CommandEventHelper.cs
@@ -149,12 +149,12 @@ namespace MongoDB.Driver.Core.Connections
 
         public void ErrorSending(RequestMessage message, ConnectionId connectionId, ObjectId? serviceId, Exception exception, bool skipLogging)
         {
-            CompleteCommandActivityWithException(exception);
-
             if (_state == null)
             {
                 return;
             }
+
+            CompleteFailedCommandActivity(exception);
 
             if (_state.TryRemove(message.RequestId, out var state))
             {
@@ -198,12 +198,12 @@ namespace MongoDB.Driver.Core.Connections
 
         public void ErrorReceiving(int responseTo, ConnectionId connectionId, ObjectId? serviceId, Exception exception, bool skipLogging)
         {
-            CompleteCommandActivityWithException(exception);
-
             if (_state == null)
             {
                 return;
             }
+
+            CompleteFailedCommandActivity(exception);
 
             if (!_state.TryRemove(responseTo, out var state))
             {
@@ -232,12 +232,12 @@ namespace MongoDB.Driver.Core.Connections
                 return;
             }
 
-            CompleteCommandActivityWithException(exception);
-
             if (_state == null)
             {
                 return;
             }
+
+            CompleteFailedCommandActivity(exception);
 
             var requestIds = _state.Keys;
             foreach (var requestId in requestIds)
@@ -783,16 +783,6 @@ namespace MongoDB.Driver.Core.Connections
             if (_currentCommandActivity is not null)
             {
                 MongoTelemetry.CompleteCommandActivity(_currentCommandActivity, reply);
-                _currentCommandActivity = null;
-            }
-        }
-
-        private void CompleteCommandActivityWithException(Exception exception)
-        {
-            if (_currentCommandActivity is not null)
-            {
-                MongoTelemetry.RecordException(_currentCommandActivity, exception);
-                _currentCommandActivity.Dispose();
                 _currentCommandActivity = null;
             }
         }

--- a/tests/MongoDB.Driver.Tests/Core/Connections/CommandEventHelperTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Connections/CommandEventHelperTests.cs
@@ -58,8 +58,7 @@ namespace MongoDB.Driver.Core.Connections
         public void ShouldTrackState_should_be_correct(
             [Values(false, true)] bool logCommands,
             [Values(false, true)] bool captureCommandSucceeded,
-            [Values(false, true)] bool captureCommandFailed,
-            [Values(false, true)] bool traceCommands)
+            [Values(false, true)] bool captureCommandFailed)
         {
             var mockLogger = new Mock<ILogger<LogCategories.Command>>();
             mockLogger.Setup(m => m.IsEnabled(LogLevel.Debug)).Returns(logCommands);
@@ -76,7 +75,7 @@ namespace MongoDB.Driver.Core.Connections
             }
 
             var eventLogger = new EventLogger<LogCategories.Command>(eventCapturer, mockLogger.Object);
-            var tracingOptions = traceCommands ? new TracingOptions() : new TracingOptions { Disabled = true };
+            var tracingOptions = new TracingOptions { Disabled = true };
             var commandHelper = new CommandEventHelper(eventLogger, tracingOptions);
 
             // No ActivityListener, so tracing doesn't contribute to _shouldTrackState
@@ -85,7 +84,7 @@ namespace MongoDB.Driver.Core.Connections
 
         [Theory]
         [ParameterAttributeData]
-        public void ShouldTrackState_should_be_correct_with_activity_listener(
+        public void Callbacks_turn_on_when_listener_is_added_even_if_no_events(
             [Values(false, true)] bool logCommands,
             [Values(false, true)] bool captureCommandSucceeded,
             [Values(false, true)] bool captureCommandFailed,
@@ -94,13 +93,6 @@ namespace MongoDB.Driver.Core.Connections
             ActivityListener listener = null;
             try
             {
-                listener = new ActivityListener
-                {
-                    ShouldListenTo = source => source.Name == "MongoDB.Driver",
-                    Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
-                };
-                ActivitySource.AddActivityListener(listener);
-
                 var mockLogger = new Mock<ILogger<LogCategories.Command>>();
                 mockLogger.Setup(m => m.IsEnabled(LogLevel.Debug)).Returns(logCommands);
 
@@ -119,9 +111,27 @@ namespace MongoDB.Driver.Core.Connections
                 var tracingOptions = traceCommands ? new TracingOptions() : new TracingOptions { Disabled = true };
                 var commandHelper = new CommandEventHelper(eventLogger, tracingOptions);
 
-                // With the new implementation, _shouldTrackState only reflects event tracking,
-                // not tracing with listeners (which is checked dynamically at execution time)
-                commandHelper._shouldTrackState().Should().Be(logCommands || captureCommandSucceeded || captureCommandFailed);
+                // When there are no listeners, these only return true if logging is enabled or an event is registered,
+                // regardless of whether tracing is enabled.
+                commandHelper.ShouldCallBeforeSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands);
+                commandHelper.ShouldCallAfterSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands);
+                commandHelper.ShouldCallErrorSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands);
+                commandHelper.ShouldCallAfterReceiving.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands);
+                commandHelper.ShouldCallErrorReceiving.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands);
+
+                listener = new ActivityListener
+                {
+                    ShouldListenTo = source => source.Name == "MongoDB.Driver",
+                    Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+                };
+                ActivitySource.AddActivityListener(listener);
+
+                // With listeners registered, these always return true when unless everything is disabled.
+                commandHelper.ShouldCallBeforeSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands || traceCommands);
+                commandHelper.ShouldCallAfterSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands || traceCommands);
+                commandHelper.ShouldCallErrorSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands || traceCommands);
+                commandHelper.ShouldCallAfterReceiving.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands || traceCommands);
+                commandHelper.ShouldCallErrorReceiving.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands || traceCommands);
             }
             finally
             {

--- a/tests/MongoDB.Driver.Tests/Core/Connections/CommandEventHelperTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Connections/CommandEventHelperTests.cs
@@ -119,7 +119,9 @@ namespace MongoDB.Driver.Core.Connections
                 var tracingOptions = traceCommands ? new TracingOptions() : new TracingOptions { Disabled = true };
                 var commandHelper = new CommandEventHelper(eventLogger, tracingOptions);
 
-                commandHelper._shouldTrackState().Should().Be(logCommands || captureCommandSucceeded || captureCommandFailed || traceCommands);
+                // With the new implementation, _shouldTrackState only reflects event tracking,
+                // not tracing with listeners (which is checked dynamically at execution time)
+                commandHelper._shouldTrackState().Should().Be(logCommands || captureCommandSucceeded || captureCommandFailed);
             }
             finally
             {

--- a/tests/MongoDB.Driver.Tests/Core/Connections/CommandEventHelperTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Connections/CommandEventHelperTests.cs
@@ -78,8 +78,8 @@ namespace MongoDB.Driver.Core.Connections
             var tracingOptions = new TracingOptions { Disabled = true };
             var commandHelper = new CommandEventHelper(eventLogger, tracingOptions);
 
-            // No ActivityListener, so tracing doesn't contribute to _shouldTrackState
-            commandHelper._shouldTrackState().Should().Be(logCommands || captureCommandSucceeded || captureCommandFailed);
+            // No ActivityListener, so tracing doesn't contribute to _eventsNeedState
+            commandHelper._eventsNeedState().Should().Be(logCommands || captureCommandSucceeded || captureCommandFailed);
         }
 
         [Theory]
@@ -142,8 +142,8 @@ namespace MongoDB.Driver.Core.Connections
 
     internal static class CommandEventHelperReflector
     {
-        public static bool _shouldTrackState(this CommandEventHelper commandEventHelper) =>
-            (bool)Reflector.GetFieldValue(commandEventHelper, nameof(_shouldTrackState));
+        public static bool _eventsNeedState(this CommandEventHelper commandEventHelper) =>
+            (bool)Reflector.GetFieldValue(commandEventHelper, nameof(_eventsNeedState));
 
 
         public static bool ShouldRedactCommand(BsonDocument command) =>

--- a/tests/MongoDB.Driver.Tests/Core/Connections/CommandEventHelperTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Connections/CommandEventHelperTests.cs
@@ -126,7 +126,7 @@ namespace MongoDB.Driver.Core.Connections
                 };
                 ActivitySource.AddActivityListener(listener);
 
-                // With listeners registered, these always return true when unless everything is disabled.
+                // With listeners registered, these always return true unless everything is disabled.
                 commandHelper.ShouldCallBeforeSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands || traceCommands);
                 commandHelper.ShouldCallAfterSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands || traceCommands);
                 commandHelper.ShouldCallErrorSending.Should().Be(captureCommandSucceeded || captureCommandFailed || logCommands || traceCommands);

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/LibmongocryptTests.cs
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/LibmongocryptTests.cs
@@ -59,8 +59,7 @@ namespace MongoDB.Driver.SmokeTests.Sdk
                 kmsProviders.Add("local", localKey);
 
                 var keyVaultNamespace = CollectionNamespace.FromFullName("encryption.__keyVault");
-                var connectionString = Environment.GetEnvironmentVariable("MONGODB_URI");
-                var keyVaultMongoClient = string.IsNullOrWhiteSpace(connectionString) ? new MongoClient() : new MongoClient(connectionString);
+                var keyVaultMongoClient = new MongoClient(InfrastructureUtilities.MongoUri);
                 var clientEncryptionSettings = new ClientEncryptionOptions(
                     keyVaultMongoClient,
                     keyVaultNamespace,

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/LibmongocryptTests.cs
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/LibmongocryptTests.cs
@@ -59,7 +59,8 @@ namespace MongoDB.Driver.SmokeTests.Sdk
                 kmsProviders.Add("local", localKey);
 
                 var keyVaultNamespace = CollectionNamespace.FromFullName("encryption.__keyVault");
-                var keyVaultMongoClient = new MongoClient();
+                var connectionString = Environment.GetEnvironmentVariable("MONGODB_URI");
+                var keyVaultMongoClient = string.IsNullOrWhiteSpace(connectionString) ? new MongoClient() : new MongoClient(connectionString);
                 var clientEncryptionSettings = new ClientEncryptionOptions(
                     keyVaultMongoClient,
                     keyVaultNamespace,

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/LibmongocryptTests.cs
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/LibmongocryptTests.cs
@@ -59,7 +59,7 @@ namespace MongoDB.Driver.SmokeTests.Sdk
                 kmsProviders.Add("local", localKey);
 
                 var keyVaultNamespace = CollectionNamespace.FromFullName("encryption.__keyVault");
-                var keyVaultMongoClient = new MongoClient(InfrastructureUtilities.MongoUri);
+                var keyVaultMongoClient = new MongoClient();
                 var clientEncryptionSettings = new ClientEncryptionOptions(
                     keyVaultMongoClient,
                     keyVaultNamespace,

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/OpenTelemetryTests.cs
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/OpenTelemetryTests.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -87,7 +86,7 @@ namespace MongoDB.Driver.SmokeTests.Sdk
 
         private static ActivityListener CreateActivityListener(out IReadOnlyCollection<Activity> capturedActivities)
         {
-            var activities = new ConcurrentBag<Activity>();
+            var activities = new List<Activity>();
             var listener = new ActivityListener
             {
                 ShouldListenTo = source => source.Name == MongoTelemetry.ActivitySourceName,

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/OpenTelemetryTests.cs
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/OpenTelemetryTests.cs
@@ -17,7 +17,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Configuration;
@@ -45,8 +44,6 @@ namespace MongoDB.Driver.SmokeTests.Sdk
                 collection.InsertOne(new BsonDocument("name", "test"));
                 collection.Find(Builders<BsonDocument>.Filter.Empty).FirstOrDefault();
                 collection.DeleteOne(Builders<BsonDocument>.Filter.Eq("name", "test"));
-
-                SpinWait.SpinUntil(() => capturedActivities.Count >= 6, millisecondsTimeout: 10000);
             }
             finally
             {

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/OpenTelemetryTests.cs
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/OpenTelemetryTests.cs
@@ -26,7 +26,6 @@ namespace MongoDB.Driver.SmokeTests.Sdk
     [Trait("Category", "Integration")]
     public sealed class OpenTelemetryTests
     {
-
         [Fact]
         public void MongoClient_should_create_activities_when_tracing_enabled()
         {

--- a/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/OpenTelemetryTests.cs
+++ b/tests/SmokeTests/MongoDB.Driver.SmokeTests.Sdk/OpenTelemetryTests.cs
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Configuration;
@@ -43,6 +45,8 @@ namespace MongoDB.Driver.SmokeTests.Sdk
                 collection.InsertOne(new BsonDocument("name", "test"));
                 collection.Find(Builders<BsonDocument>.Filter.Empty).FirstOrDefault();
                 collection.DeleteOne(Builders<BsonDocument>.Filter.Eq("name", "test"));
+
+                SpinWait.SpinUntil(() => capturedActivities.Count >= 6, millisecondsTimeout: 10000);
             }
             finally
             {
@@ -84,9 +88,9 @@ namespace MongoDB.Driver.SmokeTests.Sdk
             capturedActivities.Should().BeEmpty();
         }
 
-        private static ActivityListener CreateActivityListener(out List<Activity> capturedActivities)
+        private static ActivityListener CreateActivityListener(out IReadOnlyCollection<Activity> capturedActivities)
         {
-            var activities = new List<Activity>();
+            var activities = new ConcurrentBag<Activity>();
             var listener = new ActivityListener
             {
                 ShouldListenTo = source => source.Name == MongoTelemetry.ActivitySourceName,


### PR DESCRIPTION
I was looking at flaky tests, and found MongoClient_should_create_activities_when_tracing_enabled was failing occasionally. Turns out it was an actual bug.

New fix by Claude to avoid tracking state.

## Summary

I've successfully refactored the code to fix the bug where activity listeners were being checked when the connection was created (at which point none may be set), but not checked again when the connection was pulled from the pool.

### Key Changes:

1. **Constructor (`CommandEventHelper.cs:60`)**: Removed the listener check from `_shouldTrackState` initialization. Now `_shouldTrackState` only depends on whether event tracking is needed (`_shouldTrackSucceeded || _shouldTrackFailed`), not on tracing with listeners.

2. **Property Getters (`CommandEventHelper.cs:71-94`)**: Updated all property getters (`ShouldCallBeforeSending`, `ShouldCallAfterSending`, etc.) to dynamically check `MongoTelemetry.ActivitySource.HasListeners()` at execution time, ensuring that activity tracing is detected when connections are obtained from the pool.

3. **Lazy State Initialization (`CommandEventHelper.cs:37, 741-745`)**: Changed `_state` from `readonly` to allow lazy initialization. The state dictionary is now only created when needed - either for event tracking or when tracing with listeners is detected at runtime.

4. **Null Safety (`CommandEventHelper.cs:132, 165, 192, 216, 233`)**: Added null checks before accessing `_state` in all methods to handle cases where state tracking hasn't been initialized.

5. **TrackCommandState (`CommandEventHelper.cs:734-770`)**: Updated to check for listeners at execution time and lazily initialize the state dictionary only when tracing is actually needed.

6. **Test Update (`CommandEventHelperTests.cs:122-124`)**: Updated the test to reflect the new behavior where `_shouldTrackState` only reflects event tracking, not tracing with listeners (which is now checked dynamically).

### Benefits:

- **Bug Fixed**: Activity listeners are now checked when connections are obtained from the pool, not just when they're created
- **No Unnecessary State Tracking**: State tracking is only enabled when actually needed (either for events or when listeners are registered), avoiding the performance overhead of always tracking state
- **Backward Compatible**: The behavior is the same for all scenarios, just more efficient

The changes ensure that the driver properly detects activity listeners whenever a connection is used, whether it's newly created or retrieved from the pool, while avoiding unnecessary state tracking when no listeners are registered.

----

Junie (Opus 4.6) says:

### Root Cause

`_shouldTrace` in `CommandEventHelper` was set **once** at connection construction time via `MongoTelemetry.ActivitySource.HasListeners()`. Since connections are pooled and reused, if a connection was created before an `ActivityListener` was registered (or by a test with tracing disabled), `_shouldTrace` remained `false` permanently for that connection — command activities were never created even when a listener was later active.