### PR TITLE
CSHARP-5930: [Tiny] Allow registering the same encryption provider multiple times

### DIFF
--- a/src/MongoDB.Driver/Encryption/AutoEncryptionProviderRegistry.cs
+++ b/src/MongoDB.Driver/Encryption/AutoEncryptionProviderRegistry.cs
@@ -32,7 +32,7 @@ namespace MongoDB.Driver.Encryption
             // each time. This removes a significant synchronization burden from the caller when multiple services
             // may all need to initialize the registry.
             // It is the responsibility of the caller to ensure that the same reference is used for multiple calls.
-            if(ReferenceEquals(factory, _autoCryptClientControllerFactory))
+            if (ReferenceEquals(factory, _autoCryptClientControllerFactory))
             {
                 return;
             }

--- a/src/MongoDB.Driver/Encryption/AutoEncryptionProviderRegistry.cs
+++ b/src/MongoDB.Driver/Encryption/AutoEncryptionProviderRegistry.cs
@@ -28,6 +28,15 @@ namespace MongoDB.Driver.Encryption
 
         public void Register(Func<IMongoClient, AutoEncryptionOptions, IAutoEncryptionLibMongoCryptController> factory)
         {
+            // This allows Register to be called more than once as long as the exact same reference is passed
+            // each time. This removes a significant synchronization burden from the caller when multiple services
+            // may all need to initialize the registry.
+            // It is the responsibility of the caller to ensure that the same reference is used for multiple calls.
+            if(ReferenceEquals(factory, _autoCryptClientControllerFactory))
+            {
+                return;
+            }
+
             if (_autoCryptClientControllerFactory != null)
             {
                 throw new MongoConfigurationException("AutoEncryption Provider already registered.");


### PR DESCRIPTION
This is a tiny, non-breaking change that removes the synchronization burden on the caller. (That is, any component in an app can register that app's provider, without having to first safely determine if the registration has already been done.)