### PR TITLE
CSHARP-2150 Add check that the serializer's ValueType matches the type when registering the serializer

### DIFF
--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -141,6 +141,12 @@ namespace MongoDB.Bson.Serialization
             }
             EnsureRegisteringASerializerForThisTypeIsAllowed(type);
 
+            if (type != serializer.ValueType)
+            {
+                var message = string.Format("A serializer of type {0} cannot be registered for type {1}.", BsonUtils.GetFriendlyTypeName(serializer.ValueType), BsonUtils.GetFriendlyTypeName(type));
+                throw new BsonSerializationException(message);
+            }
+
             if (_cache.TryAdd(type, serializer))
             {
                 return true;

--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -191,7 +191,7 @@ namespace MongoDB.Bson.Serialization
                 var message = string.Format("Generic type {0} has unassigned type parameters.", BsonUtils.GetFriendlyTypeName(type));
                 throw new ArgumentException(message, "type");
             }
-            if (type != serializer.ValueType)
+            if (!serializer.ValueType.IsAssignableFrom(type))
             {
                 throw new BsonSerializationException($"A serializer for {BsonUtils.GetFriendlyTypeName(serializer.ValueType)} cannot be registered for type {BsonUtils.GetFriendlyTypeName(type)}.");
             }

--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -93,13 +93,7 @@ namespace MongoDB.Bson.Serialization
             {
                 throw new ArgumentNullException("serializer");
             }
-            EnsureRegisteringASerializerForThisTypeIsAllowed(type);
-
-            if (type != serializer.ValueType)
-            {
-                var message = string.Format("A serializer of type {0} cannot be registered for type {1}.", BsonUtils.GetFriendlyTypeName(serializer.ValueType), BsonUtils.GetFriendlyTypeName(type));
-                throw new BsonSerializationException(message);
-            }
+            EnsureRegisteringASerializerForThisTypeIsAllowed(serializer, type);
 
             if (!_cache.TryAdd(type, serializer))
             {
@@ -139,13 +133,7 @@ namespace MongoDB.Bson.Serialization
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
-            EnsureRegisteringASerializerForThisTypeIsAllowed(type);
-
-            if (type != serializer.ValueType)
-            {
-                var message = string.Format("A serializer of type {0} cannot be registered for type {1}.", BsonUtils.GetFriendlyTypeName(serializer.ValueType), BsonUtils.GetFriendlyTypeName(type));
-                throw new BsonSerializationException(message);
-            }
+            EnsureRegisteringASerializerForThisTypeIsAllowed(serializer, type);
 
             if (_cache.TryAdd(type, serializer))
             {
@@ -190,7 +178,7 @@ namespace MongoDB.Bson.Serialization
             throw new BsonSerializationException(message);
         }
 
-        private void EnsureRegisteringASerializerForThisTypeIsAllowed(Type type)
+        private void EnsureRegisteringASerializerForThisTypeIsAllowed(IBsonSerializer serializer, Type type)
         {
             var typeInfo = type.GetTypeInfo();
             if (typeof(BsonValue).GetTypeInfo().IsAssignableFrom(type))
@@ -202,6 +190,10 @@ namespace MongoDB.Bson.Serialization
             {
                 var message = string.Format("Generic type {0} has unassigned type parameters.", BsonUtils.GetFriendlyTypeName(type));
                 throw new ArgumentException(message, "type");
+            }
+            if (type != serializer.ValueType)
+            {
+                throw new BsonSerializationException($"A serializer for {BsonUtils.GetFriendlyTypeName(serializer.ValueType)} cannot be registered for type {BsonUtils.GetFriendlyTypeName(type)}.");
             }
         }
     }

--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -198,6 +198,5 @@ namespace MongoDB.Bson.Serialization
                 throw new ArgumentException(message, "type");
             }
         }
-
     }
 }

--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -95,6 +95,12 @@ namespace MongoDB.Bson.Serialization
             }
             EnsureRegisteringASerializerForThisTypeIsAllowed(type);
 
+            if (type != serializer.ValueType)
+            {
+                var message = string.Format("A serializer of type {0} cannot be registered for type {1}.", BsonUtils.GetFriendlyTypeName(serializer.ValueType), BsonUtils.GetFriendlyTypeName(type));
+                throw new BsonSerializationException(message);
+            }
+
             if (!_cache.TryAdd(type, serializer))
             {
                 var message = string.Format("There is already a serializer registered for type {0}.", BsonUtils.GetFriendlyTypeName(type));
@@ -192,5 +198,6 @@ namespace MongoDB.Bson.Serialization
                 throw new ArgumentException(message, "type");
             }
         }
+
     }
 }

