### PR TITLE
CSHARP-5726: Investigate changes in SERVER-109626: Adjust behavior for emitting additional fields in change streams

### DIFF
--- a/specifications/change-streams/tests/unified/change-streams-disambiguatedPaths.json
+++ b/specifications/change-streams/tests/unified/change-streams-disambiguatedPaths.json
@@ -43,6 +43,91 @@
   ],
   "tests": [
     {
+      "description": "disambiguatedPaths is not present when showExpandedEvents is false/unset",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "6.1.0",
+          "maxServerVersion": "8.1.99",
+          "topologies": [
+            "replicaset",
+            "load-balanced",
+            "sharded"
+          ],
+          "serverless": "forbid"
+        },
+        {
+          "minServerVersion": "8.2.1",
+          "topologies": [
+            "replicaset",
+            "load-balanced",
+            "sharded"
+          ],
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "$$exists": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
       "description": "disambiguatedPaths is present on updateDescription when an ambiguous path is present",
       "operations": [
         {

--- a/specifications/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
+++ b/specifications/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
@@ -24,6 +24,41 @@ initialData:
     documents: []
 
 tests:
+  - description: "disambiguatedPaths is not present when showExpandedEvents is false/unset"
+    # skip server version 8.2.0, which emits disambiguatedPaths unconditionally
+    runOnRequirements:
+      - minServerVersion: "6.1.0"
+        maxServerVersion: "8.1.99"
+        topologies: [ replicaset, load-balanced, sharded ]
+        serverless: forbid
+      - minServerVersion: "8.2.1"
+        topologies: [ replicaset, load-balanced, sharded ]
+        serverless: forbid
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': { '1': 1 } }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { $$exists: false }
+
   - description: "disambiguatedPaths is present on updateDescription when an ambiguous path is present"
     operations:
       - name: insertOne


### PR DESCRIPTION
Syncs spec updates from upstream [mongodb/specifications](https://github.com/mongodb/specifications).

Jira: [CSHARP-5726](https://jira.mongodb.org/browse/CSHARP-5726)

## Commits synced
- https://github.com/mongodb/specifications/commit/6650c9819498eb8bbb8ee4d810811c30b5b27d09