### PR TITLE
CSHARP-5611: Eliminate the temporary byte array allocation in ObjectId.ToString

### DIFF
--- a/src/MongoDB.Bson/ObjectModel/ObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/ObjectId.cs
@@ -459,7 +459,7 @@ namespace MongoDB.Bson
         {
             if (destination.Length < 12)
             {
-                throw new ArgumentException("Not enough room in destination span.", "offset");
+                throw new ArgumentException("Not enough room in destination span.", "destination");
             }
 
             destination[0] = (byte)(_a >> 24);
@@ -485,35 +485,35 @@ namespace MongoDB.Bson
         {
             if (destination.Length < 24)
             {
-                throw new ArgumentException("Not enough room in destination span.", "offset");
+                throw new ArgumentException("Not enough room in destination span.", "destination");
             }
 
             Span<byte> span = stackalloc byte[12];
             ToByteSpan(span);
-            destination[0] = BsonUtils.ToHexChar(span[3] >> 4);
-            destination[1] = BsonUtils.ToHexChar(span[3] & 0xF);
-            destination[2] = BsonUtils.ToHexChar(span[2] >> 4);
-            destination[3] = BsonUtils.ToHexChar(span[2] & 0xF);
-            destination[4] = BsonUtils.ToHexChar(span[1] >> 4);
-            destination[5] = BsonUtils.ToHexChar(span[1] & 0xF);
-            destination[6] = BsonUtils.ToHexChar(span[0] >> 4);
-            destination[7] = BsonUtils.ToHexChar(span[0] & 0xF);
-            destination[8] = BsonUtils.ToHexChar(span[7] >> 4);
-            destination[9] = BsonUtils.ToHexChar(span[7] & 0xF);
-            destination[10] = BsonUtils.ToHexChar(span[6] >> 4);
-            destination[11] = BsonUtils.ToHexChar(span[6] & 0xF);
-            destination[12] = BsonUtils.ToHexChar(span[5] >> 4);
-            destination[13] = BsonUtils.ToHexChar(span[5] & 0xF);
-            destination[14] = BsonUtils.ToHexChar(span[4] >> 4);
-            destination[15] = BsonUtils.ToHexChar(span[4] & 0xF);
-            destination[16] = BsonUtils.ToHexChar(span[11] >> 4);
-            destination[17] = BsonUtils.ToHexChar(span[11] & 0xF);
-            destination[18] = BsonUtils.ToHexChar(span[10] >> 4);
-            destination[19] = BsonUtils.ToHexChar(span[10] & 0xF);
-            destination[20] = BsonUtils.ToHexChar(span[9] >> 4);
-            destination[21] = BsonUtils.ToHexChar(span[9] & 0xF);
-            destination[22] = BsonUtils.ToHexChar(span[8] >> 4);
-            destination[23] = BsonUtils.ToHexChar(span[8] & 0xF);
+            destination[0] = BsonUtils.ToHexChar(span[0] >> 4);
+            destination[1] = BsonUtils.ToHexChar(span[0] & 0xF);
+            destination[2] = BsonUtils.ToHexChar(span[1] >> 4);
+            destination[3] = BsonUtils.ToHexChar(span[1] & 0xF);
+            destination[4] = BsonUtils.ToHexChar(span[2] >> 4);
+            destination[5] = BsonUtils.ToHexChar(span[2] & 0xF);
+            destination[6] = BsonUtils.ToHexChar(span[3] >> 4);
+            destination[7] = BsonUtils.ToHexChar(span[3] & 0xF);
+            destination[8] = BsonUtils.ToHexChar(span[4] >> 4);
+            destination[9] = BsonUtils.ToHexChar(span[4] & 0xF);
+            destination[10] = BsonUtils.ToHexChar(span[5] >> 4);
+            destination[11] = BsonUtils.ToHexChar(span[5] & 0xF);
+            destination[12] = BsonUtils.ToHexChar(span[6] >> 4);
+            destination[13] = BsonUtils.ToHexChar(span[6] & 0xF);
+            destination[14] = BsonUtils.ToHexChar(span[7] >> 4);
+            destination[15] = BsonUtils.ToHexChar(span[7] & 0xF);
+            destination[16] = BsonUtils.ToHexChar(span[8] >> 4);
+            destination[17] = BsonUtils.ToHexChar(span[8] & 0xF);
+            destination[18] = BsonUtils.ToHexChar(span[9] >> 4);
+            destination[19] = BsonUtils.ToHexChar(span[9] & 0xF);
+            destination[20] = BsonUtils.ToHexChar(span[10] >> 4);
+            destination[21] = BsonUtils.ToHexChar(span[10] & 0xF);
+            destination[22] = BsonUtils.ToHexChar(span[11] >> 4);
+            destination[23] = BsonUtils.ToHexChar(span[11] & 0xF);
         }
 #endif
 

--- a/src/MongoDB.Bson/ObjectModel/ObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/ObjectId.cs
@@ -449,12 +449,86 @@ namespace MongoDB.Bson
             destination[offset + 11] = (byte)(_c);
         }
 
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Converts the ObjectId to a byte buffer provided by the input span.
+        /// </summary>
+        /// <param name="destination">The destination byte span.</param>
+        /// <exception cref="ArgumentException">Not enough room in destination span.</exception>
+        public void ToByteSpan(Span<byte> destination)
+        {
+            if (destination.Length < 12)
+            {
+                throw new ArgumentException("Not enough room in destination span.", "offset");
+            }
+
+            destination[0] = (byte)(_a >> 24);
+            destination[1] = (byte)(_a >> 16);
+            destination[2] = (byte)(_a >> 8);
+            destination[3] = (byte)(_a);
+            destination[4] = (byte)(_b >> 24);
+            destination[5] = (byte)(_b >> 16);
+            destination[6] = (byte)(_b >> 8);
+            destination[7] = (byte)(_b);
+            destination[8] = (byte)(_c >> 24);
+            destination[9] = (byte)(_c >> 16);
+            destination[10] = (byte)(_c >> 8);
+            destination[11] = (byte)(_c);
+        }
+
+        /// <summary>
+        /// Fills a character span with the characters corresponding to the string representation of the value.
+        /// </summary>
+        /// <param name="destination">The span to fill the characters in.</param>
+        /// <exception cref="ArgumentException">Not enough room in destination span.</exception>
+        public void ToCharSpan(Span<char> destination)
+        {
+            if (destination.Length < 24)
+            {
+                throw new ArgumentException("Not enough room in destination span.", "offset");
+            }
+
+            Span<byte> span = stackalloc byte[12];
+            ToByteSpan(span);
+            destination[0] = BsonUtils.ToHexChar(span[3] >> 4);
+            destination[1] = BsonUtils.ToHexChar(span[3] & 0xF);
+            destination[2] = BsonUtils.ToHexChar(span[2] >> 4);
+            destination[3] = BsonUtils.ToHexChar(span[2] & 0xF);
+            destination[4] = BsonUtils.ToHexChar(span[1] >> 4);
+            destination[5] = BsonUtils.ToHexChar(span[1] & 0xF);
+            destination[6] = BsonUtils.ToHexChar(span[0] >> 4);
+            destination[7] = BsonUtils.ToHexChar(span[0] & 0xF);
+            destination[8] = BsonUtils.ToHexChar(span[7] >> 4);
+            destination[9] = BsonUtils.ToHexChar(span[7] & 0xF);
+            destination[10] = BsonUtils.ToHexChar(span[6] >> 4);
+            destination[11] = BsonUtils.ToHexChar(span[6] & 0xF);
+            destination[12] = BsonUtils.ToHexChar(span[5] >> 4);
+            destination[13] = BsonUtils.ToHexChar(span[5] & 0xF);
+            destination[14] = BsonUtils.ToHexChar(span[4] >> 4);
+            destination[15] = BsonUtils.ToHexChar(span[4] & 0xF);
+            destination[16] = BsonUtils.ToHexChar(span[11] >> 4);
+            destination[17] = BsonUtils.ToHexChar(span[11] & 0xF);
+            destination[18] = BsonUtils.ToHexChar(span[10] >> 4);
+            destination[19] = BsonUtils.ToHexChar(span[10] & 0xF);
+            destination[20] = BsonUtils.ToHexChar(span[9] >> 4);
+            destination[21] = BsonUtils.ToHexChar(span[9] & 0xF);
+            destination[22] = BsonUtils.ToHexChar(span[8] >> 4);
+            destination[23] = BsonUtils.ToHexChar(span[8] & 0xF);
+        }
+#endif
+
         /// <summary>
         /// Returns a string representation of the value.
         /// </summary>
         /// <returns>A string representation of the value.</returns>
         public override string ToString()
         {
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            return string.Create(24, this, static (span, input) =>
+            {
+                input.ToCharSpan(span);
+            });
+#else
             var c = new char[24];
             c[0] = BsonUtils.ToHexChar((_a >> 28) & 0x0f);
             c[1] = BsonUtils.ToHexChar((_a >> 24) & 0x0f);
@@ -481,6 +555,7 @@ namespace MongoDB.Bson
             c[22] = BsonUtils.ToHexChar((_c >> 4) & 0x0f);
             c[23] = BsonUtils.ToHexChar(_c & 0x0f);
             return new string(c);
+#endif
         }
 
         // explicit IConvertible implementation