--- a/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
+++ b/src/MongoDB.Bson/Serialization/BsonSerializerRegistry.cs
@@ -93,7 +93,8 @@ namespace MongoDB.Bson.Serialization
             {
                 throw new ArgumentNullException("serializer");
             }
-            EnsureRegisteringASerializerForThisTypeIsAllowed(serializer, type);
+            EnsureRegisteringASerializerForThisTypeIsAllowed(type);
+            EnsureSerializerIsCompatibleWithType(serializer, type);
 
             if (!_cache.TryAdd(type, serializer))
             {
@@ -133,7 +134,8 @@ namespace MongoDB.Bson.Serialization
             {
                 throw new ArgumentNullException(nameof(serializer));
             }
-            EnsureRegisteringASerializerForThisTypeIsAllowed(serializer, type);
+            EnsureRegisteringASerializerForThisTypeIsAllowed(type);
+            EnsureSerializerIsCompatibleWithType(serializer, type);
 
             if (_cache.TryAdd(type, serializer))
             {
@@ -178,7 +180,7 @@ namespace MongoDB.Bson.Serialization
             throw new BsonSerializationException(message);
         }
 
-        private void EnsureRegisteringASerializerForThisTypeIsAllowed(IBsonSerializer serializer, Type type)
+        private void EnsureRegisteringASerializerForThisTypeIsAllowed(Type type)
         {
             var typeInfo = type.GetTypeInfo();
             if (typeof(BsonValue).GetTypeInfo().IsAssignableFrom(type))
@@ -191,9 +193,13 @@ namespace MongoDB.Bson.Serialization
                 var message = string.Format("Generic type {0} has unassigned type parameters.", BsonUtils.GetFriendlyTypeName(type));
                 throw new ArgumentException(message, "type");
             }
+        }
+
+        private void EnsureSerializerIsCompatibleWithType(IBsonSerializer serializer, Type type)
+        {
             if (!serializer.ValueType.IsAssignableFrom(type))
             {
-                throw new BsonSerializationException($"A serializer for {BsonUtils.GetFriendlyTypeName(serializer.ValueType)} cannot be registered for type {BsonUtils.GetFriendlyTypeName(type)}.");
+                throw new ArgumentException($"A serializer for {BsonUtils.GetFriendlyTypeName(serializer.ValueType)} cannot be registered for type {BsonUtils.GetFriendlyTypeName(type)}.");
             }
         }
     }

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
@@ -100,17 +100,23 @@ namespace MongoDB.Bson.Tests.Serialization
         [Fact]
         public void RegisterSerializer_should_throw_when_type_and_serializer_do_not_match()
         {
+            var subject = new BsonSerializerRegistry();
             var intSerializer = new Int32Serializer();
-            var exception = Record.Exception(() => BsonSerializer.RegisterSerializer(typeof(long), intSerializer));
+
+            var exception = Record.Exception(() => subject.RegisterSerializer(typeof(long), intSerializer));
+
             exception.Should().BeOfType<BsonSerializationException>();
-            exception.Message.Should().Contain($"A serializer for Int32 cannot be registered for type Int64.");
+            exception.Message.Should().Contain("A serializer for Int32 cannot be registered for type Int64.");
         }
 
         [Fact]
         public void TryRegisterSerializer_should_throw_when_type_and_serializer_do_not_match()
         {
+            var subject = new BsonSerializerRegistry();
             var intSerializer = new Int32Serializer();
-            var tryException = Record.Exception(() => BsonSerializer.TryRegisterSerializer(typeof(long), intSerializer));
+
+            var tryException = Record.Exception(() => subject.TryRegisterSerializer(typeof(long), intSerializer));
+
             tryException.Should().BeOfType<BsonSerializationException>();
             tryException.Message.Should().Contain("A serializer for Int32 cannot be registered for type Int64.");
         }
@@ -124,16 +130,7 @@ namespace MongoDB.Bson.Tests.Serialization
             var exception = Record.Exception(() => subject.RegisterSerializer(typeof(List<Person>), serializer));
             exception.Should().BeNull();
 
-            var people = new List<Person>
-            {
-                new Person { Name = "Alice" },
-                new Person { Name = "Bob" }
-            };
-
-            var json = people.ToJson<IEnumerable<Person>>();
-            json.Should().Contain("Alice");
-            json.Should().Contain("Bob");
-
+            subject.GetSerializer(typeof(List<Person>)).Should().BeSameAs(serializer);
         }
 
         [Fact]
@@ -142,19 +139,10 @@ namespace MongoDB.Bson.Tests.Serialization
             var subject = new BsonSerializerRegistry();
             var serializer = new PeopleSerializer();
 
-            var exception = Record.Exception(() => subject.TryRegisterSerializer(typeof(List<Person>), serializer));
-            exception.Should().BeNull();
+            var result = subject.TryRegisterSerializer(typeof(List<Person>), serializer);
+            result.Should().BeTrue();
 
