### PR TITLE
CSHARP-5949: $convert should allow any type to be converted to string

### DIFF
--- a/src/MongoDB.Driver/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver/Core/Misc/Feature.cs
@@ -44,6 +44,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __clientBulkWrite = new Feature("ClientBulkWrite", WireVersion.Server80);
         private static readonly Feature __clientSideEncryption = new Feature("ClientSideEncryption", WireVersion.Server42);
         private static readonly Feature __clusteredIndexes = new Feature("ClusteredIndexes", WireVersion.Server53);
+        private static readonly Feature __convertOperatorAnyToString = new Feature("ConvertOperatorAnyToString", WireVersion.Server83);
         private static readonly Feature __convertOperatorBinDataToFromNumeric = new Feature("ConvertOperatorBinDataToFromNumeric", WireVersion.Server81);
         private static readonly Feature __convertOperatorBinDataToFromString= new Feature("ConvertOperatorBinDataToFromString", WireVersion.Server80);
         private static readonly Feature __convertOperatorStringToObjectOrArray = new Feature("ConvertOperatorStringToObjectOrArray", WireVersion.Server83);
@@ -202,6 +203,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the clustered indexes feature.
         /// </summary>
         public static Feature ClusteredIndexes => __clusteredIndexes;
+
+        /// <summary>
+        /// Gets the conversion of any type to string feature.
+        /// </summary>
+        public static Feature ConvertOperatorAnyToString => __convertOperatorAnyToString;
 
         /// <summary>
         /// Gets the conversion of binary data to/from numeric types feature.

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/ConvertMethodToAggregationExpressionTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/ConvertMethodToAggregationExpressionTranslatorTests.cs
@@ -500,6 +500,28 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Translators.ExpressionTo
             AssertOutcome(collection, queryable, expectedStages, expectedValue);
         }
 
+        [Theory]
+        [InlineData(30, """{"a":1,"b":"hello"}""")]
+        [InlineData(31, """[1,"two",3]""")]
+        public void Convert_to_string_from_any_type_should_work(int id, string expectedResult)
+        {
+            RequireServer.Check().Supports(Feature.ConvertOperatorAnyToString);
+
+            var collection = Fixture.Collection;
+            var queryable = collection.AsQueryable()
+                .Where(x => x.Id == id)
+                .Select(x => Mql.Convert<BsonValue, string>(x.BsonValueProperty, null));
+
+            var expectedStages =
+                new[]
+                {
+                    $"{{ $match : {{ _id : {id} }} }}",
+                    "{ $project: { _v : { $toString : '$BsonValueProperty' }, _id : 0 } }",
+                };
+
+            AssertOutcome(collection, queryable, expectedStages, expectedResult);
+        }
+
         [Fact]
         public void Convert_to_BsonDocument_should_work()
         {
@@ -656,6 +678,8 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Translators.ExpressionTo
                 BsonDocument.Parse("{ _id : 22, IntProperty: 33 }"),
                 BsonDocument.Parse("{ _id : 23, StringProperty: '2018-03-03' }"),
                 BsonDocument.Parse("{ _id : 24, StringProperty: '5ab9cbfa31c2ab715d42129e' }"),
+                BsonDocument.Parse("{ _id : 30, BsonValueProperty: { a: 1, b: 'hello' } }"),
+                BsonDocument.Parse("{ _id : 31, BsonValueProperty: [1, 'two', 3] }"),
                 BsonDocument.Parse("{ _id : 40, StringProperty: '{\"a\": 1, \"b\": \"hello\"}' }"),
                 BsonDocument.Parse("{ _id : 41, StringProperty: '[1, 2, 3]' }"),
             ];
@@ -665,6 +689,7 @@ namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Translators.ExpressionTo
         {
             public int Id { get; set; }
             public BsonBinaryData BinaryProperty { get; set; }
+            public BsonValue BsonValueProperty { get; set; }
             public double DoubleProperty { get; set; }
             public int IntProperty { get; set; }
             public long LongProperty { get; set; }


### PR DESCRIPTION
We do not need to do anything specific, as we did not have any driver/c# constraint on what could have been converted. 