--- a/src/MongoDB.Bson/ObjectModel/ObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/ObjectId.cs
@@ -44,14 +44,14 @@ namespace MongoDB.Bson
         {
             if (bytes == null)
             {
-                throw new ArgumentNullException("bytes");
+                throw new ArgumentNullException(nameof(bytes));
             }
             if (bytes.Length != 12)
             {
-                throw new ArgumentException("Byte array must be 12 bytes long", "bytes");
+                throw new ArgumentException("Byte array must be 12 bytes long", nameof(bytes));
             }
 
-            FromByteArray(bytes, 0, out _a, out _b, out _c);
+            FromBytesSpan(bytes, out _a, out _b, out _c);
         }
 
         /// <summary>
@@ -61,7 +61,20 @@ namespace MongoDB.Bson
         /// <param name="index">The index into the byte array where the ObjectId starts.</param>
         internal ObjectId(byte[] bytes, int index)
         {
-            FromByteArray(bytes, index, out _a, out _b, out _c);
+            FromBytesSpan(bytes.AsSpan(index), out _a, out _b, out _c);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ObjectId class.
+        /// </summary>
+        /// <param name="span">The span of bytes.</param>
+        internal ObjectId(ReadOnlySpan<byte> span)
+        {
+            if (span.Length != 12)
+            {
+                throw new ArgumentException("Span must be 12 bytes long", nameof(span));
+            }
+            FromBytesSpan(span, out _a, out _b, out _c);
         }
 
         /// <summary>
@@ -72,11 +85,11 @@ namespace MongoDB.Bson
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             var bytes = BsonUtils.ParseHexString(value);
-            FromByteArray(bytes, 0, out _a, out _b, out _c);
+            FromBytesSpan(bytes, out _a, out _b, out _c);
         }
 
         private ObjectId(int a, int b, int c)
@@ -219,7 +232,7 @@ namespace MongoDB.Bson
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
 
             ObjectId objectId;
@@ -338,16 +351,16 @@ namespace MongoDB.Bson
             var secondsSinceEpoch = (long)Math.Floor((BsonUtils.ToUniversalTime(timestamp) - BsonConstants.UnixEpoch).TotalSeconds);
             if (secondsSinceEpoch < uint.MinValue || secondsSinceEpoch > uint.MaxValue)
             {
-                throw new ArgumentOutOfRangeException("timestamp");
+                throw new ArgumentOutOfRangeException(nameof(timestamp));
             }
             return (int)(uint)secondsSinceEpoch;
         }
 
