### PR TITLE
CSHARP-5959: Replace switch by method name in SerializerFinderVisitMethodCall with lookup table with MethodInfo as a key

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableMethod.cs
@@ -628,6 +628,22 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Reflection
         public static IReadOnlyMethodInfoSet ReverseOverloads => __reverseOverloads;
 
         // public methods
+        public static bool IsContainsMethod(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+            if (method.Name == "Contains" && method.ReturnType == typeof(bool))
+            {
+                if (method.IsStatic)
+                {
+                    return parameters.Length == 2 && parameters[0].ParameterType.ImplementsIEnumerableOf(parameters[1].ParameterType);
+                }
+
+                return parameters.Length == 1 && method.DeclaringType.ImplementsIEnumerableOf(parameters[0].ParameterType);
+            }
+
+            return false;
+        }
+
         public static bool IsContainsMethod(MethodCallExpression methodCallExpression, out Expression sourceExpression, out Expression valueExpression)
         {
             var method = methodCallExpression.Method;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableMethod.cs
@@ -647,35 +647,12 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Reflection
         public static bool IsContainsMethod(MethodCallExpression methodCallExpression, out Expression sourceExpression, out Expression valueExpression)
         {
             var method = methodCallExpression.Method;
-            var parameters = method.GetParameters();
-            var arguments = methodCallExpression.Arguments;
-
-            if (method.Name == "Contains" && method.ReturnType == typeof(bool))
+            if (IsContainsMethod(method))
             {
-                if (method.IsStatic)
-                {
-                    if (parameters.Length == 2)
-                    {
-                        if (parameters[0].ParameterType.ImplementsIEnumerableOf(parameters[1].ParameterType))
-                        {
-                            sourceExpression = arguments[0];
-                            valueExpression = arguments[1];
-                            return true;
-                        }
-                    }
-                }
-                else
-                {
-                    if (parameters.Length == 1)
-                    {
-                        if (method.DeclaringType.ImplementsIEnumerableOf(parameters[0].ParameterType))
-                        {
-                            sourceExpression = methodCallExpression.Object;
-                            valueExpression = arguments[0];
-                            return true;
-                        }
-                    }
-                }
+                var arguments = methodCallExpression.Arguments;
+                sourceExpression = method.IsStatic ? arguments[0] : methodCallExpression.Object;
+                valueExpression = method.IsStatic ? arguments[1] : arguments[0];
+                return true;
             }
 
             sourceExpression = null;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableMethod.cs
@@ -652,35 +652,12 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Reflection
         public static bool IsContainsMethod(MethodCallExpression methodCallExpression, out Expression sourceExpression, out Expression valueExpression)
         {
             var method = methodCallExpression.Method;
-            var parameters = method.GetParameters();
-            var arguments = methodCallExpression.Arguments;
-
-            if (method.Name == "Contains" && method.ReturnType == typeof(bool))
+            if (IsContainsMethod(method))
             {
-                if (method.IsStatic)
-                {
-                    if (parameters.Length == 2)
-                    {
-                        if (parameters[0].ParameterType.ImplementsIEnumerableOf(parameters[1].ParameterType))
-                        {
-                            sourceExpression = arguments[0];
-                            valueExpression = arguments[1];
-                            return true;
-                        }
-                    }
-                }
-                else
-                {
-                    if (parameters.Length == 1)
-                    {
-                        if (method.DeclaringType.ImplementsIEnumerableOf(parameters[0].ParameterType))
-                        {
-                            sourceExpression = methodCallExpression.Object;
-                            valueExpression = arguments[0];
-                            return true;
-                        }
-                    }
-                }
+                var arguments = methodCallExpression.Arguments;
+                sourceExpression = method.IsStatic ? arguments[0] : methodCallExpression.Object;
+                valueExpression = method.IsStatic ? arguments[1] : arguments[0];
+                return true;
             }
 
             sourceExpression = null;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableMethod.cs
@@ -633,6 +633,22 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Reflection
         public static IReadOnlyMethodInfoSet ReverseOverloads => __reverseOverloads;
 
         // public methods
+        public static bool IsContainsMethod(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+            if (method.Name == "Contains" && method.ReturnType == typeof(bool))
+            {
+                if (method.IsStatic)
+                {
+                    return parameters.Length == 2 && parameters[0].ParameterType.ImplementsIEnumerableOf(parameters[1].ParameterType);
+                }
+
+                return parameters.Length == 1 && method.DeclaringType.ImplementsIEnumerableOf(parameters[0].ParameterType);
+            }
+
+            return false;
+        }
+
         public static bool IsContainsMethod(MethodCallExpression methodCallExpression, out Expression sourceExpression, out Expression valueExpression)
         {
             var method = methodCallExpression.Method;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableOrQueryableMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableOrQueryableMethod.cs
@@ -79,7 +79,6 @@ internal static class EnumerableOrQueryableMethod
     // sets of methods
     private static readonly IReadOnlyMethodInfoSet __aggregateOverloads;
     private static readonly IReadOnlyMethodInfoSet __aggregateWithSeedOverloads;
-    private static readonly IReadOnlyMethodInfoSet __anyOverloads;
     private static readonly IReadOnlyMethodInfoSet __appendOrPrepend;
     private static readonly IReadOnlyMethodInfoSet __averageOverloads;
     private static readonly IReadOnlyMethodInfoSet __averageWithSelectorOverloads;
@@ -476,12 +475,6 @@ internal static class EnumerableOrQueryableMethod
         [
             __aggregateWithSeedAndFunc,
             __aggregateWithSeedFuncAndResultSelector
-        ]);
-
-        __anyOverloads = MethodInfoSet.Create(
-        [
-            __any,
-            __anyWithPredicate
         ]);
 
         __appendOrPrepend = MethodInfoSet.Create(
@@ -965,7 +958,6 @@ internal static class EnumerableOrQueryableMethod
     // sets of methods
     public static IReadOnlyMethodInfoSet AggregateOverloads => __aggregateOverloads;
     public static IReadOnlyMethodInfoSet AggregateWithSeedOverloads => __aggregateWithSeedOverloads;
-    public static IReadOnlyMethodInfoSet AnyOverloads => __anyOverloads;
     public static IReadOnlyMethodInfoSet AppendOrPrepend => __appendOrPrepend;
     public static IReadOnlyMethodInfoSet AverageOverloads => __averageOverloads;
     public static IReadOnlyMethodInfoSet AverageWithSelectorOverloads => __averageWithSelectorOverloads;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableOrQueryableMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/EnumerableOrQueryableMethod.cs
@@ -79,7 +79,6 @@ internal static class EnumerableOrQueryableMethod
     // sets of methods
     private static readonly IReadOnlyMethodInfoSet __aggregateOverloads;
     private static readonly IReadOnlyMethodInfoSet __aggregateWithSeedOverloads;
-    private static readonly IReadOnlyMethodInfoSet __anyOverloads;
     private static readonly IReadOnlyMethodInfoSet __appendOrPrepend;
     private static readonly IReadOnlyMethodInfoSet __averageOverloads;
     private static readonly IReadOnlyMethodInfoSet __averageWithSelectorOverloads;
@@ -477,12 +476,6 @@ internal static class EnumerableOrQueryableMethod
         [
             __aggregateWithSeedAndFunc,
             __aggregateWithSeedFuncAndResultSelector
-        ]);
-
-        __anyOverloads = MethodInfoSet.Create(
-        [
-            __any,
-            __anyWithPredicate
         ]);
 
         __appendOrPrepend = MethodInfoSet.Create(
@@ -973,7 +966,6 @@ internal static class EnumerableOrQueryableMethod
     // sets of methods
     public static IReadOnlyMethodInfoSet AggregateOverloads => __aggregateOverloads;
     public static IReadOnlyMethodInfoSet AggregateWithSeedOverloads => __aggregateWithSeedOverloads;
-    public static IReadOnlyMethodInfoSet AnyOverloads => __anyOverloads;
     public static IReadOnlyMethodInfoSet AppendOrPrepend => __appendOrPrepend;
     public static IReadOnlyMethodInfoSet AverageOverloads => __averageOverloads;
     public static IReadOnlyMethodInfoSet AverageWithSelectorOverloads => __averageWithSelectorOverloads;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/StringMethod.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Reflection/StringMethod.cs
@@ -46,6 +46,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
         private static readonly MethodInfo __endsWithWithString;
         private static readonly MethodInfo __endsWithWithStringAndComparisonType;
         private static readonly MethodInfo __endsWithWithStringAndIgnoreCaseAndCulture;
+        private static readonly MethodInfo __equals;
         private static readonly MethodInfo __equalsWithComparisonType;
         private static readonly MethodInfo __getChars;
         private static readonly MethodInfo __indexOfAny;
@@ -81,6 +82,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
         private static readonly MethodInfo __startsWithWithString;
         private static readonly MethodInfo __startsWithWithStringAndComparisonType;
         private static readonly MethodInfo __startsWithWithStringAndIgnoreCaseAndCulture;
+        private static readonly MethodInfo __staticEquals;
         private static readonly MethodInfo __staticEqualsWithComparisonType;
         private static readonly MethodInfo __stringInWithEnumerable;
         private static readonly MethodInfo __stringInWithParams;
@@ -174,6 +176,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
             __endsWithWithString = ReflectionInfo.Method((string s, string value) => s.EndsWith(value));
             __endsWithWithStringAndComparisonType = ReflectionInfo.Method((string s, string value, StringComparison comparisonType) => s.EndsWith(value, comparisonType));
             __endsWithWithStringAndIgnoreCaseAndCulture = ReflectionInfo.Method((string s, string value, bool ignoreCase, CultureInfo culture) => s.EndsWith(value, ignoreCase, culture));
+            __equals = ReflectionInfo.Method((string s, string value) => s.Equals(value));
             __equalsWithComparisonType = ReflectionInfo.Method((string s, string value, StringComparison comparisonType) => s.Equals(value, comparisonType));
             __getChars = ReflectionInfo.Method((string s, int index) => s[index]);
             __indexOfAny = ReflectionInfo.Method((string s, char[] anyOf) => s.IndexOfAny(anyOf));
@@ -218,6 +221,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
             __startsWithWithString = ReflectionInfo.Method((string s, string value) => s.StartsWith(value));
             __startsWithWithStringAndComparisonType = ReflectionInfo.Method((string s, string value, StringComparison comparisonType) => s.StartsWith(value, comparisonType));
             __startsWithWithStringAndIgnoreCaseAndCulture = ReflectionInfo.Method((string s, string value, bool ignoreCase, CultureInfo culture) => s.StartsWith(value, ignoreCase, culture));
+            __staticEquals = ReflectionInfo.Method((string a, string b) => string.Equals(a, b));
             __staticEqualsWithComparisonType = ReflectionInfo.Method((string a, string b, StringComparison comparisonType) => string.Equals(a, b, comparisonType));
             __stringInWithEnumerable = ReflectionInfo.Method((string s, IEnumerable<StringOrRegularExpression> values) => s.StringIn(values));
             __stringInWithParams = ReflectionInfo.Method((string s, StringOrRegularExpression[] values) => s.StringIn(values));
@@ -523,6 +527,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
         public static MethodInfo EndsWithWithString => __endsWithWithString;
         public static MethodInfo EndsWithWithStringAndComparisonType => __endsWithWithStringAndComparisonType;
         public static MethodInfo EndsWithWithStringAndIgnoreCaseAndCulture => __endsWithWithStringAndIgnoreCaseAndCulture;
+        public static MethodInfo EqualsInstanceMethod => __equals;
         public static MethodInfo EqualsWithComparisonType => __equalsWithComparisonType;
         public static MethodInfo GetChars => __getChars;
         public static MethodInfo IndexOfAny => __indexOfAny;
@@ -554,6 +559,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
         public static MethodInfo StartsWithWithString => __startsWithWithString;
         public static MethodInfo StartsWithWithStringAndComparisonType => __startsWithWithStringAndComparisonType;
         public static MethodInfo StartsWithWithStringAndIgnoreCaseAndCulture => __startsWithWithStringAndIgnoreCaseAndCulture;
+        public static MethodInfo StaticEquals => __staticEquals;
         public static MethodInfo StaticEqualsWithComparisonType => __staticEqualsWithComparisonType;
         public static MethodInfo StringInWithEnumerable => __stringInWithEnumerable;
         public static MethodInfo StringInWithParams => __stringInWithParams;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderHelperMethods.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderHelperMethods.cs
@@ -170,6 +170,7 @@ internal partial class SerializerFinderVisitor
         }
     }
 
+    // TODO: merge this and next methods.
     private void DeduceCollectionAndItemSerializers(Expression collectionExpression, Expression itemExpression)
     {
         DeduceItemAndCollectionSerializers(itemExpression, collectionExpression);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderHelperMethods.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderHelperMethods.cs
@@ -169,8 +169,7 @@ internal partial class SerializerFinderVisitor
             AddNodeSerializer(collectionExpression2, collectionSerializer2);
         }
     }
-
-    // TODO: merge this and next methods.
+    
     private void DeduceCollectionAndItemSerializers(Expression collectionExpression, Expression itemExpression)
     {
         DeduceItemAndCollectionSerializers(itemExpression, collectionExpression);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -1731,9 +1731,14 @@ internal partial class SerializerFinderVisitor
                         _ when declaringType == typeof(decimal) => DecimalSerializer.Instance,
                         _ when declaringType == typeof(double) => DoubleSerializer.Instance,
                         _ when declaringType == typeof(int) => Int32Serializer.Instance,
-                        _ when declaringType == typeof(short) => Int64Serializer.Instance,
+                        _ when declaringType == typeof(short) => Int16Serializer.Instance,
+                        _ when declaringType == typeof(long) => Int64Serializer.Instance,
+                        _ when declaringType == typeof(float) => SingleSerializer.Instance,
+                        _ when declaringType == typeof(byte) => ByteSerializer.Instance,
+                        _ when declaringType == typeof(sbyte) => SByteSerializer.Instance,
                         _ => UnknowableSerializer.Create(declaringType)
                     };
+
                     visitor.AddNodeSerializer(expression, nodeSerializer);
                 }
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -14,13 +14,16 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Options;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Linq.Linq3Implementation.ExtensionMethods;
 using MongoDB.Driver.Linq.Linq3Implementation.Misc;
 using MongoDB.Driver.Linq.Linq3Implementation.Reflection;
@@ -30,6 +33,8 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
 
 internal partial class SerializerFinderVisitor
 {
+    private static readonly Dictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerResolvers = new();
+    private static readonly ReaderWriterLockSlim __serializerResolversLock = new();
     private static readonly IBsonSerializer __binarySubTypeSerializer = NullableSerializer.Create(new EnumSerializer<BsonBinarySubType>());
 
     private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileOverloads = MethodInfoSet.Create(
@@ -59,872 +64,407 @@ internal partial class SerializerFinderVisitor
         [MongoEnumerableMethod.WhereWithLimit]
     ]);
 
-    protected override Expression VisitMethodCall(MethodCallExpression node)
+    static SerializerFinderVisitor()
     {
-        var method = node.Method;
-        var arguments = node.Arguments;
+        // DeduceAbsMethodSerializers
+        RegisterSerializerResolvers(MathMethod.AbsOverloads, (visitor, expression) => visitor.DeduceSerializers(expression, expression.Arguments[0]));
+        // DeduceAdd*MethodSerializers (Add, AddDays, AddHours, AddMilliseconds, AddMinutes, AddMonths, AddQuarters, AddSeconds, AddTicks, AddWeeks, AddYears)
+        RegisterSerializerResolvers(
+            [
+                DateTimeMethod.Add, DateTimeMethod.AddWithTimezone, DateTimeMethod.AddWithUnit, DateTimeMethod.AddWithUnitAndTimezone,
+                DateTimeMethod.AddDays, DateTimeMethod.AddDaysWithTimezone, DateTimeMethod.AddHours, DateTimeMethod.AddHoursWithTimezone,
+                DateTimeMethod.AddMilliseconds, DateTimeMethod.AddMillisecondsWithTimezone, DateTimeMethod.AddMinutes, DateTimeMethod.AddMinutesWithTimezone,
+                DateTimeMethod.AddMonths, DateTimeMethod.AddMonthsWithTimezone, DateTimeMethod.AddQuarters, DateTimeMethod.AddQuartersWithTimezone,
+                DateTimeMethod.AddSeconds, DateTimeMethod.AddSecondsWithTimezone, DateTimeMethod.AddTicks, DateTimeMethod.AddWeeks,
+                DateTimeMethod.AddWeeksWithTimezone, DateTimeMethod.AddYears, DateTimeMethod.AddYearsWithTimezone
+            ],
+            (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
 
-        DeduceMethodCallSerializers();
-        base.VisitMethodCall(node);
-        DeduceMethodCallSerializers();
+        RegisterSerializerResolver(WindowMethod.AddToSet, DeduceAddToSetMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithFunc, DeduceAggregateWithFuncMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithSeedAndFunc, DeduceAggregateWithSeedAndFuncMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector, DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers);
+        RegisterSerializerResolvers([EnumerableMethod.AllWithPredicate, QueryableMethod.AllWithPredicate], DeduceAllMethodSerializers);
+        // DeduceAnyMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Any, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AnyWithPredicate, DeduceAnyWithPredicateMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.AppendStage, DeduceAppendStageMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.As, DeduceAsMethodSerializers);
+        RegisterSerializerResolver(QueryableMethod.AsQueryable, DeduceAsQueryableMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Concat, DeduceEnumerableConcatMethodSerializers);
+        RegisterSerializerResolvers([StringMethod.EqualsInstanceMethod, StringMethod.EqualsWithComparisonType, StringMethod.StaticEqualsWithComparisonType, StringMethod.StaticEquals], DeduceStringEqualsMethodSerializers);
+        // DeduceConcatMethodSerializers + StringMethod.ConcatOverloads branch
+        RegisterSerializerResolvers(StringMethod.ConcatOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        RegisterSerializerResolvers([MqlMethod.ConstantWithRepresentation, MqlMethod.ConstantWithSerializer], DeduceConstantMethodSerializers);
+        RegisterSerializerResolver(MqlMethod.CreateObjectId, (visitor, expression) => visitor.DeduceSerializer(expression, ObjectIdSerializer.Instance));
+        RegisterSerializerResolver(MqlMethod.DeserializeEJson, DeduceDeserializeEJsonMethodSerializers);
+        RegisterSerializerResolver(MqlMethod.SerializeEJson, DeduceSerializeEJsonMethodSerializers);
+        // DeduceContainsMethodSerializers + StringMethod.ContainsOverloads branch
+        RegisterSerializerResolvers(StringMethod.ContainsOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolver(MqlMethod.Convert, DeduceConvertMethodSerializers);
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        RegisterSerializerResolver(KeyValuePairMethod.Create, DeduceKeyValuePairCreateMethodSerializers);
+#endif
+        RegisterSerializerResolvers(TupleOrValueTupleMethod.CreateOverloads, DeduceTupleOrValueTupleCreateMethodSerializers);
+        RegisterSerializerResolvers(MqlMethod.DateFromStringOverloads, DeduceDateFromStringMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.DefaultIfEmptyOverloads, DeduceDefaultIfEmptyMethodSerializers);
+        // DeduceDegreesToRadiansMethodSerializers
+        RegisterSerializerResolver(MongoDBMathMethod.DegreesToRadians, (visitor, method) => visitor.DeduceSerializer(method, DoubleSerializer.Instance));
+        RegisterSerializerResolver(MongoQueryableMethod.DensifyWithArrayPartitionByFields, DeduceDensifyMethodSerializers);
+        // DeduceDistinctMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Distinct, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+        // DeduceDocumentNumberMethodSerializers
+        RegisterSerializerResolver(WindowMethod.DocumentNumber, (visitor, expression) => visitor.DeduceStandardSerializer(expression)); // currently decimal, but might be long in the future
+        RegisterSerializerResolvers([MongoQueryableMethod.Documents, MongoQueryableMethod.DocumentsWithSerializer], DeduceDocumentsMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Except, DeduceExceptMethodSerializers);
+        // DeduceExpMethodSerializers
+        RegisterSerializerResolver(MathMethod.Exp, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        RegisterSerializerResolvers(WindowMethod.ExponentialMovingAverageOverloads, DeduceExponentialMovingAverageMethodSerializers);
+        RegisterSerializerResolver(MqlMethod.Field, DeduceFieldMethodSerializers);
+        RegisterSerializerResolver(MqlMethod.Hash, (visitor, expression) => visitor.DeduceSerializer(expression, BsonBinaryDataSerializer.Instance));
+        RegisterSerializerResolver(MqlMethod.HexHash, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceGetCharsMethodSerializers
+        RegisterSerializerResolver(StringMethod.GetChars, (visitor, expression) => visitor.DeduceSerializer(expression, CharSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.GroupByOverloads, DeduceGroupByMethodSerializers);
+        RegisterSerializerResolvers([EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin], DeduceGroupJoinMethodSerializers);
+        RegisterSerializerResolver(EnumMethod.HasFlag, DeduceHasFlagMethodSerializers);
+        // DeduceInjectMethodSerializers
+        RegisterSerializerResolver(LinqExtensionsMethod.Inject, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        // DeduceIntersectMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Intersect, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+        // DeduceIsMatchMethodSerializers
+        RegisterSerializerResolvers(RegexMethod.IsMatchOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolvers([EnumerableMethod.Join, QueryableMethod.Join], DeduceJoinMethodSerializers);
+        RegisterSerializerResolver(WindowMethod.Locf, DeduceLocfMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndPipeline, DeduceLookupWithDocumentsAndPipelineMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignField, DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndPipeline, DeduceLookupWithFromAndPipelineMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.OfType, DeduceOfTypeMethodSerializers);
+        // DeducePowMethodSerializers
+        RegisterSerializerResolver(MathMethod.Pow, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        RegisterSerializerResolver(WindowMethod.Push, DeducePushMethodSerializers);
+        // DeduceRadiansToDegreesMethodSerializers
+        RegisterSerializerResolver(MongoDBMathMethod.RadiansToDegrees, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        // DeduceRangeMethodSerializers
+        RegisterSerializerResolver(EnumerableMethod.Range, (visitor, expression) => visitor.DeduceCollectionAndItemSerializers(expression, expression.Arguments[0]));
+        // DeduceRepeatMethodSerializers
+        RegisterSerializerResolver(EnumerableMethod.Repeat, (visitor, expression) => visitor.DeduceCollectionAndItemSerializers(expression, expression.Arguments[0]));
+        // DeduceReverseMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.ReverseOverloads, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+        RegisterSerializerResolvers([MathMethod.RoundWithDecimal, MathMethod.RoundWithDecimalAndDecimals, MathMethod.RoundWithDouble, MathMethod.RoundWithDoubleAndDigits], DeduceRoundMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Select, DeduceSelectMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectWithSelectorTakingIndex, DeduceSelectWithSelectorTakingIndexMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithSelector, DeduceSelectManyWithSelectorMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector, DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex, SelectManyWithSelectorTakingIndexMethodSerializers);
+        RegisterSerializerResolvers([EnumerableMethod.SequenceEqual, QueryableMethod.SequenceEqual], DeduceSequenceEqualMethodSerializers);
+        // TODO: Definitely wrong registration copy-pasted from prev code, investigate before merge to main
+        // RegisterSerializerResolver(EnumerableMethod.First, DeduceSetWindowFieldsMethodSerializers);
+        RegisterSerializerResolvers([WindowMethod.Shift, WindowMethod.ShiftWithDefaultValue], DeduceShiftMethodSerializers);
+        // DeduceSigmoidMethodSerializers
+        RegisterSerializerResolver(MqlMethod.Sigmoid, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        RegisterSerializerResolvers(StringMethod.SplitOverloads, DeduceSplitMethodSerializers);
+        RegisterSerializerResolvers(RegexMethod.SplitOverloads, DeduceSplitMethodSerializers);
+        RegisterSerializerResolvers(StringMethod.ReplaceOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        RegisterSerializerResolvers(RegexMethod.ReplaceOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceSqrtMethodSerializers
+        RegisterSerializerResolver(MathMethod.Sqrt, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        // DeduceStrLenBytesMethodSerializers
+        RegisterSerializerResolver(StringMethod.StrLenBytes, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningDateTimeOverloads branch
+        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningDateTimeOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
+        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningInt64Overloads
+        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningInt64Overloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
+        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads
+        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads, (visitor, expression) => DeduceReturnsTimeSpanSerializer(visitor, expression, TimeSpanUnits.Milliseconds));
+        // DeduceSubtypeMethodSerializers
+        RegisterSerializerResolver(MqlMethod.Subtype, (visitor, expression) => visitor.DeduceSerializer(expression, __binarySubTypeSerializer));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SumOverloads, DeduceEnumerableSumMethodSerializers);
+        RegisterSerializerResolvers(WindowMethod.SumOverloads, DeduceWindowSumMethodSerializers);
+        // DeduceTrimSerializers
+        RegisterSerializerResolvers(StringMethod.TrimOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceTruncateSerializers + DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone branch
+        RegisterSerializerResolvers([DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone], (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
+        // DeduceTruncateSerializers + MathMethod.TruncateDecimal, MathMethod.TruncateDouble branch
+        RegisterSerializerResolvers([MathMethod.TruncateDecimal, MathMethod.TruncateDouble], DeduceReturnsNumericSerializer);
+        // DeduceUnionSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Union, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+        // DeduceWeekSerializers
+        RegisterSerializerResolvers([DateTimeMethod.Week, DateTimeMethod.WeekWithTimezone], (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+        RegisterSerializerResolvers(__whereOverloads, DeduceWhereSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.WhereWithPredicateTakingIndex, DeduceWhereWithPredicateTakingIndexSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Zip, DeduceZipSerializers);
+        // DeduceTrigonometricMethodSerializers
+        RegisterSerializerResolvers(MathMethod.TrigonometricMethods, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        // DeduceMatchingElementsMethodSerializers
+        RegisterSerializerResolvers([MongoEnumerableMethod.AllElements, MongoEnumerableMethod.AllMatchingElements, MongoEnumerableMethod.FirstMatchingElement], DeduceReturnsOneSourceItemSerializer);
+        // DeduceAnyStringInOrNinMethodSerializers
+        RegisterSerializerResolvers(StringMethod.AnyStringInOrNinOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AppendOrPrepend, DeduceAppendOrPrependMethodSerializers);
+        RegisterSerializerResolvers(__averageOrMedianOrPercentileOverloads, DeduceAverageOrMedianOrPercentileMethodSerializers);
+        RegisterSerializerResolvers(__averageOrMedianOrPercentileWindowMethodOverloads, DeduceAverageOrMedianOrPercentileWindowMethodSerializers);
+        RegisterSerializerResolvers(EnumerableMethod.PickOverloads, DeducePickMethodSerializers);
+        // DeduceCeilingOrFloorMethodSerializers
+        RegisterSerializerResolvers([MathMethod.CeilingWithDecimal, MathMethod.CeilingWithDouble, MathMethod.FloorWithDecimal, MathMethod.FloorWithDouble], DeduceReturnsNumericSerializer);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.CountOverloads, DeduceEnumerableCountMethodSerializers);
+        // DeduceCountMethodSerializers + WindowMethod.Count branch
+        RegisterSerializerResolver(WindowMethod.Count, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
+        RegisterSerializerResolvers(WindowMethod.CovarianceOverloads, DeduceCovarianceMethodSerializers);
+        // DeduceDenseRankOrRankMethodSerializers
+        RegisterSerializerResolvers([WindowMethod.DenseRank, WindowMethod.Rank], (visitor, expression) => visitor.DeduceStandardSerializer(expression)); // currently decimal, but might be long in the future
+        RegisterSerializerResolvers(WindowMethod.DerivativeOrIntegralOverloads, DeduceDerivativeOrIntegralMethodSerializers);
+        // DeduceElementAtMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.ElementAtOverloads, (visitor, expression) => visitor.DeduceItemAndCollectionSerializers(expression, expression.Arguments[0]));
+        // DeduceEndsWithOrStartsWithMethodSerializers
+        RegisterSerializerResolvers(StringMethod.EndsWithOrStartsWithOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads, DeduceFirstOrLastOrSingleMethodsSerializers);
+        RegisterSerializerResolvers([WindowMethod.First, WindowMethod.Last], DeduceFirstOrLastWindowMethodsSerializers);
+        // DeduceIndexOfMethodSerializers
+        RegisterSerializerResolvers(StringMethod.IndexOfOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+        // DeduceIsMissingOrIsNullOrMissingMethodSerializers
+        // DeduceExistsMethodSerializers + MqlMethod.Exists
+        RegisterSerializerResolvers([MqlMethod.Exists, MqlMethod.IsMissing, MqlMethod.IsNullOrMissing], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        // DeduceIsNullOrEmptyOrIsNullOrWhiteSpaceMethodSerializers
+        RegisterSerializerResolvers([StringMethod.IsNullOrEmpty, StringMethod.IsNullOrWhiteSpace], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        // DeduceLogMethodSerializers
+        RegisterSerializerResolvers(MathMethod.LogOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.MaxOrMinOverloads, DeduceMaxOrMinMethodSerializers);
+        RegisterSerializerResolvers([WindowMethod.Max, WindowMethod.Min], DeduceWindowMaxOrMinMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.OrderByOrThenByOverloads, DeduceOrderByMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SkipOrTakeOverloads, DeduceSkipOrTakeMethodSerializers);
+        RegisterSerializerResolvers(MongoEnumerableMethod.StandardDeviationOverloads, DeduceStandardDeviationMethodSerializers);
+        RegisterSerializerResolvers(WindowMethod.StandardDeviationOverloads, DeduceWindowStandardDeviationMethodSerializers);
+        // DeduceStringInOrNinMethodSerializers
+        RegisterSerializerResolvers(StringMethod.StringInOrNinOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        // DeduceSubstringMethodSerializers
+        RegisterSerializerResolvers([StringMethod.Substring, StringMethod.SubstringWithLength, StringMethod.SubstrBytes], (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceToLowerOrToUpperSerializers
+        RegisterSerializerResolvers(StringMethod.ToLowerOrToUpperOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceSimilarityFunctionsSerializers
+        RegisterSerializerResolvers(MqlMethod.SimilarityFunctionOverloads, DeduceReturnsNumericSerializer);
 
-        return node;
-
-        void DeduceMethodCallSerializers()
+        void RegisterSerializerResolver(MethodInfo method, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
         {
-            switch (node.Method.Name)
+            Ensure.IsNotNull(method, nameof(method));
+            Ensure.IsNotNull(resolver, nameof(resolver));
+
+            __serializerResolvers.Add(method, resolver);
+        }
+
+        void RegisterSerializerResolvers(IEnumerable<MethodInfo> methods, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
+        {
+            foreach (var method in methods)
             {
-                case "Abs": DeduceAbsMethodSerializers(); break;
-                case "Add": DeduceAddMethodSerializers(); break;
-                case "AddDays": DeduceAddDaysMethodSerializers(); break;
-                case "AddHours": DeduceAddHoursMethodSerializers(); break;
-                case "AddMilliseconds": DeduceAddMillisecondsMethodSerializers(); break;
-                case "AddMinutes": DeduceAddMinutesMethodSerializers(); break;
-                case "AddMonths": DeduceAddMonthsMethodSerializers(); break;
-                case "AddQuarters": DeduceAddQuartersMethodSerializers(); break;
-                case "AddSeconds": DeduceAddSecondsMethodSerializers(); break;
-                case "AddTicks": DeduceAddTicksMethodSerializers(); break;
-                case "AddToSet": DeduceAddToSetMethodSerializers(); break;
-                case "AddWeeks": DeduceAddWeeksMethodSerializers(); break;
-                case "AddYears": DeduceAddYearsMethodSerializers(); break;
-                case "Aggregate": DeduceAggregateMethodSerializers(); break;
-                case "All": DeduceAllMethodSerializers(); break;
-                case "Any": DeduceAnyMethodSerializers(); break;
-                case "AppendStage": DeduceAppendStageMethodSerializers(); break;
-                case "As": DeduceAsMethodSerializers(); break;
-                case "AsQueryable": DeduceAsQueryableMethodSerializers(); break;
-                case "Concat": DeduceConcatMethodSerializers(); break;
-                case "Constant": DeduceConstantMethodSerializers(); break;
-                case "Contains": DeduceContainsMethodSerializers(); break;
-                case "ContainsKey": DeduceContainsKeyMethodSerializers(); break;
-                case "ContainsValue": DeduceContainsValueMethodSerializers(); break;
-                case "Convert": DeduceConvertMethodSerializers(); break;
-                case "Create": DeduceCreateMethodSerializers(); break;
-                case "CreateObjectId": DeduceCreateObjectIdMethodSerializers(); break;
-                case "DateFromString": DeduceDateFromStringMethodSerializers(); break;
-                case "DefaultIfEmpty": DeduceDefaultIfEmptyMethodSerializers(); break;
-                case "DegreesToRadians": DeduceDegreesToRadiansMethodSerializers(); break;
-                case "Densify": DeduceDensifyMethodSerializers(); break;
-                case "DeserializeEJson": DeduceDeserializeEJsonMethodSerializers(); break;
-                case "Distinct": DeduceDistinctMethodSerializers(); break;
-                case "DocumentNumber": DeduceDocumentNumberMethodSerializers(); break;
-                case "Documents": DeduceDocumentsMethodSerializers(); break;
-                case "Equals": DeduceEqualsMethodSerializers(); break;
-                case "Except": DeduceExceptMethodSerializers(); break;
-                case "Exists": DeduceExistsMethodSerializers(); break;
-                case "Exp": DeduceExpMethodSerializers(); break;
-                case "ExponentialMovingAverage": DeduceExponentialMovingAverageMethodSerializers(); break;
-                case "Field": DeduceFieldMethodSerializers(); break;
-                case "get_Item": DeduceGetItemMethodSerializers(); break;
-                case "get_Chars": DeduceGetCharsMethodSerializers(); break;
-                case "GroupBy": DeduceGroupByMethodSerializers(); break;
-                case "GroupJoin": DeduceGroupJoinMethodSerializers(); break;
-                case "HasFlag": DeduceHasFlagMethodSerializers(); break;
-                case "Hash": DeduceHashMethodSerializers(); break;
-                case "HexHash": DeduceHexHashMethodSerializers(); break;
-                case "Inject": DeduceInjectMethodSerializers(); break;
-                case "Intersect": DeduceIntersectMethodSerializers(); break;
-                case "IsMatch": DeduceIsMatchMethodSerializers(); break;
-                case "IsSubsetOf": DeduceIsSubsetOfMethodSerializers(); break;
-                case "Join": DeduceJoinMethodSerializers(); break;
-                case "Locf": DeduceLocfMethodSerializers(); break;
-                case "Lookup": DeduceLookupMethodSerializers(); break;
-                case "OfType": DeduceOfTypeMethodSerializers(); break;
-                case "Parse": DeduceParseMethodSerializers(); break;
-                case "Pow": DeducePowMethodSerializers(); break;
-                case "Push": DeducePushMethodSerializers(); break;
-                case "RadiansToDegrees": DeduceRadiansToDegreesMethodSerializers(); break;
-                case "Range": DeduceRangeMethodSerializers(); break;
-                case "Repeat": DeduceRepeatMethodSerializers(); break;
-                case "Replace": DeduceReplaceMethodSerializers(); break;
-                case "Reverse": DeduceReverseMethodSerializers(); break;
-                case "Round": DeduceRoundMethodSerializers(); break;
-                case "Select": DeduceSelectMethodSerializers(); break;
-                case "SelectMany": DeduceSelectManySerializers(); break;
-                case "SequenceEqual": DeduceSequenceEqualMethodSerializers(); break;
-                case "SerializeEJson": DeduceSerializeEJsonMethodSerializers(); break;
-                case "SetEquals": DeduceSetEqualsMethodSerializers(); break;
-                case "SetWindowFields": DeduceSetWindowFieldsMethodSerializers(); break;
-                case "Shift": DeduceShiftMethodSerializers(); break;
-                case "Sigmoid": DeduceSigmoidMethodSerializers(); break;
-                case "Split": DeduceSplitMethodSerializers(); break;
-                case "Sqrt": DeduceSqrtMethodSerializers(); break;
-                case "StrLenBytes": DeduceStrLenBytesMethodSerializers(); break;
-                case "Subtract": DeduceSubtractMethodSerializers(); break;
-                case "Subtype": DeduceSubtypeMethodSerializers(); break;
-                case "Sum": DeduceSumMethodSerializers(); break;
-                case "ToArray": DeduceToArrayMethodSerializers(); break;
-                case "ToHashedIndexKey": DeduceToHashedIndexKeySerializers(); break;
-                case "ToList": DeduceToListSerializers(); break;
-                case "ToString": DeduceToStringSerializers(); break;
-                case "Trim":
-                case "TrimStart":
-                case "TrimEnd":
-                    DeduceTrimSerializers();
-                    break;
-                case "Truncate": DeduceTruncateSerializers(); break;
-                case "Union": DeduceUnionSerializers(); break;
-                case "Week": DeduceWeekSerializers(); break;
-                case "Where": DeduceWhereSerializers(); break;
-                case "Zip": DeduceZipSerializers(); break;
-
-                case "Acos":
-                case "Acosh":
-                case "Asin":
-                case "Asinh":
-                case "Atan":
-                case "Atanh":
-                case "Atan2":
-                case "Cos":
-                case "Cosh":
-                case "Sin":
-                case "Sinh":
-                case "Tan":
-                case "Tanh":
-                    DeduceTrigonometricMethodSerializers();
-                    break;
-
-                case "AllElements":
-                case "AllMatchingElements":
-                case "FirstMatchingElement":
-                    DeduceMatchingElementsMethodSerializers();
-                    break;
-
-                case "AnyStringIn":
-                case "AnyStringNin":
-                    DeduceAnyStringInOrNinMethodSerializers();
-                    break;
-
-                case "Append":
-                case "Prepend":
-                    DeduceAppendOrPrependMethodSerializers();
-                    break;
-
-                case "Average":
-                case "Median":
-                case "Percentile":
-                    DeduceAverageOrMedianOrPercentileMethodSerializers();
-                    break;
-
-                case "Bottom":
-                case "BottomN":
-                case "FirstN":
-                case "LastN":
-                case "MaxN":
-                case "MinN":
-                case "Top":
-                case "TopN":
-                    DeducePickMethodSerializers();
-                    break;
-
-                case "Ceiling":
-                case "Floor":
-                    DeduceCeilingOrFloorMethodSerializers();
-                    break;
-
-                case "Compare":
-                case "CompareTo":
-                    DeduceCompareOrCompareToMethodSerializers();
-                    break;
-
-                case "Count":
-                case "LongCount":
-                    DeduceCountMethodSerializers();
-                    break;
-
-                case "CovariancePopulation":
-                case "CovarianceSample":
-                    DeduceCovarianceMethodSerializers();
-                    break;
-
-                case "DenseRank":
-                case "Rank":
-                    DeduceDenseRankOrRankMethodSerializers();
-                    break;
-
-                case "Derivative":
-                case "Integral":
-                    DeduceDerivativeOrIntegralMethodSerializers();
-                    break;
-
-                case "ElementAt":
-                case "ElementAtOrDefault":
-                    DeduceElementAtMethodSerializers();
-                    break;
-
-                case "EndsWith":
-                case "StartsWith":
-                    DeduceEndsWithOrStartsWithMethodSerializers();
-                    break;
-
-                case "First":
-                case "FirstOrDefault":
-                case "Last":
-                case "LastOrDefault":
-                case "Single":
-                case "SingleOrDefault":
-                    DeduceFirstOrLastOrSingleMethodsSerializers();
-                    break;
-
-                case "IndexOf":
-                case "IndexOfBytes":
-                    DeduceIndexOfMethodSerializers();
-                    break;
-
-                case "IsMissing":
-                case "IsNullOrMissing":
-                    DeduceIsMissingOrIsNullOrMissingMethodSerializers();
-                    break;
-
-                case "IsNullOrEmpty":
-                case "IsNullOrWhiteSpace":
-                    DeduceIsNullOrEmptyOrIsNullOrWhiteSpaceMethodSerializers();
-                    break;
-
-                case "Ln":
-                case "Log":
-                case "Log10":
-                    DeduceLogMethodSerializers();
-                    break;
-
-                case "Max":
-                case "Min":
-                    DeduceMaxOrMinMethodSerializers();
-                    break;
-
-                case "OrderBy":
-                case "OrderByDescending":
-                case "ThenBy":
-                case "ThenByDescending":
-                    DeduceOrderByMethodSerializers();
-                    break;
-
-                case "Skip":
-                case "SkipWhile":
-                case "Take":
-                case "TakeWhile":
-                    DeduceSkipOrTakeMethodSerializers();
-                    break;
-
-                case "StandardDeviationPopulation":
-                case "StandardDeviationPopulationAsync":
-                case "StandardDeviationSample":
-                case "StandardDeviationSampleAsync":
-                    DeduceStandardDeviationMethodSerializers();
-                    break;
-
-                case "StringIn":
-                case "StringNin":
-                    DeduceStringInOrNinMethodSerializers();
-                    break;
-
-                case "Substring":
-                case "SubstrBytes":
-                    DeduceSubstringMethodSerializers();
-                    break;
-
-                case "ToLower":
-                case "ToLowerInvariant":
-                case "ToUpper":
-                case "ToUpperInvariant":
-                    DeduceToLowerOrToUpperSerializers();
-                    break;
-
-                case nameof(Mql.SimilarityDotProduct):
-                case nameof(Mql.SimilarityEuclidean):
-                case nameof(Mql.SimilarityCosine):
-                    DeduceSimilarityFunctionsSerializers();
-                    break;
-
-                default:
-                    DeduceUnknownMethodSerializer();
-                    break;
+                RegisterSerializerResolver(method, resolver);
             }
         }
 
-        void DeduceAbsMethodSerializers()
+        // DeduceAddToSetMethodSerializers
+        static void DeduceAddToSetMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(MathMethod.AbsOverloads))
-            {
-                var valueExpression = arguments[0];
-                DeduceSerializers(node, valueExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
         }
 
-        void DeduceAddMethodSerializers()
+        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithFunc branch
+        static void DeduceAggregateWithFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.Add, DateTimeMethod.AddWithTimezone, DateTimeMethod.AddWithUnit, DateTimeMethod.AddWithUnitAndTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var funcAccumulatorParameter = funcLambda.Parameters[0];
+            var funcSourceItemParameter = funcLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(funcAccumulatorParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(funcLambda.Body, sourceExpression);
+            visitor.DeduceSerializers(expression, funcLambda.Body);
         }
 
-        void DeduceAddDaysMethodSerializers()
+        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithSeedAndFunc branch
+        static void DeduceAggregateWithSeedAndFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddDays,  DateTimeMethod.AddDaysWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var seedExpression =  expression.Arguments[1];
+            var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var funcAccumulatorParameter = funcLambda.Parameters[0];
+            var funcSourceItemParameter = funcLambda.Parameters[1];
+
+            visitor.DeduceSerializers(seedExpression, funcLambda.Body);
+            visitor.DeduceSerializers(funcAccumulatorParameter, funcLambda.Body);
+            visitor.DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
+            visitor.DeduceSerializers(expression, funcLambda.Body);
         }
 
-        void DeduceAddHoursMethodSerializers()
+        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector branch
+        static void DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddHours,  DateTimeMethod.AddHoursWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var seedExpression = expression.Arguments[1];
+            var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var funcAccumulatorParameter = funcLambda.Parameters[0];
+            var funcSourceItemParameter = funcLambda.Parameters[1];
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var resultSelectorAccumulatorParameter = resultSelectorLambda.Parameters[0];
+
+            visitor.DeduceSerializers(seedExpression, funcLambda.Body);
+            visitor.DeduceSerializers(funcAccumulatorParameter, funcLambda.Body);
+            visitor.DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
+            visitor.DeduceSerializers(resultSelectorAccumulatorParameter, funcLambda.Body);
+            visitor.DeduceSerializers(expression, resultSelectorLambda.Body);
         }
 
-        void DeduceAddMillisecondsMethodSerializers()
+        // DeduceAllMethodSerializers
+        static void DeduceAllMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddMilliseconds,  DateTimeMethod.AddMillisecondsWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var predicateParameter = predicateLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        void DeduceAddMinutesMethodSerializers()
+        // DeduceAnyMethodSerializers + EnumerableOrQueryableMethod.AnyWithPredicate branch
+        static void DeduceAnyWithPredicateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddMinutes,  DateTimeMethod.AddMinutesWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var predicateParameter = predicateLambda.Parameters[0];
+
+            visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        void DeduceAddMonthsMethodSerializers()
+        // DeduceAppendStageMethodSerializers
+        static void DeduceAppendStageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddMonths,  DateTimeMethod.AddMonthsWithTimezone))
+            if (visitor.IsNotKnown(expression))
             {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
+                var sourceExpression = expression.Arguments[0];
+                var stageExpression = expression.Arguments[1];
+                var resultSerializerExpression = expression.Arguments[2];
 
-        void DeduceAddQuartersMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.AddQuarters, DateTimeMethod.AddQuartersWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddSecondsMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.AddSeconds, DateTimeMethod.AddSecondsWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddTicksMethodSerializers()
-        {
-            if (method.Is(DateTimeMethod.AddTicks))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddToSetMethodSerializers()
-        {
-            if (method.Is(WindowMethod.AddToSet))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceCollectionAndItemSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddWeeksMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.AddWeeks, DateTimeMethod.AddWeeksWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddYearsMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.AddYears, DateTimeMethod.AddYearsWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAggregateMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.AggregateOverloads))
-            {
-                var sourceExpression = arguments[0];
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.AggregateWithFunc))
+                if (stageExpression is not ConstantExpression stageConstantExpression)
                 {
-                    var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var funcAccumulatorParameter = funcLambda.Parameters[0];
-                    var funcSourceItemParameter = funcLambda.Parameters[1];
+                    throw new ExpressionNotSupportedException(expression, because: "stage argument must be a constant");
+                }
+                var stageDefinition = (IPipelineStageDefinition)stageConstantExpression.Value;
 
-                    DeduceItemAndCollectionSerializers(funcAccumulatorParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(funcLambda.Body, sourceExpression);
-                    DeduceSerializers(node, funcLambda.Body);
+                if (resultSerializerExpression is not ConstantExpression resultSerializerConstantExpression)
+                {
+                    throw new ExpressionNotSupportedException(expression, because: "resultSerializer argument must be a constant");
+                }
+                var resultItemSerializer = (IBsonSerializer)resultSerializerConstantExpression.Value;
+
+                if (resultItemSerializer == null && visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
+                {
+                    var serializerRegistry = BsonSerializer.SerializerRegistry; // TODO: get correct registry
+                    var translationOptions = new ExpressionTranslationOptions(); // TODO: get correct translation options
+                    var renderedStage = stageDefinition.Render(sourceItemSerializer, serializerRegistry, translationOptions);
+                    resultItemSerializer = renderedStage.OutputSerializer;
                 }
 
-                if (method.IsOneOf(EnumerableOrQueryableMethod.AggregateWithSeedAndFunc))
+                if (resultItemSerializer != null)
                 {
-                    var seedExpression =  arguments[1];
-                    var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var funcAccumulatorParameter = funcLambda.Parameters[0];
-                    var funcSourceItemParameter = funcLambda.Parameters[1];
-
-                    DeduceSerializers(seedExpression, funcLambda.Body);
-                    DeduceSerializers(funcAccumulatorParameter, funcLambda.Body);
-                    DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
-                    DeduceSerializers(node, funcLambda.Body);
-                }
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector))
-                {
-                    var seedExpression = arguments[1];
-                    var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var funcAccumulatorParameter = funcLambda.Parameters[0];
-                    var funcSourceItemParameter = funcLambda.Parameters[1];
-                    var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var resultSelectorAccumulatorParameter = resultSelectorLambda.Parameters[0];
-
-                    DeduceSerializers(seedExpression, funcLambda.Body);
-                    DeduceSerializers(funcAccumulatorParameter, funcLambda.Body);
-                    DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
-                    DeduceSerializers(resultSelectorAccumulatorParameter, funcLambda.Body);
-                    DeduceSerializers(node, resultSelectorLambda.Body);
+                    var resultSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultItemSerializer);
+                    visitor.AddNodeSerializer(expression, resultSerializer);
                 }
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
         }
 
-        void DeduceAllMethodSerializers()
+        // DeduceAsMethodSerializers
+        static void DeduceAsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(EnumerableMethod.AllWithPredicate, QueryableMethod.AllWithPredicate))
+            if (visitor.IsNotKnown(expression))
             {
-                var sourceExpression = arguments[0];
-                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var predicateParameter = predicateLambda.Parameters.Single();
-
-                DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAnyMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.AnyOverloads))
-            {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.AnyWithPredicate))
+                var resultSerializerExpression = expression.Arguments[1];
+                if (resultSerializerExpression is not ConstantExpression resultSerializerConstantExpression)
                 {
-                    var sourceExpression = arguments[0];
-                    var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var predicateParameter = predicateLambda.Parameters[0];
-
-                    DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+                    throw new ExpressionNotSupportedException(expression, because: "resultSerializer argument must be a constant");
                 }
 
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAnyStringInOrNinMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.AnyStringInOrNinOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAppendOrPrependMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.AppendOrPrepend))
-            {
-                var sourceExpression = arguments[0];
-                var elementExpression = arguments[1];
-
-                DeduceItemAndCollectionSerializers(elementExpression, sourceExpression);
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAsMethodSerializers()
-        {
-            if (method.Is(MongoQueryableMethod.As))
-            {
-                if (IsNotKnown(node))
+                var resultItemSerializer = (IBsonSerializer)resultSerializerConstantExpression.Value;
+                if (resultItemSerializer == null)
                 {
-                    var resultSerializerExpression = arguments[1];
-                    if (resultSerializerExpression is not ConstantExpression resultSerializerConstantExpression)
-                    {
-                        throw new ExpressionNotSupportedException(node, because: "resultSerializer argument must be a constant");
-                    }
-
-                    var resultItemSerializer = (IBsonSerializer)resultSerializerConstantExpression.Value;
-                    if (resultItemSerializer == null)
-                    {
-                        var resultItemType = method.GetGenericArguments()[1];
-                        resultItemSerializer = BsonSerializer.LookupSerializer(resultItemType);
-                    }
-
-                    var resultSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
+                    var resultItemType = expression.Method.GetGenericArguments()[1];
+                    resultItemSerializer = BsonSerializer.LookupSerializer(resultItemType);
                 }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
+
+                var resultSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultItemSerializer);
+                visitor.AddNodeSerializer(expression, resultSerializer);
             }
         }
 
-        void DeduceAppendStageMethodSerializers()
+        // DeduceAsQueryableMethodSerializers
+        static void DeduceAsQueryableMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.Is(MongoQueryableMethod.AppendStage))
+            var sourceExpression = expression.Arguments[0];
+
+            if (visitor.IsNotKnown(expression) && visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
             {
-                if (IsNotKnown(node))
+                var resultSerializer = NestedAsQueryableSerializer.Create(sourceItemSerializer);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        // DeduceConcatMethodSerializers + EnumerableMethod.Concat, QueryableMethod.Concat branch
+        static void DeduceEnumerableConcatMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var firstExpression = expression.Arguments[0];
+            var secondExpression = expression.Arguments[1];
+
+            visitor.DeduceCollectionAndCollectionSerializers(firstExpression, secondExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, firstExpression);
+        }
+
+        // DeduceConstantMethodSerializers
+        static void DeduceConstantMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var valueExpression = expression.Arguments[0];
+            IBsonSerializer serializer = null;
+
+            if (visitor.IsNotKnown(expression) || visitor.IsNotKnown(valueExpression))
+            {
+                if (expression.Method.Is(MqlMethod.ConstantWithRepresentation))
                 {
-                    var sourceExpression = arguments[0];
-                    var stageExpression = arguments[1];
-                    var resultSerializerExpression = arguments[2];
+                    var representationExpression = expression.Arguments[1];
 
-                    if (stageExpression is not ConstantExpression stageConstantExpression)
+                    var representation = representationExpression.GetConstantValue<BsonType>(expression);
+                    var defaultSerializer = BsonSerializer.LookupSerializer(valueExpression.Type); // TODO: don't use BsonSerializer
+                    if (defaultSerializer is IRepresentationConfigurable representationConfigurableSerializer)
                     {
-                        throw new ExpressionNotSupportedException(node, because: "stage argument must be a constant");
-                    }
-                    var stageDefinition = (IPipelineStageDefinition)stageConstantExpression.Value;
-
-                    if (resultSerializerExpression is not ConstantExpression resultSerializerConstantExpression)
-                    {
-                        throw new ExpressionNotSupportedException(node, because: "resultSerializer argument must be a constant");
-                    }
-                    var resultItemSerializer = (IBsonSerializer)resultSerializerConstantExpression.Value;
-
-                    if (resultItemSerializer == null && IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
-                    {
-                        var serializerRegistry = BsonSerializer.SerializerRegistry; // TODO: get correct registry
-                        var translationOptions = new ExpressionTranslationOptions(); // TODO: get correct translation options
-                        var renderedStage = stageDefinition.Render(sourceItemSerializer, serializerRegistry, translationOptions);
-                        resultItemSerializer = renderedStage.OutputSerializer;
-                    }
-
-                    if (resultItemSerializer != null)
-                    {
-                        var resultSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultItemSerializer);
-                        AddNodeSerializer(node, resultSerializer);
+                        serializer = representationConfigurableSerializer.WithRepresentation(representation);
                     }
                 }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAsQueryableMethodSerializers()
-        {
-            if (method.Is(QueryableMethod.AsQueryable))
-            {
-                var sourceExpression = arguments[0];
-
-                if (IsNotKnown(node) && IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
+                else if (expression.Method.Is(MqlMethod.ConstantWithSerializer))
                 {
-                    var resultSerializer = NestedAsQueryableSerializer.Create(sourceItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
+                    var serializerExpression = expression.Arguments[1];
+                    serializer = serializerExpression.GetConstantValue<IBsonSerializer>(expression);
                 }
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+
+            visitor.DeduceSerializer(valueExpression, serializer);
+            visitor.DeduceSerializer(expression, serializer);
         }
 
-        void DeduceAverageOrMedianOrPercentileMethodSerializers()
+        // DeduceConvertMethodSerializers
+        static void DeduceConvertMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(__averageOrMedianOrPercentileOverloads))
+            if (visitor.IsNotKnown(expression))
             {
-                if (method.IsOneOf(__averageOrMedianOrPercentileWithSelectorOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorSourceItemParameter = selectorLambda.Parameters[0];
-
-                    DeduceItemAndCollectionSerializers(selectorSourceItemParameter, sourceExpression);
-                }
-
-                if (IsNotKnown(node))
-                {
-                    var nodeSerializer = StandardSerializers.GetSerializer(node.Type);
-                    AddNodeSerializer(node, nodeSerializer);
-                }
-            }
-            else if (method.IsOneOf(__averageOrMedianOrPercentileWindowMethodOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceCeilingOrFloorMethodSerializers()
-        {
-            if (method.IsOneOf(MathMethod.CeilingWithDecimal, MathMethod.CeilingWithDouble, MathMethod.FloorWithDecimal,  MathMethod.FloorWithDouble))
-            {
-                DeduceReturnsNumericSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceCompareOrCompareToMethodSerializers()
-        {
-            if (method.IsStaticCompareMethod() ||
-                method.IsInstanceCompareToMethod() ||
-                method.IsOneOf(StringMethod.CompareOverloads))
-            {
-                var valueExpression = method.IsStatic ? arguments[0] : node.Object;
-                var comparandExpression = method.IsStatic ? arguments[1] : arguments[0];
-                DeduceSerializers(valueExpression, comparandExpression);
-                DeduceReturnsInt32Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceConcatMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Concat, QueryableMethod.Concat))
-            {
-                var firstExpression = arguments[0];
-                var secondExpression = arguments[1];
-
-                DeduceCollectionAndCollectionSerializers(firstExpression, secondExpression);
-                DeduceCollectionAndCollectionSerializers(node, firstExpression);
-            }
-            else if (method.IsOneOf(StringMethod.ConcatOverloads))
-            {
-                DeduceReturnsStringSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceConstantMethodSerializers()
-        {
-            if (method.IsOneOf(MqlMethod.ConstantWithRepresentation, MqlMethod.ConstantWithSerializer))
-            {
-                var valueExpression = arguments[0];
-                IBsonSerializer serializer = null;
-
-                if (IsNotKnown(node) || IsNotKnown(valueExpression))
-                {
-                    if (method.Is(MqlMethod.ConstantWithRepresentation))
-                    {
-                        var representationExpression = arguments[1];
-
-                        var representation = representationExpression.GetConstantValue<BsonType>(node);
-                        var defaultSerializer = BsonSerializer.LookupSerializer(valueExpression.Type); // TODO: don't use BsonSerializer
-                        if (defaultSerializer is IRepresentationConfigurable representationConfigurableSerializer)
-                        {
-                            serializer = representationConfigurableSerializer.WithRepresentation(representation);
-                        }
-                    }
-                    else if (method.Is(MqlMethod.ConstantWithSerializer))
-                    {
-                        var serializerExpression = arguments[1];
-                        serializer = serializerExpression.GetConstantValue<IBsonSerializer>(node);
-                    }
-                }
-
-                DeduceSerializer(valueExpression, serializer);
-                DeduceSerializer(node, serializer);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceContainsKeyMethodSerializers()
-        {
-            if (IsDictionaryContainsKeyExpression(out var keyExpression))
-            {
-                var dictionaryExpression = node.Object;
-                if (IsNotKnown(keyExpression) && IsKnown(dictionaryExpression, out var dictionarySerializer))
-                {
-                    var keySerializer = (dictionarySerializer as IBsonDictionarySerializer)?.KeySerializer;
-                    AddNodeSerializer(keyExpression, keySerializer);
-                }
-
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceContainsMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.ContainsOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else if (EnumerableMethod.IsContainsMethod(node, out var collectionExpression, out var itemExpression))
-            {
-                DeduceCollectionAndItemSerializers(collectionExpression, itemExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceContainsValueMethodSerializers()
-        {
-            if (IsContainsValueInstanceMethod(out var collectionExpression, out var valueExpression))
-            {
-                if (IsNotKnown(valueExpression) &&
-                    IsKnown(collectionExpression, out var collectionSerializer))
-                {
-                    if (collectionSerializer is IBsonDictionarySerializer dictionarySerializer)
-                    {
-                        var valueSerializer = dictionarySerializer.ValueSerializer;
-                        AddNodeSerializer(valueExpression, valueSerializer);
-                    }
-                }
-
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-
-            bool IsContainsValueInstanceMethod(out Expression collectionExpression, out Expression valueExpression)
-            {
-                if (method.IsPublic &&
-                    method.IsStatic == false &&
-                    method.ReturnType == typeof(bool) &&
-                    method.Name == "ContainsValue" &&
-                    method.GetParameters() is var parameters &&
-                    parameters.Length == 1)
-                {
-                    collectionExpression = node.Object;
-                    valueExpression = arguments[0];
-                    return true;
-                }
-
-                collectionExpression = null;
-                valueExpression = null;
-                return false;
-            }
-        }
-
-        void DeduceConvertMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Convert))
-            {
-                if (IsNotKnown(node))
-                {
-                    var toType = method.GetGenericArguments()[1];
-                    var resultSerializer = GetResultSerializer(node, toType);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
+                var toType = expression.Method.GetGenericArguments()[1];
+                var resultSerializer = GetResultSerializer(expression, toType);
+                visitor.AddNodeSerializer(expression, resultSerializer);
             }
 
             static IBsonSerializer GetResultSerializer(Expression expression, Type toType)
             {
                 // TODO: should we use StandardSerializers at least for the subset of types where it would return the correct serializer?
-
                 var isNullable = toType.IsNullable();
                 var valueType = isNullable ? Nullable.GetUnderlyingType(toType) : toType;
 
@@ -961,760 +501,1203 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        void DeduceCreateMethodSerializers()
-        {
 #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-            if (method.Is(KeyValuePairMethod.Create))
+        // DeduceCreateMethodSerializers + KeyValuePairMethod.Create branch
+        static void DeduceKeyValuePairCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsAnyNotKnown(expression.Arguments) && visitor.IsKnown(expression, out var nodeSerializer))
             {
-                if (IsAnyNotKnown(arguments) && IsKnown(node, out var nodeSerializer))
-                {
-                    var keyExpression = arguments[0];
-                    var valueExpression = arguments[1];
+                var keyExpression = expression.Arguments[0];
+                var valueExpression = expression.Arguments[1];
 
-                    if (nodeSerializer.IsKeyValuePairSerializer(out _, out _, out var keySerializer, out var valueSerializer))
-                    {
-                        DeduceSerializer(keyExpression, keySerializer);
-                        DeduceSerializer(valueExpression, valueSerializer);
-                    }
-                }
-
-                if (IsNotKnown(node) && AreAllKnown(arguments, out var argumentSerializers))
+                if (nodeSerializer.IsKeyValuePairSerializer(out _, out _, out var keySerializer, out var valueSerializer))
                 {
-                    var keySerializer = argumentSerializers[0];
-                    var valueSerializer = argumentSerializers[1];
-                    var keyValuePairSerializer = KeyValuePairSerializer.Create(BsonType.Document, keySerializer, valueSerializer);
-                    AddNodeSerializer(node, keyValuePairSerializer);
+                    visitor.DeduceSerializer(keyExpression, keySerializer);
+                    visitor.DeduceSerializer(valueExpression, valueSerializer);
                 }
             }
-            else
- #endif
-            if (method.IsOneOf(TupleOrValueTupleMethod.CreateOverloads))
+
+            if (visitor.IsNotKnown(expression) && visitor.AreAllKnown(expression.Arguments, out var argumentSerializers))
             {
-                if (IsAnyNotKnown(arguments) && IsKnown(node, out var nodeSerializer))
+                var keySerializer = argumentSerializers[0];
+                var valueSerializer = argumentSerializers[1];
+                var keyValuePairSerializer = KeyValuePairSerializer.Create(BsonType.Document, keySerializer, valueSerializer);
+                visitor.AddNodeSerializer(expression, keyValuePairSerializer);
+            }
+        }
+#endif
+
+        // DeduceCreateMethodSerializers + TupleOrValueTupleMethod.CreateOverloads
+        static void DeduceTupleOrValueTupleCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsAnyNotKnown(expression.Arguments) && visitor.IsKnown(expression, out var nodeSerializer))
+            {
+                if (nodeSerializer is IBsonTupleSerializer tupleSerializer)
                 {
-                    if (nodeSerializer is IBsonTupleSerializer tupleSerializer)
+                    for (var i = 1; i <= expression.Arguments.Count; i++)
                     {
-                        for (var i = 1; i <= arguments.Count; i++)
+                        var argumentExpression = expression.Arguments[i];
+                        if (visitor.IsNotKnown(argumentExpression))
                         {
-                            var argumentExpression = arguments[i];
-                            if (IsNotKnown(argumentExpression))
+                            var itemSerializer = tupleSerializer.GetItemSerializer(i);
+                            if (i == 8)
                             {
-                                var itemSerializer = tupleSerializer.GetItemSerializer(i);
-                                if (i == 8)
-                                {
-                                    itemSerializer = (itemSerializer as IBsonTupleSerializer)?.GetItemSerializer(1);
-                                }
-                                AddNodeSerializer(argumentExpression, itemSerializer);
+                                itemSerializer = (itemSerializer as IBsonTupleSerializer)?.GetItemSerializer(1);
                             }
+                            visitor.AddNodeSerializer(argumentExpression, itemSerializer);
                         }
                     }
                 }
-
-                if (IsNotKnown(node) && AreAllKnown(arguments, out var argumentSerializers))
-                {
-                    var tupleType = method.ReturnType;
-
-                    if (arguments.Count == 8)
-                    {
-                        var item8Expression = arguments[7];
-                        var item8Type = item8Expression.Type;
-                        var item8Serializer = argumentSerializers[7];
-                        var restTupleType = (tupleType.IsTuple() ? typeof(Tuple<>) : typeof(ValueTuple<>)).MakeGenericType(item8Type);
-                        var restSerializer = TupleOrValueTupleSerializer.Create(restTupleType, [item8Serializer]);
-                        argumentSerializers = argumentSerializers.Take(7).Append(restSerializer).ToArray();
-                    }
-
-                    var tupleSerializer = TupleOrValueTupleSerializer.Create(tupleType, argumentSerializers);
-                    AddNodeSerializer(node, tupleSerializer);
-                }
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
 
-        void DeduceCountMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.CountOverloads))
+            if (visitor.IsNotKnown(expression) && visitor.AreAllKnown(expression.Arguments, out var argumentSerializers))
             {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.CountWithPredicateOverloads))
+                var tupleType = expression.Method.ReturnType;
+
+                if (expression.Arguments.Count == 8)
                 {
-                    var sourceExpression = arguments[0];
-                    var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var predicateParameter = predicateLambda.Parameters.Single();
-                    DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+                    var item8Expression = expression.Arguments[7];
+                    var item8Type = item8Expression.Type;
+                    var item8Serializer = argumentSerializers[7];
+                    var restTupleType = (tupleType.IsTuple() ? typeof(Tuple<>) : typeof(ValueTuple<>)).MakeGenericType(item8Type);
+                    var restSerializer = TupleOrValueTupleSerializer.Create(restTupleType, [item8Serializer]);
+                    argumentSerializers = argumentSerializers.Take(7).Append(restSerializer).ToArray();
                 }
 
-                DeduceReturnsNumericSerializer();
-            }
-            else if (method.Is(WindowMethod.Count))
-            {
-                DeduceReturnsInt64Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
+                var tupleSerializer = TupleOrValueTupleSerializer.Create(tupleType, argumentSerializers);
+                visitor.AddNodeSerializer(expression, tupleSerializer);
             }
         }
 
-        void DeduceCovarianceMethodSerializers()
+        // DeduceDateFromStringMethodSerializers
+        static void DeduceDateFromStringMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(WindowMethod.CovarianceOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selector1Lambda = (LambdaExpression)arguments[1];
-                var selector2Lambda = (LambdaExpression)arguments[2];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selector1Lambda);
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selector2Lambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var resultSerializer = expression.Method.Is(MqlMethod.DateFromStringWithFormatAndTimezoneAndOnErrorAndOnNull) ? NullableSerializer.NullableUtcDateTimeInstance : DateTimeSerializer.UtcInstance;
+            visitor.DeduceSerializer(expression, resultSerializer);
         }
 
-        void DeduceDateFromStringMethodSerializers()
+        // DeduceDefaultIfEmptyMethodSerializers
+        static void DeduceDefaultIfEmptyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(MqlMethod.DateFromStringOverloads))
+            var sourceExpression = expression.Arguments[0];
+
+            if (expression.Method.IsOneOf(EnumerableMethod.DefaultIfEmptyWithDefaultValue, QueryableMethod.DefaultIfEmptyWithDefaultValue))
             {
-                var resultSerializer = method.Is(MqlMethod.DateFromStringWithFormatAndTimezoneAndOnErrorAndOnNull) ? NullableSerializer.NullableUtcDateTimeInstance : DateTimeSerializer.UtcInstance;
-                DeduceSerializer(node, resultSerializer);
+                var defaultValueExpression = expression.Arguments[1];
+                visitor.DeduceItemAndCollectionSerializers(defaultValueExpression, sourceExpression);
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        void DeduceDefaultIfEmptyMethodSerializers()
+        // DeduceDensifyMethodSerializers
+        static void DeduceDensifyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(EnumerableMethod.DefaultIfEmpty, EnumerableMethod.DefaultIfEmptyWithDefaultValue, QueryableMethod.DefaultIfEmpty, QueryableMethod.DefaultIfEmptyWithDefaultValue))
-            {
-                var sourceExpression = arguments[0];
+            var sourceExpression = expression.Arguments[0];
+            var fieldLambda = ExpressionHelper.UnquoteLambda(expression.Arguments[1]);
+            var fieldLambdaSourceParameter = fieldLambda.Parameters.Single();
+            var rangeExpression = expression.Arguments[2];
+            var partitionByFieldsExpression = expression.Arguments[3];
 
-                if (method.IsOneOf(EnumerableMethod.DefaultIfEmptyWithDefaultValue, QueryableMethod.DefaultIfEmptyWithDefaultValue))
+            visitor.DeduceItemAndCollectionSerializers(fieldLambdaSourceParameter, sourceExpression);
+            visitor.DeduceIgnoreSubtreeSerializer(rangeExpression);
+            if (partitionByFieldsExpression is NewArrayExpression newArrayExpression)
+            {
+                foreach (var arrayItemExpression in newArrayExpression.Expressions)
                 {
-                    var defaultValueExpression = arguments[1];
-                    DeduceItemAndCollectionSerializers(defaultValueExpression, sourceExpression);
-                }
-
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDegreesToRadiansMethodSerializers()
-        {
-            if (method.Is(MongoDBMathMethod.DegreesToRadians))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDenseRankOrRankMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.DenseRank, WindowMethod.Rank))
-            {
-                DeduceStandardSerializer(node); // currently decimal, but might be long in the future
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDerivativeOrIntegralMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.DerivativeOrIntegralOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDensifyMethodSerializers()
-        {
-            if (method.Is(MongoQueryableMethod.DensifyWithArrayPartitionByFields))
-            {
-                var sourceExpression = arguments[0];
-                var fieldLambda = ExpressionHelper.UnquoteLambda(arguments[1]);
-                var fieldLambdaSourceParameter = fieldLambda.Parameters.Single();
-                var rangeExpression = arguments[2];
-                var partitionByFieldsExpression = arguments[3];
-
-                DeduceItemAndCollectionSerializers(fieldLambdaSourceParameter, sourceExpression);
-                DeduceIgnoreSubtreeSerializer(rangeExpression);
-                if (partitionByFieldsExpression is NewArrayExpression newArrayExpression)
-                {
-                    foreach (var arrayItemExpression in newArrayExpression.Expressions)
-                    {
-                        var partitionByFieldLambda = ExpressionHelper.UnquoteLambda(arrayItemExpression);
-                        var partitionByFieldLambdaSourceParameter = partitionByFieldLambda.Parameters.Single();
-                        DeduceItemAndCollectionSerializers(partitionByFieldLambdaSourceParameter, sourceExpression);
-                    }
-                }
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDeserializeEJsonMethodSerializers()
-        {
-            if (method.Is(MqlMethod.DeserializeEJson))
-            {
-                if (IsNotKnown(node))
-                {
-                    var outputType = method.GetGenericArguments()[1];
-                    var outputSerializer = BsonSerializer.LookupSerializer(outputType);
-                    AddNodeSerializer(node, outputSerializer);
+                    var partitionByFieldLambda = ExpressionHelper.UnquoteLambda(arrayItemExpression);
+                    var partitionByFieldLambdaSourceParameter = partitionByFieldLambda.Parameters.Single();
+                    visitor.DeduceItemAndCollectionSerializers(partitionByFieldLambdaSourceParameter, sourceExpression);
                 }
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        void DeduceDistinctMethodSerializers()
+        // DeduceDocumentsMethodSerializers
+        static void DeduceDocumentsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(EnumerableMethod.Distinct, QueryableMethod.Distinct))
+            if (visitor.IsNotKnown(expression))
             {
-                var sourceExpression = arguments[0];
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDocumentNumberMethodSerializers()
-        {
-            if (method.Is(WindowMethod.DocumentNumber))
-            {
-                DeduceStandardSerializer(node); // currently decimal, but might be long in the future
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDocumentsMethodSerializers()
-        {
-            if (method.IsOneOf(MongoQueryableMethod.Documents, MongoQueryableMethod.DocumentsWithSerializer))
-            {
-                if (IsNotKnown(node))
+                IBsonSerializer documentSerializer;
+                if (expression.Method.Is(MongoQueryableMethod.DocumentsWithSerializer))
                 {
-                    IBsonSerializer documentSerializer;
-                    if (method.Is(MongoQueryableMethod.DocumentsWithSerializer))
-                    {
-                        var documentSerializerExpression = arguments[2];
-                        documentSerializer = documentSerializerExpression.GetConstantValue<IBsonSerializer>(node);
-                    }
-                    else
-                    {
-                        var documentsParameter = method.GetParameters()[1];
-                        var documentType = documentsParameter.ParameterType.GetElementType();
-                        documentSerializer = BsonSerializer.LookupSerializer(documentType); // TODO: don't use static registry
-                    }
-
-                    var nodeSerializer = IQueryableSerializer.Create(documentSerializer);
-                    AddNodeSerializer(node, nodeSerializer);
+                    var documentSerializerExpression = expression.Arguments[2];
+                    documentSerializer = documentSerializerExpression.GetConstantValue<IBsonSerializer>(expression);
                 }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceElementAtMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.ElementAtOverloads))
-            {
-                var sourceExpression = arguments[0];
-                DeduceItemAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceEqualsMethodSerializers()
-        {
-            if (IsEqualsReturningBooleanMethod(out var expression1, out var expression2))
-            {
-                DeduceSerializers(expression1, expression2);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-
-            bool IsEqualsReturningBooleanMethod(out Expression expression1, out Expression expression2)
-            {
-                if (method.Name == "Equals" &&
-                    method.ReturnType == typeof(bool) &&
-                    method.IsPublic)
+                else
                 {
-                    if (method.IsStatic &&
-                        arguments.Count == 2)
-                    {
-                        expression1 = arguments[0];
-                        expression2 = arguments[1];
-                        return true;
-                    }
-
-                    if (!method.IsStatic &&
-                        arguments.Count == 1)
-                    {
-                        expression1 = node.Object;
-                        expression2 = arguments[0];
-                        return true;
-                    }
-
-                    if (method.Is(StringMethod.EqualsWithComparisonType))
-                    {
-                        expression1 = node.Object;
-                        expression2 = arguments[0];
-                        return true;
-                    }
-
-                    if (method.Is(StringMethod.StaticEqualsWithComparisonType))
-                    {
-                        expression1 = arguments[0];
-                        expression2 = arguments[1];
-                        return true;
-                    }
+                    var documentsParameter = expression.Method.GetParameters()[1];
+                    var documentType = documentsParameter.ParameterType.GetElementType();
+                    documentSerializer = BsonSerializer.LookupSerializer(documentType); // TODO: don't use static registry
                 }
 
-                expression1 = null;
-                expression2 = null;
-                return false;
+                var nodeSerializer = IQueryableSerializer.Create(documentSerializer);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
             }
         }
 
-        void DeduceExceptMethodSerializers()
+        // DeduceExceptMethodSerializers
+        static void DeduceExceptMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(EnumerableMethod.Except, QueryableMethod.Except))
+            var firstExpression = expression.Arguments[0];
+            var secondExpression = expression.Arguments[1];
+            visitor.DeduceCollectionAndCollectionSerializers(secondExpression, firstExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, firstExpression);
+        }
+
+        // DeduceExponentialMovingAverageMethodSerializers
+        static void DeduceExponentialMovingAverageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceFieldMethodSerializers
+        static void DeduceFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
             {
-                var firstExpression =  arguments[0];
-                var secondExpression = arguments[1];
-                DeduceCollectionAndCollectionSerializers(secondExpression, firstExpression);
-                DeduceCollectionAndCollectionSerializers(node, firstExpression);
+                var fieldSerializerExpression = expression.Arguments[2];
+                var fieldSerializer = fieldSerializerExpression.GetConstantValue<IBsonSerializer>(expression);
+                if (fieldSerializer == null)
+                {
+                    fieldSerializer = BsonSerializer.LookupSerializer(expression.Method.GetGenericArguments()[1]);
+                }
+
+                visitor.AddNodeSerializer(expression, fieldSerializer);
+            }
+        }
+
+        // DeduceGroupByMethodSerializers
+        static void DeduceGroupByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var keySelectorParameter = keySelectorLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
+
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelector))
+            {
+                if (visitor.IsNotKnown(expression) && visitor.IsKnown(keySelectorLambda.Body, out var keySerializer) && visitor.IsItemSerializerKnown(sourceExpression, out var elementSerializer))
+                {
+                    var groupingSerializer = IGroupingSerializer.Create(keySerializer, elementSerializer);
+                    var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, groupingSerializer);
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+            else if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorAndElementSelector))
+            {
+                var elementSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+                var elementSelectorParameter = elementSelectorLambda.Parameters.Single();
+                visitor.DeduceItemAndCollectionSerializers(elementSelectorParameter, sourceExpression);
+                if (visitor.IsNotKnown(expression) && visitor.IsKnown(keySelectorLambda.Body, out var keySerializer) && visitor.IsKnown(elementSelectorLambda.Body, out var elementSerializer))
+                {
+                    var groupingSerializer = IGroupingSerializer.Create(keySerializer, elementSerializer);
+                    var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, groupingSerializer);
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+            else if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorAndResultSelector))
+            {
+                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+                var resultSelectorKeyParameter = resultSelectorLambda.Parameters[0];
+                var resultSelectorElementsParameter = resultSelectorLambda.Parameters[1];
+                visitor.DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
+                visitor.DeduceSerializers(resultSelectorKeyParameter, keySelectorLambda.Body);
+                visitor.DeduceCollectionAndCollectionSerializers(resultSelectorElementsParameter, sourceExpression);
+                DeduceResultSerializer(resultSelectorLambda.Body);
+            }
+            else if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorElementSelectorAndResultSelector))
+            {
+                var elementSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+                var elementSelectorParameter = elementSelectorLambda.Parameters.Single();
+                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+                var resultSelectorKeyParameter = resultSelectorLambda.Parameters[0];
+                var resultSelectorElementsParameter = resultSelectorLambda.Parameters[1];
+                visitor.DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
+                visitor.DeduceItemAndCollectionSerializers(elementSelectorParameter, sourceExpression);
+                visitor.DeduceSerializers(resultSelectorKeyParameter, keySelectorLambda.Body);
+                visitor.DeduceCollectionAndItemSerializers(resultSelectorElementsParameter, elementSelectorLambda.Body);
+                DeduceResultSerializer(resultSelectorLambda.Body);
+            }
+
+            void DeduceResultSerializer(Expression resultExpression)
+            {
+                if (visitor.IsNotKnown(expression) && visitor.IsKnown(resultExpression, out var resultSerializer))
+                {
+                    var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultSerializer);
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+        }
+
+        // DeduceGroupJoinMethodSerializers
+        static void DeduceGroupJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var outerExpression = expression.Arguments[0];
+            var innerExpression = expression.Arguments[1];
+            var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
+            var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
+            var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorInnerItemsParameter = resultSelectorLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
+            visitor.DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(resultSelectorInnerItemsParameter, innerExpression);
+            visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
+        }
+
+        // DeduceHasFlagMethodSerializers
+        static void DeduceHasFlagMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var objectExpression = expression.Object;
+            var flagExpression = expression.Arguments[0];
+            if (visitor.IsNotKnown(flagExpression) && visitor.IsKnown(objectExpression, out var enumSerializer))
+            {
+                visitor.AddNodeSerializer(flagExpression, enumSerializer);
+            }
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        }
+
+        // DeduceJoinMethodSerializers
+        static void DeduceJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var outerExpression = expression.Arguments[0];
+            var innerExpression = expression.Arguments[1];
+            var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
+            var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
+            var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorInnerItemsParameter = resultSelectorLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
+            visitor.DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorInnerItemsParameter, innerExpression);
+            visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
+        }
+
+        // DeduceLocfMethodSerializers
+        static void DeduceLocfMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceLookupMethodSerializers + MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField branch
+        static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var documentsLambdaParameter = documentsLambda.Parameters.Single();
+            var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
+            var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(foreignFieldLambdaParameter, documentsLambda.Body);
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(documentsLambda.Body, out var documentSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, documentSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+        // DeduceLookupMethodSerializers + LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline branch
+        static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var documentsLambdaParameter = documentsLambda.Parameters.Single();
+            var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
+            var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
+            var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
+            var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
+            var pipelineLambdaForeignQueryableParameter = pipelineLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(foreignFieldLambdaParameter, documentsLambda.Body);
+            visitor.DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(pipelineLambdaForeignQueryableParameter, documentsLambda.Body);
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(pipelineLambda.Body, out var pipelineDocumentSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineDocumentSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+
+        // DeduceLookupMethodSerializers + LookupWithDocumentsAndPipeline branch
+        static void DeduceLookupWithDocumentsAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var documentsLambdaParameter = documentsLambda.Parameters.Single();
+            var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var pipelineLambdaSourceParameter = pipelineLambda.Parameters[0];
+            var pipelineLambdaQueryableDocumentParameter = pipelineLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(pipelineLambdaSourceParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(pipelineLambdaQueryableDocumentParameter, documentsLambda.Body);
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+
+        // DeduceLookupMethodSerializers + LookupWithFromAndLocalFieldAndForeignField branch
+        static void DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var fromExpression = expression.Arguments[1];
+            var fromCollection = fromExpression.GetConstantValue<IMongoCollection>(expression);
+            var foreignDocumentSerializer = fromCollection.DocumentSerializer;
+            var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
+            var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
+            visitor.DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, foreignDocumentSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+
+        // DeduceLookupMethodSerializers + LookupWithFromAndLocalFieldAndForeignFieldAndPipeline branch
+        static void DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var fromExpression = expression.Arguments[1];
+            var fromCollection = fromExpression.GetConstantValue<IMongoCollection>(expression);
+            var foreignDocumentSerializer = fromCollection.DocumentSerializer;
+            var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
+            var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
+            var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
+            var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
+            var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
+            visitor.DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
+            visitor.DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
+
+            if (visitor.IsNotKnown(pipelineLamdbaForeignQueryableParameter))
+            {
+                var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
+                visitor.AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
+            }
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
+            {
+                var lookupResultsSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultsSerializer));
+            }
+        }
+
+        // DeduceLookupMethodSerializers + LookupWithFromAndPipeline branch
+        static void DeduceLookupWithFromAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var fromCollection = expression.Arguments[1].GetConstantValue<IMongoCollection>(expression);
+            var foreignDocumentSerializer = fromCollection.DocumentSerializer;
+            var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
+            var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
+
+            if (visitor.IsNotKnown(pipelineLamdbaForeignQueryableParameter))
+            {
+                var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
+                visitor.AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
+            }
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+
+        // DeduceOfTypeMethodSerializers
+        void DeduceOfTypeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var resultType = expression.Method.GetGenericArguments()[0];
+
+            if (visitor.IsNotKnown(expression) && visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
+            {
+                var resultItemSerializer = sourceItemSerializer.GetDerivedTypeSerializer(resultType);
+                var resultSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultItemSerializer);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        // DeducePushMethodSerializers
+        static void DeducePushMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceRoundMethodSerializers
+        void DeduceRoundMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var resultSerializer = StandardSerializers.GetSerializer(expression.Type);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        // DeduceSelectMethodSerializers
+        static void DeduceSelectMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var selectorParameter = selectorLambda.Parameters.Single();
+            visitor.DeduceItemAndCollectionSerializers(selectorParameter, sourceExpression);
+            visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
+        }
+
+        static void DeduceSelectWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var itemParameter = selectorLambda.Parameters[0];
+            var indexParameter = selectorLambda.Parameters[1];
+            visitor.DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
+            if (visitor.IsNotKnown(indexParameter))
+            {
+                visitor.AddNodeSerializer(indexParameter, Int32Serializer.Instance);
+            }
+            visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelector branch
+        static void DeduceSelectManyWithSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var selectorSourceParameter = selectorLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(selectorSourceParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector branch
+        static void DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var collectionSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var resultSelectorLambda =  ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+
+            var collectionSelectorSourceItemParameter = collectionSelectorLambda.Parameters.Single();
+            var resultSelectorSourceItemParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorCollectionItemParameter = resultSelectorLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(collectionSelectorSourceItemParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorSourceItemParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorCollectionItemParameter, collectionSelectorLambda.Body);
+            visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
+        }
+
+        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex branch
+        static void SelectManyWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var itemParameter = selectorLambda.Parameters[0];
+            var indexParameter = selectorLambda.Parameters[1];
+            visitor.DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
+            if (visitor.IsNotKnown(indexParameter))
+            {
+                visitor.AddNodeSerializer(indexParameter, Int32Serializer.Instance);
+            }
+            visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSequenceEqualMethodSerializers
+        static void DeduceSequenceEqualMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            visitor.DeduceCollectionAndCollectionSerializers(expression.Arguments[0], expression.Arguments[1]);
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        }
+
+        // DeduceSetWindowFieldsMethodSerializers
+        // static void DeduceSetWindowFieldsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        // {
+        //     visitor.DeduceCollectionAndCollectionSerializers(expression.Object, expression.Arguments[0]);
+        //     visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        // }
+
+        // DeduceShiftMethodSerializers
+        static void DeduceShiftMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSplitMethodSerializers
+        static void DeduceSplitMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var nodeSerializer = ArraySerializer.Create(StringSerializer.Instance);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
+            }
+        }
+
+        // DeduceSumMethodSerializers + EnumerableOrQueryableMethod.SumOverloads branch
+        static void DeduceEnumerableSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.SumWithSelectorOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var selectorParameter = selectorLambda.Parameters.Single();
+                visitor.DeduceItemAndCollectionSerializers(selectorParameter, sourceExpression);
+            }
+
+            var returnType = expression.Type;
+            // TODO: check if can replace with StandardSerializers.
+            var serializer = returnType switch
+            {
+                not null when returnType == typeof(decimal) => DecimalSerializer.Instance,
+                not null when returnType == typeof(double) => DoubleSerializer.Instance,
+                not null when returnType == typeof(int) => Int32Serializer.Instance,
+                not null when returnType == typeof(long) => Int64Serializer.Instance,
+                not null when returnType == typeof(float) => SingleSerializer.Instance,
+                not null when returnType == typeof(decimal?) => NullableSerializer.NullableDecimalInstance,
+                not null when returnType == typeof(double?) => NullableSerializer.NullableDoubleInstance,
+                not null when returnType == typeof(int?) => NullableSerializer.NullableInt32Instance,
+                not null when returnType == typeof(long?) => NullableSerializer.NullableInt64Instance,
+                not null when returnType == typeof(float?) => NullableSerializer.NullableSingleInstance,
+                _ => throw new NotImplementedException($"Cannot resolver serializer for {returnType}")
+            };
+
+            visitor.DeduceSerializer(expression, serializer);
+        }
+
+        // DeduceSumMethodSerializers + WindowMethod.SumOverloads branch
+        void DeduceWindowSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceWhereSerializers
+        static void DeduceWhereSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var predicateParameter =  predicateLambda.Parameters.Single();
+            visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        static void DeduceWhereWithPredicateTakingIndexSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var itemParameter = predicateLambda.Parameters[0];
+            var indexParameter = predicateLambda.Parameters[1];
+            visitor.DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
+            if (visitor.IsNotKnown(indexParameter))
+            {
+                visitor.AddNodeSerializer(indexParameter, Int32Serializer.Instance);
+            }
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceZipSerializers
+        static void DeduceZipSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var firstExpression = expression.Arguments[0];
+            var secondExpression = expression.Arguments[1];
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var resultSelectorFirstParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorSecondParameter =  resultSelectorLambda.Parameters[1];
+
+            if (visitor.IsNotKnown(resultSelectorFirstParameter) && visitor.IsKnown(firstExpression, out var firstSerializer))
+            {
+                var firstItemSerializer =  ArraySerializerHelper.GetItemSerializer(firstSerializer);
+                visitor.AddNodeSerializer(resultSelectorFirstParameter, firstItemSerializer);
+            }
+
+            if (visitor.IsNotKnown(resultSelectorSecondParameter) && visitor.IsKnown(secondExpression, out var secondSerializer))
+            {
+                var secondItemSerializer =  ArraySerializerHelper.GetItemSerializer(secondSerializer);
+                visitor.AddNodeSerializer(resultSelectorSecondParameter, secondItemSerializer);
+            }
+
+            if (visitor.IsNotKnown(expression) && visitor.IsKnown(resultSelectorLambda.Body, out var resultItemSerializer))
+            {
+                var resultSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultItemSerializer);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        // DeduceAppendOrPrependMethodSerializers
+        static void DeduceAppendOrPrependMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var elementExpression = expression.Arguments[1];
+
+            visitor.DeduceItemAndCollectionSerializers(elementExpression, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceAverageOrMedianOrPercentileMethodSerializers + __averageOrMedianOrPercentileOverloads branch
+        static void DeduceAverageOrMedianOrPercentileMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(__averageOrMedianOrPercentileWithSelectorOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var selectorSourceItemParameter = selectorLambda.Parameters[0];
+
+                visitor.DeduceItemAndCollectionSerializers(selectorSourceItemParameter, sourceExpression);
+            }
+
+            if (visitor.IsNotKnown(expression))
+            {
+                var nodeSerializer = StandardSerializers.GetSerializer(expression.Type);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
+            }
+        }
+
+        // DeduceAverageOrMedianOrPercentileMethodSerializers + __averageOrMedianOrPercentileWindowMethodOverloads branch
+        static void DeduceAverageOrMedianOrPercentileWindowMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        static void DeduceDeserializeEJsonMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var outputType = expression.Method.GetGenericArguments()[1];
+                var outputSerializer = BsonSerializer.LookupSerializer(outputType);
+                visitor.AddNodeSerializer(expression, outputSerializer);
+            }
+        }
+
+        static void DeduceSerializeEJsonMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var outputType = expression.Method.GetGenericArguments()[1];
+                var outputSerializer = BsonSerializer.LookupSerializer(outputType);
+                visitor.AddNodeSerializer(expression, outputSerializer);
+            }
+        }
+
+        // DeducePickMethodSerializers
+        static void DeducePickMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var method = expression.Method;
+            if (method.IsOneOf(EnumerableMethod.PickWithSortByOverloads))
+            {
+                var sortByExpression = expression.Arguments[1];
+                if (visitor.IsNotKnown(sortByExpression))
+                {
+                    var ignoreSubTreeSerializer = IgnoreSubtreeSerializer.Create(sortByExpression.Type);
+                    visitor.AddNodeSerializer(sortByExpression, ignoreSubTreeSerializer);
+                }
+            }
+
+            var sourceExpression = expression.Arguments[0];
+            if (visitor.IsKnown(sourceExpression, out var sourceSerializer))
+            {
+                var sourceItemSerializer =  ArraySerializerHelper.GetItemSerializer(sourceSerializer);
+
+                var selectorExpression = expression.Arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 2 : 1];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, selectorExpression);
+                var selectorSourceItemParameter = selectorLambda.Parameters.Single();
+                if (visitor.IsNotKnown(selectorSourceItemParameter))
+                {
+                    visitor.AddNodeSerializer(selectorSourceItemParameter, sourceItemSerializer);
+                }
+            }
+
+            if (method.IsOneOf(EnumerableMethod.PickWithComputedNOverloads))
+            {
+                var keyExpression = expression.Arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 3 : 2];
+                if (visitor.IsKnown(keyExpression, out var keySerializer))
+                {
+                    var nExpression = expression.Arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 4 : 3];
+                    var nLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, nExpression);
+                    var nLambdaKeyParameter = nLambda.Parameters.Single();
+
+                    if (visitor.IsNotKnown(nLambdaKeyParameter))
+                    {
+                        visitor.AddNodeSerializer(nLambdaKeyParameter, keySerializer);
+                    }
+                }
+            }
+
+            if (visitor.IsNotKnown(expression))
+            {
+                var selectorExpressionIndex = method switch
+                {
+                    _ when method.Is(EnumerableMethod.Bottom) => 2,
+                    _ when method.Is(EnumerableMethod.BottomN) => 2,
+                    _ when method.Is(EnumerableMethod.BottomNWithComputedN) => 2,
+                    _ when method.Is(EnumerableMethod.FirstN) => 1,
+                    _ when method.Is(EnumerableMethod.FirstNWithComputedN) => 1,
+                    _ when method.Is(EnumerableMethod.LastN) => 1,
+                    _ when method.Is(EnumerableMethod.LastNWithComputedN) => 1,
+                    _ when method.Is(EnumerableMethod.MaxN) => 1,
+                    _ when method.Is(EnumerableMethod.MaxNWithComputedN) => 1,
+                    _ when method.Is(EnumerableMethod.MinN) => 1,
+                    _ when method.Is(EnumerableMethod.MinNWithComputedN) => 1,
+                    _ when method.Is(EnumerableMethod.Top) => 2,
+                    _ when method.Is(EnumerableMethod.TopN) => 2,
+                    _ when method.Is(EnumerableMethod.TopNWithComputedN) => 2,
+                    _ => throw new ArgumentException($"Unrecognized method: {method.Name}.")
+                };
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, expression.Arguments[selectorExpressionIndex]);
+
+                if (visitor.IsKnown(selectorLambda.Body, out var selectorItemSerializer))
+                {
+                    var nodeSerializer = method.IsOneOf(EnumerableMethod.Bottom, EnumerableMethod.Top) ?
+                        selectorItemSerializer :
+                        IEnumerableSerializer.Create(selectorItemSerializer);
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+        }
+
+        // DeduceCountMethodSerializers + EnumerableOrQueryableMethod.CountOverloads branch
+        static void DeduceEnumerableCountMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.CountWithPredicateOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var predicateParameter = predicateLambda.Parameters.Single();
+                visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            }
+
+            DeduceReturnsNumericSerializer(visitor, expression);
+        }
+
+        // DeduceCovarianceMethodSerializers
+        static void DeduceCovarianceMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selector1Lambda = (LambdaExpression)expression.Arguments[1];
+            var selector2Lambda = (LambdaExpression)expression.Arguments[2];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selector1Lambda);
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selector2Lambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceDerivativeOrIntegralMethodSerializers
+        static void DeduceDerivativeOrIntegralMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceFirstOrLastOrSingleMethodsSerializers + EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads
+        static void DeduceFirstOrLastOrSingleMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.FirstOrLastOrSingleWithPredicateOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var predicateParameter = predicateLambda.Parameters.Single();
+                visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            }
+
+            DeduceReturnsOneSourceItemSerializer(visitor, expression);
+        }
+
+        // DeduceFirstOrLastOrSingleMethodsSerializers + WindowMethod.First, WindowMethod.Last branch
+        static void DeduceFirstOrLastWindowMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor,partitionExpression, selectorLambda);
+            visitor.DeduceSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceMaxOrMinMethodSerializers + EnumerableOrQueryableMethod.MaxOrMinOverloads branch
+        static void DeduceMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.MaxOrMinWithSelectorOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var selectorItemParameter = selectorLambda.Parameters.Single();
+
+                visitor.DeduceItemAndCollectionSerializers(selectorItemParameter, sourceExpression);
+                visitor.DeduceSerializers(expression, selectorLambda.Body);
             }
             else
             {
-                DeduceUnknownMethodSerializer();
+                DeduceReturnsOneSourceItemSerializer(visitor, expression);
             }
         }
 
-        void DeduceExistsMethodSerializers()
+        // DeduceMaxOrMinMethodSerializers + WindowMethod.Max, WindowMethod.Min branch
+        static void DeduceWindowMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.Is(ArrayMethod.Exists) || ListMethod.IsExistsMethod(method))
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceOrderByMethodSerializers
+        static void DeduceOrderByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var keySelectorParameter = keySelectorLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceSkipOrTakeMethodSerializers
+        static void DeduceSkipOrTakeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.SkipWhileOrTakeWhile))
             {
-                var collectionExpression = method.IsStatic ? arguments[0] : node.Object;
-                var predicateExpression = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, method.IsStatic ? arguments[1] : arguments[0]);
+                var predicateLambda =  ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var predicateParameter = predicateLambda.Parameters[0];
+                visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+
+                if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.SkipWhileWithPredicateTakingIndexOrTakeWhileWithPredicateTakingIndex))
+                {
+                    var indexParameter = predicateLambda.Parameters[1];
+                    if (visitor.IsNotKnown(indexParameter))
+                    {
+                        visitor.AddNodeSerializer(indexParameter, Int32Serializer.Instance);
+                    }
+                }
+            }
+
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceStandardDeviationMethodSerializers + MongoEnumerableMethod.StandardDeviationOverloads branch
+        static void DeduceStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(MongoEnumerableMethod.StandardDeviationWithSelectorOverloads, MongoQueryableMethod.StandardDeviationWithSelectorOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var selectorItemParameter = selectorLambda.Parameters.Single();
+                visitor.DeduceCollectionAndItemSerializers(sourceExpression, selectorItemParameter);
+            }
+
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        static void DeduceStringEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var expression1 = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+            var expression2 = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
+
+            visitor.DeduceSerializers(expression1, expression2);
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        }
+
+        // DeduceStandardDeviationMethodSerializers + WindowMethod.StandardDeviationOverloads branch
+        static void DeduceWindowStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        static void DeduceReturnsNumericSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression) && expression.Type.IsNumeric())
+            {
+                var numericSerializer = StandardSerializers.GetSerializer(expression.Type);
+                visitor.AddNodeSerializer(expression, numericSerializer);
+            }
+        }
+
+        static void DeduceReturnsTimeSpanSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression, TimeSpanUnits units)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var resultSerializer = new TimeSpanSerializer(BsonType.Int64, units);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        static void DeduceReturnsOneSourceItemSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+
+            if (visitor.IsNotKnown(expression) && visitor.IsKnown(sourceExpression, out var sourceSerializer))
+            {
+                var nodeSerializer = sourceSerializer is IUnknowableSerializer ?
+                    UnknowableSerializer.Create(expression.Type) :
+                    ArraySerializerHelper.GetItemSerializer(sourceSerializer);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
+            }
+        }
+
+        static void DeduceWindowMethodSelectorParameterSerializer(SerializerFinderVisitor visitor, Expression partitionExpression, LambdaExpression selectorLambda)
+        {
+            var inputParameter = selectorLambda.Parameters.Single();
+            if (visitor.IsNotKnown(inputParameter) && visitor.IsKnown(partitionExpression, out var partitionSerializer))
+            {
+                var inputSerializer = ((ISetWindowFieldsPartitionSerializer)partitionSerializer).InputSerializer;
+                visitor.AddNodeSerializer(inputParameter, inputSerializer);
+            }
+        }
+    }
+
+    protected override Expression VisitMethodCall(MethodCallExpression node)
+    {
+        var methodInfo = node.Method.IsGenericMethod && !node.Method.ContainsGenericParameters ? node.Method.GetGenericMethodDefinition() : node.Method;
+
+        DeduceMethodCallSerializers();
+        base.VisitMethodCall(node);
+        DeduceMethodCallSerializers();
+
+        return node;
+
+        void DeduceMethodCallSerializers()
+        {
+            Action<SerializerFinderVisitor, MethodCallExpression> resolver;
+            __serializerResolversLock.EnterReadLock();
+            try
+            {
+                __serializerResolvers.TryGetValue(methodInfo, out resolver);
+            }
+            finally
+            {
+                __serializerResolversLock.ExitReadLock();
+            }
+
+            if (resolver == null)
+            {
+                __serializerResolversLock.EnterWriteLock();
+                try
+                {
+                    if (!__serializerResolvers.TryGetValue(methodInfo, out resolver))
+                    {
+                        resolver = CreateDynamicSerializerResolver(methodInfo);
+                        __serializerResolvers.Add(methodInfo, resolver);
+                    }
+                }
+                finally
+                {
+                    __serializerResolversLock.ExitWriteLock();
+                }
+            }
+
+            if (resolver == null)
+            {
+                DeduceUnknowableSerializer(node);
+            }
+            else
+            {
+                resolver(this, node);
+            }
+        }
+
+        // Processes special cases where we do not have fixed list of methodInfos that we support,
+        // but trying to deduce serializers based on method name and arguments
+        static Action<SerializerFinderVisitor, MethodCallExpression> CreateDynamicSerializerResolver(MethodInfo method)
+        {
+            return method.Name switch
+            {
+                "Contains" when EnumerableMethod.IsContainsMethod(method) => DeduceContainsMethodSerializers,
+                "ContainsKey" when DictionaryMethod.IsContainsKeyMethod(method) => DeduceDictionaryContainsKeyMethodSerializers,
+                "ContainsValue" when IsContainsValueMethod(method) => DeduceContainsValueMethodSerializers,
+                "Equals" when IsEqualsReturningBooleanMethod(method) => DeduceEqualsMethodSerializers,
+                "Exists" when method.Is(ArrayMethod.Exists) || ListMethod.IsExistsMethod(method) => DeduceExistsMethodSerializers,
+                "get_Item" when BsonValueMethod.IsGetItemWithIntMethod(method) || BsonValueMethod.IsGetItemWithStringMethod(method) =>
+                    (visitor, expression) => visitor.DeduceSerializer(expression, BsonValueSerializer.Instance),
+                "get_Item" when !method.IsStatic => DeduceGetItemInstanceMethodSerializers,
+                "IsSubsetOf" when IsSubsetOfMethod(method) => DeduceIsSubsetOfMethodSerializers,
+                "Parse" when IsParseMethod(method) => DeduceParseMethodSerializers,
+                "SetEquals" when ISetMethod.IsSetEqualsMethod(method) => DeduceSetEqualsMethodSerializers,
+                "ToArray" when IsToArrayMethod(method) => DeduceToArrayMethodSerializers,
+                "ToList" => DeduceToListSerializers,
+                "ToString" => (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance),
+                "Compare" or "CompareTo" when IsCompareMethod(method) => DeduceCompareOrCompareToMethodSerializers,
+                _ => null
+            };
+
+            static bool IsCompareMethod(MethodInfo method) =>
+                method.IsStaticCompareMethod() ||
+                method.IsInstanceCompareToMethod() ||
+                method.IsOneOf(StringMethod.CompareOverloads);
+
+            static void DeduceCompareOrCompareToMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var valueExpression = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                var comparandExpression = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
+                visitor.DeduceSerializers(valueExpression, comparandExpression);
+                visitor.DeduceSerializer(expression, Int32Serializer.Instance);
+            }
+
+            static void DeduceContainsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                if (EnumerableMethod.IsContainsMethod(expression, out var collectionExpression, out var itemExpression))
+                {
+                    visitor.DeduceCollectionAndItemSerializers(collectionExpression, itemExpression);
+                    visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+                }
+            }
+
+            static bool IsContainsValueMethod(MethodInfo method) =>
+                method.IsPublic &&
+                method.IsStatic == false &&
+                method.ReturnType == typeof(bool) &&
+                method.Name == "ContainsValue" &&
+                method.GetParameters() is var parameters &&
+                parameters.Length == 1;
+
+            void DeduceContainsValueMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var collectionExpression = expression.Object;
+                var valueExpression = expression.Arguments[0];
+
+                if (visitor.IsNotKnown(valueExpression) &&
+                    visitor.IsKnown(collectionExpression, out var collectionSerializer))
+                {
+                    if (collectionSerializer is IBsonDictionarySerializer dictionarySerializer)
+                    {
+                        var valueSerializer = dictionarySerializer.ValueSerializer;
+                        visitor.AddNodeSerializer(valueExpression, valueSerializer);
+                    }
+                }
+
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+            }
+
+            void DeduceDictionaryContainsKeyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var dictionaryExpression = expression.Object;
+                var keyExpression = expression.Arguments[0];
+                if (visitor.IsNotKnown(keyExpression) && visitor.IsKnown(dictionaryExpression, out var dictionarySerializer))
+                {
+                    var keySerializer = (dictionarySerializer as IBsonDictionarySerializer)?.KeySerializer;
+                    visitor.AddNodeSerializer(keyExpression, keySerializer);
+                }
+
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+            }
+
+            static bool IsEqualsReturningBooleanMethod(MethodInfo method)
+            {
+                var arguments = method.GetParameters();
+                return method.Name == "Equals" &&
+                       method.ReturnType == typeof(bool) &&
+                       method.IsPublic &&
+                       (
+                           (method.IsStatic && arguments.Length == 2) ||
+                           (!method.IsStatic && arguments.Length == 1)
+                       );
+            }
+
+            void DeduceEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var expression1 = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                var expression2 = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
+
+                visitor.DeduceSerializers(expression1, expression2);
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+            }
+
+            static void DeduceExistsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var collectionExpression = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                var predicateExpression = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0]);
                 var predicateParameter = predicateExpression.Parameters.Single();
-                DeduceItemAndCollectionSerializers(predicateParameter, collectionExpression);
-                DeduceReturnsBooleanSerializer();
+                visitor.DeduceItemAndCollectionSerializers(predicateParameter, collectionExpression);
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
             }
-            else if (method.Is(MqlMethod.Exists))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
 
-        void DeduceExpMethodSerializers()
-        {
-            if (method.Is(MathMethod.Exp))
+            static void DeduceGetItemInstanceMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceExponentialMovingAverageMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.ExponentialMovingAverageOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceFieldMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Field))
-            {
-                if (IsNotKnown(node))
+                if (visitor.IsNotKnown(expression))
                 {
-                    var fieldSerializerExpression = arguments[2];
-                    var fieldSerializer = fieldSerializerExpression.GetConstantValue<IBsonSerializer>(node);
-                    if (fieldSerializer == null)
-                    {
-                        fieldSerializer = BsonSerializer.LookupSerializer(method.GetGenericArguments()[1]);
-                    }
+                    var collectionExpression = expression.Object;
+                    var indexExpression = expression.Arguments[0];
 
-                    AddNodeSerializer(node, fieldSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceCreateObjectIdMethodSerializers()
-        {
-            if (method.Is(MqlMethod.CreateObjectId))
-            {
-                if (IsNotKnown(node))
-                {
-                    DeduceSerializer(node, ObjectIdSerializer.Instance);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceFirstOrLastOrSingleMethodsSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads))
-            {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.FirstOrLastOrSingleWithPredicateOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var predicateParameter = predicateLambda.Parameters.Single();
-                    DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
-                }
-
-                DeduceReturnsOneSourceItemSerializer();
-            }
-            else if (method.IsOneOf(WindowMethod.First, WindowMethod.Last))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceGetItemMethodSerializers()
-        {
-            if (IsNotKnown(node))
-            {
-                if (BsonValueMethod.IsGetItemWithIntMethod(method) || BsonValueMethod.IsGetItemWithStringMethod(method))
-                {
-                    AddNodeSerializer(node, BsonValueSerializer.Instance);
-                }
-                else if (IsInstanceGetItemMethod(out var collectionExpression, out var indexExpression))
-                {
-                    if (IsKnown(collectionExpression, out var collectionSerializer))
+                    if (visitor.IsKnown(collectionExpression, out var collectionSerializer))
                     {
                         if (collectionSerializer is IBsonArraySerializer arraySerializer &&
                             indexExpression.Type == typeof(int) &&
                             arraySerializer.GetItemSerializer() is var itemSerializer &&
-                            itemSerializer.ValueType == method.ReturnType)
+                            itemSerializer.ValueType == expression.Method.ReturnType)
                         {
-                            AddNodeSerializer(node, itemSerializer);
+                            visitor.AddNodeSerializer(expression, itemSerializer);
                         }
                         else if (
                             collectionSerializer is IBsonDictionarySerializer dictionarySerializer &&
                             dictionarySerializer.KeySerializer is var keySerializer &&
                             dictionarySerializer.ValueSerializer is var valueSerializer &&
                             keySerializer.ValueType == indexExpression.Type &&
-                            valueSerializer.ValueType == method.ReturnType)
+                            valueSerializer.ValueType == expression.Method.ReturnType)
                         {
-                            AddNodeSerializer(node, valueSerializer);
+                            visitor.AddNodeSerializer(expression, valueSerializer);
                         }
                     }
                 }
-                else
-                {
-                    DeduceUnknownMethodSerializer();
-                }
-            }
-
-            bool IsInstanceGetItemMethod(out Expression collectionExpression, out Expression indexExpression)
-            {
-                if (method.IsStatic == false &&
-                    method.Name == "get_Item")
-                {
-                    collectionExpression = node.Object;
-                    indexExpression = arguments[0];
-                    return true;
-                }
-
-                collectionExpression = null;
-                indexExpression = null;
-                return false;
-            }
-        }
-
-        void DeduceGetCharsMethodSerializers()
-        {
-            if (method.Is(StringMethod.GetChars))
-            {
-                DeduceCharSerializer(node);
-            }
-
-            DeduceUnknowableSerializer(node);
-        }
-
-        void DeduceGroupByMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByOverloads))
-            {
-                var sourceExpression = arguments[0];
-                var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var keySelectorParameter = keySelectorLambda.Parameters.Single();
-
-                DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelector))
-                {
-                    if (IsNotKnown(node) && IsKnown(keySelectorLambda.Body, out var keySerializer) && IsItemSerializerKnown(sourceExpression, out var elementSerializer))
-                    {
-                        var groupingSerializer = IGroupingSerializer.Create(keySerializer, elementSerializer);
-                        var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, groupingSerializer);
-                        AddNodeSerializer(node, nodeSerializer);
-                    }
-                }
-                else if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorAndElementSelector))
-                {
-                    var elementSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var elementSelectorParameter = elementSelectorLambda.Parameters.Single();
-                    DeduceItemAndCollectionSerializers(elementSelectorParameter, sourceExpression);
-                    if (IsNotKnown(node) && IsKnown(keySelectorLambda.Body, out var keySerializer) && IsKnown(elementSelectorLambda.Body, out var elementSerializer))
-                    {
-                        var groupingSerializer = IGroupingSerializer.Create(keySerializer, elementSerializer);
-                        var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, groupingSerializer);
-                        AddNodeSerializer(node, nodeSerializer);
-                    }
-                }
-                else if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorAndResultSelector))
-                {
-                    var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var resultSelectorKeyParameter = resultSelectorLambda.Parameters[0];
-                    var resultSelectorElementsParameter = resultSelectorLambda.Parameters[1];
-                    DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
-                    DeduceSerializers(resultSelectorKeyParameter, keySelectorLambda.Body);
-                    DeduceCollectionAndCollectionSerializers(resultSelectorElementsParameter, sourceExpression);
-                    DeduceResultSerializer(resultSelectorLambda.Body);
-                }
-                else if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorElementSelectorAndResultSelector))
-                {
-                    var elementSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var elementSelectorParameter = elementSelectorLambda.Parameters.Single();
-                    var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var resultSelectorKeyParameter = resultSelectorLambda.Parameters[0];
-                    var resultSelectorElementsParameter = resultSelectorLambda.Parameters[1];
-                    DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(elementSelectorParameter, sourceExpression);
-                    DeduceSerializers(resultSelectorKeyParameter, keySelectorLambda.Body);
-                    DeduceCollectionAndItemSerializers(resultSelectorElementsParameter, elementSelectorLambda.Body);
-                    DeduceResultSerializer(resultSelectorLambda.Body);
-                }
-
-                void DeduceResultSerializer(Expression resultExpression)
-                {
-                    if (IsNotKnown(node) && IsKnown(resultExpression, out var resultSerializer))
-                    {
-                        var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultSerializer);
-                        AddNodeSerializer(node, nodeSerializer);
-                    }
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceGroupJoinMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin))
-            {
-                var outerExpression = arguments[0];
-                var innerExpression = arguments[1];
-                var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
-                var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
-                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
-                var resultSelectorInnerItemsParameter = resultSelectorLambda.Parameters[1];
-
-                DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
-                DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
-                DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
-                DeduceCollectionAndCollectionSerializers(resultSelectorInnerItemsParameter, innerExpression);
-                DeduceCollectionAndItemSerializers(node, resultSelectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIndexOfMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.IndexOfOverloads))
-            {
-                DeduceReturnsInt32Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceHasFlagMethodSerializers()
-        {
-            if (method.Is(EnumMethod.HasFlag))
-            {
-                var objectExpression = node.Object;
-                var flagExpression = arguments[0];
-                if (IsNotKnown(flagExpression) && IsKnown(objectExpression, out var enumSerializer))
-                {
-                    AddNodeSerializer(flagExpression, enumSerializer);
-                }
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceHashMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Hash))
-            {
-                DeduceSerializer(node, BsonBinaryDataSerializer.Instance);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceHexHashMethodSerializers()
-        {
-            if (method.Is(MqlMethod.HexHash))
-            {
-                DeduceSerializer(node, StringSerializer.Instance);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceInjectMethodSerializers()
-        {
-            if (method.Is(LinqExtensionsMethod.Inject))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIntersectMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Intersect, QueryableMethod.Intersect))
-            {
-                var sourceExpression = arguments[0];
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIsMatchMethodSerializers()
-        {
-            if (method.IsOneOf(RegexMethod.IsMatchOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIsMissingOrIsNullOrMissingMethodSerializers()
-        {
-            if (method.IsOneOf(MqlMethod.IsMissing, MqlMethod.IsNullOrMissing))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIsSubsetOfMethodSerializers()
-        {
-            if (IsSubsetOfMethod(method))
-            {
-                var objectExpression =  node.Object;
-                var otherExpression = arguments[0];
-
-                DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
             }
 
             static bool IsSubsetOfMethod(MethodInfo method)
@@ -1732,403 +1715,14 @@ internal partial class SerializerFinderVisitor
                     otherParameter.ParameterType.ImplementsIEnumerable(out var otherTypeItemType) &&
                     otherTypeItemType == declaringTypeItemType;
             }
-        }
 
-        void DeduceJoinMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Join, QueryableMethod.Join))
+            static void DeduceIsSubsetOfMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
-                var outerExpression = arguments[0];
-                var innerExpression = arguments[1];
-                var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
-                var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
-                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
-                var resultSelectorInnerItemsParameter = resultSelectorLambda.Parameters[1];
+                var objectExpression = expression.Object;
+                var otherExpression = expression.Arguments[0];
 
-                DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
-                DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
-                DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
-                DeduceItemAndCollectionSerializers(resultSelectorInnerItemsParameter, innerExpression);
-                DeduceCollectionAndItemSerializers(node, resultSelectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIsNullOrEmptyOrIsNullOrWhiteSpaceMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.IsNullOrEmpty, StringMethod.IsNullOrWhiteSpace))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceLocfMethodSerializers()
-        {
-            if (method.Is(WindowMethod.Locf))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceLogMethodSerializers()
-        {
-            if (method.IsOneOf(MathMethod.LogOverloads))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceLookupMethodSerializers()
-        {
-            if (method.IsOneOf(MongoQueryableMethod.LookupOverloads))
-            {
-                var sourceExpression = arguments[0];
-
-                if (method.Is(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField))
-                {
-                    var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var documentsLambdaParameter = documentsLambda.Parameters.Single();
-                    var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
-                    var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
-
-                    DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(foreignFieldLambdaParameter, documentsLambda.Body);
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(documentsLambda.Body, out var documentSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, documentSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-                else if (method.Is(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline))
-                {
-                    var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var documentsLambdaParameter = documentsLambda.Parameters.Single();
-                    var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
-                    var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
-                    var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                    var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
-                    var pipelineLambdaForeignQueryableParameter = pipelineLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(foreignFieldLambdaParameter, documentsLambda.Body);
-                    DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
-                    DeduceCollectionAndCollectionSerializers(pipelineLambdaForeignQueryableParameter, documentsLambda.Body);
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(pipelineLambda.Body, out var pipelineDocumentSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineDocumentSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-                else if (method.Is(MongoQueryableMethod.LookupWithDocumentsAndPipeline))
-                {
-                    var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var documentsLambdaParameter = documentsLambda.Parameters.Single();
-                    var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var pipelineLambdaSourceParameter = pipelineLambda.Parameters[0];
-                    var pipelineLambdaQueryableDocumentParameter = pipelineLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(pipelineLambdaSourceParameter, sourceExpression);
-                    DeduceCollectionAndCollectionSerializers(pipelineLambdaQueryableDocumentParameter, documentsLambda.Body);
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-
-                if (method.Is(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignField))
-                {
-                    var fromExpression = arguments[1];
-                    var fromCollection = fromExpression.GetConstantValue<IMongoCollection>(node);
-                    var foreignDocumentSerializer = fromCollection.DocumentSerializer;
-                    var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
-                    var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
-
-                    DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
-                    DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, foreignDocumentSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-                else if (method.Is(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignFieldAndPipeline))
-                {
-                    var fromExpression = arguments[1];
-                    var fromCollection = fromExpression.GetConstantValue<IMongoCollection>(node);
-                    var foreignDocumentSerializer = fromCollection.DocumentSerializer;
-                    var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
-                    var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
-                    var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                    var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
-                    var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
-                    DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
-                    DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
-
-                    if (IsNotKnown(pipelineLamdbaForeignQueryableParameter))
-                    {
-                        var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
-                        AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
-                    }
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
-                    {
-                        var lookupResultsSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultsSerializer));
-                    }
-                }
-                else if (method.Is(MongoQueryableMethod.LookupWithFromAndPipeline))
-                {
-                    var fromCollection = arguments[1].GetConstantValue<IMongoCollection>(node);
-                    var foreignDocumentSerializer = fromCollection.DocumentSerializer;
-                    var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
-                    var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
-
-                    if (IsNotKnown(pipelineLamdbaForeignQueryableParameter))
-                    {
-                        var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
-                        AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
-                    }
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceMatchingElementsMethodSerializers()
-        {
-            if (method.IsOneOf(MongoEnumerableMethod.AllElements, MongoEnumerableMethod.AllMatchingElements, MongoEnumerableMethod.FirstMatchingElement))
-            {
-                DeduceReturnsOneSourceItemSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceMaxOrMinMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.MaxOrMinOverloads))
-            {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.MaxOrMinWithSelectorOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorItemParameter = selectorLambda.Parameters.Single();
-
-                    DeduceItemAndCollectionSerializers(selectorItemParameter, sourceExpression);
-                    DeduceSerializers(node, selectorLambda.Body);
-                }
-                else
-                {
-                    DeduceReturnsOneSourceItemSerializer();
-                }
-            }
-            else if (method.IsOneOf(WindowMethod.Max, WindowMethod.Min))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceOfTypeMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.OfType, QueryableMethod.OfType))
-            {
-                var sourceExpression = arguments[0];
-                var resultType = method.GetGenericArguments()[0];
-
-                if (IsNotKnown(node) && IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
-                {
-                    var resultItemSerializer = sourceItemSerializer.GetDerivedTypeSerializer(resultType);
-                    var resultSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceOrderByMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.OrderByOrThenByOverloads))
-            {
-                var sourceExpression = arguments[0];
-                var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var keySelectorParameter = keySelectorLambda.Parameters.Single();
-
-                DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeducePickMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.PickOverloads))
-            {
-                if (method.IsOneOf(EnumerableMethod.PickWithSortByOverloads))
-                {
-                    var sortByExpression = arguments[1];
-                    if (IsNotKnown(sortByExpression))
-                    {
-                        var ignoreSubTreeSerializer = IgnoreSubtreeSerializer.Create(sortByExpression.Type);
-                        AddNodeSerializer(sortByExpression, ignoreSubTreeSerializer);
-                    }
-                }
-
-                var sourceExpression = arguments[0];
-                if (IsKnown(sourceExpression, out var sourceSerializer))
-                {
-                    var sourceItemSerializer =  ArraySerializerHelper.GetItemSerializer(sourceSerializer);
-
-                    var selectorExpression = arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 2 : 1];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, selectorExpression);
-                    var selectorSourceItemParameter = selectorLambda.Parameters.Single();
-                    if (IsNotKnown(selectorSourceItemParameter))
-                    {
-                        AddNodeSerializer(selectorSourceItemParameter, sourceItemSerializer);
-                    }
-                }
-
-                if (method.IsOneOf(EnumerableMethod.PickWithComputedNOverloads))
-                {
-                    var keyExpression = arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 3 : 2];
-                    if (IsKnown(keyExpression, out var keySerializer))
-                    {
-                        var nExpression = arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 4 : 3];
-                        var nLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, nExpression);
-                        var nLambdaKeyParameter = nLambda.Parameters.Single();
-
-                        if (IsNotKnown(nLambdaKeyParameter))
-                        {
-                            AddNodeSerializer(nLambdaKeyParameter, keySerializer);
-                        }
-                    }
-                }
-
-                if (IsNotKnown(node))
-                {
-                    var selectorExpressionIndex = method switch
-                    {
-                        _ when method.Is(EnumerableMethod.Bottom) => 2,
-                        _ when method.Is(EnumerableMethod.BottomN) => 2,
-                        _ when method.Is(EnumerableMethod.BottomNWithComputedN) => 2,
-                        _ when method.Is(EnumerableMethod.FirstN) => 1,
-                        _ when method.Is(EnumerableMethod.FirstNWithComputedN) => 1,
-                        _ when method.Is(EnumerableMethod.LastN) => 1,
-                        _ when method.Is(EnumerableMethod.LastNWithComputedN) => 1,
-                        _ when method.Is(EnumerableMethod.MaxN) => 1,
-                        _ when method.Is(EnumerableMethod.MaxNWithComputedN) => 1,
-                        _ when method.Is(EnumerableMethod.MinN) => 1,
-                        _ when method.Is(EnumerableMethod.MinNWithComputedN) => 1,
-                        _ when method.Is(EnumerableMethod.Top) => 2,
-                        _ when method.Is(EnumerableMethod.TopN) => 2,
-                        _ when method.Is(EnumerableMethod.TopNWithComputedN) => 2,
-                        _ => throw new ArgumentException($"Unrecognized method: {method.Name}.")
-                    };
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[selectorExpressionIndex]);
-
-                    if (IsKnown(selectorLambda.Body, out var selectorItemSerializer))
-                    {
-                        var nodeSerializer = method.IsOneOf(EnumerableMethod.Bottom, EnumerableMethod.Top) ?
-                            selectorItemSerializer :
-                            IEnumerableSerializer.Create(selectorItemSerializer);
-                        AddNodeSerializer(node, nodeSerializer);
-                    }
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceParseMethodSerializers()
-        {
-            if (IsNotKnown(node))
-            {
-                if (IsParseMethod(method))
-                {
-                    var nodeSerializer = GetParseResultSerializer(method.DeclaringType);
-                    AddNodeSerializer(node, nodeSerializer);
-                }
-                else
-                {
-                    DeduceUnknownMethodSerializer();
-                }
+                visitor.DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
             }
 
             static bool IsParseMethod(MethodInfo method)
@@ -2142,878 +1736,57 @@ internal partial class SerializerFinderVisitor
                     parameters[0].ParameterType == typeof(string);
             }
 
-            static IBsonSerializer GetParseResultSerializer(Type declaringType)
+            static void DeduceParseMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
-                return declaringType switch
+                if (visitor.IsNotKnown(expression))
                 {
-                    _ when declaringType == typeof(DateTime) => DateTimeSerializer.Instance,
-                    _ when declaringType == typeof(decimal) => DecimalSerializer.Instance,
-                    _ when declaringType == typeof(double) => DoubleSerializer.Instance,
-                    _ when declaringType == typeof(int) => Int32Serializer.Instance,
-                    _ when declaringType == typeof(short) => Int16Serializer.Instance,
-                    _ when declaringType == typeof(long) => Int64Serializer.Instance,
-                    _ when declaringType == typeof(float) => SingleSerializer.Instance,
-                    _ when declaringType == typeof(byte) => ByteSerializer.Instance,
-                    _ when declaringType == typeof(sbyte) => SByteSerializer.Instance,
-                    _ => UnknowableSerializer.Create(declaringType)
-                };
-            }
-        }
-
-        void DeducePowMethodSerializers()
-        {
-            if (method.Is(MathMethod.Pow))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeducePushMethodSerializers()
-        {
-            if (method.Is(WindowMethod.Push))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceCollectionAndItemSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceRadiansToDegreesMethodSerializers()
-        {
-            if (method.Is(MongoDBMathMethod.RadiansToDegrees))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceReturnsBooleanSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, BooleanSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsDateTimeSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, DateTimeSerializer.UtcInstance);
-            }
-        }
-
-        void DeduceReturnsDecimalSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, DecimalSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsDoubleSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, DoubleSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsInt32Serializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, Int32Serializer.Instance);
-            }
-        }
-
-        void DeduceReturnsInt64Serializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, Int64Serializer.Instance);
-            }
-        }
-
-        void DeduceReturnsNullableDecimalSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableDecimalInstance);
-            }
-        }
-
-        void DeduceReturnsNullableDoubleSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableDoubleInstance);
-            }
-        }
-
-        void DeduceReturnsNullableInt32Serializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableInt32Instance);
-            }
-        }
-
-        void DeduceReturnsNullableInt64Serializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableInt64Instance);
-            }
-        }
-
-        void DeduceReturnsNullableSingleSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableSingleInstance);
-            }
-        }
-
-        void DeduceReturnsNumericSerializer()
-        {
-            if (IsNotKnown(node) && node.Type.IsNumeric())
-            {
-                var numericSerializer = StandardSerializers.GetSerializer(node.Type);
-                AddNodeSerializer(node, numericSerializer);
-            }
-        }
-
-        void DeduceReturnsOneSourceItemSerializer()
-        {
-            var sourceExpression = arguments[0];
-
-            if (IsNotKnown(node) && IsKnown(sourceExpression, out var sourceSerializer))
-            {
-                var nodeSerializer = sourceSerializer is IUnknowableSerializer ?
-                    UnknowableSerializer.Create(node.Type) :
-                    ArraySerializerHelper.GetItemSerializer(sourceSerializer);
-                AddNodeSerializer(node, nodeSerializer);
-            }
-        }
-
-        void DeduceReturnsSingleSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, SingleSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsStringSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, StringSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsTimeSpanSerializer(TimeSpanUnits units)
-        {
-            if (IsNotKnown(node))
-            {
-                var resultSerializer = new TimeSpanSerializer(BsonType.Int64, units);
-                AddNodeSerializer(node, resultSerializer);
-            }
-        }
-
-        void DeduceRangeMethodSerializers()
-        {
-            if (method.Is(EnumerableMethod.Range))
-            {
-                var elementExpression = arguments[0];
-                DeduceCollectionAndItemSerializers(node, elementExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceRepeatMethodSerializers()
-        {
-            if (method.Is(EnumerableMethod.Repeat))
-            {
-                var elementExpression = arguments[0];
-                DeduceCollectionAndItemSerializers(node, elementExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceReplaceMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.ReplaceOverloads, RegexMethod.ReplaceOverloads))
-            {
-                DeduceSerializer(node, StringSerializer.Instance);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceReverseMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.ReverseOverloads))
-            {
-                var sourceExpression = arguments[0];
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceRoundMethodSerializers()
-        {
-            if (method.IsOneOf(MathMethod.RoundWithDecimal, MathMethod.RoundWithDecimalAndDecimals, MathMethod.RoundWithDouble, MathMethod.RoundWithDoubleAndDigits))
-            {
-                if (IsNotKnown(node))
-                {
-                    var resultSerializer = StandardSerializers.GetSerializer(node.Type);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSelectMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Select, QueryableMethod.Select))
-            {
-                var sourceExpression = arguments[0];
-                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var selectorParameter = selectorLambda.Parameters.Single();
-                DeduceItemAndCollectionSerializers(selectorParameter, sourceExpression);
-                DeduceCollectionAndItemSerializers(node, selectorLambda.Body);
-            }
-            else if (method.IsOneOf(EnumerableOrQueryableMethod.SelectWithSelectorTakingIndex))
-            {
-                var sourceExpression = arguments[0];
-                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var itemParameter = selectorLambda.Parameters[0];
-                var indexParameter = selectorLambda.Parameters[1];
-                DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
-                if (IsNotKnown(indexParameter))
-                {
-                    AddNodeSerializer(indexParameter, Int32Serializer.Instance);
-                }
-                DeduceCollectionAndItemSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSelectManySerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.SelectManyOverloads))
-            {
-                var sourceExpression = arguments[0];
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.SelectManyWithSelector))
-                {
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorSourceParameter = selectorLambda.Parameters.Single();
-
-                    DeduceItemAndCollectionSerializers(selectorSourceParameter, sourceExpression);
-                    DeduceCollectionAndCollectionSerializers(node, selectorLambda.Body);
-                }
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector))
-                {
-                    var collectionSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var resultSelectorLambda =  ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-
-                    var collectionSelectorSourceItemParameter = collectionSelectorLambda.Parameters.Single();
-                    var resultSelectorSourceItemParameter = resultSelectorLambda.Parameters[0];
-                    var resultSelectorCollectionItemParameter = resultSelectorLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(collectionSelectorSourceItemParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(resultSelectorSourceItemParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(resultSelectorCollectionItemParameter, collectionSelectorLambda.Body);
-                    DeduceCollectionAndItemSerializers(node, resultSelectorLambda.Body);
-                }
-            }
-            else if (method.IsOneOf(EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex))
-            {
-                var sourceExpression = arguments[0];
-                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var itemParameter = selectorLambda.Parameters[0];
-                var indexParameter = selectorLambda.Parameters[1];
-                DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
-                if (IsNotKnown(indexParameter))
-                {
-                    AddNodeSerializer(indexParameter, Int32Serializer.Instance);
-                }
-                DeduceCollectionAndCollectionSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSequenceEqualMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.SequenceEqual, QueryableMethod.SequenceEqual))
-            {
-                var source1Expression =  arguments[0];
-                var source2Expression = arguments[1];
-
-                DeduceCollectionAndCollectionSerializers(source1Expression, source2Expression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSerializeEJsonMethodSerializers()
-        {
-            if (method.Is(MqlMethod.SerializeEJson))
-            {
-                if (IsNotKnown(node))
-                {
-                    var outputType = method.GetGenericArguments()[1];
-                    var outputSerializer = BsonSerializer.LookupSerializer(outputType);
-                    AddNodeSerializer(node, outputSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSetEqualsMethodSerializers()
-        {
-            if (ISetMethod.IsSetEqualsMethod(method))
-            {
-                var objectExpression =  node.Object;
-                var otherExpression = arguments[0];
-
-                DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSetWindowFieldsMethodSerializers()
-        {
-            if (method.Is(EnumerableMethod.First))
-            {
-                var objectExpression =  node.Object;
-                var otherExpression = arguments[0];
-
-                DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceShiftMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.Shift, WindowMethod.ShiftWithDefaultValue))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSigmoidMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Sigmoid))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSimilarityFunctionsSerializers()
-        {
-            if (method.IsOneOf(MqlMethod.SimilarityFunctionOverloads))
-            {
-                DeduceReturnsNumericSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSplitMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.SplitOverloads, RegexMethod.SplitOverloads))
-            {
-                if (IsNotKnown(node))
-                {
-                    var nodeSerializer = ArraySerializer.Create(StringSerializer.Instance);
-                    AddNodeSerializer(node, nodeSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSqrtMethodSerializers()
-        {
-            if (method.Is(MathMethod.Sqrt))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceStandardDeviationMethodSerializers()
-        {
-            if (method.IsOneOf(MongoEnumerableMethod.StandardDeviationOverloads, MongoQueryableMethod.StandardDeviationOverloads))
-            {
-                if (method.IsOneOf(MongoEnumerableMethod.StandardDeviationWithSelectorOverloads, MongoQueryableMethod.StandardDeviationWithSelectorOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorItemParameter = selectorLambda.Parameters.Single();
-                    DeduceCollectionAndItemSerializers(sourceExpression, selectorItemParameter);
-                }
-
-                DeduceStandardSerializer(node);
-            }
-            else if (method.IsOneOf(WindowMethod.StandardDeviationOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceEndsWithOrStartsWithMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.EndsWithOrStartsWithOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceStringInOrNinMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.StringInOrNinOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceStrLenBytesMethodSerializers()
-        {
-            if (method.Is(StringMethod.StrLenBytes))
-            {
-                DeduceReturnsInt32Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSubstringMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.Substring, StringMethod.SubstringWithLength, StringMethod.SubstrBytes))
-            {
-                DeduceReturnsStringSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSubtractMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.SubtractReturningDateTimeOverloads))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else if (method.IsOneOf(DateTimeMethod.SubtractReturningInt64Overloads))
-            {
-                DeduceReturnsInt64Serializer();
-            }
-            else if (method.IsOneOf(DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads))
-            {
-                var units = TimeSpanUnits.Milliseconds;
-                DeduceReturnsTimeSpanSerializer(units);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSumMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.SumOverloads))
-            {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.SumWithSelectorOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorParameter = selectorLambda.Parameters.Single();
-                    DeduceItemAndCollectionSerializers(selectorParameter, sourceExpression);
-                }
-
-                var returnType = node.Type;
-                switch (returnType)
-                {
-                    case not null when returnType == typeof(decimal): DeduceReturnsDecimalSerializer(); break;
-                    case not null when returnType == typeof(double): DeduceReturnsDoubleSerializer(); break;
-                    case not null when returnType == typeof(int): DeduceReturnsInt32Serializer(); break;
-                    case not null when returnType == typeof(long): DeduceReturnsInt64Serializer(); break;
-                    case not null when returnType == typeof(float): DeduceReturnsSingleSerializer(); break;
-                    case not null when returnType == typeof(decimal?): DeduceReturnsNullableDecimalSerializer(); break;
-                    case not null when returnType == typeof(double?): DeduceReturnsNullableDoubleSerializer(); break;
-                    case not null when returnType == typeof(int?): DeduceReturnsNullableInt32Serializer(); break;
-                    case not null when returnType == typeof(long?): DeduceReturnsNullableInt64Serializer(); break;
-                    case not null when returnType == typeof(float?): DeduceReturnsNullableSingleSerializer(); break;
-                }
-            }
-            else if (method.IsOneOf(WindowMethod.SumOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSubtypeMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Subtype))
-            {
-                DeduceSerializer(node, __binarySubTypeSerializer);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSkipOrTakeMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.SkipOrTakeOverloads))
-            {
-                var sourceExpression = arguments[0];
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.SkipWhileOrTakeWhile))
-                {
-                    var predicateLambda =  ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var itemParameter = predicateLambda.Parameters[0];
-                    DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
-
-                    if (method.IsOneOf(EnumerableOrQueryableMethod.SkipWhileWithPredicateTakingIndexOrTakeWhileWithPredicateTakingIndex))
+                    var declaringType = expression.Method.DeclaringType;
+                    var nodeSerializer = declaringType switch
                     {
-                        var indexParameter = predicateLambda.Parameters[1];
-                        if (IsNotKnown(indexParameter))
-                        {
-                            AddNodeSerializer(indexParameter, Int32Serializer.Instance);
-                        }
+                        _ when declaringType == typeof(DateTime) => DateTimeSerializer.Instance,
+                        _ when declaringType == typeof(decimal) => DecimalSerializer.Instance,
+                        _ when declaringType == typeof(double) => DoubleSerializer.Instance,
+                        _ when declaringType == typeof(int) => Int32Serializer.Instance,
+                        _ when declaringType == typeof(short) => Int64Serializer.Instance,
+                        _ => UnknowableSerializer.Create(declaringType)
+                    };
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+
+            static void DeduceSetEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var objectExpression = expression.Object;
+                var otherExpression = expression.Arguments[0];
+
+                visitor.DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+            }
+
+            static bool IsToArrayMethod(MethodInfo method) =>
+                method.IsPublic &&
+                method.Name == "ToArray" &&
+                method.GetParameters().Length == (method.IsStatic ? 1 : 0);
+
+            static void DeduceToArrayMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var sourceExpression = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+            }
+
+            static void DeduceToListSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                if (visitor.IsNotKnown(expression))
+                {
+                    var source = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                    if (visitor.IsKnown(source, out var sourceSerializer))
+                    {
+                        var sourceItemSerializer = ArraySerializerHelper.GetItemSerializer(sourceSerializer);
+                        var resultSerializer = ListSerializer.Create(sourceItemSerializer);
+                        visitor.AddNodeSerializer(expression, resultSerializer);
                     }
                 }
-
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceToArrayMethodSerializers()
-        {
-            if (IsToArrayMethod(out var sourceExpression))
-            {
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-
-            bool IsToArrayMethod(out Expression sourceExpression)
-            {
-                if (method.IsPublic &&
-                    method.Name == "ToArray" &&
-                    method.GetParameters().Length == (method.IsStatic ? 1 : 0))
-                {
-                    sourceExpression = method.IsStatic ? arguments[0] : node.Object;
-                    return true;
-                }
-
-                sourceExpression = null;
-                return false;
-            }
-        }
-
-        void DeduceToHashedIndexKeySerializers()
-        {
-            if (method.Is(MqlMethod.ToHashedIndexKey))
-            {
-                DeduceReturnsInt64Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceToListSerializers()
-        {
-            if (IsNotKnown(node))
-            {
-                var source = method.IsStatic ? arguments[0] : node.Object;
-                if (IsKnown(source, out var sourceSerializer))
-                {
-                    var sourceItemSerializer = ArraySerializerHelper.GetItemSerializer(sourceSerializer);
-                    var resultSerializer = ListSerializer.Create(sourceItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-        }
-
-        void DeduceToLowerOrToUpperSerializers()
-        {
-            if (method.IsOneOf(StringMethod.ToLowerOrToUpperOverloads))
-            {
-                DeduceReturnsStringSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceToStringSerializers()
-        {
-            DeduceReturnsStringSerializer();
-        }
-
-        void DeduceTrigonometricMethodSerializers()
-        {
-            if (method.IsOneOf(MathMethod.TrigonometricMethods))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceTrimSerializers()
-        {
-            if (method.IsOneOf(StringMethod.TrimOverloads))
-            {
-                DeduceReturnsStringSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceTruncateSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else if (method.IsOneOf(MathMethod.TruncateDecimal, MathMethod.TruncateDouble))
-            {
-                DeduceReturnsNumericSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceUnionSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Union, QueryableMethod.Union))
-            {
-                var sourceExpression = arguments[0];
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceUnknownMethodSerializer()
-        {
-            DeduceUnknowableSerializer(node);
-        }
-
-        void DeduceWeekSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.Week, DateTimeMethod.WeekWithTimezone))
-            {
-                if (IsNotKnown(node))
-                {
-                    AddNodeSerializer(node, Int32Serializer.Instance);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceWhereSerializers()
-        {
-            if (method.IsOneOf(__whereOverloads))
-            {
-                var sourceExpression = arguments[0];
-                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var predicateParameter =  predicateLambda.Parameters.Single();
-                DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else if (method.IsOneOf(EnumerableOrQueryableMethod.WhereWithPredicateTakingIndex))
-            {
-                var sourceExpression = arguments[0];
-                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var itemParameter = predicateLambda.Parameters[0];
-                var indexParameter = predicateLambda.Parameters[1];
-                DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
-                if (IsNotKnown(indexParameter))
-                {
-                    AddNodeSerializer(indexParameter, Int32Serializer.Instance);
-                }
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceWindowMethodSelectorParameterSerializer(Expression partitionExpression, LambdaExpression selectorLambda)
-        {
-            var inputParameter = selectorLambda.Parameters.Single();
-            if (IsNotKnown(inputParameter) && IsKnown(partitionExpression, out var partitionSerializer))
-            {
-                var inputSerializer = ((ISetWindowFieldsPartitionSerializer)partitionSerializer).InputSerializer;
-                AddNodeSerializer(inputParameter, inputSerializer);
-            }
-        }
-
-        void DeduceZipSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Zip, QueryableMethod.Zip))
-            {
-                var firstExpression = arguments[0];
-                var secondExpression = arguments[1];
-                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                var resultSelectorFirstParameter = resultSelectorLambda.Parameters[0];
-                var resultSelectorSecondParameter =  resultSelectorLambda.Parameters[1];
-
-                if (IsNotKnown(resultSelectorFirstParameter) && IsKnown(firstExpression, out var firstSerializer))
-                {
-                    var firstItemSerializer =  ArraySerializerHelper.GetItemSerializer(firstSerializer);
-                    AddNodeSerializer(resultSelectorFirstParameter, firstItemSerializer);
-                }
-
-                if (IsNotKnown(resultSelectorSecondParameter) && IsKnown(secondExpression, out var secondSerializer))
-                {
-                    var secondItemSerializer =  ArraySerializerHelper.GetItemSerializer(secondSerializer);
-                    AddNodeSerializer(resultSelectorSecondParameter, secondItemSerializer);
-                }
-
-                if (IsNotKnown(node) && IsKnown(resultSelectorLambda.Body, out var resultItemSerializer))
-                {
-                    var resultSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        bool IsDictionaryContainsKeyExpression(out Expression keyExpression)
-        {
-            if (DictionaryMethod.IsContainsKeyMethod(method))
-            {
-                keyExpression = arguments[0];
-                return true;
-            }
-
-            keyExpression = null;
-            return false;
         }
     }
 }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -33,237 +33,239 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
 
 internal partial class SerializerFinderVisitor
 {
-    private static readonly Dictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerResolvers = new();
-    private static readonly ReaderWriterLockSlim __serializerResolversLock = new();
-    private static readonly IBsonSerializer __binarySubTypeSerializer = NullableSerializer.Create(new EnumSerializer<BsonBinarySubType>());
-
-    private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileOverloads = MethodInfoSet.Create(
-    [
-        EnumerableOrQueryableMethod.AverageOverloads,
-        MongoEnumerableMethod.MedianOverloads,
-        MongoEnumerableMethod.PercentileOverloads
-    ]);
-
-    private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileWindowMethodOverloads = MethodInfoSet.Create(
-    [
-        WindowMethod.AverageOverloads,
-        WindowMethod.MedianOverloads,
-        WindowMethod.PercentileOverloads
-    ]);
-
-    private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileWithSelectorOverloads = MethodInfoSet.Create(
-    [
-        EnumerableOrQueryableMethod.AverageWithSelectorOverloads,
-        MongoEnumerableMethod.MedianWithSelectorOverloads,
-        MongoEnumerableMethod.PercentileWithSelectorOverloads
-    ]);
-
-    private static readonly IReadOnlyMethodInfoSet __whereOverloads = MethodInfoSet.Create(
-    [
-        EnumerableOrQueryableMethod.Where,
-        [MongoEnumerableMethod.WhereWithLimit]
-    ]);
-
-    static SerializerFinderVisitor()
+    protected override Expression VisitMethodCall(MethodCallExpression node)
     {
-        // DeduceAbsMethodSerializers
-        RegisterSerializerResolvers(MathMethod.AbsOverloads, (visitor, expression) => visitor.DeduceSerializers(expression, expression.Arguments[0]));
-        // DeduceAdd*MethodSerializers (Add, AddDays, AddHours, AddMilliseconds, AddMinutes, AddMonths, AddQuarters, AddSeconds, AddTicks, AddWeeks, AddYears)
-        RegisterSerializerResolvers(
-            [
-                DateTimeMethod.Add, DateTimeMethod.AddWithTimezone, DateTimeMethod.AddWithUnit, DateTimeMethod.AddWithUnitAndTimezone,
-                DateTimeMethod.AddDays, DateTimeMethod.AddDaysWithTimezone, DateTimeMethod.AddHours, DateTimeMethod.AddHoursWithTimezone,
-                DateTimeMethod.AddMilliseconds, DateTimeMethod.AddMillisecondsWithTimezone, DateTimeMethod.AddMinutes, DateTimeMethod.AddMinutesWithTimezone,
-                DateTimeMethod.AddMonths, DateTimeMethod.AddMonthsWithTimezone, DateTimeMethod.AddQuarters, DateTimeMethod.AddQuartersWithTimezone,
-                DateTimeMethod.AddSeconds, DateTimeMethod.AddSecondsWithTimezone, DateTimeMethod.AddTicks, DateTimeMethod.AddWeeks,
-                DateTimeMethod.AddWeeksWithTimezone, DateTimeMethod.AddYears, DateTimeMethod.AddYearsWithTimezone
-            ],
-            (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
+        var methodInfo = node.Method.IsGenericMethod && !node.Method.ContainsGenericParameters ? node.Method.GetGenericMethodDefinition() : node.Method;
+        var deducer = MethodCallSerializerDeducers.GetSerializerDeducer(methodInfo);
 
-        RegisterSerializerResolver(WindowMethod.AddToSet, DeduceAddToSetMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithFunc, DeduceAggregateWithFuncMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithSeedAndFunc, DeduceAggregateWithSeedAndFuncMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector, DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers);
-        RegisterSerializerResolvers([EnumerableMethod.AllWithPredicate, QueryableMethod.AllWithPredicate], DeduceAllMethodSerializers);
-        // DeduceAnyMethodSerializers
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Any, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AnyWithPredicate, DeduceAnyWithPredicateMethodSerializers);
-        RegisterSerializerResolver(MongoQueryableMethod.AppendStage, DeduceAppendStageMethodSerializers);
-        RegisterSerializerResolver(MongoQueryableMethod.As, DeduceAsMethodSerializers);
-        RegisterSerializerResolver(QueryableMethod.AsQueryable, DeduceAsQueryableMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Concat, DeduceEnumerableConcatMethodSerializers);
-        RegisterSerializerResolvers([StringMethod.EqualsInstanceMethod, StringMethod.EqualsWithComparisonType, StringMethod.StaticEqualsWithComparisonType, StringMethod.StaticEquals], DeduceStringEqualsMethodSerializers);
-        // DeduceConcatMethodSerializers + StringMethod.ConcatOverloads branch
-        RegisterSerializerResolvers(StringMethod.ConcatOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
-        RegisterSerializerResolvers([MqlMethod.ConstantWithRepresentation, MqlMethod.ConstantWithSerializer], DeduceConstantMethodSerializers);
-        RegisterSerializerResolver(MqlMethod.CreateObjectId, (visitor, expression) => visitor.DeduceSerializer(expression, ObjectIdSerializer.Instance));
-        RegisterSerializerResolver(MqlMethod.DeserializeEJson, DeduceDeserializeEJsonMethodSerializers);
-        RegisterSerializerResolver(MqlMethod.SerializeEJson, DeduceSerializeEJsonMethodSerializers);
-        // DeduceContainsMethodSerializers + StringMethod.ContainsOverloads branch
-        RegisterSerializerResolvers(StringMethod.ContainsOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        RegisterSerializerResolver(MqlMethod.Convert, DeduceConvertMethodSerializers);
-#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-        RegisterSerializerResolver(KeyValuePairMethod.Create, DeduceKeyValuePairCreateMethodSerializers);
-#endif
-        RegisterSerializerResolvers(TupleOrValueTupleMethod.CreateOverloads, DeduceTupleOrValueTupleCreateMethodSerializers);
-        RegisterSerializerResolvers(MqlMethod.DateFromStringOverloads, DeduceDateFromStringMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.DefaultIfEmptyOverloads, DeduceDefaultIfEmptyMethodSerializers);
-        // DeduceDegreesToRadiansMethodSerializers
-        RegisterSerializerResolver(MongoDBMathMethod.DegreesToRadians, (visitor, method) => visitor.DeduceSerializer(method, DoubleSerializer.Instance));
-        RegisterSerializerResolver(MongoQueryableMethod.DensifyWithArrayPartitionByFields, DeduceDensifyMethodSerializers);
-        // DeduceDistinctMethodSerializers
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Distinct, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
-        // DeduceDocumentNumberMethodSerializers
-        RegisterSerializerResolver(WindowMethod.DocumentNumber, (visitor, expression) => visitor.DeduceStandardSerializer(expression)); // currently decimal, but might be long in the future
-        RegisterSerializerResolvers([MongoQueryableMethod.Documents, MongoQueryableMethod.DocumentsWithSerializer], DeduceDocumentsMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Except, DeduceExceptMethodSerializers);
-        // DeduceExpMethodSerializers
-        RegisterSerializerResolver(MathMethod.Exp, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
-        RegisterSerializerResolvers(WindowMethod.ExponentialMovingAverageOverloads, DeduceExponentialMovingAverageMethodSerializers);
-        RegisterSerializerResolver(MqlMethod.Field, DeduceFieldMethodSerializers);
-        RegisterSerializerResolver(MqlMethod.Hash, (visitor, expression) => visitor.DeduceSerializer(expression, BsonBinaryDataSerializer.Instance));
-        RegisterSerializerResolver(MqlMethod.HexHash, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
-        // DeduceGetCharsMethodSerializers
-        RegisterSerializerResolver(StringMethod.GetChars, (visitor, expression) => visitor.DeduceSerializer(expression, CharSerializer.Instance));
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.GroupByOverloads, DeduceGroupByMethodSerializers);
-        RegisterSerializerResolvers([EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin], DeduceGroupJoinMethodSerializers);
-        RegisterSerializerResolver(EnumMethod.HasFlag, DeduceHasFlagMethodSerializers);
-        // DeduceInjectMethodSerializers
-        RegisterSerializerResolver(LinqExtensionsMethod.Inject, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        // DeduceIntersectMethodSerializers
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Intersect, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
-        // DeduceIsMatchMethodSerializers
-        RegisterSerializerResolvers(RegexMethod.IsMatchOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        RegisterSerializerResolvers([EnumerableMethod.Join, QueryableMethod.Join], DeduceJoinMethodSerializers);
-        RegisterSerializerResolver(WindowMethod.Locf, DeduceLocfMethodSerializers);
-        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers);
-        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
-        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndPipeline, DeduceLookupWithDocumentsAndPipelineMethodSerializers);
-        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignField, DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers);
-        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
-        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndPipeline, DeduceLookupWithFromAndPipelineMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.OfType, DeduceOfTypeMethodSerializers);
-        // DeducePowMethodSerializers
-        RegisterSerializerResolver(MathMethod.Pow, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
-        RegisterSerializerResolver(WindowMethod.Push, DeducePushMethodSerializers);
-        // DeduceRadiansToDegreesMethodSerializers
-        RegisterSerializerResolver(MongoDBMathMethod.RadiansToDegrees, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
-        // DeduceRangeMethodSerializers
-        RegisterSerializerResolver(EnumerableMethod.Range, (visitor, expression) => visitor.DeduceCollectionAndItemSerializers(expression, expression.Arguments[0]));
-        // DeduceRepeatMethodSerializers
-        RegisterSerializerResolver(EnumerableMethod.Repeat, (visitor, expression) => visitor.DeduceCollectionAndItemSerializers(expression, expression.Arguments[0]));
-        // DeduceReverseMethodSerializers
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.ReverseOverloads, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
-        RegisterSerializerResolvers([MathMethod.RoundWithDecimal, MathMethod.RoundWithDecimalAndDecimals, MathMethod.RoundWithDouble, MathMethod.RoundWithDoubleAndDigits], DeduceRoundMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Select, DeduceSelectMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectWithSelectorTakingIndex, DeduceSelectWithSelectorTakingIndexMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithSelector, DeduceSelectManyWithSelectorMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector, DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex, SelectManyWithSelectorTakingIndexMethodSerializers);
-        RegisterSerializerResolvers([EnumerableMethod.SequenceEqual, QueryableMethod.SequenceEqual], DeduceSequenceEqualMethodSerializers);
-        // TODO: Definitely wrong registration copy-pasted from prev code, investigate before merge to main
-        // RegisterSerializerResolver(EnumerableMethod.First, DeduceSetWindowFieldsMethodSerializers);
-        RegisterSerializerResolvers([WindowMethod.Shift, WindowMethod.ShiftWithDefaultValue], DeduceShiftMethodSerializers);
-        // DeduceSigmoidMethodSerializers
-        RegisterSerializerResolver(MqlMethod.Sigmoid, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
-        RegisterSerializerResolvers(StringMethod.SplitOverloads, DeduceSplitMethodSerializers);
-        RegisterSerializerResolvers(RegexMethod.SplitOverloads, DeduceSplitMethodSerializers);
-        RegisterSerializerResolvers(StringMethod.ReplaceOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
-        RegisterSerializerResolvers(RegexMethod.ReplaceOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
-        // DeduceSqrtMethodSerializers
-        RegisterSerializerResolver(MathMethod.Sqrt, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
-        // DeduceStrLenBytesMethodSerializers
-        RegisterSerializerResolver(StringMethod.StrLenBytes, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
-        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningDateTimeOverloads branch
-        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningDateTimeOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
-        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningInt64Overloads
-        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningInt64Overloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
-        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads
-        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads, (visitor, expression) => DeduceReturnsTimeSpanSerializer(visitor, expression, TimeSpanUnits.Milliseconds));
-        // DeduceSubtypeMethodSerializers
-        RegisterSerializerResolver(MqlMethod.Subtype, (visitor, expression) => visitor.DeduceSerializer(expression, __binarySubTypeSerializer));
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SumOverloads, DeduceEnumerableSumMethodSerializers);
-        RegisterSerializerResolvers(WindowMethod.SumOverloads, DeduceWindowSumMethodSerializers);
-        // DeduceTrimSerializers
-        RegisterSerializerResolvers(StringMethod.TrimOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
-        // DeduceTruncateSerializers + DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone branch
-        RegisterSerializerResolvers([DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone], (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
-        // DeduceTruncateSerializers + MathMethod.TruncateDecimal, MathMethod.TruncateDouble branch
-        RegisterSerializerResolvers([MathMethod.TruncateDecimal, MathMethod.TruncateDouble], DeduceReturnsNumericSerializer);
-        // DeduceUnionSerializers
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Union, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
-        // DeduceWeekSerializers
-        RegisterSerializerResolvers([DateTimeMethod.Week, DateTimeMethod.WeekWithTimezone], (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
-        RegisterSerializerResolvers(__whereOverloads, DeduceWhereSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.WhereWithPredicateTakingIndex, DeduceWhereWithPredicateTakingIndexSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Zip, DeduceZipSerializers);
-        // DeduceTrigonometricMethodSerializers
-        RegisterSerializerResolvers(MathMethod.TrigonometricMethods, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
-        // DeduceMatchingElementsMethodSerializers
-        RegisterSerializerResolvers([MongoEnumerableMethod.AllElements, MongoEnumerableMethod.AllMatchingElements, MongoEnumerableMethod.FirstMatchingElement], DeduceReturnsOneSourceItemSerializer);
-        // DeduceAnyStringInOrNinMethodSerializers
-        RegisterSerializerResolvers(StringMethod.AnyStringInOrNinOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AppendOrPrepend, DeduceAppendOrPrependMethodSerializers);
-        RegisterSerializerResolvers(__averageOrMedianOrPercentileOverloads, DeduceAverageOrMedianOrPercentileMethodSerializers);
-        RegisterSerializerResolvers(__averageOrMedianOrPercentileWindowMethodOverloads, DeduceAverageOrMedianOrPercentileWindowMethodSerializers);
-        RegisterSerializerResolvers(EnumerableMethod.PickOverloads, DeducePickMethodSerializers);
-        // DeduceCeilingOrFloorMethodSerializers
-        RegisterSerializerResolvers([MathMethod.CeilingWithDecimal, MathMethod.CeilingWithDouble, MathMethod.FloorWithDecimal, MathMethod.FloorWithDouble], DeduceReturnsNumericSerializer);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.CountOverloads, DeduceEnumerableCountMethodSerializers);
-        // DeduceCountMethodSerializers + WindowMethod.Count branch
-        RegisterSerializerResolver(WindowMethod.Count, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
-        RegisterSerializerResolvers(WindowMethod.CovarianceOverloads, DeduceCovarianceMethodSerializers);
-        // DeduceDenseRankOrRankMethodSerializers
-        RegisterSerializerResolvers([WindowMethod.DenseRank, WindowMethod.Rank], (visitor, expression) => visitor.DeduceStandardSerializer(expression)); // currently decimal, but might be long in the future
-        RegisterSerializerResolvers(WindowMethod.DerivativeOrIntegralOverloads, DeduceDerivativeOrIntegralMethodSerializers);
-        // DeduceElementAtMethodSerializers
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.ElementAtOverloads, (visitor, expression) => visitor.DeduceItemAndCollectionSerializers(expression, expression.Arguments[0]));
-        // DeduceEndsWithOrStartsWithMethodSerializers
-        RegisterSerializerResolvers(StringMethod.EndsWithOrStartsWithOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads, DeduceFirstOrLastOrSingleMethodsSerializers);
-        RegisterSerializerResolvers([WindowMethod.First, WindowMethod.Last], DeduceFirstOrLastWindowMethodsSerializers);
-        // DeduceIndexOfMethodSerializers
-        RegisterSerializerResolvers(StringMethod.IndexOfOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
-        // DeduceIsMissingOrIsNullOrMissingMethodSerializers
-        // DeduceExistsMethodSerializers + MqlMethod.Exists
-        RegisterSerializerResolvers([MqlMethod.Exists, MqlMethod.IsMissing, MqlMethod.IsNullOrMissing], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        // DeduceIsNullOrEmptyOrIsNullOrWhiteSpaceMethodSerializers
-        RegisterSerializerResolvers([StringMethod.IsNullOrEmpty, StringMethod.IsNullOrWhiteSpace], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        // DeduceLogMethodSerializers
-        RegisterSerializerResolvers(MathMethod.LogOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.MaxOrMinOverloads, DeduceMaxOrMinMethodSerializers);
-        RegisterSerializerResolvers([WindowMethod.Max, WindowMethod.Min], DeduceWindowMaxOrMinMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.OrderByOrThenByOverloads, DeduceOrderByMethodSerializers);
-        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SkipOrTakeOverloads, DeduceSkipOrTakeMethodSerializers);
-        RegisterSerializerResolvers(MongoEnumerableMethod.StandardDeviationOverloads, DeduceStandardDeviationMethodSerializers);
-        RegisterSerializerResolvers(WindowMethod.StandardDeviationOverloads, DeduceWindowStandardDeviationMethodSerializers);
-        // DeduceStringInOrNinMethodSerializers
-        RegisterSerializerResolvers(StringMethod.StringInOrNinOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-        // DeduceSubstringMethodSerializers
-        RegisterSerializerResolvers([StringMethod.Substring, StringMethod.SubstringWithLength, StringMethod.SubstrBytes], (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
-        // DeduceToLowerOrToUpperSerializers
-        RegisterSerializerResolvers(StringMethod.ToLowerOrToUpperOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
-        // DeduceSimilarityFunctionsSerializers
-        RegisterSerializerResolvers(MqlMethod.SimilarityFunctionOverloads, DeduceReturnsNumericSerializer);
+        DeduceMethodCallSerializers();
+        base.VisitMethodCall(node);
+        DeduceMethodCallSerializers();
 
-        void RegisterSerializerResolver(MethodInfo method, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
+        return node;
+
+        void DeduceMethodCallSerializers()
         {
-            Ensure.IsNotNull(method, nameof(method));
-            Ensure.IsNotNull(resolver, nameof(resolver));
-
-            __serializerResolvers.Add(method, resolver);
-        }
-
-        void RegisterSerializerResolvers(IEnumerable<MethodInfo> methods, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
-        {
-            foreach (var method in methods)
+            if (deducer == null)
             {
-                RegisterSerializerResolver(method, resolver);
+                DeduceUnknowableSerializer(node);
+            }
+            else
+            {
+                deducer(this, node);
             }
         }
+    }
 
+    private static class MethodCallSerializerDeducers
+    {
+        private static readonly Dictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerDeducers = new();
+        private static readonly ReaderWriterLockSlim __serializerDeducersLock = new();
+        private static readonly IBsonSerializer __binarySubTypeSerializer = NullableSerializer.Create(new EnumSerializer<BsonBinarySubType>());
+
+        private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileOverloads = MethodInfoSet.Create(
+        [
+            EnumerableOrQueryableMethod.AverageOverloads,
+            MongoEnumerableMethod.MedianOverloads,
+            MongoEnumerableMethod.PercentileOverloads
+        ]);
+
+        private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileWindowMethodOverloads = MethodInfoSet.Create(
+        [
+            WindowMethod.AverageOverloads,
+            WindowMethod.MedianOverloads,
+            WindowMethod.PercentileOverloads
+        ]);
+
+        private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileWithSelectorOverloads = MethodInfoSet.Create(
+        [
+            EnumerableOrQueryableMethod.AverageWithSelectorOverloads,
+            MongoEnumerableMethod.MedianWithSelectorOverloads,
+            MongoEnumerableMethod.PercentileWithSelectorOverloads
+        ]);
+
+        private static readonly IReadOnlyMethodInfoSet __whereOverloads = MethodInfoSet.Create(
+        [
+            EnumerableOrQueryableMethod.Where,
+            [MongoEnumerableMethod.WhereWithLimit]
+        ]);
+
+        static MethodCallSerializerDeducers()
+        {
+            // DateTimeMethod
+            RegisterSerializerDeducers(
+                [
+                    DateTimeMethod.Add, DateTimeMethod.AddWithTimezone, DateTimeMethod.AddWithUnit, DateTimeMethod.AddWithUnitAndTimezone,
+                    DateTimeMethod.AddDays, DateTimeMethod.AddDaysWithTimezone, DateTimeMethod.AddHours, DateTimeMethod.AddHoursWithTimezone,
+                    DateTimeMethod.AddMilliseconds, DateTimeMethod.AddMillisecondsWithTimezone, DateTimeMethod.AddMinutes, DateTimeMethod.AddMinutesWithTimezone,
+                    DateTimeMethod.AddMonths, DateTimeMethod.AddMonthsWithTimezone, DateTimeMethod.AddQuarters, DateTimeMethod.AddQuartersWithTimezone,
+                    DateTimeMethod.AddSeconds, DateTimeMethod.AddSecondsWithTimezone, DateTimeMethod.AddTicks, DateTimeMethod.AddWeeks,
+                    DateTimeMethod.AddWeeksWithTimezone, DateTimeMethod.AddYears, DateTimeMethod.AddYearsWithTimezone
+                ],
+                (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
+            RegisterSerializerDeducers(DateTimeMethod.SubtractReturningDateTimeOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
+            RegisterSerializerDeducers(DateTimeMethod.SubtractReturningInt64Overloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
+            RegisterSerializerDeducers(DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads, (visitor, expression) => DeduceReturnsTimeSpanSerializer(visitor, expression, TimeSpanUnits.Milliseconds));
+            RegisterSerializerDeducers([DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone], (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
+            RegisterSerializerDeducers([DateTimeMethod.Week, DateTimeMethod.WeekWithTimezone], (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+
+            // EnumMethod
+            RegisterSerializerDeducer(EnumMethod.HasFlag, DeduceHasFlagMethodSerializers);
+
+            // EnumerableOrQueryableMethod
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.AggregateWithFunc, DeduceAggregateWithFuncMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.AggregateWithSeedAndFunc, DeduceAggregateWithSeedAndFuncMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector, DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers);
+            RegisterSerializerDeducers([MongoEnumerableMethod.AllElements, MongoEnumerableMethod.AllMatchingElements, MongoEnumerableMethod.FirstMatchingElement], DeduceReturnsOneSourceItemSerializer);
+            RegisterSerializerDeducers([EnumerableMethod.AllWithPredicate, QueryableMethod.AllWithPredicate], DeduceAllMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.Any, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.AnyWithPredicate, DeduceAnyWithPredicateMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.AppendOrPrepend, DeduceAppendOrPrependMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.AppendStage, DeduceAppendStageMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.As, DeduceAsMethodSerializers);
+            RegisterSerializerDeducer(QueryableMethod.AsQueryable, DeduceAsQueryableMethodSerializers);
+            RegisterSerializerDeducers(__averageOrMedianOrPercentileOverloads, DeduceAverageOrMedianOrPercentileMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.Concat, DeduceEnumerableConcatMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.CountOverloads, DeduceEnumerableCountMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.DefaultIfEmptyOverloads, DeduceDefaultIfEmptyMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.DensifyWithArrayPartitionByFields, DeduceDensifyMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.Distinct, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+            RegisterSerializerDeducers([MongoQueryableMethod.Documents, MongoQueryableMethod.DocumentsWithSerializer], DeduceDocumentsMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.ElementAtOverloads, (visitor, expression) => visitor.DeduceItemAndCollectionSerializers(expression, expression.Arguments[0]));
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.Except, DeduceExceptMethodSerializers);
+            // TODO: Definitely wrong registration copy-pasted from prev code, investigate before merge to main
+            // RegisterSerializerResolver(EnumerableMethod.First, DeduceSetWindowFieldsMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads, DeduceFirstOrLastOrSingleMethodsSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.GroupByOverloads, DeduceGroupByMethodSerializers);
+            RegisterSerializerDeducers([EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin], DeduceGroupJoinMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.Intersect, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+            RegisterSerializerDeducers([EnumerableMethod.Join, QueryableMethod.Join], DeduceJoinMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.LookupWithDocumentsAndPipeline, DeduceLookupWithDocumentsAndPipelineMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignField, DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
+            RegisterSerializerDeducer(MongoQueryableMethod.LookupWithFromAndPipeline, DeduceLookupWithFromAndPipelineMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.MaxOrMinOverloads, DeduceMaxOrMinMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.OfType, DeduceOfTypeMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.OrderByOrThenByOverloads, DeduceOrderByMethodSerializers);
+            RegisterSerializerDeducers(EnumerableMethod.PickOverloads, DeducePickMethodSerializers);
+            RegisterSerializerDeducer(EnumerableMethod.Range, (visitor, expression) => visitor.DeduceCollectionAndItemSerializers(expression, expression.Arguments[0]));
+            RegisterSerializerDeducer(EnumerableMethod.Repeat, (visitor, expression) => visitor.DeduceCollectionAndItemSerializers(expression, expression.Arguments[0]));
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.ReverseOverloads, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.Select, DeduceSelectMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector, DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectManyWithSelector, DeduceSelectManyWithSelectorMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex, SelectManyWithSelectorTakingIndexMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectWithSelectorTakingIndex, DeduceSelectWithSelectorTakingIndexMethodSerializers);
+            RegisterSerializerDeducers([EnumerableMethod.SequenceEqual, QueryableMethod.SequenceEqual], DeduceSequenceEqualMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.SkipOrTakeOverloads, DeduceSkipOrTakeMethodSerializers);
+            RegisterSerializerDeducers(MongoEnumerableMethod.StandardDeviationOverloads, DeduceStandardDeviationMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.SumOverloads, DeduceEnumerableSumMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.Union, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+            RegisterSerializerDeducers(__whereOverloads, DeduceWhereSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.WhereWithPredicateTakingIndex, DeduceWhereWithPredicateTakingIndexSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.Zip, DeduceZipSerializers);
+
+            // KeyValuePairMethod
+    #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            RegisterSerializerDeducer(KeyValuePairMethod.Create, DeduceKeyValuePairCreateMethodSerializers);
+    #endif
+
+            // LinqExtensionsMethod
+            RegisterSerializerDeducer(LinqExtensionsMethod.Inject, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+
+            // MathMethod
+            RegisterSerializerDeducers(MathMethod.AbsOverloads, (visitor, expression) => visitor.DeduceSerializers(expression, expression.Arguments[0]));
+            RegisterSerializerDeducers([MathMethod.CeilingWithDecimal, MathMethod.CeilingWithDouble, MathMethod.FloorWithDecimal, MathMethod.FloorWithDouble], DeduceReturnsNumericSerializer);
+            RegisterSerializerDeducer(MathMethod.Exp, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+            RegisterSerializerDeducers(MathMethod.LogOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+            RegisterSerializerDeducer(MathMethod.Pow, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+            RegisterSerializerDeducers([MathMethod.RoundWithDecimal, MathMethod.RoundWithDecimalAndDecimals, MathMethod.RoundWithDouble, MathMethod.RoundWithDoubleAndDigits], DeduceRoundMethodSerializers);
+            RegisterSerializerDeducer(MathMethod.Sqrt, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+            RegisterSerializerDeducers(MathMethod.TrigonometricMethods, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+            RegisterSerializerDeducers([MathMethod.TruncateDecimal, MathMethod.TruncateDouble], DeduceReturnsNumericSerializer);
+
+            // MongoDBMathMethod
+            RegisterSerializerDeducer(MongoDBMathMethod.DegreesToRadians, (visitor, method) => visitor.DeduceSerializer(method, DoubleSerializer.Instance));
+            RegisterSerializerDeducer(MongoDBMathMethod.RadiansToDegrees, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+
+            // MqlMethod
+            RegisterSerializerDeducers([MqlMethod.ConstantWithRepresentation, MqlMethod.ConstantWithSerializer], DeduceConstantMethodSerializers);
+            RegisterSerializerDeducer(MqlMethod.Convert, DeduceConvertMethodSerializers);
+            RegisterSerializerDeducer(MqlMethod.CreateObjectId, (visitor, expression) => visitor.DeduceSerializer(expression, ObjectIdSerializer.Instance));
+            RegisterSerializerDeducers(MqlMethod.DateFromStringOverloads, DeduceDateFromStringMethodSerializers);
+            RegisterSerializerDeducer(MqlMethod.DeserializeEJson, DeduceDeserializeEJsonMethodSerializers);
+            RegisterSerializerDeducers([MqlMethod.Exists, MqlMethod.IsMissing, MqlMethod.IsNullOrMissing], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+            RegisterSerializerDeducer(MqlMethod.Field, DeduceFieldMethodSerializers);
+            RegisterSerializerDeducer(MqlMethod.Hash, (visitor, expression) => visitor.DeduceSerializer(expression, BsonBinaryDataSerializer.Instance));
+            RegisterSerializerDeducer(MqlMethod.HexHash, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+            RegisterSerializerDeducer(MqlMethod.SerializeEJson, DeduceSerializeEJsonMethodSerializers);
+            RegisterSerializerDeducer(MqlMethod.Sigmoid, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+            RegisterSerializerDeducers(MqlMethod.SimilarityFunctionOverloads, DeduceReturnsNumericSerializer);
+            RegisterSerializerDeducer(MqlMethod.Subtype, (visitor, expression) => visitor.DeduceSerializer(expression, __binarySubTypeSerializer));
+            RegisterSerializerDeducer(MqlMethod.ToHashedIndexKey, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
+
+            // RegexMethod
+            RegisterSerializerDeducers(RegexMethod.IsMatchOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+            RegisterSerializerDeducers(RegexMethod.ReplaceOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+            RegisterSerializerDeducers(RegexMethod.SplitOverloads, DeduceSplitMethodSerializers);
+
+            // StringMethod
+            RegisterSerializerDeducers(StringMethod.AnyStringInOrNinOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+            RegisterSerializerDeducers(StringMethod.ConcatOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+            RegisterSerializerDeducers(StringMethod.ContainsOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+            RegisterSerializerDeducers(StringMethod.EndsWithOrStartsWithOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+            RegisterSerializerDeducers([StringMethod.EqualsInstanceMethod, StringMethod.EqualsWithComparisonType, StringMethod.StaticEqualsWithComparisonType, StringMethod.StaticEquals], DeduceStringEqualsMethodSerializers);
+            RegisterSerializerDeducer(StringMethod.GetChars, (visitor, expression) => visitor.DeduceSerializer(expression, CharSerializer.Instance));
+            RegisterSerializerDeducers(StringMethod.IndexOfOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+            RegisterSerializerDeducers([StringMethod.IsNullOrEmpty, StringMethod.IsNullOrWhiteSpace], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+            RegisterSerializerDeducers(StringMethod.ReplaceOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+            RegisterSerializerDeducers(StringMethod.SplitOverloads, DeduceSplitMethodSerializers);
+            RegisterSerializerDeducer(StringMethod.StrLenBytes, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+            RegisterSerializerDeducers(StringMethod.StringInOrNinOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+            RegisterSerializerDeducers([StringMethod.Substring, StringMethod.SubstringWithLength, StringMethod.SubstrBytes], (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+            RegisterSerializerDeducers(StringMethod.ToLowerOrToUpperOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+            RegisterSerializerDeducers(StringMethod.TrimOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+
+            // TupleOrValueTupleMethod
+            RegisterSerializerDeducers(TupleOrValueTupleMethod.CreateOverloads, DeduceTupleOrValueTupleCreateMethodSerializers);
+
+            // WindowMethod
+            RegisterSerializerDeducer(WindowMethod.AddToSet, DeduceAddToSetMethodSerializers);
+            RegisterSerializerDeducers(__averageOrMedianOrPercentileWindowMethodOverloads, DeduceAverageOrMedianOrPercentileWindowMethodSerializers);
+            RegisterSerializerDeducer(WindowMethod.Count, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
+            RegisterSerializerDeducers(WindowMethod.CovarianceOverloads, DeduceCovarianceMethodSerializers);
+            RegisterSerializerDeducers([WindowMethod.DenseRank, WindowMethod.Rank], (visitor, expression) => visitor.DeduceStandardSerializer(expression)); // currently decimal, but might be long in the future
+            RegisterSerializerDeducers(WindowMethod.DerivativeOrIntegralOverloads, DeduceDerivativeOrIntegralMethodSerializers);
+            RegisterSerializerDeducer(WindowMethod.DocumentNumber, (visitor, expression) => visitor.DeduceStandardSerializer(expression)); // currently decimal, but might be long in the future
+            RegisterSerializerDeducers(WindowMethod.ExponentialMovingAverageOverloads, DeduceExponentialMovingAverageMethodSerializers);
+            RegisterSerializerDeducers([WindowMethod.First, WindowMethod.Last], DeduceFirstOrLastWindowMethodsSerializers);
+            RegisterSerializerDeducer(WindowMethod.Locf, DeduceLocfMethodSerializers);
+            RegisterSerializerDeducers([WindowMethod.Max, WindowMethod.Min], DeduceWindowMaxOrMinMethodSerializers);
+            RegisterSerializerDeducer(WindowMethod.Push, DeducePushMethodSerializers);
+            RegisterSerializerDeducers([WindowMethod.Shift, WindowMethod.ShiftWithDefaultValue], DeduceShiftMethodSerializers);
+            RegisterSerializerDeducers(WindowMethod.StandardDeviationOverloads, DeduceWindowStandardDeviationMethodSerializers);
+            RegisterSerializerDeducers(WindowMethod.SumOverloads, DeduceWindowSumMethodSerializers);
+
+            void RegisterSerializerDeducer(MethodInfo method, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
+            {
+                Ensure.IsNotNull(method, nameof(method));
+                Ensure.IsNotNull(resolver, nameof(resolver));
+
+                __serializerDeducers.Add(method, resolver);
+            }
+
+            void RegisterSerializerDeducers(IEnumerable<MethodInfo> methods, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
+            {
+                foreach (var method in methods)
+                {
+                    RegisterSerializerDeducer(method, resolver);
+                }
+            }
+        }
         // DeduceAddToSetMethodSerializers
-        static void DeduceAddToSetMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAddToSetMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -272,7 +274,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithFunc branch
-        static void DeduceAggregateWithFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAggregateWithFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -286,7 +288,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithSeedAndFunc branch
-        static void DeduceAggregateWithSeedAndFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAggregateWithSeedAndFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var seedExpression =  expression.Arguments[1];
@@ -301,7 +303,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector branch
-        static void DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var seedExpression = expression.Arguments[1];
@@ -319,7 +321,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAllMethodSerializers
-        static void DeduceAllMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAllMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -330,7 +332,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAnyMethodSerializers + EnumerableOrQueryableMethod.AnyWithPredicate branch
-        static void DeduceAnyWithPredicateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAnyWithPredicateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -341,7 +343,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAppendStageMethodSerializers
-        static void DeduceAppendStageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAppendStageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -378,7 +380,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAsMethodSerializers
-        static void DeduceAsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -401,7 +403,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAsQueryableMethodSerializers
-        static void DeduceAsQueryableMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAsQueryableMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
 
@@ -413,7 +415,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceConcatMethodSerializers + EnumerableMethod.Concat, QueryableMethod.Concat branch
-        static void DeduceEnumerableConcatMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceEnumerableConcatMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var firstExpression = expression.Arguments[0];
             var secondExpression = expression.Arguments[1];
@@ -423,7 +425,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceConstantMethodSerializers
-        static void DeduceConstantMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceConstantMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var valueExpression = expression.Arguments[0];
             IBsonSerializer serializer = null;
@@ -453,7 +455,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceConvertMethodSerializers
-        static void DeduceConvertMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceConvertMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -503,7 +505,7 @@ internal partial class SerializerFinderVisitor
 
 #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         // DeduceCreateMethodSerializers + KeyValuePairMethod.Create branch
-        static void DeduceKeyValuePairCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceKeyValuePairCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsAnyNotKnown(expression.Arguments) && visitor.IsKnown(expression, out var nodeSerializer))
             {
@@ -528,7 +530,7 @@ internal partial class SerializerFinderVisitor
 #endif
 
         // DeduceCreateMethodSerializers + TupleOrValueTupleMethod.CreateOverloads
-        static void DeduceTupleOrValueTupleCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceTupleOrValueTupleCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsAnyNotKnown(expression.Arguments) && visitor.IsKnown(expression, out var nodeSerializer))
             {
@@ -570,14 +572,14 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceDateFromStringMethodSerializers
-        static void DeduceDateFromStringMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceDateFromStringMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var resultSerializer = expression.Method.Is(MqlMethod.DateFromStringWithFormatAndTimezoneAndOnErrorAndOnNull) ? NullableSerializer.NullableUtcDateTimeInstance : DateTimeSerializer.UtcInstance;
             visitor.DeduceSerializer(expression, resultSerializer);
         }
 
         // DeduceDefaultIfEmptyMethodSerializers
-        static void DeduceDefaultIfEmptyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceDefaultIfEmptyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
 
@@ -591,7 +593,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceDensifyMethodSerializers
-        static void DeduceDensifyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceDensifyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var fieldLambda = ExpressionHelper.UnquoteLambda(expression.Arguments[1]);
@@ -614,7 +616,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceDocumentsMethodSerializers
-        static void DeduceDocumentsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceDocumentsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -637,7 +639,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceExceptMethodSerializers
-        static void DeduceExceptMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceExceptMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var firstExpression = expression.Arguments[0];
             var secondExpression = expression.Arguments[1];
@@ -646,7 +648,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceExponentialMovingAverageMethodSerializers
-        static void DeduceExponentialMovingAverageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceExponentialMovingAverageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -655,7 +657,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceFieldMethodSerializers
-        static void DeduceFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -671,7 +673,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceGroupByMethodSerializers
-        static void DeduceGroupByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceGroupByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -735,7 +737,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceGroupJoinMethodSerializers
-        static void DeduceGroupJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceGroupJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var outerExpression = expression.Arguments[0];
             var innerExpression = expression.Arguments[1];
@@ -755,7 +757,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceHasFlagMethodSerializers
-        static void DeduceHasFlagMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceHasFlagMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var objectExpression = expression.Object;
             var flagExpression = expression.Arguments[0];
@@ -767,7 +769,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceJoinMethodSerializers
-        static void DeduceJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var outerExpression = expression.Arguments[0];
             var innerExpression = expression.Arguments[1];
@@ -787,7 +789,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceLocfMethodSerializers
-        static void DeduceLocfMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceLocfMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -796,7 +798,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceLookupMethodSerializers + MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField branch
-        static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -819,7 +821,7 @@ internal partial class SerializerFinderVisitor
             }
         }
         // DeduceLookupMethodSerializers + LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline branch
-        static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -848,7 +850,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceLookupMethodSerializers + LookupWithDocumentsAndPipeline branch
-        static void DeduceLookupWithDocumentsAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceLookupWithDocumentsAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -871,7 +873,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceLookupMethodSerializers + LookupWithFromAndLocalFieldAndForeignField branch
-        static void DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var fromExpression = expression.Arguments[1];
@@ -894,7 +896,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceLookupMethodSerializers + LookupWithFromAndLocalFieldAndForeignFieldAndPipeline branch
-        static void DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var fromExpression = expression.Arguments[1];
@@ -928,7 +930,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceLookupMethodSerializers + LookupWithFromAndPipeline branch
-        static void DeduceLookupWithFromAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceLookupWithFromAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var fromCollection = expression.Arguments[1].GetConstantValue<IMongoCollection>(expression);
@@ -955,7 +957,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceOfTypeMethodSerializers
-        void DeduceOfTypeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceOfTypeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var resultType = expression.Method.GetGenericArguments()[0];
@@ -969,7 +971,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeducePushMethodSerializers
-        static void DeducePushMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeducePushMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -978,7 +980,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceRoundMethodSerializers
-        void DeduceRoundMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceRoundMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -988,7 +990,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSelectMethodSerializers
-        static void DeduceSelectMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSelectMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -997,7 +999,7 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
         }
 
-        static void DeduceSelectWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSelectWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1012,7 +1014,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelector branch
-        static void DeduceSelectManyWithSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSelectManyWithSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1023,7 +1025,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector branch
-        static void DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var collectionSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1040,7 +1042,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex branch
-        static void SelectManyWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void SelectManyWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1055,7 +1057,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSequenceEqualMethodSerializers
-        static void DeduceSequenceEqualMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSequenceEqualMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             visitor.DeduceCollectionAndCollectionSerializers(expression.Arguments[0], expression.Arguments[1]);
             visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
@@ -1069,7 +1071,7 @@ internal partial class SerializerFinderVisitor
         // }
 
         // DeduceShiftMethodSerializers
-        static void DeduceShiftMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceShiftMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1078,7 +1080,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSplitMethodSerializers
-        static void DeduceSplitMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSplitMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -1088,7 +1090,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSumMethodSerializers + EnumerableOrQueryableMethod.SumOverloads branch
-        static void DeduceEnumerableSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceEnumerableSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.SumWithSelectorOverloads))
             {
@@ -1119,7 +1121,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSumMethodSerializers + WindowMethod.SumOverloads branch
-        void DeduceWindowSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceWindowSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -1128,7 +1130,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceWhereSerializers
-        static void DeduceWhereSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceWhereSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1137,7 +1139,7 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        static void DeduceWhereWithPredicateTakingIndexSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceWhereWithPredicateTakingIndexSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1152,7 +1154,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceZipSerializers
-        static void DeduceZipSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceZipSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var firstExpression = expression.Arguments[0];
             var secondExpression = expression.Arguments[1];
@@ -1180,7 +1182,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAppendOrPrependMethodSerializers
-        static void DeduceAppendOrPrependMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAppendOrPrependMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var elementExpression = expression.Arguments[1];
@@ -1190,7 +1192,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAverageOrMedianOrPercentileMethodSerializers + __averageOrMedianOrPercentileOverloads branch
-        static void DeduceAverageOrMedianOrPercentileMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAverageOrMedianOrPercentileMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(__averageOrMedianOrPercentileWithSelectorOverloads))
             {
@@ -1209,7 +1211,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceAverageOrMedianOrPercentileMethodSerializers + __averageOrMedianOrPercentileWindowMethodOverloads branch
-        static void DeduceAverageOrMedianOrPercentileWindowMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceAverageOrMedianOrPercentileWindowMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -1217,7 +1219,7 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        static void DeduceDeserializeEJsonMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceDeserializeEJsonMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -1227,7 +1229,7 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        static void DeduceSerializeEJsonMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSerializeEJsonMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -1238,7 +1240,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeducePickMethodSerializers
-        static void DeducePickMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeducePickMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var method = expression.Method;
             if (method.IsOneOf(EnumerableMethod.PickWithSortByOverloads))
@@ -1254,7 +1256,7 @@ internal partial class SerializerFinderVisitor
             var sourceExpression = expression.Arguments[0];
             if (visitor.IsKnown(sourceExpression, out var sourceSerializer))
             {
-                var sourceItemSerializer =  ArraySerializerHelper.GetItemSerializer(sourceSerializer);
+                var sourceItemSerializer = ArraySerializerHelper.GetItemSerializer(sourceSerializer);
 
                 var selectorExpression = expression.Arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 2 : 1];
                 var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, selectorExpression);
@@ -1314,7 +1316,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceCountMethodSerializers + EnumerableOrQueryableMethod.CountOverloads branch
-        static void DeduceEnumerableCountMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceEnumerableCountMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.CountWithPredicateOverloads))
             {
@@ -1328,7 +1330,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceCovarianceMethodSerializers
-        static void DeduceCovarianceMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceCovarianceMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selector1Lambda = (LambdaExpression)expression.Arguments[1];
@@ -1339,7 +1341,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceDerivativeOrIntegralMethodSerializers
-        static void DeduceDerivativeOrIntegralMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceDerivativeOrIntegralMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -1348,7 +1350,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceFirstOrLastOrSingleMethodsSerializers + EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads
-        static void DeduceFirstOrLastOrSingleMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceFirstOrLastOrSingleMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.FirstOrLastOrSingleWithPredicateOverloads))
             {
@@ -1362,7 +1364,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceFirstOrLastOrSingleMethodsSerializers + WindowMethod.First, WindowMethod.Last branch
-        static void DeduceFirstOrLastWindowMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceFirstOrLastWindowMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -1371,7 +1373,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceMaxOrMinMethodSerializers + EnumerableOrQueryableMethod.MaxOrMinOverloads branch
-        static void DeduceMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.MaxOrMinWithSelectorOverloads))
             {
@@ -1389,7 +1391,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceMaxOrMinMethodSerializers + WindowMethod.Max, WindowMethod.Min branch
-        static void DeduceWindowMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceWindowMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -1398,7 +1400,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceOrderByMethodSerializers
-        static void DeduceOrderByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceOrderByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1409,7 +1411,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSkipOrTakeMethodSerializers
-        static void DeduceSkipOrTakeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSkipOrTakeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
 
@@ -1433,7 +1435,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceStandardDeviationMethodSerializers + MongoEnumerableMethod.StandardDeviationOverloads branch
-        static void DeduceStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(MongoEnumerableMethod.StandardDeviationWithSelectorOverloads, MongoQueryableMethod.StandardDeviationWithSelectorOverloads))
             {
@@ -1446,7 +1448,7 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        static void DeduceStringEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceStringEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var expression1 = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
             var expression2 = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
@@ -1456,7 +1458,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceStandardDeviationMethodSerializers + WindowMethod.StandardDeviationOverloads branch
-        static void DeduceWindowStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceWindowStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
@@ -1464,7 +1466,7 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        static void DeduceReturnsNumericSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceReturnsNumericSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression) && expression.Type.IsNumeric())
             {
@@ -1473,7 +1475,7 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        static void DeduceReturnsTimeSpanSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression, TimeSpanUnits units)
+        private static void DeduceReturnsTimeSpanSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression, TimeSpanUnits units)
         {
             if (visitor.IsNotKnown(expression))
             {
@@ -1482,7 +1484,7 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        static void DeduceReturnsOneSourceItemSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceReturnsOneSourceItemSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
 
@@ -1495,7 +1497,7 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        static void DeduceWindowMethodSelectorParameterSerializer(SerializerFinderVisitor visitor, Expression partitionExpression, LambdaExpression selectorLambda)
+        private static void DeduceWindowMethodSelectorParameterSerializer(SerializerFinderVisitor visitor, Expression partitionExpression, LambdaExpression selectorLambda)
         {
             var inputParameter = selectorLambda.Parameters.Single();
             if (visitor.IsNotKnown(inputParameter) && visitor.IsKnown(partitionExpression, out var partitionSerializer))
@@ -1504,61 +1506,43 @@ internal partial class SerializerFinderVisitor
                 visitor.AddNodeSerializer(inputParameter, inputSerializer);
             }
         }
-    }
 
-    protected override Expression VisitMethodCall(MethodCallExpression node)
-    {
-        var methodInfo = node.Method.IsGenericMethod && !node.Method.ContainsGenericParameters ? node.Method.GetGenericMethodDefinition() : node.Method;
-
-        DeduceMethodCallSerializers();
-        base.VisitMethodCall(node);
-        DeduceMethodCallSerializers();
-
-        return node;
-
-        void DeduceMethodCallSerializers()
+        public static Action<SerializerFinderVisitor,MethodCallExpression> GetSerializerDeducer(MethodInfo methodInfo)
         {
-            Action<SerializerFinderVisitor, MethodCallExpression> resolver;
-            __serializerResolversLock.EnterReadLock();
+            __serializerDeducersLock.EnterReadLock();
             try
             {
-                __serializerResolvers.TryGetValue(methodInfo, out resolver);
+                if (__serializerDeducers.TryGetValue(methodInfo, out var deducer))
+                {
+                    return deducer;
+                }
             }
             finally
             {
-                __serializerResolversLock.ExitReadLock();
+                __serializerDeducersLock.ExitReadLock();
             }
 
-            if (resolver == null)
+            __serializerDeducersLock.EnterWriteLock();
+            try
             {
-                __serializerResolversLock.EnterWriteLock();
-                try
+                if (__serializerDeducers.TryGetValue(methodInfo, out var deducer))
                 {
-                    if (!__serializerResolvers.TryGetValue(methodInfo, out resolver))
-                    {
-                        resolver = CreateDynamicSerializerResolver(methodInfo);
-                        __serializerResolvers.Add(methodInfo, resolver);
-                    }
+                    return deducer;
                 }
-                finally
-                {
-                    __serializerResolversLock.ExitWriteLock();
-                }
-            }
 
-            if (resolver == null)
-            {
-                DeduceUnknowableSerializer(node);
+                deducer = CreateDynamicSerializerDeducer(methodInfo);
+                __serializerDeducers.Add(methodInfo, deducer);
+                return deducer;
             }
-            else
+            finally
             {
-                resolver(this, node);
+                __serializerDeducersLock.ExitWriteLock();
             }
         }
 
         // Processes special cases where we do not have fixed list of methodInfos that we support,
         // but trying to deduce serializers based on method name and arguments
-        static Action<SerializerFinderVisitor, MethodCallExpression> CreateDynamicSerializerResolver(MethodInfo method)
+        static Action<SerializerFinderVisitor, MethodCallExpression> CreateDynamicSerializerDeducer(MethodInfo method)
         {
             return method.Name switch
             {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -59,8 +59,8 @@ internal partial class SerializerFinderVisitor
 
     private static class MethodCallSerializerDeducers
     {
-        private static readonly Dictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerDeducers = new();
-        private static readonly ReaderWriterLockSlim __serializerDeducersLock = new();
+        private static readonly Dictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerResolvers = new();
+        private static readonly ReaderWriterLockSlim __serializerResolversLock = new();
         private static readonly IBsonSerializer __binarySubTypeSerializer = NullableSerializer.Create(new EnumSerializer<BsonBinarySubType>());
 
         private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileOverloads = MethodInfoSet.Create(
@@ -253,7 +253,7 @@ internal partial class SerializerFinderVisitor
                 Ensure.IsNotNull(method, nameof(method));
                 Ensure.IsNotNull(resolver, nameof(resolver));
 
-                __serializerDeducers.Add(method, resolver);
+                __serializerResolvers.Add(method, resolver);
             }
 
             void RegisterSerializerDeducers(IEnumerable<MethodInfo> methods, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
@@ -1509,34 +1509,34 @@ internal partial class SerializerFinderVisitor
 
         public static Action<SerializerFinderVisitor,MethodCallExpression> GetSerializerDeducer(MethodInfo methodInfo)
         {
-            __serializerDeducersLock.EnterReadLock();
+            __serializerResolversLock.EnterReadLock();
             try
             {
-                if (__serializerDeducers.TryGetValue(methodInfo, out var deducer))
+                if (__serializerResolvers.TryGetValue(methodInfo, out var deducer))
                 {
                     return deducer;
                 }
             }
             finally
             {
-                __serializerDeducersLock.ExitReadLock();
+                __serializerResolversLock.ExitReadLock();
             }
 
-            __serializerDeducersLock.EnterWriteLock();
+            __serializerResolversLock.EnterWriteLock();
             try
             {
-                if (__serializerDeducers.TryGetValue(methodInfo, out var deducer))
+                if (__serializerResolvers.TryGetValue(methodInfo, out var deducer))
                 {
                     return deducer;
                 }
 
                 deducer = CreateDynamicSerializerDeducer(methodInfo);
-                __serializerDeducers.Add(methodInfo, deducer);
+                __serializerResolvers.Add(methodInfo, deducer);
                 return deducer;
             }
             finally
             {
-                __serializerDeducersLock.ExitWriteLock();
+                __serializerResolversLock.ExitWriteLock();
             }
         }
 
@@ -1738,7 +1738,6 @@ internal partial class SerializerFinderVisitor
                         _ when declaringType == typeof(sbyte) => SByteSerializer.Instance,
                         _ => UnknowableSerializer.Create(declaringType)
                     };
-
                     visitor.AddNodeSerializer(expression, nodeSerializer);
                 }
             }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -14,11 +14,11 @@
  */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Options;
@@ -59,8 +59,7 @@ internal partial class SerializerFinderVisitor
 
     private static class MethodCallSerializerDeducers
     {
-        private static readonly Dictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerResolvers = new();
-        private static readonly ReaderWriterLockSlim __serializerResolversLock = new();
+        private static readonly ConcurrentDictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerDeducers = new();
         private static readonly IBsonSerializer __binarySubTypeSerializer = NullableSerializer.Create(new EnumSerializer<BsonBinarySubType>());
 
         private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileOverloads = MethodInfoSet.Create(
@@ -134,7 +133,7 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.ElementAtOverloads, (visitor, expression) => visitor.DeduceItemAndCollectionSerializers(expression, expression.Arguments[0]));
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.Except, DeduceExceptMethodSerializers);
             // TODO: Definitely wrong registration copy-pasted from prev code, investigate before merge to main
-            // RegisterSerializerResolver(EnumerableMethod.First, DeduceSetWindowFieldsMethodSerializers);
+            // RegisterSerializerDeducer(EnumerableMethod.First, DeduceSetWindowFieldsMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads, DeduceFirstOrLastOrSingleMethodsSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.GroupByOverloads, DeduceGroupByMethodSerializers);
             RegisterSerializerDeducers([EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin], DeduceGroupJoinMethodSerializers);
@@ -156,7 +155,7 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.Select, DeduceSelectMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector, DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectManyWithSelector, DeduceSelectManyWithSelectorMethodSerializers);
-            RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex, SelectManyWithSelectorTakingIndexMethodSerializers);
+            RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex, DeduceSelectManyWithSelectorTakingIndexMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.SelectWithSelectorTakingIndex, DeduceSelectWithSelectorTakingIndexMethodSerializers);
             RegisterSerializerDeducers([EnumerableMethod.SequenceEqual, QueryableMethod.SequenceEqual], DeduceSequenceEqualMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.SkipOrTakeOverloads, DeduceSkipOrTakeMethodSerializers);
@@ -168,9 +167,9 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.Zip, DeduceZipSerializers);
 
             // KeyValuePairMethod
-    #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
             RegisterSerializerDeducer(KeyValuePairMethod.Create, DeduceKeyValuePairCreateMethodSerializers);
-    #endif
+#endif
 
             // LinqExtensionsMethod
             RegisterSerializerDeducer(LinqExtensionsMethod.Inject, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
@@ -216,7 +215,7 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers(StringMethod.ConcatOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
             RegisterSerializerDeducers(StringMethod.ContainsOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
             RegisterSerializerDeducers(StringMethod.EndsWithOrStartsWithOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
-            RegisterSerializerDeducers([StringMethod.EqualsInstanceMethod, StringMethod.EqualsWithComparisonType, StringMethod.StaticEqualsWithComparisonType, StringMethod.StaticEquals], DeduceStringEqualsMethodSerializers);
+            RegisterSerializerDeducers([StringMethod.EqualsInstanceMethod, StringMethod.EqualsWithComparisonType, StringMethod.StaticEqualsWithComparisonType, StringMethod.StaticEquals], DeduceEqualsMethodSerializers);
             RegisterSerializerDeducer(StringMethod.GetChars, (visitor, expression) => visitor.DeduceSerializer(expression, CharSerializer.Instance));
             RegisterSerializerDeducers(StringMethod.IndexOfOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
             RegisterSerializerDeducers([StringMethod.IsNullOrEmpty, StringMethod.IsNullOrWhiteSpace], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
@@ -248,22 +247,26 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers(WindowMethod.StandardDeviationOverloads, DeduceWindowStandardDeviationMethodSerializers);
             RegisterSerializerDeducers(WindowMethod.SumOverloads, DeduceWindowSumMethodSerializers);
 
-            void RegisterSerializerDeducer(MethodInfo method, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
+            void RegisterSerializerDeducer(MethodInfo method, Action<SerializerFinderVisitor, MethodCallExpression> deducer)
             {
                 Ensure.IsNotNull(method, nameof(method));
-                Ensure.IsNotNull(resolver, nameof(resolver));
+                Ensure.IsNotNull(deducer, nameof(deducer));
 
-                __serializerResolvers.Add(method, resolver);
+                if (!__serializerDeducers.TryAdd(method, deducer))
+                {
+                    throw new InvalidOperationException($"Serializer deducer for method {method} is already registered");
+                }
             }
 
-            void RegisterSerializerDeducers(IEnumerable<MethodInfo> methods, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
+            void RegisterSerializerDeducers(IEnumerable<MethodInfo> methods, Action<SerializerFinderVisitor, MethodCallExpression> deducer)
             {
                 foreach (var method in methods)
                 {
-                    RegisterSerializerDeducer(method, resolver);
+                    RegisterSerializerDeducer(method, deducer);
                 }
             }
         }
+
         // DeduceAddToSetMethodSerializers
         private static void DeduceAddToSetMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
@@ -908,16 +911,16 @@ internal partial class SerializerFinderVisitor
             var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
             var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
             var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
-            var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
+            var pipelineLambdaForeignQueryableParameter = pipelineLambda.Parameters[1];
 
             visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
             visitor.DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
             visitor.DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
 
-            if (visitor.IsNotKnown(pipelineLamdbaForeignQueryableParameter))
+            if (visitor.IsNotKnown(pipelineLambdaForeignQueryableParameter))
             {
                 var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
-                visitor.AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
+                visitor.AddNodeSerializer(pipelineLambdaForeignQueryableParameter, foreignQueryableSerializer);
             }
 
             if (visitor.IsNotKnown(expression) &&
@@ -1042,7 +1045,7 @@ internal partial class SerializerFinderVisitor
         }
 
         // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex branch
-        private static void SelectManyWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceSelectManyWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
             var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
@@ -1114,7 +1117,7 @@ internal partial class SerializerFinderVisitor
                 not null when returnType == typeof(int?) => NullableSerializer.NullableInt32Instance,
                 not null when returnType == typeof(long?) => NullableSerializer.NullableInt64Instance,
                 not null when returnType == typeof(float?) => NullableSerializer.NullableSingleInstance,
-                _ => throw new NotImplementedException($"Cannot resolver serializer for {returnType}")
+                _ => throw new NotImplementedException($"Cannot resolve serializer for {returnType}")
             };
 
             visitor.DeduceSerializer(expression, serializer);
@@ -1448,7 +1451,7 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        private static void DeduceStringEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        private static void DeduceEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var expression1 = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
             var expression2 = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
@@ -1507,37 +1510,20 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        public static Action<SerializerFinderVisitor,MethodCallExpression> GetSerializerDeducer(MethodInfo methodInfo)
+        public static Action<SerializerFinderVisitor, MethodCallExpression> GetSerializerDeducer(MethodInfo methodInfo)
         {
-            __serializerResolversLock.EnterReadLock();
-            try
+            if (__serializerDeducers.TryGetValue(methodInfo, out var deducer))
             {
-                if (__serializerResolvers.TryGetValue(methodInfo, out var deducer))
-                {
-                    return deducer;
-                }
-            }
-            finally
-            {
-                __serializerResolversLock.ExitReadLock();
-            }
-
-            __serializerResolversLock.EnterWriteLock();
-            try
-            {
-                if (__serializerResolvers.TryGetValue(methodInfo, out var deducer))
-                {
-                    return deducer;
-                }
-
-                deducer = CreateDynamicSerializerDeducer(methodInfo);
-                __serializerResolvers.Add(methodInfo, deducer);
                 return deducer;
             }
-            finally
+
+            deducer = CreateDynamicSerializerDeducer(methodInfo);
+            if (deducer == null)
             {
-                __serializerResolversLock.ExitWriteLock();
+                return null;
             }
+
+            return __serializerDeducers.GetOrAdd(methodInfo, deducer);
         }
 
         // Processes special cases where we do not have fixed list of methodInfos that we support,
@@ -1594,7 +1580,7 @@ internal partial class SerializerFinderVisitor
                 method.GetParameters() is var parameters &&
                 parameters.Length == 1;
 
-            void DeduceContainsValueMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            static void DeduceContainsValueMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
                 var collectionExpression = expression.Object;
                 var valueExpression = expression.Arguments[0];
@@ -1612,7 +1598,7 @@ internal partial class SerializerFinderVisitor
                 visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
             }
 
-            void DeduceDictionaryContainsKeyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            static void DeduceDictionaryContainsKeyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
                 var dictionaryExpression = expression.Object;
                 var keyExpression = expression.Arguments[0];
@@ -1635,15 +1621,6 @@ internal partial class SerializerFinderVisitor
                            (method.IsStatic && arguments.Length == 2) ||
                            (!method.IsStatic && arguments.Length == 1)
                        );
-            }
-
-            void DeduceEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
-            {
-                var expression1 = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
-                var expression2 = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
-
-                visitor.DeduceSerializers(expression1, expression2);
-                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
             }
 
             static void DeduceExistsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -59,7 +59,19 @@ internal partial class SerializerFinderVisitor
 
     private static class MethodCallSerializerDeducers
     {
-        private static readonly ConcurrentDictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerDeducers = new();
+        private readonly record struct MethodKey
+        {
+            public MethodKey(MethodInfo method)
+            {
+                Token = method.MetadataToken;
+                Module = method.Module;
+            }
+
+            public int Token { get; }
+            public Module Module { get; }
+        }
+
+        private static readonly ConcurrentDictionary<MethodKey, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerDeducers = new();
         private static readonly IBsonSerializer __binarySubTypeSerializer = NullableSerializer.Create(new EnumSerializer<BsonBinarySubType>());
 
         private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileOverloads = MethodInfoSet.Create(
@@ -252,7 +264,7 @@ internal partial class SerializerFinderVisitor
                 Ensure.IsNotNull(method, nameof(method));
                 Ensure.IsNotNull(deducer, nameof(deducer));
 
-                if (!__serializerDeducers.TryAdd(method, deducer))
+                if (!__serializerDeducers.TryAdd(new MethodKey(method), deducer))
                 {
                     throw new InvalidOperationException($"Serializer deducer for method {method} is already registered");
                 }
@@ -1512,7 +1524,8 @@ internal partial class SerializerFinderVisitor
 
         public static Action<SerializerFinderVisitor, MethodCallExpression> GetSerializerDeducer(MethodInfo methodInfo)
         {
-            if (__serializerDeducers.TryGetValue(methodInfo, out var deducer))
+            var methodKey = new MethodKey(methodInfo);
+            if (__serializerDeducers.TryGetValue(methodKey, out var deducer))
             {
                 return deducer;
             }
@@ -1523,7 +1536,7 @@ internal partial class SerializerFinderVisitor
                 return null;
             }
 
-            return __serializerDeducers.GetOrAdd(methodInfo, deducer);
+            return __serializerDeducers.GetOrAdd(methodKey, deducer);
         }
 
         // Processes special cases where we do not have fixed list of methodInfos that we support,

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -14,13 +14,16 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Options;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Linq.Linq3Implementation.ExtensionMethods;
 using MongoDB.Driver.Linq.Linq3Implementation.Misc;
 using MongoDB.Driver.Linq.Linq3Implementation.Reflection;
@@ -30,9 +33,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.SerializerFinders;
 
 internal partial class SerializerFinderVisitor
 {
+    private static readonly Dictionary<MethodInfo, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerResolvers = new();
+    private static readonly ReaderWriterLockSlim __serializerResolversLock = new();
     private static readonly IBsonSerializer __binarySubTypeSerializer = NullableSerializer.Create(new EnumSerializer<BsonBinarySubType>());
-
-    private static readonly IBsonSerializer __bsonBinaryDataSerializer = new BsonValueCSharpNullSerializer<BsonBinaryData>(BsonBinaryDataSerializer.Instance);
 
     private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileOverloads = MethodInfoSet.Create(
     [
@@ -48,14 +51,6 @@ internal partial class SerializerFinderVisitor
         WindowMethod.PercentileOverloads
     ]);
 
-    private static readonly IReadOnlyMethodInfoSet __pickWindowMethodWithSortByOverloads = MethodInfoSet.Create(
-    [
-        WindowMethod.Bottom,
-        WindowMethod.BottomN,
-        WindowMethod.Top,
-        WindowMethod.TopN
-    ]);
-
     private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileWithSelectorOverloads = MethodInfoSet.Create(
     [
         EnumerableOrQueryableMethod.AverageWithSelectorOverloads,
@@ -69,901 +64,407 @@ internal partial class SerializerFinderVisitor
         [MongoEnumerableMethod.WhereWithLimit]
     ]);
 
-    protected override Expression VisitMethodCall(MethodCallExpression node)
+    static SerializerFinderVisitor()
     {
-        var method = node.Method;
-        var arguments = node.Arguments;
+        // DeduceAbsMethodSerializers
+        RegisterSerializerResolvers(MathMethod.AbsOverloads, (visitor, expression) => visitor.DeduceSerializers(expression, expression.Arguments[0]));
+        // DeduceAdd*MethodSerializers (Add, AddDays, AddHours, AddMilliseconds, AddMinutes, AddMonths, AddQuarters, AddSeconds, AddTicks, AddWeeks, AddYears)
+        RegisterSerializerResolvers(
+            [
+                DateTimeMethod.Add, DateTimeMethod.AddWithTimezone, DateTimeMethod.AddWithUnit, DateTimeMethod.AddWithUnitAndTimezone,
+                DateTimeMethod.AddDays, DateTimeMethod.AddDaysWithTimezone, DateTimeMethod.AddHours, DateTimeMethod.AddHoursWithTimezone,
+                DateTimeMethod.AddMilliseconds, DateTimeMethod.AddMillisecondsWithTimezone, DateTimeMethod.AddMinutes, DateTimeMethod.AddMinutesWithTimezone,
+                DateTimeMethod.AddMonths, DateTimeMethod.AddMonthsWithTimezone, DateTimeMethod.AddQuarters, DateTimeMethod.AddQuartersWithTimezone,
+                DateTimeMethod.AddSeconds, DateTimeMethod.AddSecondsWithTimezone, DateTimeMethod.AddTicks, DateTimeMethod.AddWeeks,
+                DateTimeMethod.AddWeeksWithTimezone, DateTimeMethod.AddYears, DateTimeMethod.AddYearsWithTimezone
+            ],
+            (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
 
-        DeduceMethodCallSerializers();
-        base.VisitMethodCall(node);
-        DeduceMethodCallSerializers();
+        RegisterSerializerResolver(WindowMethod.AddToSet, DeduceAddToSetMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithFunc, DeduceAggregateWithFuncMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithSeedAndFunc, DeduceAggregateWithSeedAndFuncMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector, DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers);
+        RegisterSerializerResolvers([EnumerableMethod.AllWithPredicate, QueryableMethod.AllWithPredicate], DeduceAllMethodSerializers);
+        // DeduceAnyMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Any, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AnyWithPredicate, DeduceAnyWithPredicateMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.AppendStage, DeduceAppendStageMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.As, DeduceAsMethodSerializers);
+        RegisterSerializerResolver(QueryableMethod.AsQueryable, DeduceAsQueryableMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Concat, DeduceEnumerableConcatMethodSerializers);
+        RegisterSerializerResolvers([StringMethod.EqualsInstanceMethod, StringMethod.EqualsWithComparisonType, StringMethod.StaticEqualsWithComparisonType, StringMethod.StaticEquals], DeduceStringEqualsMethodSerializers);
+        // DeduceConcatMethodSerializers + StringMethod.ConcatOverloads branch
+        RegisterSerializerResolvers(StringMethod.ConcatOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        RegisterSerializerResolvers([MqlMethod.ConstantWithRepresentation, MqlMethod.ConstantWithSerializer], DeduceConstantMethodSerializers);
+        RegisterSerializerResolver(MqlMethod.CreateObjectId, (visitor, expression) => visitor.DeduceSerializer(expression, ObjectIdSerializer.Instance));
+        RegisterSerializerResolver(MqlMethod.DeserializeEJson, DeduceDeserializeEJsonMethodSerializers);
+        RegisterSerializerResolver(MqlMethod.SerializeEJson, DeduceSerializeEJsonMethodSerializers);
+        // DeduceContainsMethodSerializers + StringMethod.ContainsOverloads branch
+        RegisterSerializerResolvers(StringMethod.ContainsOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolver(MqlMethod.Convert, DeduceConvertMethodSerializers);
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        RegisterSerializerResolver(KeyValuePairMethod.Create, DeduceKeyValuePairCreateMethodSerializers);
+#endif
+        RegisterSerializerResolvers(TupleOrValueTupleMethod.CreateOverloads, DeduceTupleOrValueTupleCreateMethodSerializers);
+        RegisterSerializerResolvers(MqlMethod.DateFromStringOverloads, DeduceDateFromStringMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.DefaultIfEmptyOverloads, DeduceDefaultIfEmptyMethodSerializers);
+        // DeduceDegreesToRadiansMethodSerializers
+        RegisterSerializerResolver(MongoDBMathMethod.DegreesToRadians, (visitor, method) => visitor.DeduceSerializer(method, DoubleSerializer.Instance));
+        RegisterSerializerResolver(MongoQueryableMethod.DensifyWithArrayPartitionByFields, DeduceDensifyMethodSerializers);
+        // DeduceDistinctMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Distinct, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+        // DeduceDocumentNumberMethodSerializers
+        RegisterSerializerResolver(WindowMethod.DocumentNumber, (visitor, expression) => visitor.DeduceStandardSerializer(expression)); // currently decimal, but might be long in the future
+        RegisterSerializerResolvers([MongoQueryableMethod.Documents, MongoQueryableMethod.DocumentsWithSerializer], DeduceDocumentsMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Except, DeduceExceptMethodSerializers);
+        // DeduceExpMethodSerializers
+        RegisterSerializerResolver(MathMethod.Exp, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        RegisterSerializerResolvers(WindowMethod.ExponentialMovingAverageOverloads, DeduceExponentialMovingAverageMethodSerializers);
+        RegisterSerializerResolver(MqlMethod.Field, DeduceFieldMethodSerializers);
+        RegisterSerializerResolver(MqlMethod.Hash, (visitor, expression) => visitor.DeduceSerializer(expression, BsonBinaryDataSerializer.Instance));
+        RegisterSerializerResolver(MqlMethod.HexHash, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceGetCharsMethodSerializers
+        RegisterSerializerResolver(StringMethod.GetChars, (visitor, expression) => visitor.DeduceSerializer(expression, CharSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.GroupByOverloads, DeduceGroupByMethodSerializers);
+        RegisterSerializerResolvers([EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin], DeduceGroupJoinMethodSerializers);
+        RegisterSerializerResolver(EnumMethod.HasFlag, DeduceHasFlagMethodSerializers);
+        // DeduceInjectMethodSerializers
+        RegisterSerializerResolver(LinqExtensionsMethod.Inject, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        // DeduceIntersectMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Intersect, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+        // DeduceIsMatchMethodSerializers
+        RegisterSerializerResolvers(RegexMethod.IsMatchOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolvers([EnumerableMethod.Join, QueryableMethod.Join], DeduceJoinMethodSerializers);
+        RegisterSerializerResolver(WindowMethod.Locf, DeduceLocfMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithDocumentsAndPipeline, DeduceLookupWithDocumentsAndPipelineMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignField, DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
+        RegisterSerializerResolver(MongoQueryableMethod.LookupWithFromAndPipeline, DeduceLookupWithFromAndPipelineMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.OfType, DeduceOfTypeMethodSerializers);
+        // DeducePowMethodSerializers
+        RegisterSerializerResolver(MathMethod.Pow, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        RegisterSerializerResolver(WindowMethod.Push, DeducePushMethodSerializers);
+        // DeduceRadiansToDegreesMethodSerializers
+        RegisterSerializerResolver(MongoDBMathMethod.RadiansToDegrees, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        // DeduceRangeMethodSerializers
+        RegisterSerializerResolver(EnumerableMethod.Range, (visitor, expression) => visitor.DeduceCollectionAndItemSerializers(expression, expression.Arguments[0]));
+        // DeduceRepeatMethodSerializers
+        RegisterSerializerResolver(EnumerableMethod.Repeat, (visitor, expression) => visitor.DeduceCollectionAndItemSerializers(expression, expression.Arguments[0]));
+        // DeduceReverseMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.ReverseOverloads, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+        RegisterSerializerResolvers([MathMethod.RoundWithDecimal, MathMethod.RoundWithDecimalAndDecimals, MathMethod.RoundWithDouble, MathMethod.RoundWithDoubleAndDigits], DeduceRoundMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Select, DeduceSelectMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectWithSelectorTakingIndex, DeduceSelectWithSelectorTakingIndexMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithSelector, DeduceSelectManyWithSelectorMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector, DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex, SelectManyWithSelectorTakingIndexMethodSerializers);
+        RegisterSerializerResolvers([EnumerableMethod.SequenceEqual, QueryableMethod.SequenceEqual], DeduceSequenceEqualMethodSerializers);
+        // TODO: Definitely wrong registration copy-pasted from prev code, investigate before merge to main
+        // RegisterSerializerResolver(EnumerableMethod.First, DeduceSetWindowFieldsMethodSerializers);
+        RegisterSerializerResolvers([WindowMethod.Shift, WindowMethod.ShiftWithDefaultValue], DeduceShiftMethodSerializers);
+        // DeduceSigmoidMethodSerializers
+        RegisterSerializerResolver(MqlMethod.Sigmoid, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        RegisterSerializerResolvers(StringMethod.SplitOverloads, DeduceSplitMethodSerializers);
+        RegisterSerializerResolvers(RegexMethod.SplitOverloads, DeduceSplitMethodSerializers);
+        RegisterSerializerResolvers(StringMethod.ReplaceOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        RegisterSerializerResolvers(RegexMethod.ReplaceOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceSqrtMethodSerializers
+        RegisterSerializerResolver(MathMethod.Sqrt, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        // DeduceStrLenBytesMethodSerializers
+        RegisterSerializerResolver(StringMethod.StrLenBytes, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningDateTimeOverloads branch
+        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningDateTimeOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
+        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningInt64Overloads
+        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningInt64Overloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
+        // DeduceSubtractMethodSerializers + DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads
+        RegisterSerializerResolvers(DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads, (visitor, expression) => DeduceReturnsTimeSpanSerializer(visitor, expression, TimeSpanUnits.Milliseconds));
+        // DeduceSubtypeMethodSerializers
+        RegisterSerializerResolver(MqlMethod.Subtype, (visitor, expression) => visitor.DeduceSerializer(expression, __binarySubTypeSerializer));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SumOverloads, DeduceEnumerableSumMethodSerializers);
+        RegisterSerializerResolvers(WindowMethod.SumOverloads, DeduceWindowSumMethodSerializers);
+        // DeduceTrimSerializers
+        RegisterSerializerResolvers(StringMethod.TrimOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceTruncateSerializers + DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone branch
+        RegisterSerializerResolvers([DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone], (visitor, expression) => visitor.DeduceSerializer(expression, DateTimeSerializer.UtcInstance));
+        // DeduceTruncateSerializers + MathMethod.TruncateDecimal, MathMethod.TruncateDouble branch
+        RegisterSerializerResolvers([MathMethod.TruncateDecimal, MathMethod.TruncateDouble], DeduceReturnsNumericSerializer);
+        // DeduceUnionSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Union, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
+        // DeduceWeekSerializers
+        RegisterSerializerResolvers([DateTimeMethod.Week, DateTimeMethod.WeekWithTimezone], (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+        RegisterSerializerResolvers(__whereOverloads, DeduceWhereSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.WhereWithPredicateTakingIndex, DeduceWhereWithPredicateTakingIndexSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.Zip, DeduceZipSerializers);
+        // DeduceTrigonometricMethodSerializers
+        RegisterSerializerResolvers(MathMethod.TrigonometricMethods, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        // DeduceMatchingElementsMethodSerializers
+        RegisterSerializerResolvers([MongoEnumerableMethod.AllElements, MongoEnumerableMethod.AllMatchingElements, MongoEnumerableMethod.FirstMatchingElement], DeduceReturnsOneSourceItemSerializer);
+        // DeduceAnyStringInOrNinMethodSerializers
+        RegisterSerializerResolvers(StringMethod.AnyStringInOrNinOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.AppendOrPrepend, DeduceAppendOrPrependMethodSerializers);
+        RegisterSerializerResolvers(__averageOrMedianOrPercentileOverloads, DeduceAverageOrMedianOrPercentileMethodSerializers);
+        RegisterSerializerResolvers(__averageOrMedianOrPercentileWindowMethodOverloads, DeduceAverageOrMedianOrPercentileWindowMethodSerializers);
+        RegisterSerializerResolvers(EnumerableMethod.PickOverloads, DeducePickMethodSerializers);
+        // DeduceCeilingOrFloorMethodSerializers
+        RegisterSerializerResolvers([MathMethod.CeilingWithDecimal, MathMethod.CeilingWithDouble, MathMethod.FloorWithDecimal, MathMethod.FloorWithDouble], DeduceReturnsNumericSerializer);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.CountOverloads, DeduceEnumerableCountMethodSerializers);
+        // DeduceCountMethodSerializers + WindowMethod.Count branch
+        RegisterSerializerResolver(WindowMethod.Count, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
+        RegisterSerializerResolvers(WindowMethod.CovarianceOverloads, DeduceCovarianceMethodSerializers);
+        // DeduceDenseRankOrRankMethodSerializers
+        RegisterSerializerResolvers([WindowMethod.DenseRank, WindowMethod.Rank], (visitor, expression) => visitor.DeduceStandardSerializer(expression)); // currently decimal, but might be long in the future
+        RegisterSerializerResolvers(WindowMethod.DerivativeOrIntegralOverloads, DeduceDerivativeOrIntegralMethodSerializers);
+        // DeduceElementAtMethodSerializers
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.ElementAtOverloads, (visitor, expression) => visitor.DeduceItemAndCollectionSerializers(expression, expression.Arguments[0]));
+        // DeduceEndsWithOrStartsWithMethodSerializers
+        RegisterSerializerResolvers(StringMethod.EndsWithOrStartsWithOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads, DeduceFirstOrLastOrSingleMethodsSerializers);
+        RegisterSerializerResolvers([WindowMethod.First, WindowMethod.Last], DeduceFirstOrLastWindowMethodsSerializers);
+        // DeduceIndexOfMethodSerializers
+        RegisterSerializerResolvers(StringMethod.IndexOfOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, Int32Serializer.Instance));
+        // DeduceIsMissingOrIsNullOrMissingMethodSerializers
+        // DeduceExistsMethodSerializers + MqlMethod.Exists
+        RegisterSerializerResolvers([MqlMethod.Exists, MqlMethod.IsMissing, MqlMethod.IsNullOrMissing], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        // DeduceIsNullOrEmptyOrIsNullOrWhiteSpaceMethodSerializers
+        RegisterSerializerResolvers([StringMethod.IsNullOrEmpty, StringMethod.IsNullOrWhiteSpace], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        // DeduceLogMethodSerializers
+        RegisterSerializerResolvers(MathMethod.LogOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.MaxOrMinOverloads, DeduceMaxOrMinMethodSerializers);
+        RegisterSerializerResolvers([WindowMethod.Max, WindowMethod.Min], DeduceWindowMaxOrMinMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.OrderByOrThenByOverloads, DeduceOrderByMethodSerializers);
+        RegisterSerializerResolvers(EnumerableOrQueryableMethod.SkipOrTakeOverloads, DeduceSkipOrTakeMethodSerializers);
+        RegisterSerializerResolvers(MongoEnumerableMethod.StandardDeviationOverloads, DeduceStandardDeviationMethodSerializers);
+        RegisterSerializerResolvers(WindowMethod.StandardDeviationOverloads, DeduceWindowStandardDeviationMethodSerializers);
+        // DeduceStringInOrNinMethodSerializers
+        RegisterSerializerResolvers(StringMethod.StringInOrNinOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
+        // DeduceSubstringMethodSerializers
+        RegisterSerializerResolvers([StringMethod.Substring, StringMethod.SubstringWithLength, StringMethod.SubstrBytes], (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceToLowerOrToUpperSerializers
+        RegisterSerializerResolvers(StringMethod.ToLowerOrToUpperOverloads, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
+        // DeduceSimilarityFunctionsSerializers
+        RegisterSerializerResolvers(MqlMethod.SimilarityFunctionOverloads, DeduceReturnsNumericSerializer);
 
-        return node;
-
-        void DeduceMethodCallSerializers()
+        void RegisterSerializerResolver(MethodInfo method, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
         {
-            switch (node.Method.Name)
+            Ensure.IsNotNull(method, nameof(method));
+            Ensure.IsNotNull(resolver, nameof(resolver));
+
+            __serializerResolvers.Add(method, resolver);
+        }
+
+        void RegisterSerializerResolvers(IEnumerable<MethodInfo> methods, Action<SerializerFinderVisitor, MethodCallExpression> resolver)
+        {
+            foreach (var method in methods)
             {
-                case "Abs": DeduceAbsMethodSerializers(); break;
-                case "Add": DeduceAddMethodSerializers(); break;
-                case "AddDays": DeduceAddDaysMethodSerializers(); break;
-                case "AddHours": DeduceAddHoursMethodSerializers(); break;
-                case "AddMilliseconds": DeduceAddMillisecondsMethodSerializers(); break;
-                case "AddMinutes": DeduceAddMinutesMethodSerializers(); break;
-                case "AddMonths": DeduceAddMonthsMethodSerializers(); break;
-                case "AddQuarters": DeduceAddQuartersMethodSerializers(); break;
-                case "AddSeconds": DeduceAddSecondsMethodSerializers(); break;
-                case "AddTicks": DeduceAddTicksMethodSerializers(); break;
-                case "AddToSet": DeduceAddToSetMethodSerializers(); break;
-                case "AddWeeks": DeduceAddWeeksMethodSerializers(); break;
-                case "AddYears": DeduceAddYearsMethodSerializers(); break;
-                case "Aggregate": DeduceAggregateMethodSerializers(); break;
-                case "All": DeduceAllMethodSerializers(); break;
-                case "Any": DeduceAnyMethodSerializers(); break;
-                case "AppendStage": DeduceAppendStageMethodSerializers(); break;
-                case "As": DeduceAsMethodSerializers(); break;
-                case "AsQueryable": DeduceAsQueryableMethodSerializers(); break;
-                case "Concat": DeduceConcatMethodSerializers(); break;
-                case "ConcatArrays": DeduceConcatArraysMethodSerializers(); break;
-                case "Constant": DeduceConstantMethodSerializers(); break;
-                case "Contains": DeduceContainsMethodSerializers(); break;
-                case "ContainsKey": DeduceContainsKeyMethodSerializers(); break;
-                case "ContainsValue": DeduceContainsValueMethodSerializers(); break;
-                case "Convert": DeduceConvertMethodSerializers(); break;
-                case "Create": DeduceCreateMethodSerializers(); break;
-                case "CreateObjectId": DeduceCreateObjectIdMethodSerializers(); break;
-                case "DateFromString": DeduceDateFromStringMethodSerializers(); break;
-                case "DefaultIfEmpty": DeduceDefaultIfEmptyMethodSerializers(); break;
-                case "DegreesToRadians": DeduceDegreesToRadiansMethodSerializers(); break;
-                case "Densify": DeduceDensifyMethodSerializers(); break;
-                case "DeserializeEJson": DeduceDeserializeEJsonMethodSerializers(); break;
-                case "Distinct": DeduceDistinctMethodSerializers(); break;
-                case "DocumentNumber": DeduceDocumentNumberMethodSerializers(); break;
-                case "Documents": DeduceDocumentsMethodSerializers(); break;
-                case "EncStrContains":
-                case "EncStrEndsWith":
-                case "EncStrNormalizedEq":
-                case "EncStrStartsWith":
-                    DeduceEncStrMethodSerializers();
-                    break;
-                case "Equals": DeduceEqualsMethodSerializers(); break;
-                case "Except": DeduceExceptMethodSerializers(); break;
-                case "Exists": DeduceExistsMethodSerializers(); break;
-                case "Exp": DeduceExpMethodSerializers(); break;
-                case "ExponentialMovingAverage": DeduceExponentialMovingAverageMethodSerializers(); break;
-                case "Field": DeduceFieldMethodSerializers(); break;
-                case "get_Item": DeduceGetItemMethodSerializers(); break;
-                case "get_Chars": DeduceGetCharsMethodSerializers(); break;
-                case "GroupBy": DeduceGroupByMethodSerializers(); break;
-                case "GroupJoin": DeduceGroupJoinMethodSerializers(); break;
-                case "HasFlag": DeduceHasFlagMethodSerializers(); break;
-                case "Hash": DeduceHashMethodSerializers(); break;
-                case "HexHash": DeduceHexHashMethodSerializers(); break;
-                case "Inject": DeduceInjectMethodSerializers(); break;
-                case "Intersect": DeduceIntersectMethodSerializers(); break;
-                case "IsMatch": DeduceIsMatchMethodSerializers(); break;
-                case "IsSubsetOf": DeduceIsSubsetOfMethodSerializers(); break;
-                case "Join": DeduceJoinMethodSerializers(); break;
-                case "LeftJoin": DeduceLeftJoinMethodSerializers(); break;
-                case "Locf": DeduceLocfMethodSerializers(); break;
-                case "Lookup": DeduceLookupMethodSerializers(); break;
-                case "OfType": DeduceOfTypeMethodSerializers(); break;
-                case "Parse": DeduceParseMethodSerializers(); break;
-                case "Pow": DeducePowMethodSerializers(); break;
-                case "Push": DeducePushMethodSerializers(); break;
-                case "RadiansToDegrees": DeduceRadiansToDegreesMethodSerializers(); break;
-                case "Range": DeduceRangeMethodSerializers(); break;
-                case "Repeat": DeduceRepeatMethodSerializers(); break;
-                case "Replace": DeduceReplaceMethodSerializers(); break;
-                case "Reverse": DeduceReverseMethodSerializers(); break;
-                case "Round": DeduceRoundMethodSerializers(); break;
-                case "Select": DeduceSelectMethodSerializers(); break;
-                case "SelectMany": DeduceSelectManySerializers(); break;
-                case "SequenceEqual": DeduceSequenceEqualMethodSerializers(); break;
-                case "SerializeEJson": DeduceSerializeEJsonMethodSerializers(); break;
-                case "SetEquals": DeduceSetEqualsMethodSerializers(); break;
-                case "SetUnion": DeduceSetUnionMethodSerializers(); break;
-                case "SetWindowFields": DeduceSetWindowFieldsMethodSerializers(); break;
-                case "Shift": DeduceShiftMethodSerializers(); break;
-                case "Sigmoid": DeduceSigmoidMethodSerializers(); break;
-                case "Split": DeduceSplitMethodSerializers(); break;
-                case "Sqrt": DeduceSqrtMethodSerializers(); break;
-                case "StrLenBytes": DeduceStrLenBytesMethodSerializers(); break;
-                case "Subtract": DeduceSubtractMethodSerializers(); break;
-                case "Subtype": DeduceSubtypeMethodSerializers(); break;
-                case "Sum": DeduceSumMethodSerializers(); break;
-                case "ToArray": DeduceToArrayMethodSerializers(); break;
-                case "ToHashedIndexKey": DeduceToHashedIndexKeySerializers(); break;
-                case "ToList": DeduceToListSerializers(); break;
-                case "ToString": DeduceToStringSerializers(); break;
-                case "Trim":
-                case "TrimStart":
-                case "TrimEnd":
-                    DeduceTrimSerializers();
-                    break;
-                case "Truncate": DeduceTruncateSerializers(); break;
-                case "Union": DeduceUnionSerializers(); break;
-                case "Week": DeduceWeekSerializers(); break;
-                case "Where": DeduceWhereSerializers(); break;
-                case "Zip": DeduceZipSerializers(); break;
-
-                case "Acos":
-                case "Acosh":
-                case "Asin":
-                case "Asinh":
-                case "Atan":
-                case "Atanh":
-                case "Atan2":
-                case "Cos":
-                case "Cosh":
-                case "Sin":
-                case "Sinh":
-                case "Tan":
-                case "Tanh":
-                    DeduceTrigonometricMethodSerializers();
-                    break;
-
-                case "AllElements":
-                case "AllMatchingElements":
-                case "FirstMatchingElement":
-                    DeduceMatchingElementsMethodSerializers();
-                    break;
-
-                case "AnyStringIn":
-                case "AnyStringNin":
-                    DeduceAnyStringInOrNinMethodSerializers();
-                    break;
-
-                case "Append":
-                case "Prepend":
-                    DeduceAppendOrPrependMethodSerializers();
-                    break;
-
-                case "Average":
-                case "Median":
-                case "Percentile":
-                    DeduceAverageOrMedianOrPercentileMethodSerializers();
-                    break;
-
-                case "Bottom":
-                case "BottomN":
-                case "FirstN":
-                case "LastN":
-                case "MaxN":
-                case "MinN":
-                case "Top":
-                case "TopN":
-                    DeducePickMethodSerializers();
-                    break;
-
-                case "Ceiling":
-                case "Floor":
-                    DeduceCeilingOrFloorMethodSerializers();
-                    break;
-
-                case "Compare":
-                case "CompareTo":
-                    DeduceCompareOrCompareToMethodSerializers();
-                    break;
-
-                case "Count":
-                case "LongCount":
-                    DeduceCountMethodSerializers();
-                    break;
-
-                case "CovariancePopulation":
-                case "CovarianceSample":
-                    DeduceCovarianceMethodSerializers();
-                    break;
-
-                case "DenseRank":
-                case "Rank":
-                    DeduceDenseRankOrRankMethodSerializers();
-                    break;
-
-                case "Derivative":
-                case "Integral":
-                    DeduceDerivativeOrIntegralMethodSerializers();
-                    break;
-
-                case "ElementAt":
-                case "ElementAtOrDefault":
-                    DeduceElementAtMethodSerializers();
-                    break;
-
-                case "EndsWith":
-                case "StartsWith":
-                    DeduceEndsWithOrStartsWithMethodSerializers();
-                    break;
-
-                case "First":
-                case "FirstOrDefault":
-                case "Last":
-                case "LastOrDefault":
-                case "Single":
-                case "SingleOrDefault":
-                    DeduceFirstOrLastOrSingleMethodsSerializers();
-                    break;
-
-                case "IndexOf":
-                case "IndexOfBytes":
-                    DeduceIndexOfMethodSerializers();
-                    break;
-
-                case "IsMissing":
-                case "IsNullOrMissing":
-                    DeduceIsMissingOrIsNullOrMissingMethodSerializers();
-                    break;
-
-                case "IsNullOrEmpty":
-                case "IsNullOrWhiteSpace":
-                    DeduceIsNullOrEmptyOrIsNullOrWhiteSpaceMethodSerializers();
-                    break;
-
-                case "Ln":
-                case "Log":
-                case "Log10":
-                    DeduceLogMethodSerializers();
-                    break;
-
-                case "Max":
-                case "Min":
-                    DeduceMaxOrMinMethodSerializers();
-                    break;
-
-                case "MinMaxScaler":
-                    DeduceMinMaxScalerMethodSerializers();
-                    break;
-
-                case "OrderBy":
-                case "OrderByDescending":
-                case "ThenBy":
-                case "ThenByDescending":
-                    DeduceOrderByMethodSerializers();
-                    break;
-
-                case "Skip":
-                case "SkipWhile":
-                case "Take":
-                case "TakeLast":
-                case "TakeWhile":
-                    DeduceSkipOrTakeMethodSerializers();
-                    break;
-
-                case "StandardDeviationPopulation":
-                case "StandardDeviationPopulationAsync":
-                case "StandardDeviationSample":
-                case "StandardDeviationSampleAsync":
-                    DeduceStandardDeviationMethodSerializers();
-                    break;
-
-                case "StringIn":
-                case "StringNin":
-                    DeduceStringInOrNinMethodSerializers();
-                    break;
-
-                case "Substring":
-                case "SubstrBytes":
-                    DeduceSubstringMethodSerializers();
-                    break;
-
-                case "ToLower":
-                case "ToLowerInvariant":
-                case "ToUpper":
-                case "ToUpperInvariant":
-                    DeduceToLowerOrToUpperSerializers();
-                    break;
-
-                case nameof(Mql.SimilarityDotProduct):
-                case nameof(Mql.SimilarityEuclidean):
-                case nameof(Mql.SimilarityCosine):
-                    DeduceSimilarityFunctionsSerializers();
-                    break;
-
-                default:
-                    DeduceUnknownMethodSerializer();
-                    break;
+                RegisterSerializerResolver(method, resolver);
             }
         }
 
-        void DeduceAbsMethodSerializers()
+        // DeduceAddToSetMethodSerializers
+        static void DeduceAddToSetMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(MathMethod.AbsOverloads))
-            {
-                var valueExpression = arguments[0];
-                DeduceSerializers(node, valueExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
         }
 
-        void DeduceAddMethodSerializers()
+        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithFunc branch
+        static void DeduceAggregateWithFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.Add, DateTimeMethod.AddWithTimezone, DateTimeMethod.AddWithUnit, DateTimeMethod.AddWithUnitAndTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var funcAccumulatorParameter = funcLambda.Parameters[0];
+            var funcSourceItemParameter = funcLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(funcAccumulatorParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(funcLambda.Body, sourceExpression);
+            visitor.DeduceSerializers(expression, funcLambda.Body);
         }
 
-        void DeduceAddDaysMethodSerializers()
+        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithSeedAndFunc branch
+        static void DeduceAggregateWithSeedAndFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddDays,  DateTimeMethod.AddDaysWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var seedExpression =  expression.Arguments[1];
+            var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var funcAccumulatorParameter = funcLambda.Parameters[0];
+            var funcSourceItemParameter = funcLambda.Parameters[1];
+
+            visitor.DeduceSerializers(seedExpression, funcLambda.Body);
+            visitor.DeduceSerializers(funcAccumulatorParameter, funcLambda.Body);
+            visitor.DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
+            visitor.DeduceSerializers(expression, funcLambda.Body);
         }
 
-        void DeduceAddHoursMethodSerializers()
+        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector branch
+        static void DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddHours,  DateTimeMethod.AddHoursWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var seedExpression = expression.Arguments[1];
+            var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var funcAccumulatorParameter = funcLambda.Parameters[0];
+            var funcSourceItemParameter = funcLambda.Parameters[1];
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var resultSelectorAccumulatorParameter = resultSelectorLambda.Parameters[0];
+
+            visitor.DeduceSerializers(seedExpression, funcLambda.Body);
+            visitor.DeduceSerializers(funcAccumulatorParameter, funcLambda.Body);
+            visitor.DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
+            visitor.DeduceSerializers(resultSelectorAccumulatorParameter, funcLambda.Body);
+            visitor.DeduceSerializers(expression, resultSelectorLambda.Body);
         }
 
-        void DeduceAddMillisecondsMethodSerializers()
+        // DeduceAllMethodSerializers
+        static void DeduceAllMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddMilliseconds,  DateTimeMethod.AddMillisecondsWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var predicateParameter = predicateLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        void DeduceAddMinutesMethodSerializers()
+        // DeduceAnyMethodSerializers + EnumerableOrQueryableMethod.AnyWithPredicate branch
+        static void DeduceAnyWithPredicateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddMinutes,  DateTimeMethod.AddMinutesWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var sourceExpression = expression.Arguments[0];
+            var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var predicateParameter = predicateLambda.Parameters[0];
+
+            visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        void DeduceAddMonthsMethodSerializers()
+        // DeduceAppendStageMethodSerializers
+        static void DeduceAppendStageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(DateTimeMethod.AddMonths,  DateTimeMethod.AddMonthsWithTimezone))
+            if (visitor.IsNotKnown(expression))
             {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
+                var sourceExpression = expression.Arguments[0];
+                var stageExpression = expression.Arguments[1];
+                var resultSerializerExpression = expression.Arguments[2];
 
-        void DeduceAddQuartersMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.AddQuarters, DateTimeMethod.AddQuartersWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddSecondsMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.AddSeconds, DateTimeMethod.AddSecondsWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddTicksMethodSerializers()
-        {
-            if (method.Is(DateTimeMethod.AddTicks))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddToSetMethodSerializers()
-        {
-            if (method.Is(WindowMethod.AddToSet))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceCollectionAndItemSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddWeeksMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.AddWeeks, DateTimeMethod.AddWeeksWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAddYearsMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.AddYears, DateTimeMethod.AddYearsWithTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAggregateMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.AggregateOverloads))
-            {
-                var sourceExpression = arguments[0];
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.AggregateWithFunc))
+                if (stageExpression is not ConstantExpression stageConstantExpression)
                 {
-                    var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var funcAccumulatorParameter = funcLambda.Parameters[0];
-                    var funcSourceItemParameter = funcLambda.Parameters[1];
+                    throw new ExpressionNotSupportedException(expression, because: "stage argument must be a constant");
+                }
+                var stageDefinition = (IPipelineStageDefinition)stageConstantExpression.Value;
 
-                    DeduceItemAndCollectionSerializers(funcAccumulatorParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(funcLambda.Body, sourceExpression);
-                    DeduceSerializers(node, funcLambda.Body);
+                if (resultSerializerExpression is not ConstantExpression resultSerializerConstantExpression)
+                {
+                    throw new ExpressionNotSupportedException(expression, because: "resultSerializer argument must be a constant");
+                }
+                var resultItemSerializer = (IBsonSerializer)resultSerializerConstantExpression.Value;
+
+                if (resultItemSerializer == null && visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
+                {
+                    var serializerRegistry = BsonSerializer.SerializerRegistry; // TODO: get correct registry
+                    var translationOptions = new ExpressionTranslationOptions(); // TODO: get correct translation options
+                    var renderedStage = stageDefinition.Render(sourceItemSerializer, serializerRegistry, translationOptions);
+                    resultItemSerializer = renderedStage.OutputSerializer;
                 }
 
-                if (method.IsOneOf(EnumerableOrQueryableMethod.AggregateWithSeedAndFunc))
+                if (resultItemSerializer != null)
                 {
-                    var seedExpression =  arguments[1];
-                    var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var funcAccumulatorParameter = funcLambda.Parameters[0];
-                    var funcSourceItemParameter = funcLambda.Parameters[1];
-
-                    DeduceSerializers(seedExpression, funcLambda.Body);
-                    DeduceSerializers(funcAccumulatorParameter, funcLambda.Body);
-                    DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
-                    DeduceSerializers(node, funcLambda.Body);
-                }
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector))
-                {
-                    var seedExpression = arguments[1];
-                    var funcLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var funcAccumulatorParameter = funcLambda.Parameters[0];
-                    var funcSourceItemParameter = funcLambda.Parameters[1];
-                    var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var resultSelectorAccumulatorParameter = resultSelectorLambda.Parameters[0];
-
-                    DeduceSerializers(seedExpression, funcLambda.Body);
-                    DeduceSerializers(funcAccumulatorParameter, funcLambda.Body);
-                    DeduceItemAndCollectionSerializers(funcSourceItemParameter, sourceExpression);
-                    DeduceSerializers(resultSelectorAccumulatorParameter, funcLambda.Body);
-                    DeduceSerializers(node, resultSelectorLambda.Body);
+                    var resultSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultItemSerializer);
+                    visitor.AddNodeSerializer(expression, resultSerializer);
                 }
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
         }
 
-        void DeduceAllMethodSerializers()
+        // DeduceAsMethodSerializers
+        static void DeduceAsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(EnumerableMethod.AllWithPredicate, QueryableMethod.AllWithPredicate))
+            if (visitor.IsNotKnown(expression))
             {
-                var sourceExpression = arguments[0];
-                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var predicateParameter = predicateLambda.Parameters.Single();
-
-                DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAnyMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.AnyOverloads))
-            {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.AnyWithPredicate))
+                var resultSerializerExpression = expression.Arguments[1];
+                if (resultSerializerExpression is not ConstantExpression resultSerializerConstantExpression)
                 {
-                    var sourceExpression = arguments[0];
-                    var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var predicateParameter = predicateLambda.Parameters[0];
-
-                    DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+                    throw new ExpressionNotSupportedException(expression, because: "resultSerializer argument must be a constant");
                 }
 
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAnyStringInOrNinMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.AnyStringInOrNinOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAppendOrPrependMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.AppendOrPrepend))
-            {
-                var sourceExpression = arguments[0];
-                var elementExpression = arguments[1];
-
-                DeduceItemAndCollectionSerializers(elementExpression, sourceExpression);
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAsMethodSerializers()
-        {
-            if (method.Is(MongoQueryableMethod.As))
-            {
-                if (IsNotKnown(node))
+                var resultItemSerializer = (IBsonSerializer)resultSerializerConstantExpression.Value;
+                if (resultItemSerializer == null)
                 {
-                    var resultSerializerExpression = arguments[1];
-                    if (resultSerializerExpression is not ConstantExpression resultSerializerConstantExpression)
-                    {
-                        throw new ExpressionNotSupportedException(node, because: "resultSerializer argument must be a constant");
-                    }
-
-                    var resultItemSerializer = (IBsonSerializer)resultSerializerConstantExpression.Value;
-                    if (resultItemSerializer == null)
-                    {
-                        var resultItemType = method.GetGenericArguments()[1];
-                        resultItemSerializer = BsonSerializer.LookupSerializer(resultItemType);
-                    }
-
-                    var resultSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
+                    var resultItemType = expression.Method.GetGenericArguments()[1];
+                    resultItemSerializer = BsonSerializer.LookupSerializer(resultItemType);
                 }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
+
+                var resultSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultItemSerializer);
+                visitor.AddNodeSerializer(expression, resultSerializer);
             }
         }
 
-        void DeduceAppendStageMethodSerializers()
+        // DeduceAsQueryableMethodSerializers
+        static void DeduceAsQueryableMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.Is(MongoQueryableMethod.AppendStage))
+            var sourceExpression = expression.Arguments[0];
+
+            if (visitor.IsNotKnown(expression) && visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
             {
-                if (IsNotKnown(node))
+                var resultSerializer = NestedAsQueryableSerializer.Create(sourceItemSerializer);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        // DeduceConcatMethodSerializers + EnumerableMethod.Concat, QueryableMethod.Concat branch
+        static void DeduceEnumerableConcatMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var firstExpression = expression.Arguments[0];
+            var secondExpression = expression.Arguments[1];
+
+            visitor.DeduceCollectionAndCollectionSerializers(firstExpression, secondExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, firstExpression);
+        }
+
+        // DeduceConstantMethodSerializers
+        static void DeduceConstantMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var valueExpression = expression.Arguments[0];
+            IBsonSerializer serializer = null;
+
+            if (visitor.IsNotKnown(expression) || visitor.IsNotKnown(valueExpression))
+            {
+                if (expression.Method.Is(MqlMethod.ConstantWithRepresentation))
                 {
-                    var sourceExpression = arguments[0];
-                    var stageExpression = arguments[1];
-                    var resultSerializerExpression = arguments[2];
+                    var representationExpression = expression.Arguments[1];
 
-                    if (stageExpression is not ConstantExpression stageConstantExpression)
+                    var representation = representationExpression.GetConstantValue<BsonType>(expression);
+                    var defaultSerializer = BsonSerializer.LookupSerializer(valueExpression.Type); // TODO: don't use BsonSerializer
+                    if (defaultSerializer is IRepresentationConfigurable representationConfigurableSerializer)
                     {
-                        throw new ExpressionNotSupportedException(node, because: "stage argument must be a constant");
-                    }
-                    var stageDefinition = (IPipelineStageDefinition)stageConstantExpression.Value;
-
-                    if (resultSerializerExpression is not ConstantExpression resultSerializerConstantExpression)
-                    {
-                        throw new ExpressionNotSupportedException(node, because: "resultSerializer argument must be a constant");
-                    }
-                    var resultItemSerializer = (IBsonSerializer)resultSerializerConstantExpression.Value;
-
-                    if (resultItemSerializer == null && IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
-                    {
-                        var serializerRegistry = BsonSerializer.SerializerRegistry; // TODO: get correct registry
-                        var translationOptions = new ExpressionTranslationOptions(); // TODO: get correct translation options
-                        var renderedStage = stageDefinition.Render(sourceItemSerializer, serializerRegistry, translationOptions);
-                        resultItemSerializer = renderedStage.OutputSerializer;
-                    }
-
-                    if (resultItemSerializer != null)
-                    {
-                        var resultSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultItemSerializer);
-                        AddNodeSerializer(node, resultSerializer);
+                        serializer = representationConfigurableSerializer.WithRepresentation(representation);
                     }
                 }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceAsQueryableMethodSerializers()
-        {
-            if (method.Is(QueryableMethod.AsQueryable))
-            {
-                var sourceExpression = arguments[0];
-
-                if (IsNotKnown(node) && IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
+                else if (expression.Method.Is(MqlMethod.ConstantWithSerializer))
                 {
-                    var resultSerializer = NestedAsQueryableSerializer.Create(sourceItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
+                    var serializerExpression = expression.Arguments[1];
+                    serializer = serializerExpression.GetConstantValue<IBsonSerializer>(expression);
                 }
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+
+            visitor.DeduceSerializer(valueExpression, serializer);
+            visitor.DeduceSerializer(expression, serializer);
         }
 
-        void DeduceAverageOrMedianOrPercentileMethodSerializers()
+        // DeduceConvertMethodSerializers
+        static void DeduceConvertMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(__averageOrMedianOrPercentileOverloads))
+            if (visitor.IsNotKnown(expression))
             {
-                if (method.IsOneOf(__averageOrMedianOrPercentileWithSelectorOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorSourceItemParameter = selectorLambda.Parameters[0];
-
-                    DeduceItemAndCollectionSerializers(selectorSourceItemParameter, sourceExpression);
-                }
-
-                if (IsNotKnown(node))
-                {
-                    var nodeSerializer = StandardSerializers.GetSerializer(node.Type);
-                    AddNodeSerializer(node, nodeSerializer);
-                }
-            }
-            else if (method.IsOneOf(__averageOrMedianOrPercentileWindowMethodOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceCeilingOrFloorMethodSerializers()
-        {
-            if (method.IsOneOf(MathMethod.CeilingWithDecimal, MathMethod.CeilingWithDouble, MathMethod.FloorWithDecimal,  MathMethod.FloorWithDouble))
-            {
-                DeduceReturnsNumericSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceCompareOrCompareToMethodSerializers()
-        {
-            if (method.IsStaticCompareMethod() ||
-                method.IsInstanceCompareToMethod() ||
-                method.IsOneOf(StringMethod.CompareOverloads))
-            {
-                var valueExpression = method.IsStatic ? arguments[0] : node.Object;
-                var comparandExpression = method.IsStatic ? arguments[1] : arguments[0];
-                DeduceSerializers(valueExpression, comparandExpression);
-                DeduceReturnsInt32Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceConcatMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Concat, QueryableMethod.Concat))
-            {
-                var firstExpression = arguments[0];
-                var secondExpression = arguments[1];
-
-                DeduceCollectionAndCollectionSerializers(firstExpression, secondExpression);
-                DeduceCollectionAndCollectionSerializers(node, firstExpression);
-            }
-            else if (method.IsOneOf(StringMethod.ConcatOverloads))
-            {
-                DeduceReturnsStringSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceConcatArraysMethodSerializers()
-        {
-            if (method.Is(WindowMethod.ConcatArrays))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceCollectionAndCollectionSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceConstantMethodSerializers()
-        {
-            if (method.IsOneOf(MqlMethod.ConstantWithRepresentation, MqlMethod.ConstantWithSerializer))
-            {
-                var valueExpression = arguments[0];
-                IBsonSerializer serializer = null;
-
-                if (IsNotKnown(node) || IsNotKnown(valueExpression))
-                {
-                    if (method.Is(MqlMethod.ConstantWithRepresentation))
-                    {
-                        var representationExpression = arguments[1];
-
-                        var representation = representationExpression.GetConstantValue<BsonType>(node);
-                        var defaultSerializer = BsonSerializer.LookupSerializer(valueExpression.Type); // TODO: don't use BsonSerializer
-                        if (defaultSerializer is IRepresentationConfigurable representationConfigurableSerializer)
-                        {
-                            serializer = representationConfigurableSerializer.WithRepresentation(representation);
-                        }
-                    }
-                    else if (method.Is(MqlMethod.ConstantWithSerializer))
-                    {
-                        var serializerExpression = arguments[1];
-                        serializer = serializerExpression.GetConstantValue<IBsonSerializer>(node);
-                    }
-                }
-
-                DeduceSerializer(valueExpression, serializer);
-                DeduceSerializer(node, serializer);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceContainsKeyMethodSerializers()
-        {
-            if (IsDictionaryContainsKeyExpression(out var keyExpression))
-            {
-                var dictionaryExpression = node.Object;
-                if (IsNotKnown(keyExpression) && IsKnown(dictionaryExpression, out var dictionarySerializer))
-                {
-                    var keySerializer = (dictionarySerializer as IBsonDictionarySerializer)?.KeySerializer;
-                    AddNodeSerializer(keyExpression, keySerializer);
-                }
-
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceContainsMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.ContainsOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else if (EnumerableMethod.IsContainsMethod(node, out var collectionExpression, out var itemExpression))
-            {
-                DeduceCollectionAndItemSerializers(collectionExpression, itemExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceContainsValueMethodSerializers()
-        {
-            if (IsContainsValueInstanceMethod(out var collectionExpression, out var valueExpression))
-            {
-                if (IsNotKnown(valueExpression) &&
-                    IsKnown(collectionExpression, out var collectionSerializer))
-                {
-                    if (collectionSerializer is IBsonDictionarySerializer dictionarySerializer)
-                    {
-                        var valueSerializer = dictionarySerializer.ValueSerializer;
-                        AddNodeSerializer(valueExpression, valueSerializer);
-                    }
-                }
-
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-
-            bool IsContainsValueInstanceMethod(out Expression collectionExpression, out Expression valueExpression)
-            {
-                if (method.IsPublic &&
-                    method.IsStatic == false &&
-                    method.ReturnType == typeof(bool) &&
-                    method.Name == "ContainsValue" &&
-                    method.GetParameters() is var parameters &&
-                    parameters.Length == 1)
-                {
-                    collectionExpression = node.Object;
-                    valueExpression = arguments[0];
-                    return true;
-                }
-
-                collectionExpression = null;
-                valueExpression = null;
-                return false;
-            }
-        }
-
-        void DeduceConvertMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Convert))
-            {
-                if (IsNotKnown(node))
-                {
-                    var toType = method.GetGenericArguments()[1];
-                    var resultSerializer = GetResultSerializer(node, toType);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
+                var toType = expression.Method.GetGenericArguments()[1];
+                var resultSerializer = GetResultSerializer(expression, toType);
+                visitor.AddNodeSerializer(expression, resultSerializer);
             }
 
             static IBsonSerializer GetResultSerializer(Expression expression, Type toType)
             {
                 // TODO: should we use StandardSerializers at least for the subset of types where it would return the correct serializer?
-
                 var isNullable = toType.IsNullable();
                 var valueType = isNullable ? Nullable.GetUnderlyingType(toType) : toType;
 
@@ -1000,782 +501,1203 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        void DeduceCreateMethodSerializers()
-        {
 #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-            if (method.Is(KeyValuePairMethod.Create))
+        // DeduceCreateMethodSerializers + KeyValuePairMethod.Create branch
+        static void DeduceKeyValuePairCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsAnyNotKnown(expression.Arguments) && visitor.IsKnown(expression, out var nodeSerializer))
             {
-                if (IsAnyNotKnown(arguments) && IsKnown(node, out var nodeSerializer))
-                {
-                    var keyExpression = arguments[0];
-                    var valueExpression = arguments[1];
+                var keyExpression = expression.Arguments[0];
+                var valueExpression = expression.Arguments[1];
 
-                    if (nodeSerializer.IsKeyValuePairSerializer(out _, out _, out var keySerializer, out var valueSerializer))
-                    {
-                        DeduceSerializer(keyExpression, keySerializer);
-                        DeduceSerializer(valueExpression, valueSerializer);
-                    }
-                }
-
-                if (IsNotKnown(node) && AreAllKnown(arguments, out var argumentSerializers))
+                if (nodeSerializer.IsKeyValuePairSerializer(out _, out _, out var keySerializer, out var valueSerializer))
                 {
-                    var keySerializer = argumentSerializers[0];
-                    var valueSerializer = argumentSerializers[1];
-                    var keyValuePairSerializer = KeyValuePairSerializer.Create(BsonType.Document, keySerializer, valueSerializer);
-                    AddNodeSerializer(node, keyValuePairSerializer);
+                    visitor.DeduceSerializer(keyExpression, keySerializer);
+                    visitor.DeduceSerializer(valueExpression, valueSerializer);
                 }
             }
-            else
- #endif
-            if (method.IsOneOf(TupleOrValueTupleMethod.CreateOverloads))
+
+            if (visitor.IsNotKnown(expression) && visitor.AreAllKnown(expression.Arguments, out var argumentSerializers))
             {
-                if (IsAnyNotKnown(arguments) && IsKnown(node, out var nodeSerializer))
+                var keySerializer = argumentSerializers[0];
+                var valueSerializer = argumentSerializers[1];
+                var keyValuePairSerializer = KeyValuePairSerializer.Create(BsonType.Document, keySerializer, valueSerializer);
+                visitor.AddNodeSerializer(expression, keyValuePairSerializer);
+            }
+        }
+#endif
+
+        // DeduceCreateMethodSerializers + TupleOrValueTupleMethod.CreateOverloads
+        static void DeduceTupleOrValueTupleCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsAnyNotKnown(expression.Arguments) && visitor.IsKnown(expression, out var nodeSerializer))
+            {
+                if (nodeSerializer is IBsonTupleSerializer tupleSerializer)
                 {
-                    if (nodeSerializer is IBsonTupleSerializer tupleSerializer)
+                    for (var i = 1; i <= expression.Arguments.Count; i++)
                     {
-                        for (var i = 1; i <= arguments.Count; i++)
+                        var argumentExpression = expression.Arguments[i];
+                        if (visitor.IsNotKnown(argumentExpression))
                         {
-                            var argumentExpression = arguments[i];
-                            if (IsNotKnown(argumentExpression))
+                            var itemSerializer = tupleSerializer.GetItemSerializer(i);
+                            if (i == 8)
                             {
-                                var itemSerializer = tupleSerializer.GetItemSerializer(i);
-                                if (i == 8)
-                                {
-                                    itemSerializer = (itemSerializer as IBsonTupleSerializer)?.GetItemSerializer(1);
-                                }
-                                AddNodeSerializer(argumentExpression, itemSerializer);
+                                itemSerializer = (itemSerializer as IBsonTupleSerializer)?.GetItemSerializer(1);
                             }
+                            visitor.AddNodeSerializer(argumentExpression, itemSerializer);
                         }
                     }
                 }
+            }
 
-                if (IsNotKnown(node) && AreAllKnown(arguments, out var argumentSerializers))
+            if (visitor.IsNotKnown(expression) && visitor.AreAllKnown(expression.Arguments, out var argumentSerializers))
+            {
+                var tupleType = expression.Method.ReturnType;
+
+                if (expression.Arguments.Count == 8)
                 {
-                    var tupleType = method.ReturnType;
+                    var item8Expression = expression.Arguments[7];
+                    var item8Type = item8Expression.Type;
+                    var item8Serializer = argumentSerializers[7];
+                    var restTupleType = (tupleType.IsTuple() ? typeof(Tuple<>) : typeof(ValueTuple<>)).MakeGenericType(item8Type);
+                    var restSerializer = TupleOrValueTupleSerializer.Create(restTupleType, [item8Serializer]);
+                    argumentSerializers = argumentSerializers.Take(7).Append(restSerializer).ToArray();
+                }
 
-                    if (arguments.Count == 8)
+                var tupleSerializer = TupleOrValueTupleSerializer.Create(tupleType, argumentSerializers);
+                visitor.AddNodeSerializer(expression, tupleSerializer);
+            }
+        }
+
+        // DeduceDateFromStringMethodSerializers
+        static void DeduceDateFromStringMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var resultSerializer = expression.Method.Is(MqlMethod.DateFromStringWithFormatAndTimezoneAndOnErrorAndOnNull) ? NullableSerializer.NullableUtcDateTimeInstance : DateTimeSerializer.UtcInstance;
+            visitor.DeduceSerializer(expression, resultSerializer);
+        }
+
+        // DeduceDefaultIfEmptyMethodSerializers
+        static void DeduceDefaultIfEmptyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+
+            if (expression.Method.IsOneOf(EnumerableMethod.DefaultIfEmptyWithDefaultValue, QueryableMethod.DefaultIfEmptyWithDefaultValue))
+            {
+                var defaultValueExpression = expression.Arguments[1];
+                visitor.DeduceItemAndCollectionSerializers(defaultValueExpression, sourceExpression);
+            }
+
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceDensifyMethodSerializers
+        static void DeduceDensifyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var fieldLambda = ExpressionHelper.UnquoteLambda(expression.Arguments[1]);
+            var fieldLambdaSourceParameter = fieldLambda.Parameters.Single();
+            var rangeExpression = expression.Arguments[2];
+            var partitionByFieldsExpression = expression.Arguments[3];
+
+            visitor.DeduceItemAndCollectionSerializers(fieldLambdaSourceParameter, sourceExpression);
+            visitor.DeduceIgnoreSubtreeSerializer(rangeExpression);
+            if (partitionByFieldsExpression is NewArrayExpression newArrayExpression)
+            {
+                foreach (var arrayItemExpression in newArrayExpression.Expressions)
+                {
+                    var partitionByFieldLambda = ExpressionHelper.UnquoteLambda(arrayItemExpression);
+                    var partitionByFieldLambdaSourceParameter = partitionByFieldLambda.Parameters.Single();
+                    visitor.DeduceItemAndCollectionSerializers(partitionByFieldLambdaSourceParameter, sourceExpression);
+                }
+            }
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceDocumentsMethodSerializers
+        static void DeduceDocumentsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                IBsonSerializer documentSerializer;
+                if (expression.Method.Is(MongoQueryableMethod.DocumentsWithSerializer))
+                {
+                    var documentSerializerExpression = expression.Arguments[2];
+                    documentSerializer = documentSerializerExpression.GetConstantValue<IBsonSerializer>(expression);
+                }
+                else
+                {
+                    var documentsParameter = expression.Method.GetParameters()[1];
+                    var documentType = documentsParameter.ParameterType.GetElementType();
+                    documentSerializer = BsonSerializer.LookupSerializer(documentType); // TODO: don't use static registry
+                }
+
+                var nodeSerializer = IQueryableSerializer.Create(documentSerializer);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
+            }
+        }
+
+        // DeduceExceptMethodSerializers
+        static void DeduceExceptMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var firstExpression = expression.Arguments[0];
+            var secondExpression = expression.Arguments[1];
+            visitor.DeduceCollectionAndCollectionSerializers(secondExpression, firstExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, firstExpression);
+        }
+
+        // DeduceExponentialMovingAverageMethodSerializers
+        static void DeduceExponentialMovingAverageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceFieldMethodSerializers
+        static void DeduceFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var fieldSerializerExpression = expression.Arguments[2];
+                var fieldSerializer = fieldSerializerExpression.GetConstantValue<IBsonSerializer>(expression);
+                if (fieldSerializer == null)
+                {
+                    fieldSerializer = BsonSerializer.LookupSerializer(expression.Method.GetGenericArguments()[1]);
+                }
+
+                visitor.AddNodeSerializer(expression, fieldSerializer);
+            }
+        }
+
+        // DeduceGroupByMethodSerializers
+        static void DeduceGroupByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var keySelectorParameter = keySelectorLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
+
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelector))
+            {
+                if (visitor.IsNotKnown(expression) && visitor.IsKnown(keySelectorLambda.Body, out var keySerializer) && visitor.IsItemSerializerKnown(sourceExpression, out var elementSerializer))
+                {
+                    var groupingSerializer = IGroupingSerializer.Create(keySerializer, elementSerializer);
+                    var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, groupingSerializer);
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+            else if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorAndElementSelector))
+            {
+                var elementSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+                var elementSelectorParameter = elementSelectorLambda.Parameters.Single();
+                visitor.DeduceItemAndCollectionSerializers(elementSelectorParameter, sourceExpression);
+                if (visitor.IsNotKnown(expression) && visitor.IsKnown(keySelectorLambda.Body, out var keySerializer) && visitor.IsKnown(elementSelectorLambda.Body, out var elementSerializer))
+                {
+                    var groupingSerializer = IGroupingSerializer.Create(keySerializer, elementSerializer);
+                    var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, groupingSerializer);
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+            else if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorAndResultSelector))
+            {
+                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+                var resultSelectorKeyParameter = resultSelectorLambda.Parameters[0];
+                var resultSelectorElementsParameter = resultSelectorLambda.Parameters[1];
+                visitor.DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
+                visitor.DeduceSerializers(resultSelectorKeyParameter, keySelectorLambda.Body);
+                visitor.DeduceCollectionAndCollectionSerializers(resultSelectorElementsParameter, sourceExpression);
+                DeduceResultSerializer(resultSelectorLambda.Body);
+            }
+            else if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorElementSelectorAndResultSelector))
+            {
+                var elementSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+                var elementSelectorParameter = elementSelectorLambda.Parameters.Single();
+                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+                var resultSelectorKeyParameter = resultSelectorLambda.Parameters[0];
+                var resultSelectorElementsParameter = resultSelectorLambda.Parameters[1];
+                visitor.DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
+                visitor.DeduceItemAndCollectionSerializers(elementSelectorParameter, sourceExpression);
+                visitor.DeduceSerializers(resultSelectorKeyParameter, keySelectorLambda.Body);
+                visitor.DeduceCollectionAndItemSerializers(resultSelectorElementsParameter, elementSelectorLambda.Body);
+                DeduceResultSerializer(resultSelectorLambda.Body);
+            }
+
+            void DeduceResultSerializer(Expression resultExpression)
+            {
+                if (visitor.IsNotKnown(expression) && visitor.IsKnown(resultExpression, out var resultSerializer))
+                {
+                    var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultSerializer);
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+        }
+
+        // DeduceGroupJoinMethodSerializers
+        static void DeduceGroupJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var outerExpression = expression.Arguments[0];
+            var innerExpression = expression.Arguments[1];
+            var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
+            var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
+            var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorInnerItemsParameter = resultSelectorLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
+            visitor.DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(resultSelectorInnerItemsParameter, innerExpression);
+            visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
+        }
+
+        // DeduceHasFlagMethodSerializers
+        static void DeduceHasFlagMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var objectExpression = expression.Object;
+            var flagExpression = expression.Arguments[0];
+            if (visitor.IsNotKnown(flagExpression) && visitor.IsKnown(objectExpression, out var enumSerializer))
+            {
+                visitor.AddNodeSerializer(flagExpression, enumSerializer);
+            }
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        }
+
+        // DeduceJoinMethodSerializers
+        static void DeduceJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var outerExpression = expression.Arguments[0];
+            var innerExpression = expression.Arguments[1];
+            var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
+            var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
+            var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorInnerItemsParameter = resultSelectorLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
+            visitor.DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorInnerItemsParameter, innerExpression);
+            visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
+        }
+
+        // DeduceLocfMethodSerializers
+        static void DeduceLocfMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceLookupMethodSerializers + MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField branch
+        static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var documentsLambdaParameter = documentsLambda.Parameters.Single();
+            var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
+            var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(foreignFieldLambdaParameter, documentsLambda.Body);
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(documentsLambda.Body, out var documentSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, documentSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+        // DeduceLookupMethodSerializers + LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline branch
+        static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var documentsLambdaParameter = documentsLambda.Parameters.Single();
+            var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
+            var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
+            var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
+            var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
+            var pipelineLambdaForeignQueryableParameter = pipelineLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(foreignFieldLambdaParameter, documentsLambda.Body);
+            visitor.DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(pipelineLambdaForeignQueryableParameter, documentsLambda.Body);
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(pipelineLambda.Body, out var pipelineDocumentSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineDocumentSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+
+        // DeduceLookupMethodSerializers + LookupWithDocumentsAndPipeline branch
+        static void DeduceLookupWithDocumentsAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var documentsLambdaParameter = documentsLambda.Parameters.Single();
+            var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var pipelineLambdaSourceParameter = pipelineLambda.Parameters[0];
+            var pipelineLambdaQueryableDocumentParameter = pipelineLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(pipelineLambdaSourceParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(pipelineLambdaQueryableDocumentParameter, documentsLambda.Body);
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+
+        // DeduceLookupMethodSerializers + LookupWithFromAndLocalFieldAndForeignField branch
+        static void DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var fromExpression = expression.Arguments[1];
+            var fromCollection = fromExpression.GetConstantValue<IMongoCollection>(expression);
+            var foreignDocumentSerializer = fromCollection.DocumentSerializer;
+            var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
+            var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
+            visitor.DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, foreignDocumentSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+
+        // DeduceLookupMethodSerializers + LookupWithFromAndLocalFieldAndForeignFieldAndPipeline branch
+        static void DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var fromExpression = expression.Arguments[1];
+            var fromCollection = fromExpression.GetConstantValue<IMongoCollection>(expression);
+            var foreignDocumentSerializer = fromCollection.DocumentSerializer;
+            var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
+            var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[3]);
+            var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
+            var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[4]);
+            var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
+            var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
+            visitor.DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
+            visitor.DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
+
+            if (visitor.IsNotKnown(pipelineLamdbaForeignQueryableParameter))
+            {
+                var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
+                visitor.AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
+            }
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
+            {
+                var lookupResultsSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultsSerializer));
+            }
+        }
+
+        // DeduceLookupMethodSerializers + LookupWithFromAndPipeline branch
+        static void DeduceLookupWithFromAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var fromCollection = expression.Arguments[1].GetConstantValue<IMongoCollection>(expression);
+            var foreignDocumentSerializer = fromCollection.DocumentSerializer;
+            var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
+            var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
+
+            if (visitor.IsNotKnown(pipelineLamdbaForeignQueryableParameter))
+            {
+                var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
+                visitor.AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
+            }
+
+            if (visitor.IsNotKnown(expression) &&
+                visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
+                visitor.IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
+            {
+                var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
+                visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
+            }
+        }
+
+        // DeduceOfTypeMethodSerializers
+        void DeduceOfTypeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var resultType = expression.Method.GetGenericArguments()[0];
+
+            if (visitor.IsNotKnown(expression) && visitor.IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
+            {
+                var resultItemSerializer = sourceItemSerializer.GetDerivedTypeSerializer(resultType);
+                var resultSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultItemSerializer);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        // DeducePushMethodSerializers
+        static void DeducePushMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceRoundMethodSerializers
+        void DeduceRoundMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var resultSerializer = StandardSerializers.GetSerializer(expression.Type);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        // DeduceSelectMethodSerializers
+        static void DeduceSelectMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var selectorParameter = selectorLambda.Parameters.Single();
+            visitor.DeduceItemAndCollectionSerializers(selectorParameter, sourceExpression);
+            visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
+        }
+
+        static void DeduceSelectWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var itemParameter = selectorLambda.Parameters[0];
+            var indexParameter = selectorLambda.Parameters[1];
+            visitor.DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
+            if (visitor.IsNotKnown(indexParameter))
+            {
+                visitor.AddNodeSerializer(indexParameter, Int32Serializer.Instance);
+            }
+            visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelector branch
+        static void DeduceSelectManyWithSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var selectorSourceParameter = selectorLambda.Parameters.Single();
+
+            visitor.DeduceItemAndCollectionSerializers(selectorSourceParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector branch
+        static void DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var collectionSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var resultSelectorLambda =  ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+
+            var collectionSelectorSourceItemParameter = collectionSelectorLambda.Parameters.Single();
+            var resultSelectorSourceItemParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorCollectionItemParameter = resultSelectorLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(collectionSelectorSourceItemParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorSourceItemParameter, sourceExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorCollectionItemParameter, collectionSelectorLambda.Body);
+            visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
+        }
+
+        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex branch
+        static void SelectManyWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var itemParameter = selectorLambda.Parameters[0];
+            var indexParameter = selectorLambda.Parameters[1];
+            visitor.DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
+            if (visitor.IsNotKnown(indexParameter))
+            {
+                visitor.AddNodeSerializer(indexParameter, Int32Serializer.Instance);
+            }
+            visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSequenceEqualMethodSerializers
+        static void DeduceSequenceEqualMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            visitor.DeduceCollectionAndCollectionSerializers(expression.Arguments[0], expression.Arguments[1]);
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        }
+
+        // DeduceSetWindowFieldsMethodSerializers
+        // static void DeduceSetWindowFieldsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        // {
+        //     visitor.DeduceCollectionAndCollectionSerializers(expression.Object, expression.Arguments[0]);
+        //     visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        // }
+
+        // DeduceShiftMethodSerializers
+        static void DeduceShiftMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSplitMethodSerializers
+        static void DeduceSplitMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var nodeSerializer = ArraySerializer.Create(StringSerializer.Instance);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
+            }
+        }
+
+        // DeduceSumMethodSerializers + EnumerableOrQueryableMethod.SumOverloads branch
+        static void DeduceEnumerableSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.SumWithSelectorOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var selectorParameter = selectorLambda.Parameters.Single();
+                visitor.DeduceItemAndCollectionSerializers(selectorParameter, sourceExpression);
+            }
+
+            var returnType = expression.Type;
+            // TODO: check if can replace with StandardSerializers.
+            var serializer = returnType switch
+            {
+                not null when returnType == typeof(decimal) => DecimalSerializer.Instance,
+                not null when returnType == typeof(double) => DoubleSerializer.Instance,
+                not null when returnType == typeof(int) => Int32Serializer.Instance,
+                not null when returnType == typeof(long) => Int64Serializer.Instance,
+                not null when returnType == typeof(float) => SingleSerializer.Instance,
+                not null when returnType == typeof(decimal?) => NullableSerializer.NullableDecimalInstance,
+                not null when returnType == typeof(double?) => NullableSerializer.NullableDoubleInstance,
+                not null when returnType == typeof(int?) => NullableSerializer.NullableInt32Instance,
+                not null when returnType == typeof(long?) => NullableSerializer.NullableInt64Instance,
+                not null when returnType == typeof(float?) => NullableSerializer.NullableSingleInstance,
+                _ => throw new NotImplementedException($"Cannot resolver serializer for {returnType}")
+            };
+
+            visitor.DeduceSerializer(expression, serializer);
+        }
+
+        // DeduceSumMethodSerializers + WindowMethod.SumOverloads branch
+        void DeduceWindowSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceWhereSerializers
+        static void DeduceWhereSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var predicateParameter =  predicateLambda.Parameters.Single();
+            visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        static void DeduceWhereWithPredicateTakingIndexSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var itemParameter = predicateLambda.Parameters[0];
+            var indexParameter = predicateLambda.Parameters[1];
+            visitor.DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
+            if (visitor.IsNotKnown(indexParameter))
+            {
+                visitor.AddNodeSerializer(indexParameter, Int32Serializer.Instance);
+            }
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceZipSerializers
+        static void DeduceZipSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var firstExpression = expression.Arguments[0];
+            var secondExpression = expression.Arguments[1];
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
+            var resultSelectorFirstParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorSecondParameter =  resultSelectorLambda.Parameters[1];
+
+            if (visitor.IsNotKnown(resultSelectorFirstParameter) && visitor.IsKnown(firstExpression, out var firstSerializer))
+            {
+                var firstItemSerializer =  ArraySerializerHelper.GetItemSerializer(firstSerializer);
+                visitor.AddNodeSerializer(resultSelectorFirstParameter, firstItemSerializer);
+            }
+
+            if (visitor.IsNotKnown(resultSelectorSecondParameter) && visitor.IsKnown(secondExpression, out var secondSerializer))
+            {
+                var secondItemSerializer =  ArraySerializerHelper.GetItemSerializer(secondSerializer);
+                visitor.AddNodeSerializer(resultSelectorSecondParameter, secondItemSerializer);
+            }
+
+            if (visitor.IsNotKnown(expression) && visitor.IsKnown(resultSelectorLambda.Body, out var resultItemSerializer))
+            {
+                var resultSerializer = IEnumerableOrIQueryableSerializer.Create(expression.Type, resultItemSerializer);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        // DeduceAppendOrPrependMethodSerializers
+        static void DeduceAppendOrPrependMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+            var elementExpression = expression.Arguments[1];
+
+            visitor.DeduceItemAndCollectionSerializers(elementExpression, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceAverageOrMedianOrPercentileMethodSerializers + __averageOrMedianOrPercentileOverloads branch
+        static void DeduceAverageOrMedianOrPercentileMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(__averageOrMedianOrPercentileWithSelectorOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var selectorSourceItemParameter = selectorLambda.Parameters[0];
+
+                visitor.DeduceItemAndCollectionSerializers(selectorSourceItemParameter, sourceExpression);
+            }
+
+            if (visitor.IsNotKnown(expression))
+            {
+                var nodeSerializer = StandardSerializers.GetSerializer(expression.Type);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
+            }
+        }
+
+        // DeduceAverageOrMedianOrPercentileMethodSerializers + __averageOrMedianOrPercentileWindowMethodOverloads branch
+        static void DeduceAverageOrMedianOrPercentileWindowMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        static void DeduceDeserializeEJsonMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var outputType = expression.Method.GetGenericArguments()[1];
+                var outputSerializer = BsonSerializer.LookupSerializer(outputType);
+                visitor.AddNodeSerializer(expression, outputSerializer);
+            }
+        }
+
+        static void DeduceSerializeEJsonMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression))
+            {
+                var outputType = expression.Method.GetGenericArguments()[1];
+                var outputSerializer = BsonSerializer.LookupSerializer(outputType);
+                visitor.AddNodeSerializer(expression, outputSerializer);
+            }
+        }
+
+        // DeducePickMethodSerializers
+        static void DeducePickMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var method = expression.Method;
+            if (method.IsOneOf(EnumerableMethod.PickWithSortByOverloads))
+            {
+                var sortByExpression = expression.Arguments[1];
+                if (visitor.IsNotKnown(sortByExpression))
+                {
+                    var ignoreSubTreeSerializer = IgnoreSubtreeSerializer.Create(sortByExpression.Type);
+                    visitor.AddNodeSerializer(sortByExpression, ignoreSubTreeSerializer);
+                }
+            }
+
+            var sourceExpression = expression.Arguments[0];
+            if (visitor.IsKnown(sourceExpression, out var sourceSerializer))
+            {
+                var sourceItemSerializer =  ArraySerializerHelper.GetItemSerializer(sourceSerializer);
+
+                var selectorExpression = expression.Arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 2 : 1];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, selectorExpression);
+                var selectorSourceItemParameter = selectorLambda.Parameters.Single();
+                if (visitor.IsNotKnown(selectorSourceItemParameter))
+                {
+                    visitor.AddNodeSerializer(selectorSourceItemParameter, sourceItemSerializer);
+                }
+            }
+
+            if (method.IsOneOf(EnumerableMethod.PickWithComputedNOverloads))
+            {
+                var keyExpression = expression.Arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 3 : 2];
+                if (visitor.IsKnown(keyExpression, out var keySerializer))
+                {
+                    var nExpression = expression.Arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 4 : 3];
+                    var nLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, nExpression);
+                    var nLambdaKeyParameter = nLambda.Parameters.Single();
+
+                    if (visitor.IsNotKnown(nLambdaKeyParameter))
                     {
-                        var item8Expression = arguments[7];
-                        var item8Type = item8Expression.Type;
-                        var item8Serializer = argumentSerializers[7];
-                        var restTupleType = (tupleType.IsTuple() ? typeof(Tuple<>) : typeof(ValueTuple<>)).MakeGenericType(item8Type);
-                        var restSerializer = TupleOrValueTupleSerializer.Create(restTupleType, [item8Serializer]);
-                        argumentSerializers = argumentSerializers.Take(7).Append(restSerializer).ToArray();
+                        visitor.AddNodeSerializer(nLambdaKeyParameter, keySerializer);
                     }
-
-                    var tupleSerializer = TupleOrValueTupleSerializer.Create(tupleType, argumentSerializers);
-                    AddNodeSerializer(node, tupleSerializer);
                 }
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
 
-        void DeduceCountMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.CountOverloads))
+            if (visitor.IsNotKnown(expression))
             {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.CountWithPredicateOverloads))
+                var selectorExpressionIndex = method switch
                 {
-                    var sourceExpression = arguments[0];
-                    var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var predicateParameter = predicateLambda.Parameters.Single();
-                    DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+                    _ when method.Is(EnumerableMethod.Bottom) => 2,
+                    _ when method.Is(EnumerableMethod.BottomN) => 2,
+                    _ when method.Is(EnumerableMethod.BottomNWithComputedN) => 2,
+                    _ when method.Is(EnumerableMethod.FirstN) => 1,
+                    _ when method.Is(EnumerableMethod.FirstNWithComputedN) => 1,
+                    _ when method.Is(EnumerableMethod.LastN) => 1,
+                    _ when method.Is(EnumerableMethod.LastNWithComputedN) => 1,
+                    _ when method.Is(EnumerableMethod.MaxN) => 1,
+                    _ when method.Is(EnumerableMethod.MaxNWithComputedN) => 1,
+                    _ when method.Is(EnumerableMethod.MinN) => 1,
+                    _ when method.Is(EnumerableMethod.MinNWithComputedN) => 1,
+                    _ when method.Is(EnumerableMethod.Top) => 2,
+                    _ when method.Is(EnumerableMethod.TopN) => 2,
+                    _ when method.Is(EnumerableMethod.TopNWithComputedN) => 2,
+                    _ => throw new ArgumentException($"Unrecognized method: {method.Name}.")
+                };
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, expression.Arguments[selectorExpressionIndex]);
+
+                if (visitor.IsKnown(selectorLambda.Body, out var selectorItemSerializer))
+                {
+                    var nodeSerializer = method.IsOneOf(EnumerableMethod.Bottom, EnumerableMethod.Top) ?
+                        selectorItemSerializer :
+                        IEnumerableSerializer.Create(selectorItemSerializer);
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
                 }
-
-                DeduceReturnsNumericSerializer();
-            }
-            else if (method.Is(WindowMethod.Count))
-            {
-                DeduceReturnsInt64Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
             }
         }
 
-        void DeduceCovarianceMethodSerializers()
+        // DeduceCountMethodSerializers + EnumerableOrQueryableMethod.CountOverloads branch
+        static void DeduceEnumerableCountMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(WindowMethod.CovarianceOverloads))
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.CountWithPredicateOverloads))
             {
-                var partitionExpression = arguments[0];
-                var selector1Lambda = (LambdaExpression)arguments[1];
-                var selector2Lambda = (LambdaExpression)arguments[2];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selector1Lambda);
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selector2Lambda);
-                DeduceStandardSerializer(node);
+                var sourceExpression = expression.Arguments[0];
+                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var predicateParameter = predicateLambda.Parameters.Single();
+                visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            }
+
+            DeduceReturnsNumericSerializer(visitor, expression);
+        }
+
+        // DeduceCovarianceMethodSerializers
+        static void DeduceCovarianceMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selector1Lambda = (LambdaExpression)expression.Arguments[1];
+            var selector2Lambda = (LambdaExpression)expression.Arguments[2];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selector1Lambda);
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selector2Lambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceDerivativeOrIntegralMethodSerializers
+        static void DeduceDerivativeOrIntegralMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceFirstOrLastOrSingleMethodsSerializers + EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads
+        static void DeduceFirstOrLastOrSingleMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.FirstOrLastOrSingleWithPredicateOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var predicateParameter = predicateLambda.Parameters.Single();
+                visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+            }
+
+            DeduceReturnsOneSourceItemSerializer(visitor, expression);
+        }
+
+        // DeduceFirstOrLastOrSingleMethodsSerializers + WindowMethod.First, WindowMethod.Last branch
+        static void DeduceFirstOrLastWindowMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor,partitionExpression, selectorLambda);
+            visitor.DeduceSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceMaxOrMinMethodSerializers + EnumerableOrQueryableMethod.MaxOrMinOverloads branch
+        static void DeduceMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.MaxOrMinWithSelectorOverloads))
+            {
+                var sourceExpression = expression.Arguments[0];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var selectorItemParameter = selectorLambda.Parameters.Single();
+
+                visitor.DeduceItemAndCollectionSerializers(selectorItemParameter, sourceExpression);
+                visitor.DeduceSerializers(expression, selectorLambda.Body);
             }
             else
             {
-                DeduceUnknownMethodSerializer();
+                DeduceReturnsOneSourceItemSerializer(visitor, expression);
             }
         }
 
-        void DeduceDateFromStringMethodSerializers()
+        // DeduceMaxOrMinMethodSerializers + WindowMethod.Max, WindowMethod.Min branch
+        static void DeduceWindowMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(MqlMethod.DateFromStringOverloads))
-            {
-                var resultSerializer = method.Is(MqlMethod.DateFromStringWithFormatAndTimezoneAndOnErrorAndOnNull) ? NullableSerializer.NullableUtcDateTimeInstance : DateTimeSerializer.UtcInstance;
-                DeduceSerializer(node, resultSerializer);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceSerializers(expression, selectorLambda.Body);
         }
 
-        void DeduceDefaultIfEmptyMethodSerializers()
+        // DeduceOrderByMethodSerializers
+        static void DeduceOrderByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
-            if (method.IsOneOf(EnumerableMethod.DefaultIfEmpty, EnumerableMethod.DefaultIfEmptyWithDefaultValue, QueryableMethod.DefaultIfEmpty, QueryableMethod.DefaultIfEmptyWithDefaultValue))
-            {
-                var sourceExpression = arguments[0];
+            var sourceExpression = expression.Arguments[0];
+            var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+            var keySelectorParameter = keySelectorLambda.Parameters.Single();
 
-                if (method.IsOneOf(EnumerableMethod.DefaultIfEmptyWithDefaultValue, QueryableMethod.DefaultIfEmptyWithDefaultValue))
+            visitor.DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceSkipOrTakeMethodSerializers
+        static void DeduceSkipOrTakeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+
+            if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.SkipWhileOrTakeWhile))
+            {
+                var predicateLambda =  ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var predicateParameter = predicateLambda.Parameters[0];
+                visitor.DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
+
+                if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.SkipWhileWithPredicateTakingIndexOrTakeWhileWithPredicateTakingIndex))
                 {
-                    var defaultValueExpression = arguments[1];
-                    DeduceItemAndCollectionSerializers(defaultValueExpression, sourceExpression);
-                }
-
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDegreesToRadiansMethodSerializers()
-        {
-            if (method.Is(MongoDBMathMethod.DegreesToRadians))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDenseRankOrRankMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.DenseRank, WindowMethod.Rank))
-            {
-                DeduceStandardSerializer(node); // currently decimal, but might be long in the future
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDerivativeOrIntegralMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.DerivativeOrIntegralOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDensifyMethodSerializers()
-        {
-            if (method.Is(MongoQueryableMethod.DensifyWithArrayPartitionByFields))
-            {
-                var sourceExpression = arguments[0];
-                var fieldLambda = ExpressionHelper.UnquoteLambda(arguments[1]);
-                var fieldLambdaSourceParameter = fieldLambda.Parameters.Single();
-                var rangeExpression = arguments[2];
-                var partitionByFieldsExpression = arguments[3];
-
-                DeduceItemAndCollectionSerializers(fieldLambdaSourceParameter, sourceExpression);
-                DeduceIgnoreSubtreeSerializer(rangeExpression);
-                if (partitionByFieldsExpression is NewArrayExpression newArrayExpression)
-                {
-                    foreach (var arrayItemExpression in newArrayExpression.Expressions)
+                    var indexParameter = predicateLambda.Parameters[1];
+                    if (visitor.IsNotKnown(indexParameter))
                     {
-                        var partitionByFieldLambda = ExpressionHelper.UnquoteLambda(arrayItemExpression);
-                        var partitionByFieldLambdaSourceParameter = partitionByFieldLambda.Parameters.Single();
-                        DeduceItemAndCollectionSerializers(partitionByFieldLambdaSourceParameter, sourceExpression);
+                        visitor.AddNodeSerializer(indexParameter, Int32Serializer.Instance);
                     }
                 }
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
             }
-            else
+
+            visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+        }
+
+        // DeduceStandardDeviationMethodSerializers + MongoEnumerableMethod.StandardDeviationOverloads branch
+        static void DeduceStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (expression.Method.IsOneOf(MongoEnumerableMethod.StandardDeviationWithSelectorOverloads, MongoQueryableMethod.StandardDeviationWithSelectorOverloads))
             {
-                DeduceUnknownMethodSerializer();
+                var sourceExpression = expression.Arguments[0];
+                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[1]);
+                var selectorItemParameter = selectorLambda.Parameters.Single();
+                visitor.DeduceCollectionAndItemSerializers(sourceExpression, selectorItemParameter);
+            }
+
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        static void DeduceStringEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var expression1 = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+            var expression2 = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
+
+            visitor.DeduceSerializers(expression1, expression2);
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        }
+
+        // DeduceStandardDeviationMethodSerializers + WindowMethod.StandardDeviationOverloads branch
+        static void DeduceWindowStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        static void DeduceReturnsNumericSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            if (visitor.IsNotKnown(expression) && expression.Type.IsNumeric())
+            {
+                var numericSerializer = StandardSerializers.GetSerializer(expression.Type);
+                visitor.AddNodeSerializer(expression, numericSerializer);
             }
         }
 
-        void DeduceDeserializeEJsonMethodSerializers()
+        static void DeduceReturnsTimeSpanSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression, TimeSpanUnits units)
         {
-            if (method.Is(MqlMethod.DeserializeEJson))
+            if (visitor.IsNotKnown(expression))
             {
-                if (IsNotKnown(node))
+                var resultSerializer = new TimeSpanSerializer(BsonType.Int64, units);
+                visitor.AddNodeSerializer(expression, resultSerializer);
+            }
+        }
+
+        static void DeduceReturnsOneSourceItemSerializer(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var sourceExpression = expression.Arguments[0];
+
+            if (visitor.IsNotKnown(expression) && visitor.IsKnown(sourceExpression, out var sourceSerializer))
+            {
+                var nodeSerializer = sourceSerializer is IUnknowableSerializer ?
+                    UnknowableSerializer.Create(expression.Type) :
+                    ArraySerializerHelper.GetItemSerializer(sourceSerializer);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
+            }
+        }
+
+        static void DeduceWindowMethodSelectorParameterSerializer(SerializerFinderVisitor visitor, Expression partitionExpression, LambdaExpression selectorLambda)
+        {
+            var inputParameter = selectorLambda.Parameters.Single();
+            if (visitor.IsNotKnown(inputParameter) && visitor.IsKnown(partitionExpression, out var partitionSerializer))
+            {
+                var inputSerializer = ((ISetWindowFieldsPartitionSerializer)partitionSerializer).InputSerializer;
+                visitor.AddNodeSerializer(inputParameter, inputSerializer);
+            }
+        }
+    }
+
+    protected override Expression VisitMethodCall(MethodCallExpression node)
+    {
+        var methodInfo = node.Method.IsGenericMethod && !node.Method.ContainsGenericParameters ? node.Method.GetGenericMethodDefinition() : node.Method;
+
+        DeduceMethodCallSerializers();
+        base.VisitMethodCall(node);
+        DeduceMethodCallSerializers();
+
+        return node;
+
+        void DeduceMethodCallSerializers()
+        {
+            Action<SerializerFinderVisitor, MethodCallExpression> resolver;
+            __serializerResolversLock.EnterReadLock();
+            try
+            {
+                __serializerResolvers.TryGetValue(methodInfo, out resolver);
+            }
+            finally
+            {
+                __serializerResolversLock.ExitReadLock();
+            }
+
+            if (resolver == null)
+            {
+                __serializerResolversLock.EnterWriteLock();
+                try
                 {
-                    var outputType = method.GetGenericArguments()[1];
-                    var outputSerializer = BsonSerializer.LookupSerializer(outputType);
-                    AddNodeSerializer(node, outputSerializer);
+                    if (!__serializerResolvers.TryGetValue(methodInfo, out resolver))
+                    {
+                        resolver = CreateDynamicSerializerResolver(methodInfo);
+                        __serializerResolvers.Add(methodInfo, resolver);
+                    }
                 }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDistinctMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Distinct, QueryableMethod.Distinct))
-            {
-                var sourceExpression = arguments[0];
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDocumentNumberMethodSerializers()
-        {
-            if (method.Is(WindowMethod.DocumentNumber))
-            {
-                DeduceStandardSerializer(node); // currently decimal, but might be long in the future
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceDocumentsMethodSerializers()
-        {
-            if (method.IsOneOf(MongoQueryableMethod.Documents, MongoQueryableMethod.DocumentsWithSerializer))
-            {
-                if (IsNotKnown(node))
+                finally
                 {
-                    IBsonSerializer documentSerializer;
-                    if (method.Is(MongoQueryableMethod.DocumentsWithSerializer))
-                    {
-                        var documentSerializerExpression = arguments[2];
-                        documentSerializer = documentSerializerExpression.GetConstantValue<IBsonSerializer>(node);
-                    }
-                    else
-                    {
-                        var documentsParameter = method.GetParameters()[1];
-                        var documentType = documentsParameter.ParameterType.GetElementType();
-                        documentSerializer = BsonSerializer.LookupSerializer(documentType); // TODO: don't use static registry
-                    }
-
-                    var nodeSerializer = IQueryableSerializer.Create(documentSerializer);
-                    AddNodeSerializer(node, nodeSerializer);
+                    __serializerResolversLock.ExitWriteLock();
                 }
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
 
-        void DeduceElementAtMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.ElementAtOverloads))
+            if (resolver == null)
             {
-                var sourceExpression = arguments[0];
-                DeduceItemAndCollectionSerializers(node, sourceExpression);
+                DeduceUnknowableSerializer(node);
             }
             else
             {
-                DeduceUnknownMethodSerializer();
+                resolver(this, node);
             }
         }
 
-        void DeduceEncStrMethodSerializers()
+        // Processes special cases where we do not have fixed list of methodInfos that we support,
+        // but trying to deduce serializers based on method name and arguments
+        static Action<SerializerFinderVisitor, MethodCallExpression> CreateDynamicSerializerResolver(MethodInfo method)
         {
-            if (method.IsOneOf(MqlMethod.EncStrMethodOverloads))
+            return method.Name switch
             {
-                var inputExpression = arguments[0];
-                var valueExpression = arguments[1];
-                if (IsNotKnown(inputExpression))
+                "Contains" when EnumerableMethod.IsContainsMethod(method) => DeduceContainsMethodSerializers,
+                "ContainsKey" when DictionaryMethod.IsContainsKeyMethod(method) => DeduceDictionaryContainsKeyMethodSerializers,
+                "ContainsValue" when IsContainsValueMethod(method) => DeduceContainsValueMethodSerializers,
+                "Equals" when IsEqualsReturningBooleanMethod(method) => DeduceEqualsMethodSerializers,
+                "Exists" when method.Is(ArrayMethod.Exists) || ListMethod.IsExistsMethod(method) => DeduceExistsMethodSerializers,
+                "get_Item" when BsonValueMethod.IsGetItemWithIntMethod(method) || BsonValueMethod.IsGetItemWithStringMethod(method) =>
+                    (visitor, expression) => visitor.DeduceSerializer(expression, BsonValueSerializer.Instance),
+                "get_Item" when !method.IsStatic => DeduceGetItemInstanceMethodSerializers,
+                "IsSubsetOf" when IsSubsetOfMethod(method) => DeduceIsSubsetOfMethodSerializers,
+                "Parse" when IsParseMethod(method) => DeduceParseMethodSerializers,
+                "SetEquals" when ISetMethod.IsSetEqualsMethod(method) => DeduceSetEqualsMethodSerializers,
+                "ToArray" when IsToArrayMethod(method) => DeduceToArrayMethodSerializers,
+                "ToList" => DeduceToListSerializers,
+                "ToString" => (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance),
+                "Compare" or "CompareTo" when IsCompareMethod(method) => DeduceCompareOrCompareToMethodSerializers,
+                _ => null
+            };
+
+            static bool IsCompareMethod(MethodInfo method) =>
+                method.IsStaticCompareMethod() ||
+                method.IsInstanceCompareToMethod() ||
+                method.IsOneOf(StringMethod.CompareOverloads);
+
+            static void DeduceCompareOrCompareToMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var valueExpression = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                var comparandExpression = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
+                visitor.DeduceSerializers(valueExpression, comparandExpression);
+                visitor.DeduceSerializer(expression, Int32Serializer.Instance);
+            }
+
+            static void DeduceContainsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                if (EnumerableMethod.IsContainsMethod(expression, out var collectionExpression, out var itemExpression))
                 {
-                    AddNodeSerializer(inputExpression, StringSerializer.Instance);
+                    visitor.DeduceCollectionAndItemSerializers(collectionExpression, itemExpression);
+                    visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
                 }
-                if (IsNotKnown(valueExpression))
+            }
+
+            static bool IsContainsValueMethod(MethodInfo method) =>
+                method.IsPublic &&
+                method.IsStatic == false &&
+                method.ReturnType == typeof(bool) &&
+                method.Name == "ContainsValue" &&
+                method.GetParameters() is var parameters &&
+                parameters.Length == 1;
+
+            void DeduceContainsValueMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var collectionExpression = expression.Object;
+                var valueExpression = expression.Arguments[0];
+
+                if (visitor.IsNotKnown(valueExpression) &&
+                    visitor.IsKnown(collectionExpression, out var collectionSerializer))
                 {
-                    AddNodeSerializer(valueExpression, StringSerializer.Instance);
+                    if (collectionSerializer is IBsonDictionarySerializer dictionarySerializer)
+                    {
+                        var valueSerializer = dictionarySerializer.ValueSerializer;
+                        visitor.AddNodeSerializer(valueExpression, valueSerializer);
+                    }
                 }
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
 
-        void DeduceEqualsMethodSerializers()
-        {
-            if (IsEqualsReturningBooleanMethod(out var expression1, out var expression2))
-            {
-                DeduceSerializers(expression1, expression2);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
             }
 
-            bool IsEqualsReturningBooleanMethod(out Expression expression1, out Expression expression2)
+            void DeduceDictionaryContainsKeyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
-                if (method.Name == "Equals" &&
-                    method.ReturnType == typeof(bool) &&
-                    method.IsPublic)
+                var dictionaryExpression = expression.Object;
+                var keyExpression = expression.Arguments[0];
+                if (visitor.IsNotKnown(keyExpression) && visitor.IsKnown(dictionaryExpression, out var dictionarySerializer))
                 {
-                    if (method.IsStatic &&
-                        arguments.Count == 2)
-                    {
-                        expression1 = arguments[0];
-                        expression2 = arguments[1];
-                        return true;
-                    }
-
-                    if (!method.IsStatic &&
-                        arguments.Count == 1)
-                    {
-                        expression1 = node.Object;
-                        expression2 = arguments[0];
-                        return true;
-                    }
-
-                    if (method.Is(StringMethod.EqualsWithComparisonType))
-                    {
-                        expression1 = node.Object;
-                        expression2 = arguments[0];
-                        return true;
-                    }
-
-                    if (method.Is(StringMethod.StaticEqualsWithComparisonType))
-                    {
-                        expression1 = arguments[0];
-                        expression2 = arguments[1];
-                        return true;
-                    }
+                    var keySerializer = (dictionarySerializer as IBsonDictionarySerializer)?.KeySerializer;
+                    visitor.AddNodeSerializer(keyExpression, keySerializer);
                 }
 
-                expression1 = null;
-                expression2 = null;
-                return false;
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
             }
-        }
 
-        void DeduceExceptMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Except, QueryableMethod.Except))
+            static bool IsEqualsReturningBooleanMethod(MethodInfo method)
             {
-                var firstExpression =  arguments[0];
-                var secondExpression = arguments[1];
-                DeduceCollectionAndCollectionSerializers(secondExpression, firstExpression);
-                DeduceCollectionAndCollectionSerializers(node, firstExpression);
+                var arguments = method.GetParameters();
+                return method.Name == "Equals" &&
+                       method.ReturnType == typeof(bool) &&
+                       method.IsPublic &&
+                       (
+                           (method.IsStatic && arguments.Length == 2) ||
+                           (!method.IsStatic && arguments.Length == 1)
+                       );
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
 
-        void DeduceExistsMethodSerializers()
-        {
-            if (method.Is(ArrayMethod.Exists) || ListMethod.IsExistsMethod(method))
+            void DeduceEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
-                var collectionExpression = method.IsStatic ? arguments[0] : node.Object;
-                var predicateExpression = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, method.IsStatic ? arguments[1] : arguments[0]);
+                var expression1 = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                var expression2 = expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0];
+
+                visitor.DeduceSerializers(expression1, expression2);
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+            }
+
+            static void DeduceExistsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var collectionExpression = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                var predicateExpression = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Method.IsStatic ? expression.Arguments[1] : expression.Arguments[0]);
                 var predicateParameter = predicateExpression.Parameters.Single();
-                DeduceItemAndCollectionSerializers(predicateParameter, collectionExpression);
-                DeduceReturnsBooleanSerializer();
+                visitor.DeduceItemAndCollectionSerializers(predicateParameter, collectionExpression);
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
             }
-            else if (method.Is(MqlMethod.Exists))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
 
-        void DeduceExpMethodSerializers()
-        {
-            if (method.Is(MathMethod.Exp))
+            static void DeduceGetItemInstanceMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceExponentialMovingAverageMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.ExponentialMovingAverageOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceFieldMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Field))
-            {
-                if (IsNotKnown(node))
+                if (visitor.IsNotKnown(expression))
                 {
-                    var fieldSerializerExpression = arguments[2];
-                    var fieldSerializer = fieldSerializerExpression.GetConstantValue<IBsonSerializer>(node);
-                    if (fieldSerializer == null)
-                    {
-                        fieldSerializer = BsonSerializer.LookupSerializer(method.GetGenericArguments()[1]);
-                    }
+                    var collectionExpression = expression.Object;
+                    var indexExpression = expression.Arguments[0];
 
-                    AddNodeSerializer(node, fieldSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceCreateObjectIdMethodSerializers()
-        {
-            if (method.Is(MqlMethod.CreateObjectId))
-            {
-                if (IsNotKnown(node))
-                {
-                    DeduceSerializer(node, ObjectIdSerializer.Instance);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceFirstOrLastOrSingleMethodsSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads))
-            {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.FirstOrLastOrSingleWithPredicateOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var predicateParameter = predicateLambda.Parameters.Single();
-                    DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
-                }
-
-                DeduceReturnsOneSourceItemSerializer();
-            }
-            else if (method.IsOneOf(WindowMethod.First, WindowMethod.Last))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceGetItemMethodSerializers()
-        {
-            if (IsNotKnown(node))
-            {
-                if (BsonValueMethod.IsGetItemWithIntMethod(method) || BsonValueMethod.IsGetItemWithStringMethod(method))
-                {
-                    AddNodeSerializer(node, BsonValueSerializer.Instance);
-                }
-                else if (IsInstanceGetItemMethod(out var collectionExpression, out var indexExpression))
-                {
-                    if (IsKnown(collectionExpression, out var collectionSerializer))
+                    if (visitor.IsKnown(collectionExpression, out var collectionSerializer))
                     {
                         if (collectionSerializer is IBsonArraySerializer arraySerializer &&
                             indexExpression.Type == typeof(int) &&
                             arraySerializer.GetItemSerializer() is var itemSerializer &&
-                            itemSerializer.ValueType == method.ReturnType)
+                            itemSerializer.ValueType == expression.Method.ReturnType)
                         {
-                            AddNodeSerializer(node, itemSerializer);
+                            visitor.AddNodeSerializer(expression, itemSerializer);
                         }
                         else if (
                             collectionSerializer is IBsonDictionarySerializer dictionarySerializer &&
                             dictionarySerializer.KeySerializer is var keySerializer &&
                             dictionarySerializer.ValueSerializer is var valueSerializer &&
                             keySerializer.ValueType == indexExpression.Type &&
-                            valueSerializer.ValueType == method.ReturnType)
+                            valueSerializer.ValueType == expression.Method.ReturnType)
                         {
-                            AddNodeSerializer(node, valueSerializer);
+                            visitor.AddNodeSerializer(expression, valueSerializer);
                         }
                     }
                 }
-                else
-                {
-                    DeduceUnknownMethodSerializer();
-                }
-            }
-
-            bool IsInstanceGetItemMethod(out Expression collectionExpression, out Expression indexExpression)
-            {
-                if (method.IsStatic == false &&
-                    method.Name == "get_Item")
-                {
-                    collectionExpression = node.Object;
-                    indexExpression = arguments[0];
-                    return true;
-                }
-
-                collectionExpression = null;
-                indexExpression = null;
-                return false;
-            }
-        }
-
-        void DeduceGetCharsMethodSerializers()
-        {
-            if (method.Is(StringMethod.GetChars))
-            {
-                DeduceCharSerializer(node);
-            }
-
-            DeduceUnknowableSerializer(node);
-        }
-
-        void DeduceGroupByMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByOverloads))
-            {
-                var sourceExpression = arguments[0];
-                var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var keySelectorParameter = keySelectorLambda.Parameters.Single();
-
-                DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelector))
-                {
-                    if (IsNotKnown(node) && IsKnown(keySelectorLambda.Body, out var keySerializer) && IsItemSerializerKnown(sourceExpression, out var elementSerializer))
-                    {
-                        var groupingSerializer = IGroupingSerializer.Create(keySerializer, elementSerializer);
-                        var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, groupingSerializer);
-                        AddNodeSerializer(node, nodeSerializer);
-                    }
-                }
-                else if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorAndElementSelector))
-                {
-                    var elementSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var elementSelectorParameter = elementSelectorLambda.Parameters.Single();
-                    DeduceItemAndCollectionSerializers(elementSelectorParameter, sourceExpression);
-                    if (IsNotKnown(node) && IsKnown(keySelectorLambda.Body, out var keySerializer) && IsKnown(elementSelectorLambda.Body, out var elementSerializer))
-                    {
-                        var groupingSerializer = IGroupingSerializer.Create(keySerializer, elementSerializer);
-                        var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, groupingSerializer);
-                        AddNodeSerializer(node, nodeSerializer);
-                    }
-                }
-                else if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorAndResultSelector))
-                {
-                    var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var resultSelectorKeyParameter = resultSelectorLambda.Parameters[0];
-                    var resultSelectorElementsParameter = resultSelectorLambda.Parameters[1];
-                    DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
-                    DeduceSerializers(resultSelectorKeyParameter, keySelectorLambda.Body);
-                    DeduceCollectionAndCollectionSerializers(resultSelectorElementsParameter, sourceExpression);
-                    DeduceResultSerializer(resultSelectorLambda.Body);
-                }
-                else if (method.IsOneOf(EnumerableOrQueryableMethod.GroupByWithKeySelectorElementSelectorAndResultSelector))
-                {
-                    var elementSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var elementSelectorParameter = elementSelectorLambda.Parameters.Single();
-                    var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var resultSelectorKeyParameter = resultSelectorLambda.Parameters[0];
-                    var resultSelectorElementsParameter = resultSelectorLambda.Parameters[1];
-                    DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(elementSelectorParameter, sourceExpression);
-                    DeduceSerializers(resultSelectorKeyParameter, keySelectorLambda.Body);
-                    DeduceCollectionAndItemSerializers(resultSelectorElementsParameter, elementSelectorLambda.Body);
-                    DeduceResultSerializer(resultSelectorLambda.Body);
-                }
-
-                void DeduceResultSerializer(Expression resultExpression)
-                {
-                    if (IsNotKnown(node) && IsKnown(resultExpression, out var resultSerializer))
-                    {
-                        var nodeSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultSerializer);
-                        AddNodeSerializer(node, nodeSerializer);
-                    }
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceGroupJoinMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin))
-            {
-                var outerExpression = arguments[0];
-                var innerExpression = arguments[1];
-                var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
-                var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
-                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
-                var resultSelectorInnerItemsParameter = resultSelectorLambda.Parameters[1];
-
-                DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
-                DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
-                DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
-                DeduceCollectionAndCollectionSerializers(resultSelectorInnerItemsParameter, innerExpression);
-                DeduceCollectionAndItemSerializers(node, resultSelectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIndexOfMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.IndexOfOverloads))
-            {
-                DeduceReturnsInt32Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceHasFlagMethodSerializers()
-        {
-            if (method.Is(EnumMethod.HasFlag))
-            {
-                var objectExpression = node.Object;
-                var flagExpression = arguments[0];
-                if (IsNotKnown(flagExpression) && IsKnown(objectExpression, out var enumSerializer))
-                {
-                    AddNodeSerializer(flagExpression, enumSerializer);
-                }
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceHashMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Hash))
-            {
-                DeduceSerializer(node, __bsonBinaryDataSerializer);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceHexHashMethodSerializers()
-        {
-            if (method.Is(MqlMethod.HexHash))
-            {
-                DeduceSerializer(node, StringSerializer.Instance);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceInjectMethodSerializers()
-        {
-            if (method.Is(LinqExtensionsMethod.Inject))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIntersectMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Intersect, QueryableMethod.Intersect))
-            {
-                var sourceExpression = arguments[0];
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIsMatchMethodSerializers()
-        {
-            if (method.IsOneOf(RegexMethod.IsMatchOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIsMissingOrIsNullOrMissingMethodSerializers()
-        {
-            if (method.IsOneOf(MqlMethod.IsMissing, MqlMethod.IsNullOrMissing))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIsSubsetOfMethodSerializers()
-        {
-            if (IsSubsetOfMethod(method))
-            {
-                var objectExpression =  node.Object;
-                var otherExpression = arguments[0];
-
-                DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
             }
 
             static bool IsSubsetOfMethod(MethodInfo method)
@@ -1793,470 +1715,14 @@ internal partial class SerializerFinderVisitor
                     otherParameter.ParameterType.ImplementsIEnumerable(out var otherTypeItemType) &&
                     otherTypeItemType == declaringTypeItemType;
             }
-        }
 
-        void DeduceJoinMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Join, QueryableMethod.Join))
+            static void DeduceIsSubsetOfMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
-                var outerExpression = arguments[0];
-                var innerExpression = arguments[1];
-                var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
-                var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
-                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
-                var resultSelectorInnerItemsParameter = resultSelectorLambda.Parameters[1];
+                var objectExpression = expression.Object;
+                var otherExpression = expression.Arguments[0];
 
-                DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
-                DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
-                DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
-                DeduceItemAndCollectionSerializers(resultSelectorInnerItemsParameter, innerExpression);
-                DeduceCollectionAndItemSerializers(node, resultSelectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceLeftJoinMethodSerializers()
-        {
-            if (method.IsOneOf(MongoQueryableMethod.LeftJoin, QueryableMethod.LeftJoin))
-            {
-                var outerExpression = arguments[0];
-                var innerExpression = arguments[1];
-                var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
-                var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
-                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
-                var resultSelectorInnerItemParameter = resultSelectorLambda.Parameters[1];
-
-                DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
-                DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
-                DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
-                DeduceItemAndCollectionSerializers(resultSelectorInnerItemParameter, innerExpression);
-                DeduceCollectionAndItemSerializers(node, resultSelectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceIsNullOrEmptyOrIsNullOrWhiteSpaceMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.IsNullOrEmpty, StringMethod.IsNullOrWhiteSpace))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceLocfMethodSerializers()
-        {
-            if (method.Is(WindowMethod.Locf))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceLogMethodSerializers()
-        {
-            if (method.IsOneOf(MathMethod.LogOverloads))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceLookupMethodSerializers()
-        {
-            if (method.IsOneOf(MongoQueryableMethod.LookupOverloads))
-            {
-                var sourceExpression = arguments[0];
-
-                if (method.Is(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField))
-                {
-                    var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var documentsLambdaParameter = documentsLambda.Parameters.Single();
-                    var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
-                    var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
-
-                    DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(foreignFieldLambdaParameter, documentsLambda.Body);
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(documentsLambda.Body, out var documentSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, documentSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-                else if (method.Is(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline))
-                {
-                    var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var documentsLambdaParameter = documentsLambda.Parameters.Single();
-                    var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
-                    var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
-                    var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                    var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
-                    var pipelineLambdaForeignQueryableParameter = pipelineLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(foreignFieldLambdaParameter, documentsLambda.Body);
-                    DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
-                    DeduceCollectionAndCollectionSerializers(pipelineLambdaForeignQueryableParameter, documentsLambda.Body);
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(pipelineLambda.Body, out var pipelineDocumentSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineDocumentSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-                else if (method.Is(MongoQueryableMethod.LookupWithDocumentsAndPipeline))
-                {
-                    var documentsLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var documentsLambdaParameter = documentsLambda.Parameters.Single();
-                    var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var pipelineLambdaSourceParameter = pipelineLambda.Parameters[0];
-                    var pipelineLambdaQueryableDocumentParameter = pipelineLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(documentsLambdaParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(pipelineLambdaSourceParameter, sourceExpression);
-                    DeduceCollectionAndCollectionSerializers(pipelineLambdaQueryableDocumentParameter, documentsLambda.Body);
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-
-                if (method.Is(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignField))
-                {
-                    var fromExpression = arguments[1];
-                    var fromCollection = fromExpression.GetConstantValue<IMongoCollection>(node);
-                    var foreignDocumentSerializer = fromCollection.DocumentSerializer;
-                    var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
-                    var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
-
-                    DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
-                    DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, foreignDocumentSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-                else if (method.Is(MongoQueryableMethod.LookupWithFromAndLocalFieldAndForeignFieldAndPipeline))
-                {
-                    var fromExpression = arguments[1];
-                    var fromCollection = fromExpression.GetConstantValue<IMongoCollection>(node);
-                    var foreignDocumentSerializer = fromCollection.DocumentSerializer;
-                    var localFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var localFieldLambdaParameter = localFieldLambda.Parameters.Single();
-                    var foreignFieldLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[3]);
-                    var foreignFieldLambdaParameter = foreignFieldLambda.Parameters.Single();
-                    var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[4]);
-                    var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
-                    var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(localFieldLambdaParameter, sourceExpression);
-                    DeduceSerializer(foreignFieldLambdaParameter, foreignDocumentSerializer);
-                    DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
-
-                    if (IsNotKnown(pipelineLamdbaForeignQueryableParameter))
-                    {
-                        var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
-                        AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
-                    }
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
-                    {
-                        var lookupResultsSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultsSerializer));
-                    }
-                }
-                else if (method.Is(MongoQueryableMethod.LookupWithFromAndPipeline))
-                {
-                    var fromCollection = arguments[1].GetConstantValue<IMongoCollection>(node);
-                    var foreignDocumentSerializer = fromCollection.DocumentSerializer;
-                    var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                    var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
-                    var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
-
-                    if (IsNotKnown(pipelineLamdbaForeignQueryableParameter))
-                    {
-                        var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
-                        AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
-                    }
-
-                    if (IsNotKnown(node) &&
-                        IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer) &&
-                        IsItemSerializerKnown(pipelineLambda.Body, out var pipelineItemSerializer))
-                    {
-                        var lookupResultSerializer = LookupResultSerializer.Create(sourceItemSerializer, pipelineItemSerializer);
-                        AddNodeSerializer(node, IQueryableSerializer.Create(lookupResultSerializer));
-                    }
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceMatchingElementsMethodSerializers()
-        {
-            if (method.IsOneOf(MongoEnumerableMethod.AllElements, MongoEnumerableMethod.AllMatchingElements, MongoEnumerableMethod.FirstMatchingElement))
-            {
-                DeduceReturnsOneSourceItemSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceMaxOrMinMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.MaxOrMinOverloads))
-            {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.MaxOrMinWithSelectorOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorItemParameter = selectorLambda.Parameters.Single();
-
-                    DeduceItemAndCollectionSerializers(selectorItemParameter, sourceExpression);
-                    DeduceSerializers(node, selectorLambda.Body);
-                }
-                else
-                {
-                    DeduceReturnsOneSourceItemSerializer();
-                }
-            }
-            else if (method.IsOneOf(WindowMethod.Max, WindowMethod.Min))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceMinMaxScalerMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.MinMaxScalerOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceOfTypeMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.OfType, QueryableMethod.OfType))
-            {
-                var sourceExpression = arguments[0];
-                var resultType = method.GetGenericArguments()[0];
-
-                if (IsNotKnown(node) && IsItemSerializerKnown(sourceExpression, out var sourceItemSerializer))
-                {
-                    var resultItemSerializer = sourceItemSerializer.GetDerivedTypeSerializer(resultType);
-                    var resultSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceOrderByMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.OrderByOrThenByOverloads))
-            {
-                var sourceExpression = arguments[0];
-                var keySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var keySelectorParameter = keySelectorLambda.Parameters.Single();
-
-                DeduceItemAndCollectionSerializers(keySelectorParameter, sourceExpression);
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeducePickMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.PickOverloads))
-            {
-                if (method.IsOneOf(EnumerableMethod.PickWithSortByOverloads))
-                {
-                    var sortByExpression = arguments[1];
-                    if (IsNotKnown(sortByExpression))
-                    {
-                        var ignoreSubTreeSerializer = IgnoreSubtreeSerializer.Create(sortByExpression.Type);
-                        AddNodeSerializer(sortByExpression, ignoreSubTreeSerializer);
-                    }
-                }
-
-                var sourceExpression = arguments[0];
-                if (IsKnown(sourceExpression, out var sourceSerializer))
-                {
-                    var sourceItemSerializer =  ArraySerializerHelper.GetItemSerializer(sourceSerializer);
-
-                    var selectorExpression = arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 2 : 1];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, selectorExpression);
-                    var selectorSourceItemParameter = selectorLambda.Parameters.Single();
-                    if (IsNotKnown(selectorSourceItemParameter))
-                    {
-                        AddNodeSerializer(selectorSourceItemParameter, sourceItemSerializer);
-                    }
-                }
-
-                if (method.IsOneOf(EnumerableMethod.PickWithComputedNOverloads))
-                {
-                    var keyExpression = arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 3 : 2];
-                    if (IsKnown(keyExpression, out var keySerializer))
-                    {
-                        var nExpression = arguments[method.IsOneOf(EnumerableMethod.PickWithSortByOverloads) ? 4 : 3];
-                        var nLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, nExpression);
-                        var nLambdaKeyParameter = nLambda.Parameters.Single();
-
-                        if (IsNotKnown(nLambdaKeyParameter))
-                        {
-                            AddNodeSerializer(nLambdaKeyParameter, keySerializer);
-                        }
-                    }
-                }
-
-                if (IsNotKnown(node))
-                {
-                    var selectorExpressionIndex = method switch
-                    {
-                        _ when method.Is(EnumerableMethod.Bottom) => 2,
-                        _ when method.Is(EnumerableMethod.BottomN) => 2,
-                        _ when method.Is(EnumerableMethod.BottomNWithComputedN) => 2,
-                        _ when method.Is(EnumerableMethod.FirstN) => 1,
-                        _ when method.Is(EnumerableMethod.FirstNWithComputedN) => 1,
-                        _ when method.Is(EnumerableMethod.LastN) => 1,
-                        _ when method.Is(EnumerableMethod.LastNWithComputedN) => 1,
-                        _ when method.Is(EnumerableMethod.MaxN) => 1,
-                        _ when method.Is(EnumerableMethod.MaxNWithComputedN) => 1,
-                        _ when method.Is(EnumerableMethod.MinN) => 1,
-                        _ when method.Is(EnumerableMethod.MinNWithComputedN) => 1,
-                        _ when method.Is(EnumerableMethod.Top) => 2,
-                        _ when method.Is(EnumerableMethod.TopN) => 2,
-                        _ when method.Is(EnumerableMethod.TopNWithComputedN) => 2,
-                        _ => throw new ArgumentException($"Unrecognized method: {method.Name}.")
-                    };
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[selectorExpressionIndex]);
-
-                    if (IsKnown(selectorLambda.Body, out var selectorItemSerializer))
-                    {
-                        var nodeSerializer = method.IsOneOf(EnumerableMethod.Bottom, EnumerableMethod.Top) ?
-                            selectorItemSerializer :
-                            IEnumerableSerializer.Create(selectorItemSerializer);
-                        AddNodeSerializer(node, nodeSerializer);
-                    }
-                }
-            }
-            else if (method.IsOneOf(WindowMethod.PickOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var withSortBy = method.IsOneOf(__pickWindowMethodWithSortByOverloads);
-
-                if (withSortBy)
-                {
-                    var sortByExpression = arguments[1];
-                    if (IsNotKnown(sortByExpression))
-                    {
-                        var ignoreSubTreeSerializer = IgnoreSubtreeSerializer.Create(sortByExpression.Type);
-                        AddNodeSerializer(sortByExpression, ignoreSubTreeSerializer);
-                    }
-                }
-
-                var selectorLambda = (LambdaExpression)arguments[withSortBy ? 2 : 1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-
-                if (IsNotKnown(node) && IsKnown(selectorLambda.Body, out var selectorBodySerializer))
-                {
-                    var nodeSerializer = method.IsOneOf(WindowMethod.Bottom, WindowMethod.Top) ?
-                        selectorBodySerializer :
-                        IEnumerableSerializer.Create(selectorBodySerializer);
-                    AddNodeSerializer(node, nodeSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceParseMethodSerializers()
-        {
-            if (IsNotKnown(node))
-            {
-                if (IsParseMethod(method))
-                {
-                    var nodeSerializer = GetParseResultSerializer(method.DeclaringType);
-                    AddNodeSerializer(node, nodeSerializer);
-                }
-                else
-                {
-                    DeduceUnknownMethodSerializer();
-                }
+                visitor.DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
             }
 
             static bool IsParseMethod(MethodInfo method)
@@ -2270,893 +1736,57 @@ internal partial class SerializerFinderVisitor
                     parameters[0].ParameterType == typeof(string);
             }
 
-            static IBsonSerializer GetParseResultSerializer(Type declaringType)
+            static void DeduceParseMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
             {
-                return declaringType switch
+                if (visitor.IsNotKnown(expression))
                 {
-                    _ when declaringType == typeof(DateTime) => DateTimeSerializer.Instance,
-                    _ when declaringType == typeof(decimal) => DecimalSerializer.Instance,
-                    _ when declaringType == typeof(double) => DoubleSerializer.Instance,
-                    _ when declaringType == typeof(int) => Int32Serializer.Instance,
-                    _ when declaringType == typeof(short) => Int16Serializer.Instance,
-                    _ when declaringType == typeof(long) => Int64Serializer.Instance,
-                    _ when declaringType == typeof(float) => SingleSerializer.Instance,
-                    _ when declaringType == typeof(byte) => ByteSerializer.Instance,
-                    _ when declaringType == typeof(sbyte) => SByteSerializer.Instance,
-                    _ => UnknowableSerializer.Create(declaringType)
-                };
-            }
-        }
-
-        void DeducePowMethodSerializers()
-        {
-            if (method.Is(MathMethod.Pow))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeducePushMethodSerializers()
-        {
-            if (method.Is(WindowMethod.Push))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceCollectionAndItemSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceRadiansToDegreesMethodSerializers()
-        {
-            if (method.Is(MongoDBMathMethod.RadiansToDegrees))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceReturnsBooleanSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, BooleanSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsDateTimeSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, DateTimeSerializer.UtcInstance);
-            }
-        }
-
-        void DeduceReturnsDecimalSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, DecimalSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsDoubleSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, DoubleSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsInt32Serializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, Int32Serializer.Instance);
-            }
-        }
-
-        void DeduceReturnsInt64Serializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, Int64Serializer.Instance);
-            }
-        }
-
-        void DeduceReturnsNullableDecimalSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableDecimalInstance);
-            }
-        }
-
-        void DeduceReturnsNullableDoubleSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableDoubleInstance);
-            }
-        }
-
-        void DeduceReturnsNullableInt32Serializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableInt32Instance);
-            }
-        }
-
-        void DeduceReturnsNullableInt64Serializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableInt64Instance);
-            }
-        }
-
-        void DeduceReturnsNullableSingleSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, NullableSerializer.NullableSingleInstance);
-            }
-        }
-
-        void DeduceReturnsNumericSerializer()
-        {
-            if (IsNotKnown(node) && node.Type.IsNumeric())
-            {
-                var numericSerializer = StandardSerializers.GetSerializer(node.Type);
-                AddNodeSerializer(node, numericSerializer);
-            }
-        }
-
-        void DeduceReturnsOneSourceItemSerializer()
-        {
-            var sourceExpression = arguments[0];
-
-            if (IsNotKnown(node) && IsKnown(sourceExpression, out var sourceSerializer))
-            {
-                var nodeSerializer = sourceSerializer is IUnknowableSerializer ?
-                    UnknowableSerializer.Create(node.Type) :
-                    ArraySerializerHelper.GetItemSerializer(sourceSerializer);
-                AddNodeSerializer(node, nodeSerializer);
-            }
-        }
-
-        void DeduceReturnsSingleSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, SingleSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsStringSerializer()
-        {
-            if (IsNotKnown(node))
-            {
-                AddNodeSerializer(node, StringSerializer.Instance);
-            }
-        }
-
-        void DeduceReturnsTimeSpanSerializer(TimeSpanUnits units)
-        {
-            if (IsNotKnown(node))
-            {
-                var resultSerializer = new TimeSpanSerializer(BsonType.Int64, units);
-                AddNodeSerializer(node, resultSerializer);
-            }
-        }
-
-        void DeduceRangeMethodSerializers()
-        {
-            if (method.Is(EnumerableMethod.Range))
-            {
-                var elementExpression = arguments[0];
-                DeduceCollectionAndItemSerializers(node, elementExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceRepeatMethodSerializers()
-        {
-            if (method.Is(EnumerableMethod.Repeat))
-            {
-                var elementExpression = arguments[0];
-                DeduceCollectionAndItemSerializers(node, elementExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceReplaceMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.ReplaceOverloads, RegexMethod.ReplaceOverloads))
-            {
-                DeduceSerializer(node, StringSerializer.Instance);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceReverseMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.ReverseOverloads))
-            {
-                var sourceExpression = arguments[0];
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceRoundMethodSerializers()
-        {
-            if (method.IsOneOf(MathMethod.RoundWithDecimal, MathMethod.RoundWithDecimalAndDecimals, MathMethod.RoundWithDouble, MathMethod.RoundWithDoubleAndDigits))
-            {
-                if (IsNotKnown(node))
-                {
-                    var resultSerializer = StandardSerializers.GetSerializer(node.Type);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSelectMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Select, QueryableMethod.Select))
-            {
-                var sourceExpression = arguments[0];
-                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var selectorParameter = selectorLambda.Parameters.Single();
-                DeduceItemAndCollectionSerializers(selectorParameter, sourceExpression);
-                DeduceCollectionAndItemSerializers(node, selectorLambda.Body);
-            }
-            else if (method.IsOneOf(EnumerableOrQueryableMethod.SelectWithSelectorTakingIndex))
-            {
-                var sourceExpression = arguments[0];
-                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var itemParameter = selectorLambda.Parameters[0];
-                var indexParameter = selectorLambda.Parameters[1];
-                DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
-                if (IsNotKnown(indexParameter))
-                {
-                    AddNodeSerializer(indexParameter, Int32Serializer.Instance);
-                }
-                DeduceCollectionAndItemSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSelectManySerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.SelectManyOverloads))
-            {
-                var sourceExpression = arguments[0];
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.SelectManyWithSelector))
-                {
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorSourceParameter = selectorLambda.Parameters.Single();
-
-                    DeduceItemAndCollectionSerializers(selectorSourceParameter, sourceExpression);
-                    DeduceCollectionAndCollectionSerializers(node, selectorLambda.Body);
-                }
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector))
-                {
-                    var collectionSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var resultSelectorLambda =  ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-
-                    var collectionSelectorSourceItemParameter = collectionSelectorLambda.Parameters.Single();
-                    var resultSelectorSourceItemParameter = resultSelectorLambda.Parameters[0];
-                    var resultSelectorCollectionItemParameter = resultSelectorLambda.Parameters[1];
-
-                    DeduceItemAndCollectionSerializers(collectionSelectorSourceItemParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(resultSelectorSourceItemParameter, sourceExpression);
-                    DeduceItemAndCollectionSerializers(resultSelectorCollectionItemParameter, collectionSelectorLambda.Body);
-                    DeduceCollectionAndItemSerializers(node, resultSelectorLambda.Body);
-                }
-            }
-            else if (method.IsOneOf(EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex))
-            {
-                var sourceExpression = arguments[0];
-                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var itemParameter = selectorLambda.Parameters[0];
-                var indexParameter = selectorLambda.Parameters[1];
-                DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
-                if (IsNotKnown(indexParameter))
-                {
-                    AddNodeSerializer(indexParameter, Int32Serializer.Instance);
-                }
-                DeduceCollectionAndCollectionSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSequenceEqualMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.SequenceEqual, QueryableMethod.SequenceEqual))
-            {
-                var source1Expression =  arguments[0];
-                var source2Expression = arguments[1];
-
-                DeduceCollectionAndCollectionSerializers(source1Expression, source2Expression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSerializeEJsonMethodSerializers()
-        {
-            if (method.Is(MqlMethod.SerializeEJson))
-            {
-                if (IsNotKnown(node))
-                {
-                    var outputType = method.GetGenericArguments()[1];
-                    var outputSerializer = BsonSerializer.LookupSerializer(outputType);
-                    AddNodeSerializer(node, outputSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSetEqualsMethodSerializers()
-        {
-            if (ISetMethod.IsSetEqualsMethod(method))
-            {
-                var objectExpression =  node.Object;
-                var otherExpression = arguments[0];
-
-                DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSetUnionMethodSerializers()
-        {
-            if (method.Is(WindowMethod.SetUnion))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceCollectionAndCollectionSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSetWindowFieldsMethodSerializers()
-        {
-            if (method.Is(EnumerableMethod.First))
-            {
-                var objectExpression =  node.Object;
-                var otherExpression = arguments[0];
-
-                DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceShiftMethodSerializers()
-        {
-            if (method.IsOneOf(WindowMethod.Shift, WindowMethod.ShiftWithDefaultValue))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceSerializers(node, selectorLambda.Body);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSigmoidMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Sigmoid))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSimilarityFunctionsSerializers()
-        {
-            if (method.IsOneOf(MqlMethod.SimilarityFunctionOverloads))
-            {
-                DeduceReturnsNumericSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSplitMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.SplitOverloads, RegexMethod.SplitOverloads))
-            {
-                if (IsNotKnown(node))
-                {
-                    var nodeSerializer = ArraySerializer.Create(StringSerializer.Instance);
-                    AddNodeSerializer(node, nodeSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSqrtMethodSerializers()
-        {
-            if (method.Is(MathMethod.Sqrt))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceStandardDeviationMethodSerializers()
-        {
-            if (method.IsOneOf(MongoEnumerableMethod.StandardDeviationOverloads, MongoQueryableMethod.StandardDeviationOverloads))
-            {
-                if (method.IsOneOf(MongoEnumerableMethod.StandardDeviationWithSelectorOverloads, MongoQueryableMethod.StandardDeviationWithSelectorOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorItemParameter = selectorLambda.Parameters.Single();
-                    DeduceCollectionAndItemSerializers(sourceExpression, selectorItemParameter);
-                }
-
-                DeduceStandardSerializer(node);
-            }
-            else if (method.IsOneOf(WindowMethod.StandardDeviationOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceEndsWithOrStartsWithMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.EndsWithOrStartsWithOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceStringInOrNinMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.StringInOrNinOverloads))
-            {
-                DeduceReturnsBooleanSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceStrLenBytesMethodSerializers()
-        {
-            if (method.Is(StringMethod.StrLenBytes))
-            {
-                DeduceReturnsInt32Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSubstringMethodSerializers()
-        {
-            if (method.IsOneOf(StringMethod.Substring, StringMethod.SubstringWithLength, StringMethod.SubstrBytes))
-            {
-                DeduceReturnsStringSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSubtractMethodSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.SubtractReturningDateTimeOverloads))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else if (method.IsOneOf(DateTimeMethod.SubtractReturningInt64Overloads))
-            {
-                DeduceReturnsInt64Serializer();
-            }
-            else if (method.IsOneOf(DateTimeMethod.SubtractReturningTimeSpanWithMillisecondsUnitsOverloads))
-            {
-                var units = TimeSpanUnits.Milliseconds;
-                DeduceReturnsTimeSpanSerializer(units);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSumMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.SumOverloads))
-            {
-                if (method.IsOneOf(EnumerableOrQueryableMethod.SumWithSelectorOverloads))
-                {
-                    var sourceExpression = arguments[0];
-                    var selectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var selectorParameter = selectorLambda.Parameters.Single();
-                    DeduceItemAndCollectionSerializers(selectorParameter, sourceExpression);
-                }
-
-                var returnType = node.Type;
-                switch (returnType)
-                {
-                    case not null when returnType == typeof(decimal): DeduceReturnsDecimalSerializer(); break;
-                    case not null when returnType == typeof(double): DeduceReturnsDoubleSerializer(); break;
-                    case not null when returnType == typeof(int): DeduceReturnsInt32Serializer(); break;
-                    case not null when returnType == typeof(long): DeduceReturnsInt64Serializer(); break;
-                    case not null when returnType == typeof(float): DeduceReturnsSingleSerializer(); break;
-                    case not null when returnType == typeof(decimal?): DeduceReturnsNullableDecimalSerializer(); break;
-                    case not null when returnType == typeof(double?): DeduceReturnsNullableDoubleSerializer(); break;
-                    case not null when returnType == typeof(int?): DeduceReturnsNullableInt32Serializer(); break;
-                    case not null when returnType == typeof(long?): DeduceReturnsNullableInt64Serializer(); break;
-                    case not null when returnType == typeof(float?): DeduceReturnsNullableSingleSerializer(); break;
-                }
-            }
-            else if (method.IsOneOf(WindowMethod.SumOverloads))
-            {
-                var partitionExpression = arguments[0];
-                var selectorLambda = (LambdaExpression)arguments[1];
-                DeduceWindowMethodSelectorParameterSerializer(partitionExpression, selectorLambda);
-                DeduceStandardSerializer(node);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSubtypeMethodSerializers()
-        {
-            if (method.Is(MqlMethod.Subtype))
-            {
-                DeduceSerializer(node, __binarySubTypeSerializer);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceSkipOrTakeMethodSerializers()
-        {
-            if (method.IsOneOf(EnumerableOrQueryableMethod.SkipOrTakeOverloads))
-            {
-                var sourceExpression = arguments[0];
-
-                if (method.IsOneOf(EnumerableOrQueryableMethod.SkipWhileOrTakeWhile))
-                {
-                    var predicateLambda =  ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                    var itemParameter = predicateLambda.Parameters[0];
-                    DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
-
-                    if (method.IsOneOf(EnumerableOrQueryableMethod.SkipWhileWithPredicateTakingIndexOrTakeWhileWithPredicateTakingIndex))
+                    var declaringType = expression.Method.DeclaringType;
+                    var nodeSerializer = declaringType switch
                     {
-                        var indexParameter = predicateLambda.Parameters[1];
-                        if (IsNotKnown(indexParameter))
-                        {
-                            AddNodeSerializer(indexParameter, Int32Serializer.Instance);
-                        }
+                        _ when declaringType == typeof(DateTime) => DateTimeSerializer.Instance,
+                        _ when declaringType == typeof(decimal) => DecimalSerializer.Instance,
+                        _ when declaringType == typeof(double) => DoubleSerializer.Instance,
+                        _ when declaringType == typeof(int) => Int32Serializer.Instance,
+                        _ when declaringType == typeof(short) => Int64Serializer.Instance,
+                        _ => UnknowableSerializer.Create(declaringType)
+                    };
+                    visitor.AddNodeSerializer(expression, nodeSerializer);
+                }
+            }
+
+            static void DeduceSetEqualsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var objectExpression = expression.Object;
+                var otherExpression = expression.Arguments[0];
+
+                visitor.DeduceCollectionAndCollectionSerializers(objectExpression, otherExpression);
+                visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+            }
+
+            static bool IsToArrayMethod(MethodInfo method) =>
+                method.IsPublic &&
+                method.Name == "ToArray" &&
+                method.GetParameters().Length == (method.IsStatic ? 1 : 0);
+
+            static void DeduceToArrayMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                var sourceExpression = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
+            }
+
+            static void DeduceToListSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+            {
+                if (visitor.IsNotKnown(expression))
+                {
+                    var source = expression.Method.IsStatic ? expression.Arguments[0] : expression.Object;
+                    if (visitor.IsKnown(source, out var sourceSerializer))
+                    {
+                        var sourceItemSerializer = ArraySerializerHelper.GetItemSerializer(sourceSerializer);
+                        var resultSerializer = ListSerializer.Create(sourceItemSerializer);
+                        visitor.AddNodeSerializer(expression, resultSerializer);
                     }
                 }
-
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
             }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceToArrayMethodSerializers()
-        {
-            if (IsToArrayMethod(out var sourceExpression))
-            {
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-
-            bool IsToArrayMethod(out Expression sourceExpression)
-            {
-                if (method.IsPublic &&
-                    method.Name == "ToArray" &&
-                    method.GetParameters().Length == (method.IsStatic ? 1 : 0))
-                {
-                    sourceExpression = method.IsStatic ? arguments[0] : node.Object;
-                    return true;
-                }
-
-                sourceExpression = null;
-                return false;
-            }
-        }
-
-        void DeduceToHashedIndexKeySerializers()
-        {
-            if (method.Is(MqlMethod.ToHashedIndexKey))
-            {
-                DeduceReturnsInt64Serializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceToListSerializers()
-        {
-            if (IsNotKnown(node))
-            {
-                var source = method.IsStatic ? arguments[0] : node.Object;
-                if (IsKnown(source, out var sourceSerializer))
-                {
-                    var sourceItemSerializer = ArraySerializerHelper.GetItemSerializer(sourceSerializer);
-                    var resultSerializer = ListSerializer.Create(sourceItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-        }
-
-        void DeduceToLowerOrToUpperSerializers()
-        {
-            if (method.IsOneOf(StringMethod.ToLowerOrToUpperOverloads))
-            {
-                DeduceReturnsStringSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceToStringSerializers()
-        {
-            DeduceReturnsStringSerializer();
-        }
-
-        void DeduceTrigonometricMethodSerializers()
-        {
-            if (method.IsOneOf(MathMethod.TrigonometricMethods))
-            {
-                DeduceReturnsDoubleSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceTrimSerializers()
-        {
-            if (method.IsOneOf(StringMethod.TrimOverloads))
-            {
-                DeduceReturnsStringSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceTruncateSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.Truncate, DateTimeMethod.TruncateWithBinSize, DateTimeMethod.TruncateWithBinSizeAndTimezone))
-            {
-                DeduceReturnsDateTimeSerializer();
-            }
-            else if (method.IsOneOf(MathMethod.TruncateDecimal, MathMethod.TruncateDouble))
-            {
-                DeduceReturnsNumericSerializer();
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceUnionSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Union, QueryableMethod.Union))
-            {
-                var sourceExpression = arguments[0];
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceUnknownMethodSerializer()
-        {
-            DeduceUnknowableSerializer(node);
-        }
-
-        void DeduceWeekSerializers()
-        {
-            if (method.IsOneOf(DateTimeMethod.Week, DateTimeMethod.WeekWithTimezone))
-            {
-                if (IsNotKnown(node))
-                {
-                    AddNodeSerializer(node, Int32Serializer.Instance);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceWhereSerializers()
-        {
-            if (method.IsOneOf(__whereOverloads))
-            {
-                var sourceExpression = arguments[0];
-                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var predicateParameter =  predicateLambda.Parameters.Single();
-                DeduceItemAndCollectionSerializers(predicateParameter, sourceExpression);
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else if (method.IsOneOf(EnumerableOrQueryableMethod.WhereWithPredicateTakingIndex))
-            {
-                var sourceExpression = arguments[0];
-                var predicateLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[1]);
-                var itemParameter = predicateLambda.Parameters[0];
-                var indexParameter = predicateLambda.Parameters[1];
-                DeduceItemAndCollectionSerializers(itemParameter, sourceExpression);
-                if (IsNotKnown(indexParameter))
-                {
-                    AddNodeSerializer(indexParameter, Int32Serializer.Instance);
-                }
-                DeduceCollectionAndCollectionSerializers(node, sourceExpression);
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        void DeduceWindowMethodSelectorParameterSerializer(Expression partitionExpression, LambdaExpression selectorLambda)
-        {
-            var inputParameter = selectorLambda.Parameters.Single();
-            if (IsNotKnown(inputParameter) && IsKnown(partitionExpression, out var partitionSerializer))
-            {
-                var inputSerializer = ((ISetWindowFieldsPartitionSerializer)partitionSerializer).InputSerializer;
-                AddNodeSerializer(inputParameter, inputSerializer);
-            }
-        }
-
-        void DeduceZipSerializers()
-        {
-            if (method.IsOneOf(EnumerableMethod.Zip, QueryableMethod.Zip))
-            {
-                var firstExpression = arguments[0];
-                var secondExpression = arguments[1];
-                var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, arguments[2]);
-                var resultSelectorFirstParameter = resultSelectorLambda.Parameters[0];
-                var resultSelectorSecondParameter =  resultSelectorLambda.Parameters[1];
-
-                if (IsNotKnown(resultSelectorFirstParameter) && IsKnown(firstExpression, out var firstSerializer))
-                {
-                    var firstItemSerializer =  ArraySerializerHelper.GetItemSerializer(firstSerializer);
-                    AddNodeSerializer(resultSelectorFirstParameter, firstItemSerializer);
-                }
-
-                if (IsNotKnown(resultSelectorSecondParameter) && IsKnown(secondExpression, out var secondSerializer))
-                {
-                    var secondItemSerializer =  ArraySerializerHelper.GetItemSerializer(secondSerializer);
-                    AddNodeSerializer(resultSelectorSecondParameter, secondItemSerializer);
-                }
-
-                if (IsNotKnown(node) && IsKnown(resultSelectorLambda.Body, out var resultItemSerializer))
-                {
-                    var resultSerializer = IEnumerableOrIQueryableSerializer.Create(node.Type, resultItemSerializer);
-                    AddNodeSerializer(node, resultSerializer);
-                }
-            }
-            else
-            {
-                DeduceUnknownMethodSerializer();
-            }
-        }
-
-        bool IsDictionaryContainsKeyExpression(out Expression keyExpression)
-        {
-            if (DictionaryMethod.IsContainsKeyMethod(method))
-            {
-                keyExpression = arguments[0];
-                return true;
-            }
-
-            keyExpression = null;
-            return false;
         }
     }
 }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -153,8 +153,6 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers([MongoQueryableMethod.Documents, MongoQueryableMethod.DocumentsWithSerializer], DeduceDocumentsMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.ElementAtOverloads, (visitor, expression) => visitor.DeduceItemAndCollectionSerializers(expression, expression.Arguments[0]));
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.Except, DeduceExceptMethodSerializers);
-            // TODO: Definitely wrong registration copy-pasted from prev code, investigate before merge to main
-            // RegisterSerializerDeducer(EnumerableMethod.First, DeduceSetWindowFieldsMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads, DeduceFirstOrLastOrSingleMethodsSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.GroupByOverloads, DeduceGroupByMethodSerializers);
             RegisterSerializerDeducers([EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin], DeduceGroupJoinMethodSerializers);
@@ -182,6 +180,7 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers([EnumerableMethod.SequenceEqual, QueryableMethod.SequenceEqual], DeduceSequenceEqualMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.SkipOrTakeOverloads, DeduceSkipOrTakeMethodSerializers);
             RegisterSerializerDeducers(MongoEnumerableMethod.StandardDeviationOverloads, DeduceStandardDeviationMethodSerializers);
+            RegisterSerializerDeducers(MongoQueryableMethod.StandardDeviationOverloads, DeduceStandardDeviationMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.SumOverloads, DeduceEnumerableSumMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.Union, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
             RegisterSerializerDeducers(__whereOverloads, DeduceWhereSerializers);
@@ -1189,13 +1188,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression.Arguments[0], expression.Arguments[1]);
             visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
-
-        // DeduceSetWindowFieldsMethodSerializers
-        // static void DeduceSetWindowFieldsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
-        // {
-        //     visitor.DeduceCollectionAndCollectionSerializers(expression.Object, expression.Arguments[0]);
-        //     visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
-        // }
 
         // DeduceShiftMethodSerializers
         private static void DeduceShiftMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -297,7 +297,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceAddToSetMethodSerializers
         private static void DeduceAddToSetMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -306,7 +305,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceConcatArraysMethodSerializers
         private static void DeduceConcatArraysMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -315,7 +313,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceSetUnionMethodSerializers
         private static void DeduceSetUnionMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -324,7 +321,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceMinMaxScalerMethodSerializers
         private static void DeduceMinMaxScalerMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -333,7 +329,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        // DeduceEncStrMethodSerializers
         private static void DeduceEncStrMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var inputExpression = expression.Arguments[0];
@@ -349,7 +344,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        // DeduceLeftJoinMethodSerializers
         private static void DeduceLeftJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var method = expression.Method;
@@ -370,7 +364,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
         }
 
-        // DeducePickWindowMethodSerializers
         private static void DeducePickWindowMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var method = expression.Method;
@@ -399,7 +392,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithFunc branch
         private static void DeduceAggregateWithFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -413,7 +405,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializers(expression, funcLambda.Body);
         }
 
-        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithSeedAndFunc branch
         private static void DeduceAggregateWithSeedAndFuncMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -428,7 +419,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializers(expression, funcLambda.Body);
         }
 
-        // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithSeedFuncAndResultSelector branch
         private static void DeduceAggregateWithSeedFuncAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -446,7 +436,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializers(expression, resultSelectorLambda.Body);
         }
 
-        // DeduceAllMethodSerializers
         private static void DeduceAllMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -457,7 +446,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        // DeduceAnyMethodSerializers + EnumerableOrQueryableMethod.AnyWithPredicate branch
         private static void DeduceAnyWithPredicateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -468,7 +456,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        // DeduceAppendStageMethodSerializers
         private static void DeduceAppendStageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
@@ -505,7 +492,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceAsMethodSerializers
         private static void DeduceAsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
@@ -528,7 +514,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceAsQueryableMethodSerializers
         private static void DeduceAsQueryableMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -540,7 +525,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceConcatMethodSerializers + EnumerableMethod.Concat, QueryableMethod.Concat branch
         private static void DeduceEnumerableConcatMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var firstExpression = expression.Arguments[0];
@@ -550,7 +534,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, firstExpression);
         }
 
-        // DeduceConstantMethodSerializers
         private static void DeduceConstantMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var valueExpression = expression.Arguments[0];
@@ -580,7 +563,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializer(expression, serializer);
         }
 
-        // DeduceConvertMethodSerializers
         private static void DeduceConvertMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
@@ -630,7 +612,6 @@ internal partial class SerializerFinderVisitor
         }
 
 #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-        // DeduceCreateMethodSerializers + KeyValuePairMethod.Create branch
         private static void DeduceKeyValuePairCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsAnyNotKnown(expression.Arguments) && visitor.IsKnown(expression, out var nodeSerializer))
@@ -655,7 +636,6 @@ internal partial class SerializerFinderVisitor
         }
 #endif
 
-        // DeduceCreateMethodSerializers + TupleOrValueTupleMethod.CreateOverloads
         private static void DeduceTupleOrValueTupleCreateMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsAnyNotKnown(expression.Arguments) && visitor.IsKnown(expression, out var nodeSerializer))
@@ -697,14 +677,12 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceDateFromStringMethodSerializers
         private static void DeduceDateFromStringMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var resultSerializer = expression.Method.Is(MqlMethod.DateFromStringWithFormatAndTimezoneAndOnErrorAndOnNull) ? NullableSerializer.NullableUtcDateTimeInstance : DateTimeSerializer.UtcInstance;
             visitor.DeduceSerializer(expression, resultSerializer);
         }
 
-        // DeduceDefaultIfEmptyMethodSerializers
         private static void DeduceDefaultIfEmptyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -718,7 +696,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        // DeduceDensifyMethodSerializers
         private static void DeduceDensifyMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -741,7 +718,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        // DeduceDocumentsMethodSerializers
         private static void DeduceDocumentsMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
@@ -764,7 +740,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceExceptMethodSerializers
         private static void DeduceExceptMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var firstExpression = expression.Arguments[0];
@@ -773,7 +748,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, firstExpression);
         }
 
-        // DeduceExponentialMovingAverageMethodSerializers
         private static void DeduceExponentialMovingAverageMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -782,7 +756,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        // DeduceFieldMethodSerializers
         private static void DeduceFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
@@ -798,7 +771,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceGroupByMethodSerializers
         private static void DeduceGroupByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -862,7 +834,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceGroupJoinMethodSerializers
         private static void DeduceGroupJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var outerExpression = expression.Arguments[0];
@@ -882,7 +853,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
         }
 
-        // DeduceHasFlagMethodSerializers
         private static void DeduceHasFlagMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var objectExpression = expression.Object;
@@ -894,7 +864,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        // DeduceJoinMethodSerializers
         private static void DeduceJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var outerExpression = expression.Arguments[0];
@@ -914,7 +883,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
         }
 
-        // DeduceLocfMethodSerializers
         private static void DeduceLocfMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -923,7 +891,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceLookupMethodSerializers + MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField branch
         private static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -946,7 +913,6 @@ internal partial class SerializerFinderVisitor
                 visitor.AddNodeSerializer(expression, IQueryableSerializer.Create(lookupResultSerializer));
             }
         }
-        // DeduceLookupMethodSerializers + LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline branch
         private static void DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -975,7 +941,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceLookupMethodSerializers + LookupWithDocumentsAndPipeline branch
         private static void DeduceLookupWithDocumentsAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -998,7 +963,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceLookupMethodSerializers + LookupWithFromAndLocalFieldAndForeignField branch
         private static void DeduceLookupWithFromAndLocalFieldAndForeignFieldMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1021,7 +985,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceLookupMethodSerializers + LookupWithFromAndLocalFieldAndForeignFieldAndPipeline branch
         private static void DeduceLookupWithFromAndLocalFieldAndForeignFieldAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1055,7 +1018,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceLookupMethodSerializers + LookupWithFromAndPipeline branch
         private static void DeduceLookupWithFromAndPipelineMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1063,14 +1025,14 @@ internal partial class SerializerFinderVisitor
             var foreignDocumentSerializer = fromCollection.DocumentSerializer;
             var pipelineLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(expression.Method, expression.Arguments[2]);
             var pipelineLambdaLocalParameter = pipelineLambda.Parameters[0];
-            var pipelineLamdbaForeignQueryableParameter = pipelineLambda.Parameters[1];
+            var pipelineLambdaForeignQueryableParameter = pipelineLambda.Parameters[1];
 
             visitor.DeduceItemAndCollectionSerializers(pipelineLambdaLocalParameter, sourceExpression);
 
-            if (visitor.IsNotKnown(pipelineLamdbaForeignQueryableParameter))
+            if (visitor.IsNotKnown(pipelineLambdaForeignQueryableParameter))
             {
                 var foreignQueryableSerializer = IQueryableSerializer.Create(foreignDocumentSerializer);
-                visitor.AddNodeSerializer(pipelineLamdbaForeignQueryableParameter, foreignQueryableSerializer);
+                visitor.AddNodeSerializer(pipelineLambdaForeignQueryableParameter, foreignQueryableSerializer);
             }
 
             if (visitor.IsNotKnown(expression) &&
@@ -1082,7 +1044,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceOfTypeMethodSerializers
         private static void DeduceOfTypeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1096,7 +1057,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeducePushMethodSerializers
         private static void DeducePushMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -1105,7 +1065,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceRoundMethodSerializers
         private static void DeduceRoundMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
@@ -1115,7 +1074,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceSelectMethodSerializers
         private static void DeduceSelectMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1139,7 +1097,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelector branch
         private static void DeduceSelectManyWithSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1150,7 +1107,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithCollectionSelectorAndResultSelector branch
         private static void DeduceSelectManyWithCollectionSelectorAndResultSelectorMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1167,7 +1123,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
         }
 
-        // DeduceSelectManySerializers + EnumerableOrQueryableMethod.SelectManyWithSelectorTakingIndex branch
         private static void DeduceSelectManyWithSelectorTakingIndexMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1182,14 +1137,12 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceSequenceEqualMethodSerializers
         private static void DeduceSequenceEqualMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             visitor.DeduceCollectionAndCollectionSerializers(expression.Arguments[0], expression.Arguments[1]);
             visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        // DeduceShiftMethodSerializers
         private static void DeduceShiftMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -1198,7 +1151,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceSplitMethodSerializers
         private static void DeduceSplitMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (visitor.IsNotKnown(expression))
@@ -1208,7 +1160,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceSumMethodSerializers + EnumerableOrQueryableMethod.SumOverloads branch
         private static void DeduceEnumerableSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.SumWithSelectorOverloads))
@@ -1239,7 +1190,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializer(expression, serializer);
         }
 
-        // DeduceSumMethodSerializers + WindowMethod.SumOverloads branch
         private static void DeduceWindowSumMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -1248,7 +1198,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        // DeduceWhereSerializers
         private static void DeduceWhereSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1272,7 +1221,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        // DeduceZipSerializers
         private static void DeduceZipSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var firstExpression = expression.Arguments[0];
@@ -1300,7 +1248,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceAppendOrPrependMethodSerializers
         private static void DeduceAppendOrPrependMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1310,7 +1257,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        // DeduceAverageOrMedianOrPercentileMethodSerializers + __averageOrMedianOrPercentileOverloads branch
         private static void DeduceAverageOrMedianOrPercentileMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(__averageOrMedianOrPercentileWithSelectorOverloads))
@@ -1329,7 +1275,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceAverageOrMedianOrPercentileMethodSerializers + __averageOrMedianOrPercentileWindowMethodOverloads branch
         private static void DeduceAverageOrMedianOrPercentileWindowMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -1358,7 +1303,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeducePickMethodSerializers
         private static void DeducePickMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var method = expression.Method;
@@ -1434,7 +1378,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceCountMethodSerializers + EnumerableOrQueryableMethod.CountOverloads branch
         private static void DeduceEnumerableCountMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.CountWithPredicateOverloads))
@@ -1448,7 +1391,6 @@ internal partial class SerializerFinderVisitor
             DeduceReturnsNumericSerializer(visitor, expression);
         }
 
-        // DeduceCovarianceMethodSerializers
         private static void DeduceCovarianceMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -1459,7 +1401,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        // DeduceDerivativeOrIntegralMethodSerializers
         private static void DeduceDerivativeOrIntegralMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -1468,7 +1409,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceStandardSerializer(expression);
         }
 
-        // DeduceFirstOrLastOrSingleMethodsSerializers + EnumerableOrQueryableMethod.FirstOrLastOrSingleOverloads
         private static void DeduceFirstOrLastOrSingleMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.FirstOrLastOrSingleWithPredicateOverloads))
@@ -1482,7 +1422,6 @@ internal partial class SerializerFinderVisitor
             DeduceReturnsOneSourceItemSerializer(visitor, expression);
         }
 
-        // DeduceFirstOrLastOrSingleMethodsSerializers + WindowMethod.First, WindowMethod.Last branch
         private static void DeduceFirstOrLastWindowMethodsSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -1491,7 +1430,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceMaxOrMinMethodSerializers + EnumerableOrQueryableMethod.MaxOrMinOverloads branch
         private static void DeduceMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(EnumerableOrQueryableMethod.MaxOrMinWithSelectorOverloads))
@@ -1509,7 +1447,6 @@ internal partial class SerializerFinderVisitor
             }
         }
 
-        // DeduceMaxOrMinMethodSerializers + WindowMethod.Max, WindowMethod.Min branch
         private static void DeduceWindowMaxOrMinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];
@@ -1518,7 +1455,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializers(expression, selectorLambda.Body);
         }
 
-        // DeduceOrderByMethodSerializers
         private static void DeduceOrderByMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1529,7 +1465,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        // DeduceSkipOrTakeMethodSerializers
         private static void DeduceSkipOrTakeMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var sourceExpression = expression.Arguments[0];
@@ -1553,7 +1488,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceCollectionAndCollectionSerializers(expression, sourceExpression);
         }
 
-        // DeduceStandardDeviationMethodSerializers + MongoEnumerableMethod.StandardDeviationOverloads branch
         private static void DeduceStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             if (expression.Method.IsOneOf(MongoEnumerableMethod.StandardDeviationWithSelectorOverloads, MongoQueryableMethod.StandardDeviationWithSelectorOverloads))
@@ -1576,7 +1510,6 @@ internal partial class SerializerFinderVisitor
             visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
         }
 
-        // DeduceStandardDeviationMethodSerializers + WindowMethod.StandardDeviationOverloads branch
         private static void DeduceWindowStandardDeviationMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
         {
             var partitionExpression = expression.Arguments[0];

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -276,8 +276,12 @@ internal partial class SerializerFinderVisitor
 
             void RegisterSerializerDeducer(MethodInfo method, Action<SerializerFinderVisitor, MethodCallExpression> deducer)
             {
-                Ensure.IsNotNull(method, nameof(method));
                 Ensure.IsNotNull(deducer, nameof(deducer));
+
+                if (method == null)
+                {
+                    return;
+                }
 
                 if (!__serializerDeducers.TryAdd(new MethodKey(method), deducer))
                 {

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitMethodCall.cs
@@ -73,6 +73,15 @@ internal partial class SerializerFinderVisitor
 
         private static readonly ConcurrentDictionary<MethodKey, Action<SerializerFinderVisitor, MethodCallExpression>> __serializerDeducers = new();
         private static readonly IBsonSerializer __binarySubTypeSerializer = NullableSerializer.Create(new EnumSerializer<BsonBinarySubType>());
+        private static readonly IBsonSerializer __bsonBinaryDataSerializer = new BsonValueCSharpNullSerializer<BsonBinaryData>(BsonBinaryDataSerializer.Instance);
+
+        private static readonly IReadOnlyMethodInfoSet __pickWindowMethodWithSortByOverloads = MethodInfoSet.Create(
+        [
+            WindowMethod.Bottom,
+            WindowMethod.BottomN,
+            WindowMethod.Top,
+            WindowMethod.TopN
+        ]);
 
         private static readonly IReadOnlyMethodInfoSet __averageOrMedianOrPercentileOverloads = MethodInfoSet.Create(
         [
@@ -151,6 +160,7 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers([EnumerableMethod.GroupJoin, QueryableMethod.GroupJoin], DeduceGroupJoinMethodSerializers);
             RegisterSerializerDeducers(EnumerableOrQueryableMethod.Intersect, (visitor, expression) => visitor.DeduceCollectionAndCollectionSerializers(expression, expression.Arguments[0]));
             RegisterSerializerDeducers([EnumerableMethod.Join, QueryableMethod.Join], DeduceJoinMethodSerializers);
+            RegisterSerializerDeducers([MongoQueryableMethod.LeftJoin, QueryableMethod.LeftJoin], DeduceLeftJoinMethodSerializers);
             RegisterSerializerDeducer(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignField, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldMethodSerializers);
             RegisterSerializerDeducer(MongoQueryableMethod.LookupWithDocumentsAndLocalFieldAndForeignFieldAndPipeline, DeduceLookupWithDocumentsAndLocalFieldAndForeignFieldAndPipelineMethodSerializers);
             RegisterSerializerDeducer(MongoQueryableMethod.LookupWithDocumentsAndPipeline, DeduceLookupWithDocumentsAndPipelineMethodSerializers);
@@ -207,9 +217,10 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducer(MqlMethod.CreateObjectId, (visitor, expression) => visitor.DeduceSerializer(expression, ObjectIdSerializer.Instance));
             RegisterSerializerDeducers(MqlMethod.DateFromStringOverloads, DeduceDateFromStringMethodSerializers);
             RegisterSerializerDeducer(MqlMethod.DeserializeEJson, DeduceDeserializeEJsonMethodSerializers);
+            RegisterSerializerDeducers(MqlMethod.EncStrMethodOverloads, DeduceEncStrMethodSerializers);
             RegisterSerializerDeducers([MqlMethod.Exists, MqlMethod.IsMissing, MqlMethod.IsNullOrMissing], (visitor, expression) => visitor.DeduceSerializer(expression, BooleanSerializer.Instance));
             RegisterSerializerDeducer(MqlMethod.Field, DeduceFieldMethodSerializers);
-            RegisterSerializerDeducer(MqlMethod.Hash, (visitor, expression) => visitor.DeduceSerializer(expression, BsonBinaryDataSerializer.Instance));
+            RegisterSerializerDeducer(MqlMethod.Hash, (visitor, expression) => visitor.DeduceSerializer(expression, __bsonBinaryDataSerializer));
             RegisterSerializerDeducer(MqlMethod.HexHash, (visitor, expression) => visitor.DeduceSerializer(expression, StringSerializer.Instance));
             RegisterSerializerDeducer(MqlMethod.SerializeEJson, DeduceSerializeEJsonMethodSerializers);
             RegisterSerializerDeducer(MqlMethod.Sigmoid, (visitor, expression) => visitor.DeduceSerializer(expression, DoubleSerializer.Instance));
@@ -244,6 +255,7 @@ internal partial class SerializerFinderVisitor
 
             // WindowMethod
             RegisterSerializerDeducer(WindowMethod.AddToSet, DeduceAddToSetMethodSerializers);
+            RegisterSerializerDeducer(WindowMethod.ConcatArrays, DeduceConcatArraysMethodSerializers);
             RegisterSerializerDeducers(__averageOrMedianOrPercentileWindowMethodOverloads, DeduceAverageOrMedianOrPercentileWindowMethodSerializers);
             RegisterSerializerDeducer(WindowMethod.Count, (visitor, expression) => visitor.DeduceSerializer(expression, Int64Serializer.Instance));
             RegisterSerializerDeducers(WindowMethod.CovarianceOverloads, DeduceCovarianceMethodSerializers);
@@ -254,7 +266,10 @@ internal partial class SerializerFinderVisitor
             RegisterSerializerDeducers([WindowMethod.First, WindowMethod.Last], DeduceFirstOrLastWindowMethodsSerializers);
             RegisterSerializerDeducer(WindowMethod.Locf, DeduceLocfMethodSerializers);
             RegisterSerializerDeducers([WindowMethod.Max, WindowMethod.Min], DeduceWindowMaxOrMinMethodSerializers);
+            RegisterSerializerDeducers(WindowMethod.MinMaxScalerOverloads, DeduceMinMaxScalerMethodSerializers);
+            RegisterSerializerDeducers(WindowMethod.PickOverloads, DeducePickWindowMethodSerializers);
             RegisterSerializerDeducer(WindowMethod.Push, DeducePushMethodSerializers);
+            RegisterSerializerDeducer(WindowMethod.SetUnion, DeduceSetUnionMethodSerializers);
             RegisterSerializerDeducers([WindowMethod.Shift, WindowMethod.ShiftWithDefaultValue], DeduceShiftMethodSerializers);
             RegisterSerializerDeducers(WindowMethod.StandardDeviationOverloads, DeduceWindowStandardDeviationMethodSerializers);
             RegisterSerializerDeducers(WindowMethod.SumOverloads, DeduceWindowSumMethodSerializers);
@@ -286,6 +301,99 @@ internal partial class SerializerFinderVisitor
             var selectorLambda = (LambdaExpression)expression.Arguments[1];
             DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
             visitor.DeduceCollectionAndItemSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceConcatArraysMethodSerializers
+        private static void DeduceConcatArraysMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceSetUnionMethodSerializers
+        private static void DeduceSetUnionMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceCollectionAndCollectionSerializers(expression, selectorLambda.Body);
+        }
+
+        // DeduceMinMaxScalerMethodSerializers
+        private static void DeduceMinMaxScalerMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var partitionExpression = expression.Arguments[0];
+            var selectorLambda = (LambdaExpression)expression.Arguments[1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+            visitor.DeduceStandardSerializer(expression);
+        }
+
+        // DeduceEncStrMethodSerializers
+        private static void DeduceEncStrMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var inputExpression = expression.Arguments[0];
+            var valueExpression = expression.Arguments[1];
+            if (visitor.IsNotKnown(inputExpression))
+            {
+                visitor.AddNodeSerializer(inputExpression, StringSerializer.Instance);
+            }
+            if (visitor.IsNotKnown(valueExpression))
+            {
+                visitor.AddNodeSerializer(valueExpression, StringSerializer.Instance);
+            }
+            visitor.DeduceSerializer(expression, BooleanSerializer.Instance);
+        }
+
+        // DeduceLeftJoinMethodSerializers
+        private static void DeduceLeftJoinMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var method = expression.Method;
+            var outerExpression = expression.Arguments[0];
+            var innerExpression = expression.Arguments[1];
+            var outerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, expression.Arguments[2]);
+            var outerKeySelectorItemParameter = outerKeySelectorLambda.Parameters.Single();
+            var innerKeySelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, expression.Arguments[3]);
+            var innerKeySelectorItemParameter = innerKeySelectorLambda.Parameters.Single();
+            var resultSelectorLambda = ExpressionHelper.UnquoteLambdaIfQueryableMethod(method, expression.Arguments[4]);
+            var resultSelectorOuterItemParameter = resultSelectorLambda.Parameters[0];
+            var resultSelectorInnerItemParameter = resultSelectorLambda.Parameters[1];
+
+            visitor.DeduceItemAndCollectionSerializers(outerKeySelectorItemParameter, outerExpression);
+            visitor.DeduceItemAndCollectionSerializers(innerKeySelectorItemParameter, innerExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorOuterItemParameter, outerExpression);
+            visitor.DeduceItemAndCollectionSerializers(resultSelectorInnerItemParameter, innerExpression);
+            visitor.DeduceCollectionAndItemSerializers(expression, resultSelectorLambda.Body);
+        }
+
+        // DeducePickWindowMethodSerializers
+        private static void DeducePickWindowMethodSerializers(SerializerFinderVisitor visitor, MethodCallExpression expression)
+        {
+            var method = expression.Method;
+            var partitionExpression = expression.Arguments[0];
+            var withSortBy = method.IsOneOf(__pickWindowMethodWithSortByOverloads);
+
+            if (withSortBy)
+            {
+                var sortByExpression = expression.Arguments[1];
+                if (visitor.IsNotKnown(sortByExpression))
+                {
+                    var ignoreSubTreeSerializer = IgnoreSubtreeSerializer.Create(sortByExpression.Type);
+                    visitor.AddNodeSerializer(sortByExpression, ignoreSubTreeSerializer);
+                }
+            }
+
+            var selectorLambda = (LambdaExpression)expression.Arguments[withSortBy ? 2 : 1];
+            DeduceWindowMethodSelectorParameterSerializer(visitor, partitionExpression, selectorLambda);
+
+            if (visitor.IsNotKnown(expression) && visitor.IsKnown(selectorLambda.Body, out var selectorBodySerializer))
+            {
+                var nodeSerializer = method.IsOneOf(WindowMethod.Bottom, WindowMethod.Top) ?
+                    selectorBodySerializer :
+                    IEnumerableSerializer.Create(selectorBodySerializer);
+                visitor.AddNodeSerializer(expression, nodeSerializer);
+            }
         }
 
         // DeduceAggregateMethodSerializers + EnumerableOrQueryableMethod.AggregateWithFunc branch

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ByteTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ByteTests.cs
@@ -42,7 +42,7 @@ public class ByteTests
         [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals((byte)1)), typeof(BooleanSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
-        [TestHelpers.MakeLambda((MyModel model) => byte.Parse("42")), typeof(ByteSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => byte.Parse(model.StringValue)), typeof(ByteSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
     ];
 
@@ -50,5 +50,6 @@ public class ByteTests
     {
         public byte Value { get; set; }
         public byte Other { get; set; }
+        public string StringValue { get; set; }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DecimalTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DecimalTests.cs
@@ -42,7 +42,7 @@ public class DecimalTests
         [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1m)), typeof(BooleanSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
-        [TestHelpers.MakeLambda((MyModel model) => decimal.Parse("42")), typeof(DecimalSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => decimal.Parse(model.StringValue)), typeof(DecimalSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
     ];
 
@@ -50,5 +50,6 @@ public class DecimalTests
     {
         public decimal Value { get; set; }
         public decimal Other { get; set; }
+        public string StringValue { get; set; }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DoubleTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/DoubleTests.cs
@@ -42,7 +42,7 @@ public class DoubleTests
         [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1.0)), typeof(BooleanSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
-        [TestHelpers.MakeLambda((MyModel model) => double.Parse("42")), typeof(DoubleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => double.Parse(model.StringValue)), typeof(DoubleSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
     ];
 
@@ -50,5 +50,6 @@ public class DoubleTests
     {
         public double Value { get; set; }
         public double Other { get; set; }
+        public string StringValue { get; set; }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/FloatTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/FloatTests.cs
@@ -42,7 +42,7 @@ public class FloatTests
         [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1f)), typeof(BooleanSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
-        [TestHelpers.MakeLambda((MyModel model) => float.Parse("42")), typeof(SingleSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => float.Parse(model.StringValue)), typeof(SingleSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
     ];
 
@@ -50,5 +50,6 @@ public class FloatTests
     {
         public float Value { get; set; }
         public float Other { get; set; }
+        public string StringValue { get; set; }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/IntTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/IntTests.cs
@@ -42,7 +42,7 @@ public class IntTests
         [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1)), typeof(BooleanSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
-        [TestHelpers.MakeLambda((MyModel model) => int.Parse("42")), typeof(Int32Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => int.Parse(model.StringValue)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
     ];
 
@@ -50,5 +50,6 @@ public class IntTests
     {
         public int Value { get; set; }
         public int Other { get; set; }
+        public string StringValue { get; set; }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/LongTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/LongTests.cs
@@ -42,7 +42,7 @@ public class LongTests
         [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(1L)), typeof(BooleanSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
-        [TestHelpers.MakeLambda((MyModel model) => long.Parse("42")), typeof(Int64Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => long.Parse(model.StringValue)), typeof(Int64Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
     ];
 
@@ -50,5 +50,6 @@ public class LongTests
     {
         public long Value { get; set; }
         public long Other { get; set; }
+        public string StringValue { get; set; }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/SByteTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/SByteTests.cs
@@ -42,7 +42,7 @@ public class SByteTests
         [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals((sbyte)1)), typeof(BooleanSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
-        [TestHelpers.MakeLambda((MyModel model) => sbyte.Parse("42")), typeof(SByteSerializer)],
+        [TestHelpers.MakeLambda((MyModel model) => sbyte.Parse(model.StringValue)), typeof(SByteSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
     ];
 
@@ -50,5 +50,6 @@ public class SByteTests
     {
         public sbyte Value { get; set; }
         public sbyte Other { get; set; }
+        public string StringValue { get; set; }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ShortTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/SerializerFinders/ShortTests.cs
@@ -42,7 +42,7 @@ public class ShortTests
         [TestHelpers.MakeLambda((MyModel model) => model.Value.CompareTo(model.Other)), typeof(Int32Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals((short)1)), typeof(BooleanSerializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.Equals(model.Other)), typeof(BooleanSerializer)],
-        [TestHelpers.MakeLambda((MyModel model) => short.Parse("42")), typeof(Int16Serializer)],
+        [TestHelpers.MakeLambda((MyModel model) => short.Parse(model.StringValue)), typeof(Int16Serializer)],
         [TestHelpers.MakeLambda((MyModel model) => model.Value.ToString()), typeof(StringSerializer)],
     ];
 
@@ -50,5 +50,6 @@ public class ShortTests
     {
         public short Value { get; set; }
         public short Other { get; set; }
+        public string StringValue { get; set; }
     }
 }


### PR DESCRIPTION
The idea of the PR is to replace the switch by string method's name and checking of methodInfo, with the dictionary of deducers by method info. Most of the use-cases is covered by "static" registration, however there are number of use-cases where we duck-typing the method call (see CreateDynamicSerializerDeducer method), in such case we do dynamic registration as we go: so the next translation of the method will use "previously registered deducer" and do not need to go through all checks.