-            var people = new List<Person>
-            {
-              new Person { Name = "Alice" },
-              new Person { Name = "Bob" }
-            };
-
-            var json = people.ToJson<IEnumerable<Person>>();
-            json.Should().Contain("Alice");
-            json.Should().Contain("Bob");
-
+            subject.GetSerializer(typeof(List<Person>)).Should().BeSameAs(serializer);
         }
 
         private class Person
@@ -169,16 +157,16 @@ namespace MongoDB.Bson.Tests.Serialization
                 context.Writer.WriteStartArray();
                 foreach (var person in value)
                 {
-                  context.Writer.WriteStartDocument();
-                  context.Writer.WriteName("Name");
-                  context.Writer.WriteString(person.Name);
-                  context.Writer.WriteEndDocument();
+                    context.Writer.WriteStartDocument();
+                    context.Writer.WriteName("Name");
+                    context.Writer.WriteString(person.Name);
+                    context.Writer.WriteEndDocument();
                 }
                 context.Writer.WriteEndArray();
             }
 
-        public override IEnumerable<Person> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
-              => throw new NotImplementedException();
+            public override IEnumerable<Person> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+                => throw new NotImplementedException();
         }
 
         [Fact]

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
@@ -103,11 +103,16 @@ namespace MongoDB.Bson.Tests.Serialization
             var intSerializer = new Int32Serializer();
             var exception = Record.Exception(() => BsonSerializer.RegisterSerializer(typeof(long), intSerializer));
             exception.Should().BeOfType<BsonSerializationException>();
-            exception.Message.Should().Contain("A serializer of type Int32 cannot be registered for type Int64.");
+            exception.Message.Should().Contain($"A serializer for Int32 cannot be registered for type Int64.");
+        }
 
+        [Fact]
+        public void TryRegisterSerializer_should_throw_when_type_and_serializer_do_not_match()
+        {
+            var intSerializer = new Int32Serializer();
             var tryException = Record.Exception(() => BsonSerializer.TryRegisterSerializer(typeof(long), intSerializer));
             tryException.Should().BeOfType<BsonSerializationException>();
-            tryException.Message.Should().Contain("A serializer of type Int32 cannot be registered for type Int64.");
+            tryException.Message.Should().Contain("A serializer for Int32 cannot be registered for type Int64.");
         }
 
         [Fact]

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
@@ -98,6 +98,15 @@ namespace MongoDB.Bson.Tests.Serialization
         }
 
         [Fact]
+        public void RegisterSerializer_should_throw_when_type_and_serializer_do_not_match()
+        {
+            var intSerializer = new Int32Serializer();
+            var exception = Record.Exception(() => BsonSerializer.RegisterSerializer(typeof(long), intSerializer));
+            exception.Should().BeOfType<BsonSerializationException>();
+            exception.Message.Should().Contain("A serializer of type Int32 cannot be registered for type Int64.");
+        }
+
+        [Fact]
         public void TryRegisterSerializer_should_return_true_when_serializer_is_not_already_registered()
         {
             var subject = new BsonSerializerRegistry();

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
@@ -104,6 +104,10 @@ namespace MongoDB.Bson.Tests.Serialization
             var exception = Record.Exception(() => BsonSerializer.RegisterSerializer(typeof(long), intSerializer));
             exception.Should().BeOfType<BsonSerializationException>();
             exception.Message.Should().Contain("A serializer of type Int32 cannot be registered for type Int64.");
+
+            var tryException = Record.Exception(() => BsonSerializer.TryRegisterSerializer(typeof(long), intSerializer));
+            tryException.Should().BeOfType<BsonSerializationException>();
+            tryException.Message.Should().Contain("A serializer of type Int32 cannot be registered for type Int64.");
         }
 
         [Fact]

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
@@ -116,6 +116,72 @@ namespace MongoDB.Bson.Tests.Serialization
         }
 
         [Fact]