-        private static void FromByteArray(byte[] bytes, int offset, out int a, out int b, out int c)
+        private static void FromBytesSpan(ReadOnlySpan<byte> bytes, out int a, out int b, out int c)
         {
-            a = (bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3];
-            b = (bytes[offset + 4] << 24) | (bytes[offset + 5] << 16) | (bytes[offset + 6] << 8) | bytes[offset + 7];
-            c = (bytes[offset + 8] << 24) | (bytes[offset + 9] << 16) | (bytes[offset + 10] << 8) | bytes[offset + 11];
+            a = (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
+            b = (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7];
+            c = (bytes[8] << 24) | (bytes[9] << 16) | (bytes[10] << 8) | bytes[11];
         }
 
         // public methods
@@ -428,11 +441,11 @@ namespace MongoDB.Bson
         {
             if (destination == null)
             {
-                throw new ArgumentNullException("destination");
+                throw new ArgumentNullException(nameof(destination));
             }
             if (offset + 12 > destination.Length)
             {
-                throw new ArgumentException("Not enough room in destination buffer.", "offset");
+                throw new ArgumentException("Not enough room in destination buffer.", nameof(offset));
             }
 
             destination[offset + 0] = (byte)(_a >> 24);
@@ -449,7 +462,6 @@ namespace MongoDB.Bson
             destination[offset + 11] = (byte)(_c);
         }
 
-#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         /// <summary>
         /// Converts the ObjectId to a byte buffer provided by the input span.
         /// </summary>
@@ -459,7 +471,7 @@ namespace MongoDB.Bson
         {
             if (destination.Length < 12)
             {
-                throw new ArgumentException("Not enough room in destination span.", "destination");
+                throw new ArgumentException("Not enough room in destination span.", nameof(destination));
             }
 
             destination[0] = (byte)(_a >> 24);
@@ -485,37 +497,34 @@ namespace MongoDB.Bson
         {
             if (destination.Length < 24)
             {
-                throw new ArgumentException("Not enough room in destination span.", "destination");
+                throw new ArgumentException("Not enough room in destination span.", nameof(destination));
             }
 
-            Span<byte> span = stackalloc byte[12];
-            ToByteSpan(span);
-            destination[0] = BsonUtils.ToHexChar(span[0] >> 4);
-            destination[1] = BsonUtils.ToHexChar(span[0] & 0xF);
-            destination[2] = BsonUtils.ToHexChar(span[1] >> 4);
-            destination[3] = BsonUtils.ToHexChar(span[1] & 0xF);
-            destination[4] = BsonUtils.ToHexChar(span[2] >> 4);
-            destination[5] = BsonUtils.ToHexChar(span[2] & 0xF);
-            destination[6] = BsonUtils.ToHexChar(span[3] >> 4);
-            destination[7] = BsonUtils.ToHexChar(span[3] & 0xF);
-            destination[8] = BsonUtils.ToHexChar(span[4] >> 4);
-            destination[9] = BsonUtils.ToHexChar(span[4] & 0xF);
-            destination[10] = BsonUtils.ToHexChar(span[5] >> 4);
-            destination[11] = BsonUtils.ToHexChar(span[5] & 0xF);
-            destination[12] = BsonUtils.ToHexChar(span[6] >> 4);
-            destination[13] = BsonUtils.ToHexChar(span[6] & 0xF);
-            destination[14] = BsonUtils.ToHexChar(span[7] >> 4);
-            destination[15] = BsonUtils.ToHexChar(span[7] & 0xF);
-            destination[16] = BsonUtils.ToHexChar(span[8] >> 4);
-            destination[17] = BsonUtils.ToHexChar(span[8] & 0xF);
-            destination[18] = BsonUtils.ToHexChar(span[9] >> 4);
-            destination[19] = BsonUtils.ToHexChar(span[9] & 0xF);
-            destination[20] = BsonUtils.ToHexChar(span[10] >> 4);
-            destination[21] = BsonUtils.ToHexChar(span[10] & 0xF);
-            destination[22] = BsonUtils.ToHexChar(span[11] >> 4);
-            destination[23] = BsonUtils.ToHexChar(span[11] & 0xF);
+            destination[0] = BsonUtils.ToHexChar((_a >> 28) & 0x0f);
+            destination[1] = BsonUtils.ToHexChar((_a >> 24) & 0x0f);
+            destination[2] = BsonUtils.ToHexChar((_a >> 20) & 0x0f);
+            destination[3] = BsonUtils.ToHexChar((_a >> 16) & 0x0f);
+            destination[4] = BsonUtils.ToHexChar((_a >> 12) & 0x0f);
+            destination[5] = BsonUtils.ToHexChar((_a >> 8) & 0x0f);
+            destination[6] = BsonUtils.ToHexChar((_a >> 4) & 0x0f);
+            destination[7] = BsonUtils.ToHexChar(_a & 0x0f);
+            destination[8] = BsonUtils.ToHexChar((_b >> 28) & 0x0f);
+            destination[9] = BsonUtils.ToHexChar((_b >> 24) & 0x0f);
+            destination[10] = BsonUtils.ToHexChar((_b >> 20) & 0x0f);
+            destination[11] = BsonUtils.ToHexChar((_b >> 16) & 0x0f);
+            destination[12] = BsonUtils.ToHexChar((_b >> 12) & 0x0f);
+            destination[13] = BsonUtils.ToHexChar((_b >> 8) & 0x0f);
+            destination[14] = BsonUtils.ToHexChar((_b >> 4) & 0x0f);
+            destination[15] = BsonUtils.ToHexChar(_b & 0x0f);
+            destination[16] = BsonUtils.ToHexChar((_c >> 28) & 0x0f);
+            destination[17] = BsonUtils.ToHexChar((_c >> 24) & 0x0f);
+            destination[18] = BsonUtils.ToHexChar((_c >> 20) & 0x0f);
+            destination[19] = BsonUtils.ToHexChar((_c >> 16) & 0x0f);
+            destination[20] = BsonUtils.ToHexChar((_c >> 12) & 0x0f);
+            destination[21] = BsonUtils.ToHexChar((_c >> 8) & 0x0f);
+            destination[22] = BsonUtils.ToHexChar((_c >> 4) & 0x0f);
+            destination[23] = BsonUtils.ToHexChar(_c & 0x0f);
         }
-#endif
 
         /// <summary>
         /// Returns a string representation of the value.
@@ -524,36 +533,10 @@ namespace MongoDB.Bson
         public override string ToString()
         {
 #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-            return string.Create(24, this, static (span, input) =>
-            {
-                input.ToCharSpan(span);
-            });
+            return string.Create(24, this, static (span, input) => input.ToCharSpan(span));
 #else
             var c = new char[24];
-            c[0] = BsonUtils.ToHexChar((_a >> 28) & 0x0f);
-            c[1] = BsonUtils.ToHexChar((_a >> 24) & 0x0f);
-            c[2] = BsonUtils.ToHexChar((_a >> 20) & 0x0f);
-            c[3] = BsonUtils.ToHexChar((_a >> 16) & 0x0f);
-            c[4] = BsonUtils.ToHexChar((_a >> 12) & 0x0f);
-            c[5] = BsonUtils.ToHexChar((_a >> 8) & 0x0f);
-            c[6] = BsonUtils.ToHexChar((_a >> 4) & 0x0f);
-            c[7] = BsonUtils.ToHexChar(_a & 0x0f);
-            c[8] = BsonUtils.ToHexChar((_b >> 28) & 0x0f);
-            c[9] = BsonUtils.ToHexChar((_b >> 24) & 0x0f);
-            c[10] = BsonUtils.ToHexChar((_b >> 20) & 0x0f);
-            c[11] = BsonUtils.ToHexChar((_b >> 16) & 0x0f);
-            c[12] = BsonUtils.ToHexChar((_b >> 12) & 0x0f);
-            c[13] = BsonUtils.ToHexChar((_b >> 8) & 0x0f);
-            c[14] = BsonUtils.ToHexChar((_b >> 4) & 0x0f);
-            c[15] = BsonUtils.ToHexChar(_b & 0x0f);
-            c[16] = BsonUtils.ToHexChar((_c >> 28) & 0x0f);
-            c[17] = BsonUtils.ToHexChar((_c >> 24) & 0x0f);
-            c[18] = BsonUtils.ToHexChar((_c >> 20) & 0x0f);
-            c[19] = BsonUtils.ToHexChar((_c >> 16) & 0x0f);
-            c[20] = BsonUtils.ToHexChar((_c >> 12) & 0x0f);
-            c[21] = BsonUtils.ToHexChar((_c >> 8) & 0x0f);
-            c[22] = BsonUtils.ToHexChar((_c >> 4) & 0x0f);
-            c[23] = BsonUtils.ToHexChar(_c & 0x0f);
+            ToCharSpan(c);
             return new string(c);
 #endif
         }

--- a/src/MongoDB.Bson/ObjectModel/ObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/ObjectId.cs
@@ -61,7 +61,7 @@ namespace MongoDB.Bson
         /// <param name="index">The index into the byte array where the ObjectId starts.</param>
         internal ObjectId(byte[] bytes, int index)
         {
-            FromBytesSpan(bytes.AsSpan(index), out _a, out _b, out _c);
+            FromBytesSpan(bytes.AsSpan(index, 12), out _a, out _b, out _c);
         }
 
         /// <summary>
@@ -443,23 +443,13 @@ namespace MongoDB.Bson
             {
                 throw new ArgumentNullException(nameof(destination));
             }
+
             if (offset + 12 > destination.Length)
             {
                 throw new ArgumentException("Not enough room in destination buffer.", nameof(offset));
             }
 
-            destination[offset + 0] = (byte)(_a >> 24);
-            destination[offset + 1] = (byte)(_a >> 16);
-            destination[offset + 2] = (byte)(_a >> 8);
-            destination[offset + 3] = (byte)(_a);
-            destination[offset + 4] = (byte)(_b >> 24);
-            destination[offset + 5] = (byte)(_b >> 16);
-            destination[offset + 6] = (byte)(_b >> 8);
-            destination[offset + 7] = (byte)(_b);
-            destination[offset + 8] = (byte)(_c >> 24);
-            destination[offset + 9] = (byte)(_c >> 16);
-            destination[offset + 10] = (byte)(_c >> 8);
-            destination[offset + 11] = (byte)(_c);
+            ToByteSpan(destination.AsSpan(offset, 12));
         }
 
         /// <summary>

