### PR TITLE
CSHARP-5930: Workaround for DNS issue with Cloudflare

### DIFF
--- a/src/MongoDB.Driver/Core/Misc/DnsClientWrapper.cs
+++ b/src/MongoDB.Driver/Core/Misc/DnsClientWrapper.cs
@@ -15,8 +15,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using DnsClient;
@@ -36,7 +38,49 @@ namespace MongoDB.Driver.Core.Misc
         // constructors
         private DnsClientWrapper()
         {
-            _lookupClient = new Lazy<LookupClient>(() => new LookupClient());
+            _lookupClient = new Lazy<LookupClient>(CreateLookupClient);
+        }
+
+        // private static methods
+        private static LookupClient CreateLookupClient()
+        {
+            try
+            {
+                var nameServers = NameServer.ResolveNameServers(skipIPv6SiteLocal: false, fallbackToGooglePublicDns: false).ToList();
+                var filteredServers = FilterNameServers(nameServers);
+                return filteredServers.Length > 0
+                    ? new LookupClient(new LookupClientOptions(filteredServers))
+                    : new LookupClient();
+            }
+            catch (Exception e)
+            {
+                Debug.Assert(false, "Failed to create LookupClient:" + Environment.NewLine + e);
+
+                return new LookupClient();
+            }
+        }
+
+        // Some DNS configurations (e.g. Cloudflare WARP on macOS) write duplicate entries to
+        // /etc/resolv.conf: both the plain IPv4 address and its IPv4-mapped IPv6 equivalent
+        // (e.g. 127.0.2.3 and ::ffff:127.0.2.3). DnsClient reads both, but its UDP path does
+        // not handle the IPv4-mapped loopback form reliably and times out. Filter them out when
+        // the equivalent plain IPv4 address is already present.
+        internal static NameServer[] FilterNameServers(IReadOnlyList<NameServer> nameServers)
+        {
+            var ipv4Addresses = new HashSet<IPAddress>();
+            foreach (var ns in nameServers)
+            {
+                if (IPAddress.TryParse(ns.Address, out var ip) && ip.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    ipv4Addresses.Add(ip);
+                }
+            }
+
+            return nameServers
+                .Where(ns =>
+                    !(IPAddress.TryParse(ns.Address, out var ip) && ip.IsIPv4MappedToIPv6 &&
+                      ipv4Addresses.Contains(ip.MapToIPv4())))
+                .ToArray();
         }
 
         // public methods

--- a/tests/MongoDB.Driver.Tests/Core/Clusters/DnsClientWrapperTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Clusters/DnsClientWrapperTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Threading;
 using DnsClient;
@@ -173,6 +174,22 @@ namespace MongoDB.Driver.Core.Clusters
             }
 
             exception.Should().Match<Exception>(e => e is OperationCanceledException || e.InnerException is OperationCanceledException);
+        }
+
+        [Theory]
+        [InlineData(new[] { "127.0.2.3" }, new[] { "127.0.2.3" })]
+        [InlineData(new[] { "::ffff:127.0.2.3" }, new[] { "::ffff:127.0.2.3" })]
+        [InlineData(new[] { "127.0.2.3", "::ffff:127.0.2.3" }, new[] { "127.0.2.3" })]
+        [InlineData(new[] { "127.0.2.2", "127.0.2.3", "::ffff:127.0.2.2", "::ffff:127.0.2.3" }, new[] { "127.0.2.2", "127.0.2.3" })]
+        [InlineData(new[] { "::1", "127.0.2.3" }, new[] { "::1", "127.0.2.3" })]
+        [InlineData(new string[0], new string[0])]
+        public void FilterNameServers_should_remove_IPv4_mapped_IPv6_duplicates(string[] inputAddresses, string[] expectedAddresses)
+        {
+            var input = inputAddresses.Select(a => (NameServer)IPAddress.Parse(a)).ToArray();
+
+            var result = DnsClientWrapper.FilterNameServers(input);
+
+            result.Select(ns => ns.Address).Should().Equal(expectedAddresses);
         }
 
         // private methods


### PR DESCRIPTION
Root cause: Cloudflare WARP writes 4 entries to /etc/resolv.conf:

- 127.0.2.2 (works — 187ms)
- 127.0.2.3 (works — 28ms)
- ::ffff:127.0.2.2 (IPv4-mapped IPv6 form)
- ::ffff:127.0.2.3 (IPv4-mapped IPv6 form)

DnsClient reads /etc/resolv.conf directly on macOS and picks up all 4 entries. When it selects one of the ::ffff: IPv4-mapped IPv6 addresses for a UDP query, macOS doesn't route that correctly (IPv4-mapped IPv6 loopback via UDP isn't reliable on macOS), so the socket times out. The error [::ffff:127.0.2.3]:53 timed out or is a transient error is exactly that — DnsClient tried the IPv6-mapped form of the address and got no response.

The fix is that DnsClientWrapper.cs — CreateLookupClient() now calls NameServer.ResolveNameServers(), filters out any IPv4-mapped IPv6 addresses whose IPv4 equivalent is already in the list, and passes the cleaned list to LookupClientOptions. This fixes the root cause for WARP (and any other config that produces such duplicates).

This makes the tests pass, but also fixes this as a possible real issues for customers using Cloudflare.