### PR TITLE
CSHARP-5826: Add builder support for $top, $bottom, $topN and $bottomN expressions new in 8.3

### DIFF
--- a/src/MongoDB.Driver/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver/Core/Misc/Feature.cs
@@ -90,6 +90,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __mmapV1StorageEngine = new Feature("MmapV1StorageEngine", WireVersion.Zero, WireVersion.Server42);
         private static readonly Feature __medianOperator = new Feature("MedianOperator", WireVersion.Server70);
         private static readonly Feature __percentileOperator = new Feature("PercentileOperator", WireVersion.Server70);
+        private static readonly Feature __pickAccumulatorsAsExpressionsNewIn83 = new Feature("PickAccumulatorsAsExpressionsNewIn83", WireVersion.Server83);
         private static readonly Feature __pickAccumulatorsNewIn52 = new Feature("PickAccumulatorsNewIn52", WireVersion.Server52);
         private static readonly Feature __rankFusionStage = new Feature("RankFusionStage", WireVersion.Server81);
         private static readonly Feature __regexMatch = new Feature("RegexMatch", WireVersion.Server42);
@@ -444,6 +445,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the $percentile operator added in 7.0
         /// </summary>
         public static Feature PercentileOperator => __percentileOperator;
+
+        /// <summary>
+        /// Gets the pick accumulators as expressions new in 8.3 feature.
+        /// </summary>
+        public static Feature PickAccumulatorsAsExpressionsNewIn83 => __pickAccumulatorsAsExpressionsNewIn83;
 
         /// <summary>
         /// Gets the pick accumulators new in 5.2 feature.