--- a/tests/MongoDB.Bson.Tests/IO/BsonStreamAdapterTests.cs
+++ b/tests/MongoDB.Bson.Tests/IO/BsonStreamAdapterTests.cs
@@ -21,6 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Bson.IO;
+using MongoDB.Bson.Tests.ObjectModel;
 using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;

--- a/tests/MongoDB.Bson.Tests/IO/ByteBufferStreamTests.cs
+++ b/tests/MongoDB.Bson.Tests/IO/ByteBufferStreamTests.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.TestHelpers;
+using MongoDB.Bson.Tests.ObjectModel;
 using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;

--- a/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
@@ -87,6 +87,11 @@ namespace MongoDB.Bson.Tests
             Assert.Equal(BsonConstants.UnixEpoch.AddSeconds(0x01020304), objectId.CreationTime);
             Assert.Equal("0102030405060708090a0b0c", objectId.ToString());
             Assert.True(bytes.SequenceEqual(objectId.ToByteArray()));
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            Span<byte> span = new byte[12];
+            objectId.ToByteSpan(span);
+            Assert.True(span.SequenceEqual(bytes));
+#endif
         }
 
         [Fact]
@@ -101,6 +106,11 @@ namespace MongoDB.Bson.Tests
             Assert.Equal(BsonConstants.UnixEpoch.AddSeconds(0x01020304), objectId.CreationTime);
             Assert.Equal("0102030405060708090a0b0c", objectId.ToString());
             Assert.True(bytes.SequenceEqual(objectId.ToByteArray()));
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            Span<char> span = new char[24];
+            objectId.ToCharSpan(span);
+            Assert.True(span.SequenceEqual("0102030405060708090a0b0c"));
+#endif
         }
 
         [Fact]

--- a/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
@@ -145,6 +145,17 @@ public class ObjectIdTests
     }
 
     [Theory]
+    [InlineData(0)]
+    [InlineData(11)]
+    public void ToByteSpan_should_throw_when_destination_is_too_short(int length)
+    {
+        var objectId = ObjectId.Empty;
+        var exception = Record.Exception(() => objectId.ToByteSpan(new byte[length]));
+        var e = exception.Should().BeOfType<ArgumentException>().Subject;
+        e.ParamName.Should().Be("destination");
+    }
+
+    [Theory]
     [MemberData(nameof(ToCharSpan_TestCases))]
     public void ToCharSpan_should_return_expected_results(byte[] data, string expectedChars)
     {
@@ -159,8 +170,18 @@ public class ObjectIdTests
     {
         yield return [new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "000000000000000000000000"];
         yield return [new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, "0102030405060708090a0b0c"];
-        yield return [new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 }, "ffffffffffffffffffffffff"
-        ];
+        yield return [new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 }, "ffffffffffffffffffffffff"];
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(23)]
+    public void ToCharSpan_should_throw_when_destination_is_too_short(int length)
+    {
+        var objectId = ObjectId.Empty;
+        var exception = Record.Exception(() => objectId.ToCharSpan(new char[length]));
+        var e = exception.Should().BeOfType<ArgumentException>().Subject;
+        e.ParamName.Should().Be("destination");
     }
 
     [Fact]

