### PR TITLE
CSHARP-5980: Fix typo 'occured' to 'occurred' in LibraryLoadingException docs

### DIFF
--- a/src/MongoDB.Driver.Encryption/LibraryLoadingException.cs
+++ b/src/MongoDB.Driver.Encryption/LibraryLoadingException.cs
@@ -18,7 +18,7 @@ using System;
 namespace MongoDB.Driver.Encryption
 {
     /// <summary>
-    /// An exception that indicates that an error occured while loading a library.
+    /// An exception that indicates that an error occurred while loading a library.
     /// </summary>
 #pragma warning disable CA1032
     public class LibraryLoadingException : Exception


### PR DESCRIPTION
The class doxygen comment on `LibraryLoadingException` in `src/MongoDB.Driver.Encryption/LibraryLoadingException.cs:21` read `an error occured while loading a library`. Doc-only change.