### PR TITLE
CSHARP-5930: [Tiny] Avoid use of generic test method

### DIFF
--- a/tests/MongoDB.Driver.Tests/Search/VectorSearchTests.cs
+++ b/tests/MongoDB.Driver.Tests/Search/VectorSearchTests.cs
@@ -40,9 +40,15 @@ namespace MongoDB.Driver.Tests.Search
 
         protected override void DisposeInternal() => _mongoClient.Dispose();
 
-        [Theory]
-        [MemberData(nameof(BinaryVectorSearchTestData))]
-        public void BinaryVectorSearch<T>(BinaryVector<T> binaryVector, string fieldName)
+        [Fact]
+        public void BinaryVectorSearch_Int8()
+            => BinaryVectorSearch(new BinaryVectorInt8(new sbyte[] { 0, 1, 2, 3, 4 }), "int8Vector");
+
+        [Fact]
+        public void BinaryVectorSearch_Float32()
+            => BinaryVectorSearch(new BinaryVectorFloat32(new[] { 0.0001f, 1.12345f, 2.23456f, 3.34567f, 4.45678f }), "float32Vector");
+
+        private void BinaryVectorSearch<T>(BinaryVector<T> binaryVector, string fieldName)
             where T : struct
         {
             const int Limit = 5;
@@ -61,12 +67,6 @@ namespace MongoDB.Driver.Tests.Search
 
             result[0].Score.Should().Be(1);
         }
-
-        public static IEnumerable<object[]> BinaryVectorSearchTestData =>
-           [
-                [new BinaryVectorInt8(new sbyte[] { 0, 1, 2, 3, 4 }), "int8Vector"],
-                [new BinaryVectorFloat32(new float[] { 0.0001f, 1.12345f, 2.23456f, 3.34567f, 4.45678f }), "float32Vector"],
-           ];
 
         [Fact]
         public void VectorSearch()


### PR DESCRIPTION
This messes with test discovery in Rider.