### PR TITLE
CSHARP-5963: Fix failed search-index variants because of cluster name conflict

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -2203,7 +2203,7 @@ task_groups:
             - "AWS_SECRET_ACCESS_KEY"
             - "AWS_SESSION_TOKEN"
           env:
-            CLUSTER_PREFIX: dbx-csharp-search-index
+            CLUSTER_PREFIX: dbx-csharp-index
             MONGODB_VERSION: "8.0"
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh


### PR DESCRIPTION
Atlas has a requirement to have unique first 23 characters in the group:

> Cluster name dbx-csharp-search-index-5843579d8414371e cannot have same first 23 characters as another cluster or serverless instance name in same group.

Reduce the prefix to let us run search index tests in parallel.