--- a/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
@@ -1,400 +1,449 @@
 ﻿/* Copyright 2010-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.TestHelpers;
 using Xunit;
 
-namespace MongoDB.Bson.Tests
+namespace MongoDB.Bson.Tests.ObjectModel;
+
+public class ObjectIdTests
 {
-    public class ObjectIdTests
+    [Theory]
+    [InlineData(0x01020304, 0x0000000506070809, 0x0a0b0c, 0x01020304, 0x05060708, 0x090a0b0c)]
+    [InlineData(0xf1f2f3f4, 0x000000f5f6f7f8f9, 0xfafbfc, 0xf1f2f3f4, 0xf5f6f7f8, 0xf9fafbfc)]
+    public void Create_should_generate_expected_a_b_c(uint timestamp, long random, uint increment, uint expectedA, uint expectedB, uint expectedC)
     {
-        [Theory]
-        [InlineData(0x01020304, 0x0000000506070809, 0x0a0b0c, 0x01020304, 0x05060708, 0x090a0b0c)]
-        [InlineData(0xf1f2f3f4, 0x000000f5f6f7f8f9, 0xfafbfc, 0xf1f2f3f4, 0xf5f6f7f8, 0xf9fafbfc)]
-        public void Create_should_generate_expected_a_b_c(uint timestamp, long random, uint increment, uint expectedA, uint expectedB, uint expectedC)
-        {
-            var objectId = ObjectIdReflector.Create((int)timestamp, random, (int)increment);
-            objectId._a().Should().Be((int)expectedA);
-            objectId._b().Should().Be((int)expectedB);
-            objectId._c().Should().Be((int)expectedC);
-        }
-
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(0xffffffffff, 0xffffff)]
-        public void Create_should_not_throw_when_arguments_are_valid(long random, int increment)
-        {
-            var _ = ObjectIdReflector.Create(1, random, increment);
-        }
-
-        [Theory]
-        [InlineData(-1)]
-        [InlineData(0x10000000000)]
-        public void Create_should_throw_when_random_is_out_of_range(long random)
-        {
-            var exception = Record.Exception(() => ObjectIdReflector.Create(1, random, 1));
-            var e = exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject;
-            e.ParamName.Should().Be("random");
-        }
-
-        [Theory]
-        [InlineData(-1)]
-        [InlineData(0x1000000)]
-        public void Create_should_throw_when_increment_is_out_of_range(int increment)
-        {
-            var exception = Record.Exception(() => ObjectIdReflector.Create(1, 1, increment));
-            var e = exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject;
-            e.ParamName.Should().Be("increment");
-        }
-
-        [Theory]
-        [InlineData(0x00000000, "1970-01-01T00:00:00Z")]
-        [InlineData(0x7FFFFFFF, "2038-01-19T03:14:07Z")]
-        [InlineData(0x80000000, "2038-01-19T03:14:08Z")]
-        [InlineData(0xFFFFFFFF, "2106-02-07T06:28:15Z")]
-        public void Ensure_that_timestamp_is_interpreted_as_unsigned_int(uint timestamp, string expectedDateString)
-        {
-            var objectId = ObjectId.GenerateNewId((int)timestamp);
-            var expectedDate = DateTime.Parse(expectedDateString, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
-            objectId.CreationTime.Should().Be(expectedDate);
-        }
-
-        [Fact]
-        public void TestByteArrayConstructor()
-        {
-            byte[] bytes = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-            var objectId = new ObjectId(bytes);
-            Assert.Equal(0x01020304, objectId.Timestamp);
-            Assert.Equal(0x01020304, objectId._a());
-            Assert.Equal(0x05060708, objectId._b());
-            Assert.Equal(0x090a0b0c, objectId._c());
-            Assert.Equal(BsonConstants.UnixEpoch.AddSeconds(0x01020304), objectId.CreationTime);
-            Assert.Equal("0102030405060708090a0b0c", objectId.ToString());
-            Assert.True(bytes.SequenceEqual(objectId.ToByteArray()));
-#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-            Span<byte> span = new byte[12];
-            objectId.ToByteSpan(span);
-            Assert.True(span.SequenceEqual(bytes));
-#endif
-        }
-
-        [Fact]
-        public void TestStringConstructor()
-        {
-            byte[] bytes = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-            var objectId = new ObjectId("0102030405060708090a0b0c");
-            Assert.Equal(0x01020304, objectId.Timestamp);
-            Assert.Equal(0x01020304, objectId._a());
-            Assert.Equal(0x05060708, objectId._b());
-            Assert.Equal(0x090a0b0c, objectId._c());
-            Assert.Equal(BsonConstants.UnixEpoch.AddSeconds(0x01020304), objectId.CreationTime);
-            Assert.Equal("0102030405060708090a0b0c", objectId.ToString());
-            Assert.True(bytes.SequenceEqual(objectId.ToByteArray()));
-#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-            Span<char> span = new char[24];
-            objectId.ToCharSpan(span);
-            Assert.True(span.SequenceEqual("0102030405060708090a0b0c"));
-#endif
-        }
-
-        [Fact]
-        public void TestGenerateNewId()
-        {
-            // compare against two timestamps in case seconds since epoch changes in middle of test
-            var timestamp1 = (int)Math.Floor((DateTime.UtcNow - BsonConstants.UnixEpoch).TotalSeconds);
-            var objectId = ObjectId.GenerateNewId();
-            var timestamp2 = (int)Math.Floor((DateTime.UtcNow - BsonConstants.UnixEpoch).TotalSeconds);
-            Assert.True(objectId.Timestamp == timestamp1 || objectId.Timestamp == timestamp2);
-            Assert.NotEqual(0, objectId._a());
-            Assert.NotEqual(0, objectId._b());
-            Assert.NotEqual(0, objectId._c());
-        }
-
-        [Fact]
-        public void TestGenerateNewIdWithDateTime()
-        {
-            var timestamp = new DateTime(2011, 1, 2, 3, 4, 5, DateTimeKind.Utc);
-            var objectId = ObjectId.GenerateNewId(timestamp);
-            Assert.True(objectId.CreationTime == timestamp);
-            Assert.NotEqual(0, objectId._a());
-            Assert.NotEqual(0, objectId._b());
-            Assert.NotEqual(0, objectId._c());
-        }
-
-        [Fact]
-        public void TestGenerateNewIdWithTimestamp()
-        {
-            var timestamp = 0x01020304;
-            var objectId = ObjectId.GenerateNewId(timestamp);
-            Assert.True(objectId.Timestamp == timestamp);
-            Assert.NotEqual(0, objectId._a());
-            Assert.NotEqual(0, objectId._b());
-            Assert.NotEqual(0, objectId._c());
-        }
-
-        [Fact]
-        public void TestIComparable()
-        {
-            var objectId1 = ObjectId.GenerateNewId();
-            var objectId2 = ObjectId.GenerateNewId();
-            Assert.Equal(0, objectId1.CompareTo(objectId1));
-            Assert.Equal(-1, objectId1.CompareTo(objectId2));
-            Assert.Equal(1, objectId2.CompareTo(objectId1));
-            Assert.Equal(0, objectId2.CompareTo(objectId2));
-        }
-
-        [Fact]
-        public void TestCompareEqualGeneratedIds()
-        {
-            var objectId1 = ObjectId.GenerateNewId();
-            var objectId2 = objectId1;
-            Assert.False(objectId1 < objectId2);
-            Assert.True(objectId1 <= objectId2);
-            Assert.False(objectId1 != objectId2);
-            Assert.True(objectId1 == objectId2);
-            Assert.False(objectId1 > objectId2);
-            Assert.True(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareSmallerTimestamp()
-        {
-            var objectId1 = new ObjectId("0102030405060708090a0b0c");
-            var objectId2 = new ObjectId("0102030505060708090a0b0c");
-            Assert.True(objectId1 < objectId2);
-            Assert.True(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.False(objectId1 > objectId2);
-            Assert.False(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareSmallerMachine()
-        {
-            var objectId1 = new ObjectId("0102030405060708090a0b0c");
-            var objectId2 = new ObjectId("0102030405060808090a0b0c");
-            Assert.True(objectId1 < objectId2);
-            Assert.True(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.False(objectId1 > objectId2);
-            Assert.False(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareSmallerPid()
-        {
-            var objectId1 = new ObjectId("0102030405060708090a0b0c");
-            var objectId2 = new ObjectId("01020304050607080a0a0b0c");
-            Assert.True(objectId1 < objectId2);
-            Assert.True(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.False(objectId1 > objectId2);
-            Assert.False(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareSmallerIncrement()
-        {
-            var objectId1 = new ObjectId("0102030405060708090a0b0c");
-            var objectId2 = new ObjectId("0102030405060708090a0b0d");
-            Assert.True(objectId1 < objectId2);
-            Assert.True(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.False(objectId1 > objectId2);
-            Assert.False(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareSmallerGeneratedId()
-        {
-            var objectId1 = ObjectId.GenerateNewId();
-            var objectId2 = ObjectId.GenerateNewId();
-            Assert.True(objectId1 < objectId2);
-            Assert.True(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.False(objectId1 > objectId2);
-            Assert.False(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareLargerTimestamp()
-        {
-            var objectId1 = new ObjectId("0102030405060708090a0b0c");
-            var objectId2 = new ObjectId("0102030305060708090a0b0c");
-            Assert.False(objectId1 < objectId2);
-            Assert.False(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.True(objectId1 > objectId2);
-            Assert.True(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareLargerMachine()
-        {
-            var objectId1 = new ObjectId("0102030405060808090a0b0c");
-            var objectId2 = new ObjectId("0102030405060708090a0b0c");
-            Assert.False(objectId1 < objectId2);
-            Assert.False(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.True(objectId1 > objectId2);
-            Assert.True(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareLargerPid()
-        {
-            var objectId1 = new ObjectId("01020304050607080a0a0b0c");
-            var objectId2 = new ObjectId("0102030405060708090a0b0c");
-            Assert.False(objectId1 < objectId2);
-            Assert.False(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.True(objectId1 > objectId2);
-            Assert.True(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareLargerIncrement()
-        {
-            var objectId1 = new ObjectId("0102030405060708090a0b0d");
-            var objectId2 = new ObjectId("0102030405060708090a0b0c");
-            Assert.False(objectId1 < objectId2);
-            Assert.False(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.True(objectId1 > objectId2);
-            Assert.True(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestCompareLargerGeneratedId()
-        {
-            var objectId2 = ObjectId.GenerateNewId(); // generate before objectId2
-            var objectId1 = ObjectId.GenerateNewId();
-            Assert.False(objectId1 < objectId2);
-            Assert.False(objectId1 <= objectId2);
-            Assert.True(objectId1 != objectId2);
-            Assert.False(objectId1 == objectId2);
-            Assert.True(objectId1 > objectId2);
-            Assert.True(objectId1 >= objectId2);
-        }
-
-        [Fact]
-        public void TestIConvertibleMethods()
-        {
-            var value = ObjectId.Empty;
-            Assert.Equal(TypeCode.Object, ((IConvertible)value).GetTypeCode());
-            Assert.Equal(value, ((IConvertible)value).ToType(typeof(object), null)); // not AreSame because of boxing
-            Assert.Equal(value, ((IConvertible)value).ToType(typeof(ObjectId), null)); // not AreSame because of boxing
-            Assert.Throws<InvalidCastException>(() => Convert.ToBoolean(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToByte(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToChar(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToDecimal(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToDouble(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToInt16(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToInt32(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToInt64(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToSByte(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToSingle(value));
-            Assert.Equal("000000000000000000000000", Convert.ToString(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToUInt16(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToUInt32(value));
-            Assert.Throws<InvalidCastException>(() => Convert.ToUInt64(value));
-
-            Assert.Equal(new BsonObjectId(value), ((IConvertible)value).ToType(typeof(BsonObjectId), null));
-            Assert.Equal(new BsonString("000000000000000000000000"), ((IConvertible)value).ToType(typeof(BsonString), null));
-            Assert.Equal("000000000000000000000000", ((IConvertible)value).ToType(typeof(string), null));
-            Assert.Throws<InvalidCastException>(() => ((IConvertible)value).ToType(typeof(UInt64), null));
-        }
-
-        [Fact]
-        public void TestParse()
-        {
-            var objectId1 = ObjectId.Parse("0102030405060708090a0b0c"); // lower case
-            var objectId2 = ObjectId.Parse("0102030405060708090A0B0C"); // upper case
-            Assert.True(objectId1.ToByteArray().SequenceEqual(objectId2.ToByteArray()));
-            Assert.True(objectId1.ToString() == "0102030405060708090a0b0c"); // ToString returns lower case
-            Assert.True(objectId1.ToString() == objectId2.ToString());
-            Assert.Throws<FormatException>(() => ObjectId.Parse("102030405060708090a0b0c")); // too short
-            Assert.Throws<FormatException>(() => ObjectId.Parse("x102030405060708090a0b0c")); // invalid character
-            Assert.Throws<FormatException>(() => ObjectId.Parse("00102030405060708090a0b0c")); // too long
-        }
-
-        [Fact]
-        public void TestTryParse()
-        {
-            ObjectId objectId1, objectId2;
-            Assert.True(ObjectId.TryParse("0102030405060708090a0b0c", out objectId1)); // lower case
-            Assert.True(ObjectId.TryParse("0102030405060708090A0B0C", out objectId2)); // upper case
-            Assert.True(objectId1.ToByteArray().SequenceEqual(objectId2.ToByteArray()));
-            Assert.True(objectId1.ToString() == "0102030405060708090a0b0c"); // ToString returns lower case
-            Assert.True(objectId1.ToString() == objectId2.ToString());
-            Assert.False(ObjectId.TryParse("102030405060708090a0b0c", out objectId1)); // too short
-            Assert.False(ObjectId.TryParse("x102030405060708090a0b0c", out objectId1)); // invalid character
-            Assert.False(ObjectId.TryParse("00102030405060708090a0b0c", out objectId1)); // too long
-            Assert.False(ObjectId.TryParse(null, out objectId1)); // should return false not throw ArgumentNullException
-        }
-
-        [Fact]
-        public void TestConvertObjectIdToObjectId()
-        {
-            var oid = ObjectId.GenerateNewId();
-
-            var oidConverted = Convert.ChangeType(oid, typeof(ObjectId));
-
-            Assert.Equal(oid, oidConverted);
-        }
+        var objectId = ObjectIdReflector.Create((int)timestamp, random, (int)increment);
+        objectId._a().Should().Be((int)expectedA);
+        objectId._b().Should().Be((int)expectedB);
+        objectId._c().Should().Be((int)expectedC);
     }
 
-    internal static class ObjectIdReflector
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(0xffffffffff, 0xffffff)]
+    public void Create_should_not_throw_when_arguments_are_valid(long random, int increment)
     {
-        public static int _a(this ObjectId obj)
-        {
-            return (int)Reflector.GetFieldValue(obj, nameof(_a));
-        }
+        var _ = ObjectIdReflector.Create(1, random, increment);
+    }
 
-        public static int _b(this ObjectId obj)
-        {
-            return (int)Reflector.GetFieldValue(obj, nameof(_b));
-        }
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0x10000000000)]
+    public void Create_should_throw_when_random_is_out_of_range(long random)
+    {
+        var exception = Record.Exception(() => ObjectIdReflector.Create(1, random, 1));
+        var e = exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject;
+        e.ParamName.Should().Be("random");
+    }
 
-        public static int _c(this ObjectId obj)
-        {
-            return (int)Reflector.GetFieldValue(obj, nameof(_c));
-        }
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0x1000000)]
+    public void Create_should_throw_when_increment_is_out_of_range(int increment)
+    {
+        var exception = Record.Exception(() => ObjectIdReflector.Create(1, 1, increment));
+        var e = exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject;
+        e.ParamName.Should().Be("increment");
+    }
 
-        public static ObjectId Create(int timestamp, long random, int increment)
-        {
-            return (ObjectId)Reflector.InvokeStatic(typeof(ObjectId), nameof(Create), timestamp, random, increment);
-        }
+    [Theory]
+    [InlineData(0x00000000, "1970-01-01T00:00:00Z")]
+    [InlineData(0x7FFFFFFF, "2038-01-19T03:14:07Z")]
+    [InlineData(0x80000000, "2038-01-19T03:14:08Z")]
+    [InlineData(0xFFFFFFFF, "2106-02-07T06:28:15Z")]
+    public void Ensure_that_timestamp_is_interpreted_as_unsigned_int(uint timestamp, string expectedDateString)
+    {
+        var objectId = ObjectId.GenerateNewId((int)timestamp);
+        var expectedDate = DateTime.Parse(expectedDateString, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+        objectId.CreationTime.Should().Be(expectedDate);
+    }
 
-        public static void __staticIncrement(int value)
-        {
-            Reflector.SetStaticFieldValue(typeof(ObjectId), nameof(__staticIncrement), value);
-        }
+    [Fact]
+    public void TestByteArrayConstructor()
+    {
+        byte[] bytes = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        var objectId = new ObjectId(bytes);
+        Assert.Equal(0x01020304, objectId.Timestamp);
+        Assert.Equal(0x01020304, objectId._a());
+        Assert.Equal(0x05060708, objectId._b());
+        Assert.Equal(0x090a0b0c, objectId._c());
+        Assert.Equal(BsonConstants.UnixEpoch.AddSeconds(0x01020304), objectId.CreationTime);
+        Assert.Equal("0102030405060708090a0b0c", objectId.ToString());
+        Assert.True(bytes.SequenceEqual(objectId.ToByteArray()));
+        Span<byte> span = new byte[12];
+        objectId.ToByteSpan(span);
+        Assert.True(span.SequenceEqual(bytes));
+    }
+
+    [Fact]
+    public void TestStringConstructor()
+    {
+        byte[] bytes = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        var objectId = new ObjectId("0102030405060708090a0b0c");
+        Assert.Equal(0x01020304, objectId.Timestamp);
+        Assert.Equal(0x01020304, objectId._a());
+        Assert.Equal(0x05060708, objectId._b());
+        Assert.Equal(0x090a0b0c, objectId._c());
+        Assert.Equal(BsonConstants.UnixEpoch.AddSeconds(0x01020304), objectId.CreationTime);
+        Assert.Equal("0102030405060708090a0b0c", objectId.ToString());
+        Assert.True(bytes.SequenceEqual(objectId.ToByteArray()));
+        Span<char> span = new char[24];
+        objectId.ToCharSpan(span);
+        Assert.True(span.SequenceEqual("0102030405060708090a0b0c".AsSpan()));
+    }
+
+    [Fact]
+    public void ReadOnlySpanByteConstructor_should_set_expected_fields()
+    {
+        ReadOnlySpan<byte> span = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        var objectId = new ObjectId(span);
+        objectId._a().Should().Be(0x01020304);
+        objectId._b().Should().Be(0x05060708);
+        objectId._c().Should().Be(0x090a0b0c);
+        objectId.ToString().Should().Be("0102030405060708090a0b0c");
+    }
+
+    [Fact]
+    public void ReadOnlySpanByteConstructor_should_throw_when_span_is_wrong_length()
+    {
+        Assert.Throws<ArgumentException>(() => new ObjectId(new byte[] { 1, 2, 3 }.AsSpan()));
+    }
+
+    [Theory]
+    [MemberData(nameof(ToByteSpan_TestCases))]
+    public void ToByteSpan_should_return_expected_results(byte[] data, byte[] expectedBytes)
+    {
+        var objectId = new ObjectId(data);
+        Span<byte> destination = new byte[12];
+        objectId.ToByteSpan(destination);
+        Assert.True(destination.SequenceEqual(expectedBytes));
+    }
+
+    public static IEnumerable<object[]> ToByteSpan_TestCases()
+    {
+        yield return [new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } ];
+        yield return [new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 } ];
+        yield return [new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 }, new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 } ];
+    }
+
+    [Theory]
+    [MemberData(nameof(ToCharSpan_TestCases))]
+    public void ToCharSpan_should_return_expected_results(byte[] data, string expectedChars)
+    {
+        var objectId = new ObjectId(data);
+        Span<char> destination = new char[24];
+        objectId.ToCharSpan(destination);
+        Assert.True(destination.SequenceEqual(expectedChars.AsSpan()));
+        Assert.Equal(expectedChars, objectId.ToString());
+    }
+
+    public static IEnumerable<object[]> ToCharSpan_TestCases()
+    {
+        yield return [new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "000000000000000000000000"];
+        yield return [new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, "0102030405060708090a0b0c"];
+        yield return [new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 }, "ffffffffffffffffffffffff"
+        ];
+    }
+
+    [Fact]
+    public void TestGenerateNewId()
+    {
+        // compare against two timestamps in case seconds since epoch changes in middle of test
+        var timestamp1 = (int)Math.Floor((DateTime.UtcNow - BsonConstants.UnixEpoch).TotalSeconds);
+        var objectId = ObjectId.GenerateNewId();
+        var timestamp2 = (int)Math.Floor((DateTime.UtcNow - BsonConstants.UnixEpoch).TotalSeconds);
+        Assert.True(objectId.Timestamp == timestamp1 || objectId.Timestamp == timestamp2);
+        Assert.NotEqual(0, objectId._a());
+        Assert.NotEqual(0, objectId._b());
+        Assert.NotEqual(0, objectId._c());
+    }
+
+    [Fact]
+    public void TestGenerateNewIdWithDateTime()
+    {
+        var timestamp = new DateTime(2011, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var objectId = ObjectId.GenerateNewId(timestamp);
+        Assert.True(objectId.CreationTime == timestamp);
+        Assert.NotEqual(0, objectId._a());
+        Assert.NotEqual(0, objectId._b());
+        Assert.NotEqual(0, objectId._c());
+    }
+
+    [Fact]
+    public void TestGenerateNewIdWithTimestamp()
+    {
+        var timestamp = 0x01020304;
+        var objectId = ObjectId.GenerateNewId(timestamp);
+        Assert.True(objectId.Timestamp == timestamp);
+        Assert.NotEqual(0, objectId._a());
+        Assert.NotEqual(0, objectId._b());
+        Assert.NotEqual(0, objectId._c());
+    }
+
+    [Fact]
+    public void TestIComparable()
+    {
+        var objectId1 = ObjectId.GenerateNewId();
+        var objectId2 = ObjectId.GenerateNewId();
+        Assert.Equal(0, objectId1.CompareTo(objectId1));
+        Assert.Equal(-1, objectId1.CompareTo(objectId2));
+        Assert.Equal(1, objectId2.CompareTo(objectId1));
+        Assert.Equal(0, objectId2.CompareTo(objectId2));
+    }
+
+    [Fact]
+    public void TestCompareEqualGeneratedIds()
+    {
+        var objectId1 = ObjectId.GenerateNewId();
+        var objectId2 = objectId1;
+        Assert.False(objectId1 < objectId2);
+        Assert.True(objectId1 <= objectId2);
+        Assert.False(objectId1 != objectId2);
+        Assert.True(objectId1 == objectId2);
+        Assert.False(objectId1 > objectId2);
+        Assert.True(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareSmallerTimestamp()
+    {
+        var objectId1 = new ObjectId("0102030405060708090a0b0c");
+        var objectId2 = new ObjectId("0102030505060708090a0b0c");
+        Assert.True(objectId1 < objectId2);
+        Assert.True(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.False(objectId1 > objectId2);
+        Assert.False(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareSmallerMachine()
+    {
+        var objectId1 = new ObjectId("0102030405060708090a0b0c");
+        var objectId2 = new ObjectId("0102030405060808090a0b0c");
+        Assert.True(objectId1 < objectId2);
+        Assert.True(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.False(objectId1 > objectId2);
+        Assert.False(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareSmallerPid()
+    {
+        var objectId1 = new ObjectId("0102030405060708090a0b0c");
+        var objectId2 = new ObjectId("01020304050607080a0a0b0c");
+        Assert.True(objectId1 < objectId2);
+        Assert.True(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.False(objectId1 > objectId2);
+        Assert.False(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareSmallerIncrement()
+    {
+        var objectId1 = new ObjectId("0102030405060708090a0b0c");
+        var objectId2 = new ObjectId("0102030405060708090a0b0d");
+        Assert.True(objectId1 < objectId2);
+        Assert.True(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.False(objectId1 > objectId2);
+        Assert.False(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareSmallerGeneratedId()
+    {
+        var objectId1 = ObjectId.GenerateNewId();
+        var objectId2 = ObjectId.GenerateNewId();
+        Assert.True(objectId1 < objectId2);
+        Assert.True(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.False(objectId1 > objectId2);
+        Assert.False(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareLargerTimestamp()
+    {
+        var objectId1 = new ObjectId("0102030405060708090a0b0c");
+        var objectId2 = new ObjectId("0102030305060708090a0b0c");
+        Assert.False(objectId1 < objectId2);
+        Assert.False(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.True(objectId1 > objectId2);
+        Assert.True(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareLargerMachine()
+    {
+        var objectId1 = new ObjectId("0102030405060808090a0b0c");
+        var objectId2 = new ObjectId("0102030405060708090a0b0c");
+        Assert.False(objectId1 < objectId2);
+        Assert.False(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.True(objectId1 > objectId2);
+        Assert.True(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareLargerPid()
+    {
+        var objectId1 = new ObjectId("01020304050607080a0a0b0c");
+        var objectId2 = new ObjectId("0102030405060708090a0b0c");
+        Assert.False(objectId1 < objectId2);
+        Assert.False(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.True(objectId1 > objectId2);
+        Assert.True(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareLargerIncrement()
+    {
+        var objectId1 = new ObjectId("0102030405060708090a0b0d");
+        var objectId2 = new ObjectId("0102030405060708090a0b0c");
+        Assert.False(objectId1 < objectId2);
+        Assert.False(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.True(objectId1 > objectId2);
+        Assert.True(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestCompareLargerGeneratedId()
+    {
+        var objectId2 = ObjectId.GenerateNewId(); // generate before objectId2
+        var objectId1 = ObjectId.GenerateNewId();
+        Assert.False(objectId1 < objectId2);
+        Assert.False(objectId1 <= objectId2);
+        Assert.True(objectId1 != objectId2);
+        Assert.False(objectId1 == objectId2);
+        Assert.True(objectId1 > objectId2);
+        Assert.True(objectId1 >= objectId2);
+    }
+
+    [Fact]
+    public void TestIConvertibleMethods()
+    {
+        var value = ObjectId.Empty;
+        Assert.Equal(TypeCode.Object, ((IConvertible)value).GetTypeCode());
+        Assert.Equal(value, ((IConvertible)value).ToType(typeof(object), null)); // not AreSame because of boxing
+        Assert.Equal(value, ((IConvertible)value).ToType(typeof(ObjectId), null)); // not AreSame because of boxing
+        Assert.Throws<InvalidCastException>(() => Convert.ToBoolean(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToByte(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToChar(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToDecimal(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToDouble(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToInt16(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToInt32(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToInt64(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToSByte(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToSingle(value));
+        Assert.Equal("000000000000000000000000", Convert.ToString(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToUInt16(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToUInt32(value));
+        Assert.Throws<InvalidCastException>(() => Convert.ToUInt64(value));
+
+        Assert.Equal(new BsonObjectId(value), ((IConvertible)value).ToType(typeof(BsonObjectId), null));
+        Assert.Equal(new BsonString("000000000000000000000000"), ((IConvertible)value).ToType(typeof(BsonString), null));
+        Assert.Equal("000000000000000000000000", ((IConvertible)value).ToType(typeof(string), null));
+        Assert.Throws<InvalidCastException>(() => ((IConvertible)value).ToType(typeof(UInt64), null));
+    }
+
+    [Fact]
+    public void TestParse()
+    {
+        var objectId1 = ObjectId.Parse("0102030405060708090a0b0c"); // lower case
+        var objectId2 = ObjectId.Parse("0102030405060708090A0B0C"); // upper case
+        Assert.True(objectId1.ToByteArray().SequenceEqual(objectId2.ToByteArray()));
+        Assert.True(objectId1.ToString() == "0102030405060708090a0b0c"); // ToString returns lower case
+        Assert.True(objectId1.ToString() == objectId2.ToString());
+        Assert.Throws<FormatException>(() => ObjectId.Parse("102030405060708090a0b0c")); // too short
+        Assert.Throws<FormatException>(() => ObjectId.Parse("x102030405060708090a0b0c")); // invalid character
+        Assert.Throws<FormatException>(() => ObjectId.Parse("00102030405060708090a0b0c")); // too long
+    }
+
+    [Fact]
+    public void TestTryParse()
+    {
+        ObjectId objectId1, objectId2;
+        Assert.True(ObjectId.TryParse("0102030405060708090a0b0c", out objectId1)); // lower case
+        Assert.True(ObjectId.TryParse("0102030405060708090A0B0C", out objectId2)); // upper case
+        Assert.True(objectId1.ToByteArray().SequenceEqual(objectId2.ToByteArray()));
+        Assert.True(objectId1.ToString() == "0102030405060708090a0b0c"); // ToString returns lower case
+        Assert.True(objectId1.ToString() == objectId2.ToString());
+        Assert.False(ObjectId.TryParse("102030405060708090a0b0c", out objectId1)); // too short
+        Assert.False(ObjectId.TryParse("x102030405060708090a0b0c", out objectId1)); // invalid character
+        Assert.False(ObjectId.TryParse("00102030405060708090a0b0c", out objectId1)); // too long
+        Assert.False(ObjectId.TryParse(null, out objectId1)); // should return false not throw ArgumentNullException
+    }
+
+    [Fact]
+    public void TestConvertObjectIdToObjectId()
+    {
+        var oid = ObjectId.GenerateNewId();
+
+        var oidConverted = Convert.ChangeType(oid, typeof(ObjectId));
+
+        Assert.Equal(oid, oidConverted);
+    }
+}
+
+internal static class ObjectIdReflector
+{
+    public static int _a(this ObjectId obj)
+    {
+        return (int)Reflector.GetFieldValue(obj, nameof(_a));
+    }
+
+    public static int _b(this ObjectId obj)
+    {
+        return (int)Reflector.GetFieldValue(obj, nameof(_b));
+    }
+
+    public static int _c(this ObjectId obj)
+    {
+        return (int)Reflector.GetFieldValue(obj, nameof(_c));
+    }
+
+    public static ObjectId Create(int timestamp, long random, int increment)
+    {
+        return (ObjectId)Reflector.InvokeStatic(typeof(ObjectId), nameof(Create), timestamp, random, increment);
+    }
+
+    public static void __staticIncrement(int value)
+    {
+        Reflector.SetStaticFieldValue(typeof(ObjectId), nameof(__staticIncrement), value);
     }
 }


### PR DESCRIPTION
[CSHARP-5611](https://jira.mongodb.org/browse/CSHARP-5611)