### PR TITLE
CSHARP-5970: Add unit tests coverage for SerializerFinderVisitor.VisitMethodCall

### DIFF
--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ArrayTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ArrayTests.cs
@@ -1,0 +1,54 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using MongoDB.Driver.Linq.Linq3Implementation.Serializers;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class ArrayTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_array_operations(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => Array.Exists(model.Items, x => x > 0)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Array.Exists(model.StringItems, s => s.StartsWith("a"))), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.ToList()), typeof(ListSerializer<int>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.StringItems.ToList()), typeof(ListSerializer<string>)],
+    ];
+
+    private class MyModel
+    {
+        public int[] Items { get; set; }
+        public string[] StringItems { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ByteTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ByteTests.cs
@@ -1,0 +1,55 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class ByteTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_byte_operations(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo((byte)1)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals((byte)1)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
+        // byte.Parse — not in GetParseResultSerializer; kept for investigation
+        // [TestHelpers.MakeLambda((MyModel model) => byte.Parse("42")), typeof(ByteSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public byte Value { get; set; }
+        public byte Other { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DateTimeTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DateTimeTests.cs
@@ -1,0 +1,89 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class DateTimeTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_date_time_methods(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Add(TimeSpan.Zero)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Add(TimeSpan.Zero, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Add(1L, DateTimeUnit.Day)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Add(1L, DateTimeUnit.Day, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddDays(1.0)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddDays(1.0, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddHours(1.0)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddHours(1.0, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddMilliseconds(1.0)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddMilliseconds(1.0, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddMinutes(1.0)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddMinutes(1.0, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddMonths(1)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddMonths(1, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddQuarters(1)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddQuarters(1, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddSeconds(1.0)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddSeconds(1.0, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddTicks(1L)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddWeeks(1)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddWeeks(1, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddYears(1)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.AddYears(1, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => DateTime.Parse(model.DateString)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Subtract(TimeSpan.Zero)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Subtract(TimeSpan.Zero, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Subtract(1L, DateTimeUnit.Day)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Subtract(1L, DateTimeUnit.Day, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Subtract(model.OtherDate)), typeof(TimeSpanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Subtract(model.OtherDate, "UTC")), typeof(TimeSpanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Subtract(model.OtherDate, DateTimeUnit.Day)), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Subtract(model.OtherDate, DateTimeUnit.Day, "UTC")), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.ToString("yyyy-MM-dd")), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.ToString("yyyy-MM-dd", "UTC")), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Truncate(DateTimeUnit.Day)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Truncate(DateTimeUnit.Day, 1L)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Truncate(DateTimeUnit.Day, 1L, "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Week()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Date.Week("UTC")), typeof(Int32Serializer)],
+    ];
+
+    private class MyModel
+    {
+        public DateTime Date { get; set; }
+        public DateTime OtherDate { get; set; }
+        public string DateString { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DecimalTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DecimalTests.cs
@@ -1,0 +1,54 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class DecimalTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_decimal_operations(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(1m)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1m)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => decimal.Parse("42")), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public decimal Value { get; set; }
+        public decimal Other { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DictionaryTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DictionaryTests.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2010-present MongoDB Inc.
+/* Copyright 2010-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,31 +13,38 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 using FluentAssertions;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
 
-public class MqlSubtypeTests
+public class DictionaryTests
 {
-    [Fact]
-    public void SerializerFinder_should_resolve_mql_subtype()
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_dictionary_methods(LambdaExpression expression, Type expectedSerializerType)
     {
-        var expression = TestHelpers.MakeLambda<MyModel, BsonBinarySubType?>(model => Mql.Subtype(model.Data));
         var serializerMap = TestHelpers.CreateSerializerMap(expression);
 
         SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
 
         serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
-        serializerMap.GetSerializer(expression.Body).Should().BeOfType<NullableSerializer<BsonBinarySubType>>();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
     }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Dict.ContainsKey("key")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Dict.ContainsValue(42)), typeof(BooleanSerializer)],
+    ];
 
     private class MyModel
     {
-        public byte[] Data { get; set; }
+        public Dictionary<string, int> Dict { get; set; }
     }
 }
-

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DoubleTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DoubleTests.cs
@@ -1,0 +1,54 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class DoubleTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_double_operations(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(1.0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1.0)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => double.Parse("42")), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public double Value { get; set; }
+        public double Other { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/EnumTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/EnumTests.cs
@@ -1,0 +1,50 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class EnumTests
+{
+    [Fact]
+    public void SerializerFinder_should_resolve_enum_has_flag()
+    {
+        var expression = TestHelpers.MakeLambda<MyModel, bool>(model => model.Status.HasFlag(MyFlags.Read));
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType<BooleanSerializer>();
+    }
+
+    [Flags]
+    private enum MyFlags
+    {
+        None = 0,
+        Read = 1,
+        Write = 2
+    }
+
+    private class MyModel
+    {
+        public MyFlags Status { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/EnumerableTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/EnumerableTests.cs
@@ -1,0 +1,236 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class EnumerableTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_enumerable_methods(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Aggregate((a, b) => a + b)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Aggregate(42, (a, b) => a + b)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Aggregate(42, (a, b) => a + b, result => result.ToString())), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Aggregate((a, b) => a + b)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Aggregate(42, (a, b) => a + b)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Aggregate(42, (a, b) => a + b, result => result.ToString())), typeof(StringSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.All(x => x > 0)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.All(x => x > 0)), typeof(BooleanSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.AllElements()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.AllElements()), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.AllMatchingElements("id")), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.AllMatchingElements("id")), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Any()), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Any(x => x > 0)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Any()), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Any(x => x > 0)), typeof(BooleanSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Average()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Average(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Average()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Average(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Average()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Average(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Average()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Average(x => x * 2)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Average()), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Average(x => x * 2)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Average()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Average(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DoubleItems.Average()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DoubleItems.Average(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.LongItems.Average()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.LongItems.Average(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DecimalItems.Average()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DecimalItems.Average(x => x * 2)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.FloatItems.Average()), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.FloatItems.Average(x => x * 2)), typeof(SingleSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Concat(model.OtherItems)), typeof(IEnumerableDeserializingAsCollectionSerializer<IEnumerable<int>,int,List<int>>)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Concat(model.OtherItems)), typeof(EnumerableInterfaceImplementerSerializer<IQueryable<int>,int>)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Contains(1)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Contains(1)), typeof(BooleanSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Count()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Count(x => x > 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Count()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Count(x => x > 0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.ElementAt(0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.ElementAt(0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.ElementAtOrDefault(0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.ElementAtOrDefault(0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.First()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.First(x => x > 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.First()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.First(x => x > 0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.FirstMatchingElement()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.FirstMatchingElement()), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.FirstOrDefault()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.FirstOrDefault(x => x > 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.FirstOrDefault()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.FirstOrDefault(x => x > 0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Last()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Last(x => x > 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Last()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Last(x => x > 0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.LastOrDefault()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.LastOrDefault(x => x > 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.LastOrDefault()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.LastOrDefault(x => x > 0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.LongCount()), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.LongCount(x => x > 0)), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.LongCount()), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.LongCount(x => x > 0)), typeof(Int64Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Max()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Max(x => x * 2)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Max()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Max()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Max()), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Max()), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Max()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Max(x => x * 2)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DoubleItems.Max()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DecimalItems.Max()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.LongItems.Max()), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.FloatItems.Max()), typeof(SingleSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Median()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Median(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Median()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Median(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Median()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Median(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Median()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Median(x => x * 2)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Median()), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Median(x => x * 2)), typeof(SingleSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Min()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Min(x => x * 2)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Min()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Min()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Min()), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Min()), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Min()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Min(x => x * 2)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DoubleItems.Min()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DecimalItems.Min()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.LongItems.Min()), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.FloatItems.Min()), typeof(SingleSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Percentile(new double[] { 0.5 })), typeof(ArraySerializer<double>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Percentile(x => x * 2, new double[] { 0.5 })), typeof(ArraySerializer<double>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Percentile(new double[] { 0.5 })), typeof(ArraySerializer<double>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Percentile(x => x * 2, new double[] { 0.5 })), typeof(ArraySerializer<double>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Percentile(new double[] { 0.5 })), typeof(ArraySerializer<double>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Percentile(x => x * 2, new double[] { 0.5 })), typeof(ArraySerializer<double>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Percentile(new double[] { 0.5 })), typeof(ArraySerializer<decimal>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Percentile(x => x * 2, new double[] { 0.5 })), typeof(ArraySerializer<decimal>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Percentile(new double[] { 0.5 })), typeof(ArraySerializer<float>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Percentile(x => x * 2, new double[] { 0.5 })), typeof(ArraySerializer<float>)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.SequenceEqual(model.OtherItems)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.SequenceEqual(model.OtherItems)), typeof(BooleanSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Single()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Single(x => x > 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Single()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Single(x => x > 0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.SingleOrDefault()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.SingleOrDefault(x => x > 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.SingleOrDefault()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.SingleOrDefault(x => x > 0)), typeof(Int32Serializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Sum()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Sum(x => x * 2)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Sum()), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.LongItems.Sum(x => x * 2)), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Sum()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DoubleItems.Sum(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Sum()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.DecimalItems.Sum(x => x * 2)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Sum()), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.FloatItems.Sum(x => x * 2)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Sum()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.Sum(x => x * 2)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.LongItems.Sum()), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.LongItems.Sum(x => x * 2)), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DoubleItems.Sum()), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DoubleItems.Sum(x => x * 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DecimalItems.Sum()), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.DecimalItems.Sum(x => x * 2)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.FloatItems.Sum()), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.FloatItems.Sum(x => x * 2)), typeof(SingleSerializer)],
+
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.ToArray()), typeof(ArraySerializer<int>)],
+        [TestHelpers.MakeLambda((MyQueryableModel model) => model.Items.ToArray()), typeof(ArraySerializer<int>)],
+    ];
+
+    private class MyModel
+    {
+        public IEnumerable<int> Items { get; set; }
+        public IEnumerable<int> OtherItems { get; set; }
+        public IEnumerable<double> DoubleItems { get; set; }
+        public IEnumerable<decimal> DecimalItems { get; set; }
+        public IEnumerable<long> LongItems { get; set; }
+        public IEnumerable<float> FloatItems { get; set; }
+    }
+
+    private class MyQueryableModel
+    {
+        public IQueryable<int> Items { get; set; }
+        public IQueryable<int> OtherItems { get; set; }
+        public IQueryable<double> DoubleItems { get; set; }
+        public IQueryable<decimal> DecimalItems { get; set; }
+        public IQueryable<long> LongItems { get; set; }
+        public IQueryable<float> FloatItems { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/HashSetTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/HashSetTests.cs
@@ -1,0 +1,61 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using MongoDB.Driver.Linq.Linq3Implementation.Serializers;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class HashSetTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_hashset_methods(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.ItemSet.Contains(1)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.StringSet.Contains("a")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.ItemSet.IsSubsetOf(model.OtherSet)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.StringSet.IsSubsetOf(model.OtherStringSet)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.ItemSet.SetEquals(model.OtherSet)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.StringSet.SetEquals(model.OtherStringSet)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.ItemSet.ToArray()), typeof(ArraySerializer<int>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.ItemSet.ToList()), typeof(ListSerializer<int>)],
+    ];
+
+    private class MyModel
+    {
+        public HashSet<int> ItemSet { get; set; }
+        public HashSet<int> OtherSet { get; set; }
+        public HashSet<string> StringSet { get; set; }
+        public HashSet<string> OtherStringSet { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/IntTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/IntTests.cs
@@ -1,0 +1,54 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class IntTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_int_operations(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(1)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => int.Parse("42")), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public int Value { get; set; }
+        public int Other { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ListTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ListTests.cs
@@ -1,0 +1,62 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using MongoDB.Driver.Linq.Linq3Implementation.Serializers;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class ListTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_list_operations(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Contains(1)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.StringItems.Contains("a")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.Exists(x => x > 0)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.StringItems.Exists(s => s.StartsWith("a"))), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.ToArray()), typeof(ArraySerializer<int>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.StringItems.ToArray()), typeof(ArraySerializer<string>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.IntArray.ToList()), typeof(ListSerializer<int>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.StringArray.ToList()), typeof(ListSerializer<string>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Items.ToList()), typeof(ListSerializer<int>)],
+    ];
+
+    private class MyModel
+    {
+        public List<int> Items { get; set; }
+        public List<string> StringItems { get; set; }
+        public int[] IntArray { get; set; }
+        public string[] StringArray { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/LongTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/LongTests.cs
@@ -1,0 +1,55 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class LongTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_long_operations(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(1L)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1L)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
+        // long.Parse — not in GetParseResultSerializer; kept for investigation
+        // [TestHelpers.MakeLambda((MyModel model) => long.Parse("42")), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public long Value { get; set; }
+        public long Other { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/MathTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/MathTests.cs
@@ -1,0 +1,95 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class MathTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_math_methods(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => Math.Abs(model.DecimalValue)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Abs(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Abs(model.ShortValue)), typeof(Int16Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Abs(model.IntValue)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Abs(model.LongValue)), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Abs(model.SByteValue)), typeof(SByteSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Abs(model.FloatValue)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Acos(model.DoubleValue)), typeof(DoubleSerializer)],
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+        [TestHelpers.MakeLambda((MyModel model) => Math.Acosh(model.DoubleValue)), typeof(DoubleSerializer)],
+#endif
+        [TestHelpers.MakeLambda((MyModel model) => Math.Asin(model.DoubleValue)), typeof(DoubleSerializer)],
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+        [TestHelpers.MakeLambda((MyModel model) => Math.Asinh(model.DoubleValue)), typeof(DoubleSerializer)],
+#endif
+        [TestHelpers.MakeLambda((MyModel model) => Math.Atan(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Atan2(model.DoubleValue, 1.0)), typeof(DoubleSerializer)],
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+        [TestHelpers.MakeLambda((MyModel model) => Math.Atanh(model.DoubleValue)), typeof(DoubleSerializer)],
+#endif
+        [TestHelpers.MakeLambda((MyModel model) => Math.Ceiling(model.DecimalValue)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Ceiling(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Cos(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Cosh(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Exp(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Floor(model.DecimalValue)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Floor(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Log(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Log(model.DoubleValue, 2.0)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Log10(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Pow(model.DoubleValue, 2.0)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Round(model.DecimalValue)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Round(model.DecimalValue, 2)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Round(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Round(model.DoubleValue, 2)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Sin(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Sinh(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Sqrt(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Tan(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Tanh(model.DoubleValue)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Truncate(model.DecimalValue)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Math.Truncate(model.DoubleValue)), typeof(DoubleSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public decimal DecimalValue { get; set; }
+        public double DoubleValue { get; set; }
+        public short ShortValue { get; set; }
+        public int IntValue { get; set; }
+        public long LongValue { get; set; }
+        public sbyte SByteValue { get; set; }
+        public float FloatValue { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/MongoDBMathTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/MongoDBMathTests.cs
@@ -1,0 +1,50 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class MongoDBMathTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_mongodb_math_methods(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => MongoDBMath.DegreesToRadians(model.Value)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => MongoDBMath.RadiansToDegrees(model.Value)), typeof(DoubleSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public double Value { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/MqlTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/MqlTests.cs
@@ -1,0 +1,65 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class MqlTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_mql_methods(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => Mql.DateFromString(model.DateString)), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.DateFromString(model.DateString, "yyyy-MM-dd")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.DateFromString(model.DateString, "yyyy-MM-dd", "UTC")), typeof(DateTimeSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.DateFromString(model.DateString, "yyyy-MM-dd", "UTC", null, null)), typeof(NullableSerializer<DateTime>)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.Exists(model.Field)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.IsMissing(model.Field)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.IsNullOrMissing(model.Field)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.Sigmoid(model.Value)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.SimilarityCosine(model.Vector1, model.Vector2, false)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.SimilarityDotProduct(model.Vector1, model.Vector2, false)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.SimilarityEuclidean(model.Vector1, model.Vector2, false)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Mql.Subtype(model.Data)), typeof(NullableSerializer<BsonBinarySubType>)],
+    ];
+
+    private class MyModel
+    {
+        public string Field { get; set; }
+        public string DateString { get; set; }
+        public byte[] Data { get; set; }
+        public double Value { get; set; }
+        public double[] Vector1 { get; set; }
+        public double[] Vector2 { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/RegexTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/RegexTests.cs
@@ -1,0 +1,51 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class RegexTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_regex_is_match(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => new Regex("pattern").IsMatch(model.Name)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Regex.IsMatch(model.Name, "pattern")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => Regex.IsMatch(model.Name, "pattern", RegexOptions.IgnoreCase)), typeof(BooleanSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public string Name { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ShortTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ShortTests.cs
@@ -1,0 +1,55 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class ShortTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_short_operations(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo((short)1)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals((short)1)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
+        // short.Parse — maps to Int64Serializer instead of Int16Serializer; kept for investigation
+        // [TestHelpers.MakeLambda((MyModel model) => short.Parse("42")), typeof(Int16Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public short Value { get; set; }
+        public short Other { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/StringTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/StringTests.cs
@@ -1,0 +1,128 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class StringTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_string_methods(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = TestHelpers.CreateSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        [TestHelpers.MakeLambda((MyModel model) => model.Tags.AnyStringIn("tag1", "tag2")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Tags.AnyStringIn(new StringOrRegularExpression[] { "tag1" })), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Tags.AnyStringNin("tag1", "tag2")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Tags.AnyStringNin(new StringOrRegularExpression[] { "tag1" })), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name[0]), typeof(CharSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Compare(model.Name, "other")), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Compare(model.Name, "other", true)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.CompareTo("other")), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Concat((object)model.Name)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Concat((object)model.A, (object)model.B)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Concat((object)model.A, (object)model.B, (object)model.C)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Concat(new object[] { model.A, model.B })), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Concat(model.A, model.B)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Concat(model.A, model.B, model.C)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Concat(model.A, model.B, model.C, model.D)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Concat(new string[] { model.A, model.B })), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Contains("test")), typeof(BooleanSerializer)],
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Contains('x')), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Contains('x', StringComparison.Ordinal)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Contains("test", StringComparison.Ordinal)), typeof(BooleanSerializer)],
+#endif
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.EndsWith("suffix")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.EndsWith("suffix", StringComparison.Ordinal)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.EndsWith("suffix", true, CultureInfo.InvariantCulture)), typeof(BooleanSerializer)],
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.EndsWith('x')), typeof(BooleanSerializer)],
+#endif
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Equals("other")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Equals("other", StringComparison.Ordinal)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Equals(model.Name, "other")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.Equals(model.Name, "other", StringComparison.Ordinal)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf('x')), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf('x', 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf('x', 0, 1)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf("test")), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf("test", 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf("test", 0, 1)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf("test", StringComparison.Ordinal)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf("test", 0, StringComparison.Ordinal)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOf("test", 0, 1, StringComparison.Ordinal)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOfBytes("x")), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOfBytes("x", 0)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.IndexOfBytes("x", 0, 1)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.IsNullOrEmpty(model.Name)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => string.IsNullOrWhiteSpace(model.Name)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Split(new char[] { ',' })), typeof(ArraySerializer<string>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Split(new char[] { ',' }, 2)), typeof(ArraySerializer<string>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Split(new char[] { ',' }, StringSplitOptions.None)), typeof(ArraySerializer<string>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Split(new char[] { ',' }, 2, StringSplitOptions.None)), typeof(ArraySerializer<string>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Split(new string[] { "," }, StringSplitOptions.None)), typeof(ArraySerializer<string>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Split(new string[] { "," }, 2, StringSplitOptions.None)), typeof(ArraySerializer<string>)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StartsWith("prefix")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StartsWith("prefix", StringComparison.Ordinal)), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StartsWith("prefix", true, CultureInfo.InvariantCulture)), typeof(BooleanSerializer)],
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StartsWith('x')), typeof(BooleanSerializer)],
+#endif
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StringIn("a", "b")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StringIn(new StringOrRegularExpression[] { "a" })), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StringNin("a", "b")), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StringNin(new StringOrRegularExpression[] { "a" })), typeof(BooleanSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.StrLenBytes()), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.SubstrBytes(0, 3)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Substring(1)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Substring(1, 3)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.ToLower()), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.ToLower(CultureInfo.InvariantCulture)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.ToLowerInvariant()), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.ToUpper()), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.ToUpper(CultureInfo.InvariantCulture)), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.ToUpperInvariant()), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Trim()), typeof(StringSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => model.Name.Trim(new char[] { ' ' })), typeof(StringSerializer)],
+    ];
+
+    private class MyModel
+    {
+        public string Name { get; set; }
+        public string A { get; set; }
+        public string B { get; set; }
+        public string C { get; set; }
+        public string D { get; set; }
+        public string[] Tags { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/WindowTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/WindowTests.cs
@@ -1,0 +1,173 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using FluentAssertions;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Linq;
+using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
+using MongoDB.Driver.Linq.Linq3Implementation.Serializers;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.SerializerFinders;
+
+public class WindowTests
+{
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SerializerFinder_should_resolve_window_methods(LambdaExpression expression, Type expectedSerializerType)
+    {
+        var serializerMap = CreatePartitionSerializerMap(expression);
+
+        SerializerFinder.FindSerializers(expression.Body, null, serializerMap);
+
+        serializerMap.IsKnown(expression.Body, out _).Should().BeTrue();
+        serializerMap.GetSerializer(expression.Body).Should().BeOfType(expectedSerializerType);
+    }
+
+    private static SerializerMap CreatePartitionSerializerMap(LambdaExpression expression)
+    {
+        var partitionParameter = expression.Parameters.Single();
+        var inputType = partitionParameter.Type.GetGenericArguments()[0];
+        var lookupMethod = typeof(BsonSerializer)
+            .GetMethod(nameof(BsonSerializer.LookupSerializer), Type.EmptyTypes)!
+            .MakeGenericMethod(inputType);
+        var inputSerializer = (IBsonSerializer)lookupMethod.Invoke(null, null)!;
+        var partitionSerializerType = typeof(ISetWindowFieldsPartitionSerializer<>).MakeGenericType(inputType);
+        var partitionSerializer = (IBsonSerializer)Activator.CreateInstance(partitionSerializerType, inputSerializer)!;
+        return TestHelpers.CreateSerializerMap(expression, partitionSerializer);
+    }
+
+    public static readonly object[][] TestCases =
+    [
+        // AddToSet
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.AddToSet(x => x.IntField, null)), typeof(IEnumerableSerializer<int>)],
+
+        // Average
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Average(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Average(x => x.DoubleField, null)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Average(x => x.FloatField, null)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Average(x => x.IntField, null)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Average(x => x.LongField, null)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Average(x => x.NullableDecimalField, null)), typeof(NullableSerializer<decimal>)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Average(x => x.NullableIntField, null)), typeof(NullableSerializer<double>)],
+
+        // Count
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Count(null)), typeof(Int64Serializer)],
+
+        // CovariancePopulation
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.CovariancePopulation(x => x.DecimalField, x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.CovariancePopulation(x => x.IntField, x => x.IntField, null)), typeof(DoubleSerializer)],
+
+        // CovarianceSample
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.CovarianceSample(x => x.DecimalField, x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.CovarianceSample(x => x.IntField, x => x.IntField, null)), typeof(DoubleSerializer)],
+
+        // DenseRank
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.DenseRank()), typeof(DecimalSerializer)],
+
+        // Derivative
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Derivative(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Derivative(x => x.DecimalField, WindowTimeUnit.Day, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Derivative(x => x.IntField, null)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Derivative(x => x.IntField, WindowTimeUnit.Day, null)), typeof(DoubleSerializer)],
+
+        // DocumentNumber
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.DocumentNumber()), typeof(DecimalSerializer)],
+
+        // ExponentialMovingAverage
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.ExponentialMovingAverage(x => x.DecimalField, ExponentialMovingAverageWeighting.Alpha(0.1), null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.ExponentialMovingAverage(x => x.FloatField, ExponentialMovingAverageWeighting.Alpha(0.1), null)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.ExponentialMovingAverage(x => x.IntField, ExponentialMovingAverageWeighting.Alpha(0.1), null)), typeof(DoubleSerializer)],
+
+        // First
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.First(x => x.IntField, null)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.First(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+
+        // Integral
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Integral(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Integral(x => x.DecimalField, WindowTimeUnit.Day, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Integral(x => x.IntField, null)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Integral(x => x.IntField, WindowTimeUnit.Day, null)), typeof(DoubleSerializer)],
+
+        // Last
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Last(x => x.IntField, null)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Last(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+
+        // Locf
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Locf(x => x.IntField, null)), typeof(Int32Serializer)],
+
+        // Max
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Max(x => x.IntField, null)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Max(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+
+        // Median
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Median(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Median(x => x.FloatField, null)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Median(x => x.IntField, null)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Median(x => x.NullableDecimalField, null)), typeof(NullableSerializer<decimal>)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Median(x => x.NullableIntField, null)), typeof(NullableSerializer<double>)],
+
+        // Min
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Min(x => x.IntField, null)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Min(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+
+        // Percentile
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Percentile(x => x.DecimalField, new double[] { 0.5 }, null)), typeof(ArraySerializer<decimal>)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Percentile(x => x.IntField, new double[] { 0.5 }, null)), typeof(ArraySerializer<double>)],
+
+        // Push
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Push(x => x.IntField, null)), typeof(IEnumerableSerializer<int>)],
+
+        // Rank
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Rank()), typeof(DecimalSerializer)],
+
+        // Shift
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Shift(x => x.IntField, 1)), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Shift(x => x.IntField, 1, 0)), typeof(Int32Serializer)],
+
+        // StandardDeviationPopulation
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.StandardDeviationPopulation(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.StandardDeviationPopulation(x => x.FloatField, null)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.StandardDeviationPopulation(x => x.IntField, null)), typeof(DoubleSerializer)],
+
+        // StandardDeviationSample
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.StandardDeviationSample(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.StandardDeviationSample(x => x.FloatField, null)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.StandardDeviationSample(x => x.IntField, null)), typeof(DoubleSerializer)],
+
+        // Sum
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Sum(x => x.DecimalField, null)), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Sum(x => x.DoubleField, null)), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Sum(x => x.FloatField, null)), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Sum(x => x.IntField, null)), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((ISetWindowFieldsPartition<MyModel> p) => p.Sum(x => x.LongField, null)), typeof(Int64Serializer)],
+    ];
+
+    private class MyModel
+    {
+        public int IntField { get; set; }
+        public long LongField { get; set; }
+        public double DoubleField { get; set; }
+        public decimal DecimalField { get; set; }
+        public float FloatField { get; set; }
+        public int? NullableIntField { get; set; }
+        public decimal? NullableDecimalField { get; set; }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Linq/TestHelpers.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/TestHelpers.cs
@@ -17,6 +17,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using MongoDB.Bson.Serialization;
+using MongoDB.Driver.Linq.Linq3Implementation.Misc;
 using MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
 using MongoDB.Driver.Linq.Linq3Implementation.Translators;
 
@@ -43,7 +44,12 @@ internal static class TestHelpers
         return context.WithSymbol(symbol);
     }
 
-    public static LambdaExpression MakeLambda<T1, TResult>(Expression<Func<T1, TResult>> func)
-        => func;
+    public static LambdaExpression MakeLambda<T1, TResult>(Expression<Func<T1, TResult>> expression)
+    {
+        // The ClrCompatExpressionRewriter must be applied because SerializerFinder does not support methods added in
+        // .NET 10, such as MemoryExtensions.Contains. The rewriter rewrites the expression so that the next stages
+        // of LINQ translation can work correctly.
+        return (LambdaExpression)ClrCompatExpressionRewriter.Rewrite(expression);
+    }
 }
 


### PR DESCRIPTION
There are no actual changes in the PR yet, it contains unit tests for the SerializerFinderVisitMethodCall only. I want this to be merged on top of the current code, so we can see the tests are green for the code BEFORE applying any refactoring, and then we will use those tests to validate the refactoring.