--- a/src/MongoDB.Driver/PickExpressionDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PickExpressionDefinitionBuilder.cs
@@ -1,0 +1,275 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver.Core.Misc;
+
+namespace MongoDB.Driver
+{
+    /// <summary>
+    /// A builder for pick aggregation expression definitions ($top, $bottom, $topN, $bottomN).
+    /// These operators sort an array and return the top or bottom element(s). Requires MongoDB 8.3+.
+    /// </summary>
+    public static class PickExpressionDefinitionBuilder
+    {
+        /// <summary>
+        /// Creates a $top expression that returns the first element of the input array after applying the sort.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the source document.</typeparam>
+        /// <typeparam name="TElement">The type of the array elements.</typeparam>
+        /// <param name="input">The array field.</param>
+        /// <param name="sortBy">The sort order.</param>
+        /// <returns>An expression definition that renders as a $top expression.</returns>
+        public static AggregateExpressionDefinition<TDocument, TElement> Top<TDocument, TElement>(
+            Expression<Func<TDocument, IEnumerable<TElement>>> input,
+            SortDefinition<TElement> sortBy)
+        {
+            Ensure.IsNotNull(input, nameof(input));
+            Ensure.IsNotNull(sortBy, nameof(sortBy));
+            return new SinglePickExpressionDefinition<TDocument, TElement>(
+                "$top",
+                new ExpressionFieldDefinition<TDocument, IEnumerable<TElement>>(input),
+                sortBy);
+        }
+
+        /// <summary>
+        /// Creates a $top expression that returns the first element of the input array after applying the sort.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the source document.</typeparam>
+        /// <typeparam name="TElement">The type of the array elements.</typeparam>
+        /// <param name="input">The array field definition.</param>
+        /// <param name="sortBy">The sort order.</param>
+        /// <returns>An expression definition that renders as a $top expression.</returns>
+        public static AggregateExpressionDefinition<TDocument, TElement> Top<TDocument, TElement>(
+            FieldDefinition<TDocument, IEnumerable<TElement>> input,
+            SortDefinition<TElement> sortBy)
+        {
+            Ensure.IsNotNull(input, nameof(input));
+            Ensure.IsNotNull(sortBy, nameof(sortBy));
+            return new SinglePickExpressionDefinition<TDocument, TElement>("$top", input, sortBy);
+        }
+
+        /// <summary>
+        /// Creates a $bottom expression that returns the last element of the input array after applying the sort.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the source document.</typeparam>
+        /// <typeparam name="TElement">The type of the array elements.</typeparam>
+        /// <param name="input">The array field.</param>
+        /// <param name="sortBy">The sort order.</param>
+        /// <returns>An expression definition that renders as a $bottom expression.</returns>
+        public static AggregateExpressionDefinition<TDocument, TElement> Bottom<TDocument, TElement>(
+            Expression<Func<TDocument, IEnumerable<TElement>>> input,
+            SortDefinition<TElement> sortBy)
+        {
+            Ensure.IsNotNull(input, nameof(input));
+            Ensure.IsNotNull(sortBy, nameof(sortBy));
+            return new SinglePickExpressionDefinition<TDocument, TElement>(
+                "$bottom",
+                new ExpressionFieldDefinition<TDocument, IEnumerable<TElement>>(input),
+                sortBy);
+        }
+
+        /// <summary>
+        /// Creates a $bottom expression that returns the last element of the input array after applying the sort.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the source document.</typeparam>
+        /// <typeparam name="TElement">The type of the array elements.</typeparam>
+        /// <param name="input">The array field definition.</param>
+        /// <param name="sortBy">The sort order.</param>
+        /// <returns>An expression definition that renders as a $bottom expression.</returns>
+        public static AggregateExpressionDefinition<TDocument, TElement> Bottom<TDocument, TElement>(
+            FieldDefinition<TDocument, IEnumerable<TElement>> input,
+            SortDefinition<TElement> sortBy)
+        {
+            Ensure.IsNotNull(input, nameof(input));
+            Ensure.IsNotNull(sortBy, nameof(sortBy));
+            return new SinglePickExpressionDefinition<TDocument, TElement>("$bottom", input, sortBy);
+        }
+
+        /// <summary>
+        /// Creates a $topN expression that returns the first n elements of the input array after applying the sort.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the source document.</typeparam>
+        /// <typeparam name="TElement">The type of the array elements.</typeparam>
+        /// <param name="input">The array field.</param>
+        /// <param name="sortBy">The sort order.</param>
+        /// <param name="n">The number of elements to return.</param>
+        /// <returns>An expression definition that renders as a $topN expression.</returns>
+        public static AggregateExpressionDefinition<TDocument, IEnumerable<TElement>> TopN<TDocument, TElement>(
+            Expression<Func<TDocument, IEnumerable<TElement>>> input,
+            SortDefinition<TElement> sortBy,
+            int n)
+        {
+            Ensure.IsNotNull(input, nameof(input));
+            Ensure.IsNotNull(sortBy, nameof(sortBy));
+            Ensure.IsGreaterThanZero(n, nameof(n));
+            return new MultiplePickExpressionDefinition<TDocument, TElement>(
+                "$topN",
+                new ExpressionFieldDefinition<TDocument, IEnumerable<TElement>>(input),
+                sortBy,
+                n);
+        }
+
+        /// <summary>
+        /// Creates a $topN expression that returns the first n elements of the input array after applying the sort.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the source document.</typeparam>
+        /// <typeparam name="TElement">The type of the array elements.</typeparam>
+        /// <param name="input">The array field definition.</param>
+        /// <param name="sortBy">The sort order.</param>
+        /// <param name="n">The number of elements to return.</param>
+        /// <returns>An expression definition that renders as a $topN expression.</returns>
+        public static AggregateExpressionDefinition<TDocument, IEnumerable<TElement>> TopN<TDocument, TElement>(
+            FieldDefinition<TDocument, IEnumerable<TElement>> input,
+            SortDefinition<TElement> sortBy,
+            int n)
+        {
+            Ensure.IsNotNull(input, nameof(input));
+            Ensure.IsNotNull(sortBy, nameof(sortBy));
+            Ensure.IsGreaterThanZero(n, nameof(n));
+            return new MultiplePickExpressionDefinition<TDocument, TElement>("$topN", input, sortBy, n);
+        }
+
+        /// <summary>
+        /// Creates a $bottomN expression that returns the last n elements of the input array after applying the sort.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the source document.</typeparam>
+        /// <typeparam name="TElement">The type of the array elements.</typeparam>
+        /// <param name="input">The array field.</param>
+        /// <param name="sortBy">The sort order.</param>
+        /// <param name="n">The number of elements to return.</param>
+        /// <returns>An expression definition that renders as a $bottomN expression.</returns>
+        public static AggregateExpressionDefinition<TDocument, IEnumerable<TElement>> BottomN<TDocument, TElement>(
+            Expression<Func<TDocument, IEnumerable<TElement>>> input,
+            SortDefinition<TElement> sortBy,
+            int n)
+        {
+            Ensure.IsNotNull(input, nameof(input));
+            Ensure.IsNotNull(sortBy, nameof(sortBy));
+            Ensure.IsGreaterThanZero(n, nameof(n));
+            return new MultiplePickExpressionDefinition<TDocument, TElement>(
+                "$bottomN",
+                new ExpressionFieldDefinition<TDocument, IEnumerable<TElement>>(input),
+                sortBy,
+                n);
+        }
+
+        /// <summary>
+        /// Creates a $bottomN expression that returns the last n elements of the input array after applying the sort.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the source document.</typeparam>
+        /// <typeparam name="TElement">The type of the array elements.</typeparam>
+        /// <param name="input">The array field definition.</param>
+        /// <param name="sortBy">The sort order.</param>
+        /// <param name="n">The number of elements to return.</param>
+        /// <returns>An expression definition that renders as a $bottomN expression.</returns>
+        public static AggregateExpressionDefinition<TDocument, IEnumerable<TElement>> BottomN<TDocument, TElement>(
+            FieldDefinition<TDocument, IEnumerable<TElement>> input,
+            SortDefinition<TElement> sortBy,
+            int n)
+        {
+            Ensure.IsNotNull(input, nameof(input));
+            Ensure.IsNotNull(sortBy, nameof(sortBy));
+            Ensure.IsGreaterThanZero(n, nameof(n));
+            return new MultiplePickExpressionDefinition<TDocument, TElement>("$bottomN", input, sortBy, n);
+        }
+
+        // -- private implementation classes --
+
+        private sealed class SinglePickExpressionDefinition<TDocument, TElement>
+            : AggregateExpressionDefinition<TDocument, TElement>
+        {
+            private readonly string _operator;
+            private readonly FieldDefinition<TDocument, IEnumerable<TElement>> _input;
+            private readonly SortDefinition<TElement> _sortBy;
+
+            public SinglePickExpressionDefinition(
+                string @operator,
+                FieldDefinition<TDocument, IEnumerable<TElement>> input,
+                SortDefinition<TElement> sortBy)
+            {
+                _operator = @operator;
+                _input = input;
+                _sortBy = sortBy;
+            }
+
+            public override BsonValue Render(RenderArgs<TDocument> args)
+            {
+                var renderedInput = _input.Render(args);
+                var elementSerializer = GetElementSerializer(renderedInput.ValueSerializer, args.SerializerRegistry);
+                var sortDocument = _sortBy.Render(args.WithNewDocumentType(elementSerializer));
+
+                return new BsonDocument(_operator, new BsonDocument
+                {
+                    { "input", "$" + renderedInput.FieldName },
+                    { "sortBy", sortDocument }
+                });
+            }
+        }
+
+        private sealed class MultiplePickExpressionDefinition<TDocument, TElement>
+            : AggregateExpressionDefinition<TDocument, IEnumerable<TElement>>
+        {
+            private readonly string _operator;
+            private readonly FieldDefinition<TDocument, IEnumerable<TElement>> _input;
+            private readonly SortDefinition<TElement> _sortBy;
+            private readonly int _n;
+
+            public MultiplePickExpressionDefinition(
+                string @operator,
+                FieldDefinition<TDocument, IEnumerable<TElement>> input,
+                SortDefinition<TElement> sortBy,
+                int n)
+            {
+                _operator = @operator;
+                _input = input;
+                _sortBy = sortBy;
+                _n = n;
+            }
+
+            public override BsonValue Render(RenderArgs<TDocument> args)
+            {
+                var renderedInput = _input.Render(args);
+                var elementSerializer = GetElementSerializer(renderedInput.ValueSerializer, args.SerializerRegistry);
+                var sortDocument = _sortBy.Render(args.WithNewDocumentType(elementSerializer));
+
+                return new BsonDocument(_operator, new BsonDocument
+                {
+                    { "input", "$" + renderedInput.FieldName },
+                    { "sortBy", sortDocument },
+                    { "n", _n }
+                });
+            }
+        }
+
+        private static IBsonSerializer<TElement> GetElementSerializer<TElement>(
+            IBsonSerializer<IEnumerable<TElement>> valueSerializer,
+            IBsonSerializerRegistry registry)
+        {
+            if (valueSerializer is IBsonArraySerializer arraySerializer &&
+                arraySerializer.TryGetItemSerializationInfo(out var itemInfo) &&
+                itemInfo.Serializer is IBsonSerializer<TElement> elementSerializer)
+            {
+                return elementSerializer;
+            }
+
+            return registry.GetSerializer<TElement>();
+        }
+    }
+}

