### PR TITLE
CSHARP-3556: Reconsider server pinning in GridFS

### DIFF
--- a/src/MongoDB.Driver/Core/Bindings/SingleServerReadBinding.cs
+++ b/src/MongoDB.Driver/Core/Bindings/SingleServerReadBinding.cs
@@ -1,4 +1,4 @@
-/* Copyright 2013-present MongoDB Inc.
+/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Servers;
 
@@ -24,18 +25,21 @@ namespace MongoDB.Driver.Core.Bindings
 {
     internal sealed class SingleServerReadBinding : IReadBinding
     {
+#pragma warning disable CA2213 // Disposable fields should be disposed
+        private readonly IClusterInternal _cluster;
+#pragma warning restore CA2213 // Disposable fields should be disposed
         private bool _disposed;
         private readonly ReadPreference _readPreference;
-        private readonly IServer _server;
-        private readonly TimeSpan _serverSelectionTimeout;
+        private readonly IServerSelector _serverSelector;
         private readonly ICoreSessionHandle _session;
 
-        public SingleServerReadBinding(IServer server, ReadPreference readPreference, ICoreSessionHandle session, TimeSpan serverSelectionTimeout)
+        public SingleServerReadBinding(IClusterInternal cluster, IServer server, ReadPreference readPreference, ICoreSessionHandle session)
         {
-            _server = Ensure.IsNotNull(server, nameof(server));
+            _cluster = Ensure.IsNotNull(cluster, nameof(cluster));
+            Ensure.IsNotNull(server, nameof(server));
+            _serverSelector = new EndPointServerSelector(server.EndPoint);
             _readPreference = Ensure.IsNotNull(readPreference, nameof(readPreference));
             _session = Ensure.IsNotNull(session, nameof(session));
-            _serverSelectionTimeout = Ensure.IsGreaterThanOrEqualToZero(serverSelectionTimeout, nameof(serverSelectionTimeout));
         }
 
         public ReadPreference ReadPreference
@@ -51,24 +55,22 @@ namespace MongoDB.Driver.Core.Bindings
         public IChannelSourceHandle GetReadChannelSource(OperationContext operationContext)
         {
             ThrowIfDisposed();
-            return GetChannelSourceHelper(operationContext);
+            var server = _cluster.SelectServer(operationContext, _serverSelector);
+            return new ChannelSourceHandle(new ServerChannelSource(server, _session.Fork()));
         }
 
-        public Task<IChannelSourceHandle> GetReadChannelSourceAsync(OperationContext operationContext)
+        public async Task<IChannelSourceHandle> GetReadChannelSourceAsync(OperationContext operationContext)
         {
             ThrowIfDisposed();
-            return Task.FromResult(GetChannelSourceHelper(operationContext));
+            var server = await _cluster.SelectServerAsync(operationContext, _serverSelector).ConfigureAwait(false);
+            return new ChannelSourceHandle(new ServerChannelSource(server, _session.Fork()));
         }
 
-        public IChannelSourceHandle GetReadChannelSource(OperationContext operationContext, IReadOnlyCollection<ServerDescription> deprioritizedServers)
-        {
-            return GetReadChannelSource(operationContext);
-        }
+        public IChannelSourceHandle GetReadChannelSource(OperationContext operationContext, IReadOnlyCollection<ServerDescription> deprioritizedServers) =>
+            GetReadChannelSource(operationContext);
 
-        public Task<IChannelSourceHandle> GetReadChannelSourceAsync(OperationContext operationContext, IReadOnlyCollection<ServerDescription> deprioritizedServers)
-        {
-            return GetReadChannelSourceAsync(operationContext);
-        }
+        public Task<IChannelSourceHandle> GetReadChannelSourceAsync(OperationContext operationContext, IReadOnlyCollection<ServerDescription> deprioritizedServers) =>
+            GetReadChannelSourceAsync(operationContext);
 
         public void Dispose()
         {
@@ -77,31 +79,6 @@ namespace MongoDB.Driver.Core.Bindings
                 _session.Dispose();
                 _disposed = true;
             }
-        }
-
-        private IChannelSourceHandle GetChannelSourceHelper(OperationContext operationContext)
-        {
-            // server might be in unknown state due to previous failed operation, allow description to be updated
-            // this is done instead of server selection
-            // TODO parameterize timeout and avoid busy wait, or offload waiting to server level
-            // Should be addressed by CSHARP-3556
-            if (_server.Description.State == ServerState.Disconnected)
-            {
-                using var serverSelectionContext = operationContext.WithTimeout(_serverSelectionTimeout);
-
-                if (SpinWait.SpinUntil(() =>
-                            _server.Description.State == ServerState.Connected || serverSelectionContext.CancellationToken.IsCancellationRequested,
-                        serverSelectionContext.RemainingTimeout))
-                {
-                    serverSelectionContext.CancellationToken.ThrowIfCancellationRequested();
-                }
-                else
-                {
-                    throw new TimeoutException($"A timeout occurred after {serverSelectionContext.Elapsed.TotalMilliseconds}ms waiting for the server to become available.");
-                }
-            }
-
-            return new ChannelSourceHandle(new ServerChannelSource(_server, _session.Fork()));
         }
 
         private void ThrowIfDisposed()

--- a/src/MongoDB.Driver/Core/Clusters/ServerSelectors/EndPointServerSelector.cs
+++ b/src/MongoDB.Driver/Core/Clusters/ServerSelectors/EndPointServerSelector.cs
@@ -1,4 +1,4 @@
-/* Copyright 2013-present MongoDB Inc.
+/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ namespace MongoDB.Driver.Core.Clusters.ServerSelectors
         {
             _endPoint = Ensure.IsNotNull(endPoint, nameof(endPoint));
         }
+
+        /// <summary>
+        /// Gets the endpoint associated with the server selector.
+        /// </summary>
+        public EndPoint EndPoint => _endPoint;
 
         // methods
         /// <inheritdoc/>

--- a/src/MongoDB.Driver/GridFS/GridFSBucket.cs
+++ b/src/MongoDB.Driver/GridFS/GridFSBucket.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2016-present MongoDB Inc.
+﻿/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1041,7 +1041,7 @@ namespace MongoDB.Driver.GridFS
             var readPreference = _options.ReadPreference ?? _database.Settings.ReadPreference;
             var selector = new ReadPreferenceServerSelector(readPreference);
             var server = _cluster.SelectServer(operationContext, selector);
-            var binding = new SingleServerReadBinding(server, readPreference, NoCoreSession.NewHandle(), _cluster.Settings.ServerSelectionTimeout);
+            var binding = new SingleServerReadBinding(_cluster, server, readPreference, NoCoreSession.NewHandle());
             return new ReadBindingHandle(binding);
         }
 
@@ -1050,7 +1050,7 @@ namespace MongoDB.Driver.GridFS
             var readPreference = _options.ReadPreference ?? _database.Settings.ReadPreference;
             var selector = new ReadPreferenceServerSelector(readPreference);
             var server = await _cluster.SelectServerAsync(operationContext, selector).ConfigureAwait(false);
-            var binding = new SingleServerReadBinding(server, readPreference, NoCoreSession.NewHandle(), _cluster.Settings.ServerSelectionTimeout);
+            var binding = new SingleServerReadBinding(_cluster, server, readPreference, NoCoreSession.NewHandle());
             return new ReadBindingHandle(binding);
         }
 

--- a/tests/MongoDB.Driver.Tests/Core/Bindings/SingleServerReadBindingTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Bindings/SingleServerReadBindingTests.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2017-present MongoDB Inc.
+﻿/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,233 +15,218 @@
 
 using System;
 using System.Net;
-using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using MongoDB.Bson.TestHelpers;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Servers;
 using Moq;
 using Xunit;
 
-namespace MongoDB.Driver.Core.Bindings
+namespace MongoDB.Driver.Core.Bindings;
+
+public class SingleServerReadBindingTests
 {
-    public class SingleServerReadBindingTests
+    [Fact]
+    public void constructor_should_initialize_instance()
     {
-        private static readonly TimeSpan __defaultServerSelectionTimeout = TimeSpan.FromSeconds(30);
+        var cluster = new Mock<IClusterInternal>().Object;
+        var server = CreateMockServer().Object;
+        var readPreference = ReadPreference.Primary;
+        var session = new Mock<ICoreSessionHandle>().Object;
 
-        [Fact]
-        public void constructor_should_initialize_instance()
+        var result = new SingleServerReadBinding(cluster, server, readPreference, session);
+
+        result._cluster().Should().BeSameAs(cluster);
+        result._disposed().Should().BeFalse();
+        result.ReadPreference.Should().BeSameAs(readPreference);
+        result.Session.Should().BeSameAs(session);
+    }
+
+    [Fact]
+    public void constructor_should_throw_when_cluster_is_null()
+    {
+        var server = CreateMockServer().Object;
+        var readPreference = ReadPreference.Primary;
+        var session = new Mock<ICoreSessionHandle>().Object;
+
+        var exception = Record.Exception(() => new SingleServerReadBinding(null, server, readPreference, session));
+
+        var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
+        e.ParamName.Should().Be("cluster");
+    }
+
+    [Fact]
+    public void constructor_should_throw_when_server_is_null()
+    {
+        var cluster = new Mock<IClusterInternal>().Object;
+        var readPreference = ReadPreference.Primary;
+        var session = new Mock<ICoreSessionHandle>().Object;
+
+        var exception = Record.Exception(() => new SingleServerReadBinding(cluster, null, readPreference, session));
+
+        var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
+        e.ParamName.Should().Be("server");
+    }
+
+    [Fact]
+    public void constructor_should_throw_when_readPreference_is_null()
+    {
+        var cluster = new Mock<IClusterInternal>().Object;
+        var server = CreateMockServer().Object;
+        var session = new Mock<ICoreSessionHandle>().Object;
+
+        var exception = Record.Exception(() => new SingleServerReadBinding(cluster, server, null, session));
+
+        var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
+        e.ParamName.Should().Be("readPreference");
+    }
+
+    [Fact]
+    public void constructor_should_throw_when_session_is_null()
+    {
+        var cluster = new Mock<IClusterInternal>().Object;
+        var server = CreateMockServer().Object;
+        var readPreference = ReadPreference.Primary;
+
+        var exception = Record.Exception(() => new SingleServerReadBinding(cluster, server, readPreference, null));
+
+        var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
+        e.ParamName.Should().Be("session");
+    }
+
+    [Fact]
+    public void ReadPreference_should_return_expected_result()
+    {
+        var readPreference = ReadPreference.Secondary;
+        var subject = CreateSubject(readPreference: readPreference);
+
+        var result = subject.ReadPreference;
+
+        result.Should().BeSameAs(readPreference);
+    }
+
+    [Fact]
+    public void Session_should_return_expected_result()
+    {
+        var session = new Mock<ICoreSessionHandle>().Object;
+        var subject = CreateSubject(session: session);
+
+        var result = subject.Session;
+
+        result.Should().BeSameAs(session);
+    }
+
+    [Fact]
+    public void Dispose_should_have_expected_result()
+    {
+        var mockSession = new Mock<ICoreSessionHandle>();
+        var subject = CreateSubject(session: mockSession.Object);
+
+        subject.Dispose();
+
+        subject._disposed().Should().BeTrue();
+        mockSession.Verify(m => m.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public void Dispose_can_be_called_more_than_once()
+    {
+        var mockSession = new Mock<ICoreSessionHandle>();
+        var subject = CreateSubject(session: mockSession.Object);
+
+        subject.Dispose();
+        subject.Dispose();
+
+        mockSession.Verify(m => m.Dispose(), Times.Once);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public async Task GetReadChannelSource_should_throw_when_disposed(
+        [Values(false, true)] bool async)
+    {
+        var subject = CreateDisposedSubject();
+
+        var exception = async ?
+            await Record.ExceptionAsync(() => subject.GetReadChannelSourceAsync(OperationContext.NoTimeout)) :
+            Record.Exception(() => subject.GetReadChannelSource(OperationContext.NoTimeout));
+
+        var e = exception.Should().BeOfType<ObjectDisposedException>().Subject;
+        e.ObjectName.Should().Be(subject.GetType().FullName);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public async Task GetReadChannelSource_should_call_cluster_SelectServer(
+        [Values(false, true)] bool async)
+    {
+        var clusterMock = new Mock<IClusterInternal>();
+        clusterMock.Setup(c => c.SelectServer(It.IsAny<OperationContext>(), It.IsAny<IServerSelector>())).Returns(Mock.Of<IServer>());
+        clusterMock.Setup(c => c.SelectServerAsync(It.IsAny<OperationContext>(), It.IsAny<IServerSelector>())).ReturnsAsync(Mock.Of<IServer>());
+
+        var endpoint = new DnsEndPoint("localhost", 27017);
+        var serverMock = new Mock<IServer>();
+        serverMock.Setup(s => s.EndPoint).Returns(endpoint);
+        var subject = CreateSubject(cluster: clusterMock.Object, server: serverMock.Object);
+
+        if (async)
         {
-            var server = new Mock<IServer>().Object;
-            var readPreference = ReadPreference.Primary;
-            var session = new Mock<ICoreSessionHandle>().Object;
-
-            var result = new SingleServerReadBinding(server, readPreference, session, __defaultServerSelectionTimeout);
-
-            result._disposed().Should().BeFalse();
-            result.ReadPreference.Should().BeSameAs(readPreference);
-            result._server().Should().BeSameAs(server);
-            result._serverSelectionTimeout().Should().Be(__defaultServerSelectionTimeout);
-            result.Session.Should().BeSameAs(session);
+            _ = await subject.GetReadChannelSourceAsync(OperationContext.NoTimeout);
+            clusterMock.Verify(c => c.SelectServerAsync(It.IsAny<OperationContext>(), It.Is<EndPointServerSelector>(s => s.EndPoint == endpoint)));
         }
-
-        [Fact]
-        public void constructor_should_throw_when_server_is_null()
+        else
         {
-            var readPreference = ReadPreference.Primary;
-            var session = new Mock<ICoreSessionHandle>().Object;
-
-            var exception = Record.Exception(() => new SingleServerReadBinding(null, readPreference, session, __defaultServerSelectionTimeout));
-
-            var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
-            e.ParamName.Should().Be("server");
-        }
-
-        [Fact]
-        public void constructor_should_throw_when_readPreference_is_null()
-        {
-            var server = new Mock<IServer>().Object;
-            var session = new Mock<ICoreSessionHandle>().Object;
-
-            var exception = Record.Exception(() => new SingleServerReadBinding(server, null, session, __defaultServerSelectionTimeout));
-
-            var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
-            e.ParamName.Should().Be("readPreference");
-        }
-
-        [Fact]
-        public void constructor_should_throw_when_session_is_null()
-        {
-            var server = new Mock<IServer>().Object;
-            var readPreference = ReadPreference.Primary;
-
-            var exception = Record.Exception(() => new SingleServerReadBinding(server, readPreference, null, __defaultServerSelectionTimeout));
-
-            var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
-            e.ParamName.Should().Be("session");
-        }
-
-        [Fact]
-        public void constructor_should_throw_when_serverSelectionTimeout_is_negative()
-        {
-            var server = new Mock<IServer>().Object;
-            var readPreference = ReadPreference.Primary;
-            var session = new Mock<ICoreSessionHandle>().Object;
-
-            var exception = Record.Exception(() => new SingleServerReadBinding(server, readPreference, session, TimeSpan.FromSeconds(-1)));
-
-            var e = exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject;
-            e.ParamName.Should().Be("serverSelectionTimeout");
-        }
-
-        [Fact]
-        public void ReadPreference_should_return_expected_result()
-        {
-            var readPreference = ReadPreference.Secondary;
-            var subject = CreateSubject(readPreference: readPreference);
-
-            var result = subject.ReadPreference;
-
-            result.Should().BeSameAs(readPreference);
-        }
-
-        [Fact]
-        public void Session_should_return_expected_result()
-        {
-            var session = new Mock<ICoreSessionHandle>().Object;
-            var subject = CreateSubject(session: session);
-
-            var result = subject.Session;
-
-            result.Should().BeSameAs(session);
-        }
-
-        [Fact]
-        public void Dispose_should_have_expected_result()
-        {
-            var mockSession = new Mock<ICoreSessionHandle>();
-            var subject = CreateSubject(session: mockSession.Object);
-
-            subject.Dispose();
-
-            subject._disposed().Should().BeTrue();
-            mockSession.Verify(m => m.Dispose(), Times.Once);
-        }
-
-        [Fact]
-        public void Dispose_can_be_called_more_than_once()
-        {
-            var mockSession = new Mock<ICoreSessionHandle>();
-            var subject = CreateSubject(session: mockSession.Object);
-
-            subject.Dispose();
-            subject.Dispose();
-
-            mockSession.Verify(m => m.Dispose(), Times.Once);
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        public async Task GetReadChannelSource_should_return_expected_result(
-            [Values(false, true)] bool async)
-        {
-            var mockSession = new Mock<ICoreSessionHandle>();
-            var subject = CreateSubject(session: mockSession.Object);
-            var forkedSession = new Mock<ICoreSessionHandle>().Object;
-            mockSession.Setup(m => m.Fork()).Returns(forkedSession);
-
-            var result = async ?
-                await subject.GetReadChannelSourceAsync(OperationContext.NoTimeout) :
-                subject.GetReadChannelSource(OperationContext.NoTimeout);
-
-            var newHandle = result.Should().BeOfType<ChannelSourceHandle>().Subject;
-            var referenceCounted = newHandle._reference();
-            var source = referenceCounted.Instance.Should().BeOfType<ServerChannelSource>().Subject;
-            source.Session.Should().BeSameAs(forkedSession);
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        public async Task GetReadChannelSource_should_throw_when_disposed(
-            [Values(false, true)] bool async)
-        {
-            var subject = CreateDisposedSubject();
-
-            var exception = async ?
-                await Record.ExceptionAsync(() => subject.GetReadChannelSourceAsync(OperationContext.NoTimeout)) :
-                Record.Exception(() => subject.GetReadChannelSource(OperationContext.NoTimeout));
-
-            var e = exception.Should().BeOfType<ObjectDisposedException>().Subject;
-            e.ObjectName.Should().Be(subject.GetType().FullName);
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        public async Task GetReadChannelSource_should_throw_TimeoutException_when_server_remains_disconnected(
-            [Values(false, true)] bool async)
-        {
-            var mockServer = new Mock<IServer>();
-            mockServer.Setup(s => s.Description).Returns(new ServerDescription(
-                new ServerId(new Clusters.ClusterId(), new DnsEndPoint("localhost", 20017)),
-                new DnsEndPoint("localhost", 20017),
-                state: ServerState.Disconnected));
-            var subject = new SingleServerReadBinding(mockServer.Object, ReadPreference.Primary, new Mock<ICoreSessionHandle>().Object, TimeSpan.FromMilliseconds(50));
-
-            var exception = async ?
-                await Record.ExceptionAsync(() => subject.GetReadChannelSourceAsync(OperationContext.NoTimeout)) :
-                Record.Exception(() => subject.GetReadChannelSource(OperationContext.NoTimeout));
-
-            exception.Should().BeOfType<TimeoutException>();
-        }
-
-        // private methods
-        private SingleServerReadBinding CreateDisposedSubject()
-        {
-            var subject = CreateSubject();
-            subject.Dispose();
-            return subject;
-        }
-
-        private SingleServerReadBinding CreateSubject(IServer server = null, ReadPreference readPreference = null, ICoreSessionHandle session = null)
-        {
-            return new SingleServerReadBinding(
-                server ?? CreateMockServer().Object,
-                readPreference ?? ReadPreference.Primary,
-                session ?? new Mock<ICoreSessionHandle>().Object,
-                __defaultServerSelectionTimeout);
-        }
-
-        private Mock<IServer> CreateMockServer()
-        {
-            var mockServer = new Mock<IServer>();
-            mockServer.Setup(s => s.Description).Returns(new ServerDescription(
-                new ServerId(new Clusters.ClusterId(), new DnsEndPoint("localhost", 20017)),
-                new DnsEndPoint("localhost", 20017),
-                state: ServerState.Connected));
-
-            return mockServer;
+            _ = subject.GetReadChannelSource(OperationContext.NoTimeout);
+            clusterMock.Verify(c => c.SelectServer(It.IsAny<OperationContext>(), It.Is<EndPointServerSelector>(s => s.EndPoint == endpoint)));
         }
     }
 
-    internal static class SingleServerReadBindingReflector
+    // private methods
+    private SingleServerReadBinding CreateDisposedSubject()
     {
-        public static bool _disposed(this SingleServerReadBinding obj)
-        {
-            var fieldInfo = typeof(SingleServerReadBinding).GetField("_disposed", BindingFlags.NonPublic | BindingFlags.Instance);
-            return (bool)fieldInfo.GetValue(obj);
-        }
-
-        public static IServer _server(this SingleServerReadBinding obj)
-        {
-            var fieldInfo = typeof(SingleServerReadBinding).GetField("_server", BindingFlags.NonPublic | BindingFlags.Instance);
-            return (IServer)fieldInfo.GetValue(obj);
-        }
-
-        public static TimeSpan _serverSelectionTimeout(this SingleServerReadBinding obj)
-        {
-            var fieldInfo = typeof(SingleServerReadBinding).GetField("_serverSelectionTimeout", BindingFlags.NonPublic | BindingFlags.Instance);
-            return (TimeSpan)fieldInfo.GetValue(obj);
-        }
+        var subject = CreateSubject();
+        subject.Dispose();
+        return subject;
     }
+
+    private SingleServerReadBinding CreateSubject(IClusterInternal cluster = null, IServer server = null, ReadPreference readPreference = null, ICoreSessionHandle session = null)
+    {
+        if (session == null)
+        {
+            var sessionMock = new Mock<ICoreSessionHandle>();
+            sessionMock.Setup(m => m.Fork()).Returns(sessionMock.Object);
+            session = sessionMock.Object;
+        }
+
+        return new SingleServerReadBinding(
+            cluster ?? new Mock<IClusterInternal>().Object,
+            server ?? CreateMockServer().Object,
+            readPreference ?? ReadPreference.Primary,
+            session);
+    }
+
+    private Mock<IServer> CreateMockServer()
+    {
+        var endpoint = new DnsEndPoint("localhost", 27017);
+        var mockServer = new Mock<IServer>();
+        mockServer.Setup(s => s.Description).Returns(new ServerDescription(
+            new ServerId(new Clusters.ClusterId(), endpoint),
+            endpoint,
+            state: ServerState.Connected));
+        mockServer.Setup(s => s.EndPoint).Returns(endpoint);
+
+        return mockServer;
+    }
+}
+
+internal static class SingleServerReadBindingReflector
+{
+    public static bool _disposed(this SingleServerReadBinding obj)
+        => (bool)Reflector.GetFieldValue(obj, "_disposed");
+
+    public static IClusterInternal _cluster(this SingleServerReadBinding obj)
+        => (IClusterInternal)Reflector.GetFieldValue(obj, "_cluster");
 }

--- a/tests/MongoDB.Driver.Tests/Core/Bindings/SingleServerReadBindingTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Bindings/SingleServerReadBindingTests.cs
@@ -20,8 +20,8 @@ using FluentAssertions;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
-using MongoDB.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Servers;
+using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;
 

--- a/tests/MongoDB.Driver.Tests/Core/Clusters/ServerSelectors/EndPointServerSelectorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Clusters/ServerSelectors/EndPointServerSelectorTests.cs
@@ -13,6 +13,8 @@
 * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using FluentAssertions;
@@ -20,56 +22,37 @@ using MongoDB.Driver.Core.Helpers;
 using MongoDB.Driver.Core.Servers;
 using Xunit;
 
-namespace MongoDB.Driver.Core.Clusters.ServerSelectors
+namespace MongoDB.Driver.Core.Clusters.ServerSelectors;
+
+public class EndPointServerSelectorTests
 {
-    public class EndPointServerSelectorTests
+    private static readonly ClusterId __clusterId = new ClusterId();
+    private static readonly ServerDescription __primary = ServerDescriptionHelper.Connected(__clusterId, new DnsEndPoint("localhost", 27017), ServerType.ReplicaSetPrimary, new TagSet(new[] { new Tag("a", "1") }));
+    private static readonly ServerDescription __secondary1 = ServerDescriptionHelper.Connected(__clusterId, new DnsEndPoint("localhost", 27018), ServerType.ReplicaSetSecondary, new TagSet(new[] { new Tag("a", "1") }));
+    private static readonly ServerDescription __secondary2 = ServerDescriptionHelper.Connected(__clusterId, new DnsEndPoint("localhost", 27019), ServerType.ReplicaSetSecondary, new TagSet(new[] { new Tag("a", "2") }));
+    private static readonly ClusterDescription __description = new ClusterDescription(
+        __clusterId,
+        false,
+        null,
+        ClusterType.ReplicaSet,
+        [__primary, __secondary1, __secondary2]);
+
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void SelectServers_should_return_expected_results(ServerDescription server, IEnumerable<ServerDescription> servers, ServerDescription[] expected)
     {
-        private readonly ClusterDescription _description;
+        var subject = new EndPointServerSelector(server.EndPoint);
 
-        public EndPointServerSelectorTests()
-        {
-            var clusterId = new ClusterId();
-            _description = new ClusterDescription(
-                clusterId,
-                false,
-                null,
-                ClusterType.Unknown,
-                [
-                    ServerDescriptionHelper.Connected(clusterId, new DnsEndPoint("localhost", 27017)),
-                    ServerDescriptionHelper.Connected(clusterId, new DnsEndPoint("localhost", 27018)),
-                    ServerDescriptionHelper.Connected(clusterId, new DnsEndPoint("localhost", 27019)),
-                ]);
-        }
+        var result = subject.SelectServers(__description, servers).ToList();
 
-        [Fact]
-        public void Should_select_the_server_if_it_exists()
-        {
-            var subject = new EndPointServerSelector(new DnsEndPoint("localhost", 27017));
-
-            var result = subject.SelectServers(_description, _description.Servers).ToList();
-
-            result.Count.Should().Be(1);
-            result.Should().BeEquivalentTo(_description.Servers[0]);
-        }
-
-        [Fact]
-        public void Should_return_empty_if_the_server_does_not_exist()
-        {
-            var subject = new EndPointServerSelector(new DnsEndPoint("blargh", 27017));
-
-            var result = subject.SelectServers(_description, _description.Servers).ToList();
-
-            result.Should().BeEmpty();
-        }
-
-        [Fact]
-        public void Should_select_no_servers_when_none_exist()
-        {
-            var subject = new EndPointServerSelector(new DnsEndPoint("blargh", 27017));
-
-            var result = subject.SelectServers(_description, Enumerable.Empty<ServerDescription>()).ToList();
-
-            result.Should().BeEmpty();
-        }
+        result.ToArray().ShouldBeEquivalentTo(expected);
     }
+
+    public static readonly object[][] TestCases =
+    [
+        [__primary, new[] { __primary, __secondary1, __secondary2 }, new[] { __primary } ],
+        [__secondary2, new[] { __primary, __secondary1, __secondary2 }, new[] { __secondary2 } ],
+        [__secondary2, new[] { __primary, __secondary1 }, Array.Empty<ServerDescription>() ],
+        [__secondary2, Array.Empty<ServerDescription>(), Array.Empty<ServerDescription>() ],
+    ];
 }


### PR DESCRIPTION
The PR replaces a busy-wait SpinWait.SpinUntil polling loop with proper cluster-level server selection, as the old TODO CSHARP-3556 comment indicated was needed.