### PR TITLE
CSHARP-5930: [Tiny] Fix unreliable DNS lookup

### DIFF
--- a/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
@@ -796,7 +796,7 @@ namespace MongoDB.Driver.Tests
             const string awsSessionToken = "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE";
 
             var preparedToken = escapeToken ? Uri.EscapeDataString(awsSessionToken) : awsSessionToken;
-            var uri = $"mongodb+srv://{username}:{Uri.EscapeDataString(password)}@awssessiontokentest.example.net/test?authSource=$external&authMechanism={authMechanism}&authMechanismProperties=AWS_SESSION_TOKEN:{preparedToken}";
+            var uri = $"mongodb://{username}:{Uri.EscapeDataString(password)}@awssessiontokentest.example.net/test?authSource=$external&authMechanism={authMechanism}&authMechanismProperties=AWS_SESSION_TOKEN:{preparedToken}";
             var url = new MongoUrl(uri);
 
             var result = MongoClientSettings.FromUrl(url).Credential;


### PR DESCRIPTION
The test URL uses `mongodb+srv://`, which causes MongoClientSettings.FromUrl to call url.Resolve() at line 904, which does a real DNS TXT lookup for awssessiontokentest.example.net. That domain doesn't exist, so DNS times out. The test was introduced in 2020 and has always made a real DNS call. Whether it passes depends entirely on how the local DNS resolver handles the awssessiontokentest.example.net query:

- Your machine: DNS query for example.net times out (your resolver sends it upstream and waits).
- CI (and possibly many other environments): The DNS server quickly returns NXDOMAIN for .example.net — it's an IANA-reserved domain under RFC 2606, and many resolvers short-circuit it. When NXDOMAIN comes back fast, DnsClient does not throw DnsResponseException for a "timed out or transient error" — it returns an empty response, GetTxtRecords returns an empty list, and GetResolvedOptionsFromTxtRecords on an empty list succeeds silently. The fix is to change `mongodb+srv://` to `mongodb://` — the SRV scheme is irrelevant to what the test verifies (credential parsing), and it's the only reason any DNS call happens at all.