--- a/src/MongoDB.Driver/SetFieldDefinition.cs
+++ b/src/MongoDB.Driver/SetFieldDefinition.cs
@@ -34,6 +34,38 @@ namespace MongoDB.Driver
     }
 
     /// <summary>
+    /// A SetFieldDefinition that uses a field and an aggregation expression to define the field to be set.
+    /// </summary>
+    /// <typeparam name="TDocument">The type of the document.</typeparam>
+    /// <typeparam name="TField">The type of the field.</typeparam>
+    public sealed class AggregateExpressionSetFieldDefinition<TDocument, TField> : SetFieldDefinition<TDocument>
+    {
+        private readonly FieldDefinition<TDocument, TField> _field;
+        private readonly AggregateExpressionDefinition<TDocument, TField> _value;
+
+        /// <summary>
+        /// Initializes an instance of AggregateExpressionSetFieldDefinition.
+        /// </summary>
+        /// <param name="field">The field.</param>
+        /// <param name="value">The aggregation expression that produces the value.</param>
+        public AggregateExpressionSetFieldDefinition(
+            FieldDefinition<TDocument, TField> field,
+            AggregateExpressionDefinition<TDocument, TField> value)
+        {
+            _field = Ensure.IsNotNull(field, nameof(field));
+            _value = Ensure.IsNotNull(value, nameof(value));
+        }
+
+        /// <inheritdoc/>
+        public override BsonElement Render(RenderArgs<TDocument> args)
+        {
+            var renderedField = _field.Render(args);
+            var renderedValue = _value.Render(args);
+            return new BsonElement(renderedField.FieldName, renderedValue);
+        }
+    }
+
+    /// <summary>
     /// A SetFieldDefinition that uses a field and a a constant to define the field to be set.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>