+        public void RegisterSerializer_should_allow_serializer_for_base_type()
+        {
+            var subject = new BsonSerializerRegistry();
+            var serializer = new PeopleSerializer();
+
+            var exception = Record.Exception(() => subject.RegisterSerializer(typeof(List<Person>), serializer));
+            exception.Should().BeNull();
+
+            var people = new List<Person>
+            {
+                new Person { Name = "Alice" },
+                new Person { Name = "Bob" }
+            };
+
+            var json = people.ToJson<IEnumerable<Person>>();
+            json.Should().Contain("Alice");
+            json.Should().Contain("Bob");
+
+        }
+
+        [Fact]
+        public void TryRegisterSerializer_should_allow_serializer_for_base_type()
+        {
+            var subject = new BsonSerializerRegistry();
+            var serializer = new PeopleSerializer();
+
+            var exception = Record.Exception(() => subject.TryRegisterSerializer(typeof(List<Person>), serializer));
+            exception.Should().BeNull();
+
+            var people = new List<Person>
+            {
+              new Person { Name = "Alice" },
+              new Person { Name = "Bob" }
+            };
+
+            var json = people.ToJson<IEnumerable<Person>>();
+            json.Should().Contain("Alice");
+            json.Should().Contain("Bob");
+
+        }
+
+        private class Person
+        {
+            public string Name { get; set; }
+        }
+
+        private class PeopleSerializer : SerializerBase<IEnumerable<Person>>
+        {
+            public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IEnumerable<Person> value)
+            {
+                context.Writer.WriteStartArray();
+                foreach (var person in value)
+                {
+                  context.Writer.WriteStartDocument();
+                  context.Writer.WriteName("Name");
+                  context.Writer.WriteString(person.Name);
+                  context.Writer.WriteEndDocument();
+                }
+                context.Writer.WriteEndArray();
+            }
+
+        public override IEnumerable<Person> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+              => throw new NotImplementedException();
+        }
+
+        [Fact]
         public void TryRegisterSerializer_should_return_true_when_serializer_is_not_already_registered()
         {
             var subject = new BsonSerializerRegistry();

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
@@ -145,20 +145,6 @@ namespace MongoDB.Bson.Tests.Serialization
             subject.GetSerializer(typeof(List<Person>)).Should().BeSameAs(serializer);
         }
 
-        private class Person
-        {
-            public string Name { get; set; }
-        }
-
-        private class PeopleSerializer : SerializerBase<IEnumerable<Person>>
-        {
-            public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IEnumerable<Person> value)
-                => throw new NotImplementedException();
-
-            public override IEnumerable<Person> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
-                => throw new NotImplementedException();
-        }
-
         [Fact]
         public void TryRegisterSerializer_should_return_true_when_serializer_is_not_already_registered()
         {
@@ -250,6 +236,20 @@ namespace MongoDB.Bson.Tests.Serialization
             subject.GetSerializer(typeof(object)).Should().NotBeSameAs(serializer2);
             exception.Should().BeOfType<BsonSerializationException>();
             exception.Message.Should().Contain("There is already a different serializer registered for type Object");
+        }
+
+        private class Person
+        {
+            public string Name { get; set; }
+        }
+
+        private class PeopleSerializer : SerializerBase<IEnumerable<Person>>
+        {
+            public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IEnumerable<Person> value)
+                => throw new NotImplementedException();
+
+            public override IEnumerable<Person> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+                => throw new NotImplementedException();
         }
     }
 }

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerRegistryTests.cs
@@ -105,8 +105,8 @@ namespace MongoDB.Bson.Tests.Serialization
 
             var exception = Record.Exception(() => subject.RegisterSerializer(typeof(long), intSerializer));
 
-            exception.Should().BeOfType<BsonSerializationException>();
-            exception.Message.Should().Contain("A serializer for Int32 cannot be registered for type Int64.");
+            exception.Should().BeOfType<ArgumentException>();
+            exception.Message.Should().Be("A serializer for Int32 cannot be registered for type Int64.");
         }
 
         [Fact]
@@ -117,8 +117,8 @@ namespace MongoDB.Bson.Tests.Serialization
 
             var tryException = Record.Exception(() => subject.TryRegisterSerializer(typeof(long), intSerializer));
 
-            tryException.Should().BeOfType<BsonSerializationException>();
-            tryException.Message.Should().Contain("A serializer for Int32 cannot be registered for type Int64.");
+            tryException.Should().BeOfType<ArgumentException>();
+            tryException.Message.Should().Be("A serializer for Int32 cannot be registered for type Int64.");
         }
 
         [Fact]
@@ -153,17 +153,7 @@ namespace MongoDB.Bson.Tests.Serialization
         private class PeopleSerializer : SerializerBase<IEnumerable<Person>>
         {
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IEnumerable<Person> value)
-            {
-                context.Writer.WriteStartArray();
-                foreach (var person in value)
-                {
-                    context.Writer.WriteStartDocument();
-                    context.Writer.WriteName("Name");
-                    context.Writer.WriteString(person.Name);
-                    context.Writer.WriteEndDocument();
-                }
-                context.Writer.WriteEndArray();
-            }
+                => throw new NotImplementedException();
 
             public override IEnumerable<Person> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
                 => throw new NotImplementedException();


### PR DESCRIPTION
`RegisterSerializer` and `TryRegisterSerializer` now throw an `ArgumentException` if the serializer's `ValueType` is not compatible with the registered type (e.g. registering an `Int32Serializer` for `typeof(long)`). Serializers registered for a base type remain valid for derived types.