--- a/src/MongoDB.Driver/SetFieldDefinitionsBuilder.cs
+++ b/src/MongoDB.Driver/SetFieldDefinitionsBuilder.cs
@@ -26,6 +26,32 @@ namespace MongoDB.Driver
     public class SetFieldDefinitionsBuilder<TDocument>
     {
         /// <summary>
+        /// Set a field to a value using an aggregation expression.
+        /// </summary>
+        /// <typeparam name="TField">The type of the field.</typeparam>
+        /// <param name="field">The field.</param>
+        /// <param name="value">The aggregation expression that produces the value.</param>
+        /// <returns>An instance of ListSetFieldDefinitions to which further set field definitions can be added.</returns>
+        public ListSetFieldDefinitions<TDocument> Set<TField>(FieldDefinition<TDocument, TField> field, AggregateExpressionDefinition<TDocument, TField> value)
+        {
+            var setFieldsDefinitions = new ListSetFieldDefinitions<TDocument>(Enumerable.Empty<SetFieldDefinition<TDocument>>());
+            return setFieldsDefinitions.Set(field, value);
+        }
+
+        /// <summary>
+        /// Set a field to a value using an expression to specify the field and an aggregation expression for the value.
+        /// </summary>
+        /// <typeparam name="TField">The type of the field.</typeparam>
+        /// <param name="field">The field.</param>
+        /// <param name="value">The aggregation expression that produces the value.</param>
+        /// <returns>An instance of ListSetFieldDefinitions to which further set field definitions can be added.</returns>
+        public ListSetFieldDefinitions<TDocument> Set<TField>(Expression<Func<TDocument, TField>> field, AggregateExpressionDefinition<TDocument, TField> value)
+        {
+            var setFieldsDefinitions = new ListSetFieldDefinitions<TDocument>(Enumerable.Empty<SetFieldDefinition<TDocument>>());
+            return setFieldsDefinitions.Set(new ExpressionFieldDefinition<TDocument, TField>(field), value);
+        }
+
+        /// <summary>
         /// Set a field to a value using a constant.
         /// </summary>
         /// <typeparam name="TField">The type of the field.</typeparam>
@@ -57,6 +83,35 @@ namespace MongoDB.Driver
     /// </summary>
     public static class ListSetFieldDefinitionsExtensions
     {
+        /// <summary>
+        /// Set an additional field to a value using an aggregation expression.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document.</typeparam>
+        /// <typeparam name="TField">The type of the field.</typeparam>
+        /// <param name="fields">The existing ListSetFieldDefinitions.</param>
+        /// <param name="field">The field.</param>
+        /// <param name="value">The aggregation expression that produces the value.</param>
+        /// <returns>The ListSetFieldDefinitions instance with a SetFieldDefinition added.</returns>
+        public static ListSetFieldDefinitions<TDocument> Set<TDocument, TField>(this ListSetFieldDefinitions<TDocument> fields, FieldDefinition<TDocument, TField> field, AggregateExpressionDefinition<TDocument, TField> value)
+        {
+            var setFieldDefinition = new AggregateExpressionSetFieldDefinition<TDocument, TField>(field, value);
+            return fields.Set(setFieldDefinition);
+        }
+
+        /// <summary>
+        /// Set an additional field to a value using an Expression to specify the field and an aggregation expression for the value.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document.</typeparam>
+        /// <typeparam name="TField">The type of the field.</typeparam>
+        /// <param name="fields">The existing ListSetFieldDefinitions.</param>
+        /// <param name="field">The field.</param>
+        /// <param name="value">The aggregation expression that produces the value.</param>
+        /// <returns>The ListSetFieldDefinitions instance with a SetFieldDefinition added.</returns>
+        public static ListSetFieldDefinitions<TDocument> Set<TDocument, TField>(this ListSetFieldDefinitions<TDocument> fields, Expression<Func<TDocument, TField>> field, AggregateExpressionDefinition<TDocument, TField> value)
+        {
+            return fields.Set(new ExpressionFieldDefinition<TDocument, TField>(field), value);
+        }
+
         /// <summary>
         /// Set an additional field to value using a constant.
         /// </summary>

--- a/tests/MongoDB.Driver.Tests/PickExpressionDefinitionBuilderIntegrationTests.cs
+++ b/tests/MongoDB.Driver.Tests/PickExpressionDefinitionBuilderIntegrationTests.cs
@@ -1,0 +1,248 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver.Core.Misc;
+using Xunit;
+
+namespace MongoDB.Driver.Tests
+{
+    public class PickExpressionDefinitionBuilderIntegrationTests
+        : IntegrationTest<PickExpressionDefinitionBuilderIntegrationTests.ClassFixture>
+    {
+        public PickExpressionDefinitionBuilderIntegrationTests(ClassFixture fixture)
+            : base(fixture, s => s.Supports(Feature.PickAccumulatorsAsExpressionsNewIn83))
+        {
+        }
+        
+        [Fact]
+        public void Top_in_set_stage_should_add_leader_field()
+        {
+            var collection = Fixture.Collection;
+            var sortBy = Builders<Player>.Sort.Descending(p => p.Score);
+
+            var results = collection.Aggregate()
+                .Set(Builders<Tournament>.SetFields.Set(
+                    new StringFieldDefinition<Tournament, Player>("Leader"),
+                    PickExpressionDefinitionBuilder.Top<Tournament, Player>(x => x.Players, sortBy)))
+                .SortBy(x => x.Id)
+                .ToList();
+
+            results[0].Leader.Name.Should().Be("Alice");
+            results[0].Leader.Score.Should().Be(10);
+            results[1].Leader.Name.Should().Be("Eve");
+            results[1].Leader.Score.Should().Be(7);
+        }
+
+        [Fact]
+        public void Bottom_in_set_stage_should_add_loser_field()
+        {
+            var collection = Fixture.Collection;
+            var sortBy = Builders<Player>.Sort.Descending(p => p.Score);
+
+            var results = collection.Aggregate()
+                .Set(Builders<Tournament>.SetFields.Set(
+                    new StringFieldDefinition<Tournament, Player>("Loser"),
+                    PickExpressionDefinitionBuilder.Bottom<Tournament, Player>(x => x.Players, sortBy)))
+                .SortBy(x => x.Id)
+                .ToList();
+
+            results[0].Loser.Name.Should().Be("Bob");
+            results[0].Loser.Score.Should().Be(5);
+            results[1].Loser.Name.Should().Be("Dave");
+            results[1].Loser.Score.Should().Be(3);
+        }
+
+        [Fact]
+        public void TopN_in_set_stage_should_add_top_players_field()
+        {
+            var collection = Fixture.Collection;
+            var sortBy = Builders<Player>.Sort.Descending(p => p.Score);
+
+            var results = collection.Aggregate()
+                .Set(Builders<Tournament>.SetFields.Set(
+                    new StringFieldDefinition<Tournament, IEnumerable<Player>>("TopPlayers"),
+                    PickExpressionDefinitionBuilder.TopN<Tournament, Player>(x => x.Players, sortBy, n: 2)))
+                .SortBy(x => x.Id)
+                .ToList();
+
+            results[0].TopPlayers.Select(p => p.Name).Should().Equal("Alice", "Charlie");
+            results[1].TopPlayers.Select(p => p.Name).Should().Equal("Eve", "Dave");
+        }
+
+        [Fact]
+        public void BottomN_in_set_stage_should_add_bottom_players_field()
+        {
+            var collection = Fixture.Collection;
+            var sortBy = Builders<Player>.Sort.Descending(p => p.Score);
+
+            var results = collection.Aggregate()
+                .Set(Builders<Tournament>.SetFields.Set(
+                    new StringFieldDefinition<Tournament, IEnumerable<Player>>("TopPlayers"),
+                    PickExpressionDefinitionBuilder.BottomN<Tournament, Player>(x => x.Players, sortBy, n: 2)))
+                .SortBy(x => x.Id)
+                .ToList();
+
+            results[0].TopPlayers.Select(p => p.Name).Should().Equal("Charlie", "Bob");
+            results[1].TopPlayers.Select(p => p.Name).Should().Equal("Eve", "Dave");
+        }
+
+        [Fact]
+        public void TopN_in_addFields_stage_should_add_top_players_field()
+        {
+            var collection = Fixture.Collection;
+            var sortBy = Builders<Player>.Sort.Descending(p => p.Score);
+            var pickExpr = PickExpressionDefinitionBuilder.TopN<Tournament, Player>(x => x.Players, sortBy, n: 2);
+
+            var registry = BsonSerializer.SerializerRegistry;
+            var serializer = registry.GetSerializer<Tournament>();
+            var rendered = pickExpr.Render(new RenderArgs<Tournament>(serializer, registry));
+
+            var addFieldsStage = new BsonDocumentPipelineStageDefinition<Tournament, Tournament>(
+                new BsonDocument("$addFields", new BsonDocument("TopPlayers", rendered)));
+
+            var results = collection.Aggregate()
+                .AppendStage(addFieldsStage)
+                .SortBy(x => x.Id)
+                .ToList();
+
+            results[0].TopPlayers.Select(p => p.Name).Should().Equal("Alice", "Charlie");
+            results[1].TopPlayers.Select(p => p.Name).Should().Equal("Eve", "Dave");
+        }
+
+        [Fact]
+        public void Top_in_project_stage_should_return_leader_field()
+        {
+            var collection = Fixture.Collection;
+            var sortBy = Builders<Player>.Sort.Descending(p => p.Score);
+            var pickExpr = PickExpressionDefinitionBuilder.Top<Tournament, Player>(x => x.Players, sortBy);
+
+            var registry = BsonSerializer.SerializerRegistry;
+            var serializer = registry.GetSerializer<Tournament>();
+            var rendered = pickExpr.Render(new RenderArgs<Tournament>(serializer, registry));
+
+            var projectStage = new BsonDocumentPipelineStageDefinition<Tournament, BsonDocument>(
+                new BsonDocument("$project", new BsonDocument
+                {
+                    { "_id", 0 },
+                    { "Leader", rendered }
+                }));
+
+            var results = collection.Aggregate()
+                .SortBy(x => x.Id)
+                .AppendStage(projectStage)
+                .ToList();
+
+            results[0]["Leader"]["Name"].AsString.Should().Be("Alice");
+            results[0]["Leader"]["Score"].AsInt32.Should().Be(10);
+            results[1]["Leader"]["Name"].AsString.Should().Be("Eve");
+        }
+
+        [Fact]
+        public void TopN_in_project_stage_should_return_top_players_field()
+        {
+            var collection = Fixture.Collection;
+            var sortBy = Builders<Player>.Sort.Descending(p => p.Score);
+            var pickExpr = PickExpressionDefinitionBuilder.TopN<Tournament, Player>(x => x.Players, sortBy, n: 2);
+
+            var registry = BsonSerializer.SerializerRegistry;
+            var serializer = registry.GetSerializer<Tournament>();
+            var rendered = pickExpr.Render(new RenderArgs<Tournament>(serializer, registry));
+
+            var projectStage = new BsonDocumentPipelineStageDefinition<Tournament, BsonDocument>(
+                new BsonDocument("$project", new BsonDocument
+                {
+                    { "_id", 0 },
+                    { "TopPlayers", rendered }
+                }));
+
+            var results = collection.Aggregate()
+                .SortBy(x => x.Id)
+                .AppendStage(projectStage)
+                .ToList();
+
+            results[0]["TopPlayers"].AsBsonArray.Select(p => p["Name"].AsString).Should().Equal("Alice", "Charlie");
+            results[1]["TopPlayers"].AsBsonArray.Select(p => p["Name"].AsString).Should().Equal("Eve", "Dave");
+        }
+
+        public class Tournament
+        {
+            [BsonId]
+            public int Id { get; set; }
+
+            [BsonElement("Name")]
+            public string Name { get; set; }
+
+            [BsonElement("Players")]
+            public List<Player> Players { get; set; }
+
+            [BsonElement("Leader")]
+            public Player Leader { get; set; }
+
+            [BsonElement("Loser")]
+            public Player Loser { get; set; }
+
+            [BsonElement("TopPlayers")]
+            public List<Player> TopPlayers { get; set; }
+        }
+
+        public class Player
+        {
+            [BsonElement("Name")]
+            public string Name { get; set; }
+
+            [BsonElement("Score")]
+            public int Score { get; set; }
+        }
+
+        public sealed class ClassFixture : MongoDatabaseFixture
+        {
+            public IMongoCollection<Tournament> Collection { get; private set; }
+
+            protected override void InitializeFixture()
+            {
+                Collection = CreateCollection<Tournament>("pickExpressionTests");
+                Collection.InsertMany([
+                    new Tournament
+                    {
+                        Id = 1,
+                        Name = "T1",
+                        Players =
+                        [
+                            new() { Name = "Alice", Score = 10 },
+                            new() { Name = "Bob", Score = 5 },
+                            new() { Name = "Charlie", Score = 8 }
+                        ]
+                    },
+                    new Tournament
+                    {
+                        Id = 2,
+                        Name = "T2",
+                        Players =
+                        [
+                            new() { Name = "Dave", Score = 3 },
+                            new() { Name = "Eve", Score = 7 }
+                        ]
+                    }
+                ]);
+            }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/PickExpressionDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PickExpressionDefinitionBuilderTests.cs
@@ -1,0 +1,270 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using Xunit;
+
+namespace MongoDB.Driver.Tests
+{
+    public class PickExpressionDefinitionBuilderTests
+    {
+        [Fact]
+        public void Top_with_lambda_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.Top<Document, Item>(
+                x => x.Items,
+                sortBy);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $top : { input : '$Items', sortBy : { Score : -1 } } }");
+        }
+
+        [Fact]
+        public void Top_with_field_definition_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.Top<Document, Item>(
+                new StringFieldDefinition<Document, IEnumerable<Item>>("Items"),
+                sortBy);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $top : { input : '$Items', sortBy : { Score : -1 } } }");
+        }
+
+        [Fact]
+        public void Top_with_compound_sort_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score).Ascending(x => x.Name);
+
+            var expression = PickExpressionDefinitionBuilder.Top<Document, Item>(x => x.Items, sortBy);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $top : { input : '$Items', sortBy : { Score : -1, Name : 1 } } }");
+        }
+
+        [Fact]
+        public void Bottom_with_lambda_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Ascending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.Bottom<Document, Item>(
+                x => x.Items,
+                sortBy);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $bottom : { input : '$Items', sortBy : { Score : 1 } } }");
+        }
+
+        [Fact]
+        public void Bottom_with_field_definition_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Ascending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.Bottom(
+                new StringFieldDefinition<Document, IEnumerable<Item>>("Items"),
+                sortBy);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $bottom : { input : '$Items', sortBy : { Score : 1 } } }");
+        }
+
+        [Fact]
+        public void TopN_with_lambda_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.TopN<Document, Item>(
+                x => x.Items,
+                sortBy,
+                n: 3);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $topN : { input : '$Items', sortBy : { Score : -1 }, n : 3 } }");
+        }
+
+        [Fact]
+        public void TopN_with_field_definition_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.TopN(
+                new StringFieldDefinition<Document, IEnumerable<Item>>("Items"),
+                sortBy,
+                n: 5);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $topN : { input : '$Items', sortBy : { Score : -1 }, n : 5 } }");
+        }
+
+        [Fact]
+        public void TopN_with_n_equals_one_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.TopN<Document, Item>(x => x.Items, sortBy, n: 1);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $topN : { input : '$Items', sortBy : { Score : -1 }, n : 1 } }");
+        }
+
+        [Fact]
+        public void TopN_with_invalid_n_should_throw()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var exception = Record.Exception(() =>
+                PickExpressionDefinitionBuilder.TopN<Document, Item>(x => x.Items, sortBy, n: 0));
+
+            exception.Should().BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void BottomN_with_lambda_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.BottomN<Document, Item>(
+                x => x.Items,
+                sortBy,
+                n: 3);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $bottomN : { input : '$Items', sortBy : { Score : -1 }, n : 3 } }");
+        }
+
+        [Fact]
+        public void BottomN_with_field_definition_should_render_expected_expression()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.BottomN(
+                new StringFieldDefinition<Document, IEnumerable<Item>>("Items"),
+                sortBy,
+                n: 2);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $bottomN : { input : '$Items', sortBy : { Score : -1 }, n : 2 } }");
+        }
+
+        [Fact]
+        public void SetFieldDefinitionsBuilder_Set_with_aggregate_expression_using_field_definition_should_render_expected_stage()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+            var pickExpr = PickExpressionDefinitionBuilder.TopN<Document, Item>(x => x.Items, sortBy, n: 3);
+
+            var setDef = Builders<Document>.SetFields.Set(
+                new StringFieldDefinition<Document, IEnumerable<Item>>("TopItems"),
+                pickExpr);
+
+            var rendered = RenderSetFieldDefinitions(setDef);
+            rendered.Should().Be("{ TopItems : { $topN : { input : '$Items', sortBy : { Score : -1 }, n : 3 } } }");
+        }
+
+        [Fact]
+        public void SetFieldDefinitionsBuilder_Set_with_aggregate_expression_using_lambda_should_render_expected_stage()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+            var pickExpr = PickExpressionDefinitionBuilder.TopN<Document, Item>(x => x.Items, sortBy, n: 3);
+
+            var setDef = Builders<Document>.SetFields.Set(
+                x => x.TopItems,
+                pickExpr);
+
+            var rendered = RenderSetFieldDefinitions(setDef);
+            rendered.Should().Be("{ TopItems : { $topN : { input : '$Items', sortBy : { Score : -1 }, n : 3 } } }");
+        }
+
+        [Fact]
+        public void ListSetFieldDefinitionsExtensions_Set_with_aggregate_expression_should_chain_correctly()
+        {
+            var sortByDesc = Builders<Item>.Sort.Descending(x => x.Score);
+            var sortByAsc = Builders<Item>.Sort.Ascending(x => x.Score);
+
+            var setDef = Builders<Document>.SetFields
+                .Set(x => x.TopItems, PickExpressionDefinitionBuilder.TopN<Document, Item>(x => x.Items, sortByDesc, n: 3))
+                .Set(x => x.TopItems, PickExpressionDefinitionBuilder.BottomN<Document, Item>(x => x.Items, sortByAsc, n: 1));
+
+            var rendered = RenderSetFieldDefinitions(setDef);
+            // Last Set wins when same field is used
+            rendered.Should().Be("{ TopItems : { $bottomN : { input : '$Items', sortBy : { Score : 1 }, n : 1 } } }");
+        }
+
+        [Fact]
+        public void TopN_with_nested_field_path_should_render_dollar_prefix_correctly()
+        {
+            var sortBy = Builders<Item>.Sort.Descending(x => x.Score);
+
+            var expression = PickExpressionDefinitionBuilder.TopN(
+                new StringFieldDefinition<DocumentWithNested, IEnumerable<Item>>("Nested.Items"),
+                sortBy,
+                n: 2);
+
+            var rendered = RenderExpression(expression);
+            rendered.Should().Be("{ $topN : { input : '$Nested.Items', sortBy : { Score : -1 }, n : 2 } }");
+        }
+
+        private static BsonValue RenderExpression<TDocument, TResult>(AggregateExpressionDefinition<TDocument, TResult> expression)
+        {
+            var registry = BsonSerializer.SerializerRegistry;
+            var serializer = registry.GetSerializer<TDocument>();
+            return expression.Render(new RenderArgs<TDocument>(serializer, registry));
+        }
+
+        private static BsonDocument RenderSetFieldDefinitions<TDocument>(SetFieldDefinitions<TDocument> setDef)
+        {
+            var registry = BsonSerializer.SerializerRegistry;
+            var serializer = registry.GetSerializer<TDocument>();
+            return setDef.Render(new RenderArgs<TDocument>(serializer, registry));
+        }
+
+        private class Document
+        {
+            [BsonElement("Items")]
+            public List<Item> Items { get; set; }
+
+            [BsonElement("TopItems")]
+            public List<Item> TopItems { get; set; }
+        }
+
+        private class DocumentWithNested
+        {
+            [BsonElement("Nested")]
+            public NestedDocument Nested { get; set; }
+        }
+
+        private class NestedDocument
+        {
+            [BsonElement("Items")]
+            public List<Item> Items { get; set; }
+        }
+
+        private class Item
+        {
+            [BsonElement("Score")]
+            public int Score { get; set; }
+
+            [BsonElement("Name")]
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Implements [CSHARP-5826](https://jira.mongodb.org/browse/CSHARP-5826)

## Summary

- Adds builder-level support for `$top`, `$bottom`, `$topN`, `$bottomN` as **aggregation array expressions** (MongoDB 8.3+)
- These operators were previously only available as group accumulators; MongoDB 8.3 extends them to work on array fields in `$set`, `$project`, `$addFields` etc.
- Adds `PickExpressionDefinitionBuilder` static class with factory methods for all four operators
- Adds `AggregateExpressionSetFieldDefinition` to enable using aggregation expressions as values in `$set` stages via `Builders<T>.SetFields`
- Adds `Feature.PickAccumulatorsAsExpressionsNewIn83` feature flag for server version gating

## Before and after

Before 8.3, finding the top scorer per tournament required a `$group` stage that collapses documents, losing all other fields:

```csharp
// MongoDB 5.2+ — must group, losing the rest of the tournament document
collection.Aggregate()
    .Group(x => x.TournamentId, g => new {
        Id = g.Key,
        Leader = g.Top(
            Builders<Score>.Sort.Descending(s => s.Points),
            e => e)
    });
// { $group: { _id: "$TournamentId", Leader: { $top: { sortBy: { Points: -1 }, output: "$$ROOT" } } } }
```

With 8.3 expressions the document passes through intact and `Leader` is computed directly from the embedded array in one `$set` stage:

```csharp
// MongoDB 8.3+ — operates on the embedded array, document shape preserved
collection.Aggregate()
    .Set(Builders<Tournament>.SetFields.Set(
        new StringFieldDefinition<Tournament, Player>("Leader"),
        PickExpressionDefinitionBuilder.Top<Tournament, Player>(
            x => x.Players,
            Builders<Player>.Sort.Descending(p => p.Score))));
// { $set: { Leader: { $top: { input: "$Players", sortBy: { Score: -1 } } } } }
```

