### PR TITLE
CSHARP-5930: Refactor CreateKmsProvider to not eagerly load all providers

### DIFF
--- a/tests/MongoDB.Driver.Tests/Encryption/AutoEncryptionTests.cs
+++ b/tests/MongoDB.Driver.Tests/Encryption/AutoEncryptionTests.cs
@@ -161,7 +161,7 @@ namespace MongoDB.Driver.Tests.Encryption
         }
 
         // private methods
-        private IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> GetKmsProviders() => EncryptionTestHelper.GetKmsProviders(filter: "local");
+        private IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> GetKmsProviders() => EncryptionTestHelper.GetKmsProviders("local");
     }
 
     internal static class LibMongoCryptControllerBaseReflector

--- a/tests/MongoDB.Driver.Tests/Encryption/ClientEncryptionTests.cs
+++ b/tests/MongoDB.Driver.Tests/Encryption/ClientEncryptionTests.cs
@@ -391,7 +391,7 @@ namespace MongoDB.Driver.Tests.Encryption
             var clientEncryptionOptions = new ClientEncryptionOptions(
                 client ?? DriverTestConfiguration.Client,
                 __keyVaultCollectionNamespace,
-                kmsProviders: EncryptionTestHelper.GetKmsProviders(filter: "local"));
+                kmsProviders: EncryptionTestHelper.GetKmsProviders("local"));
 
             return new ClientEncryption(clientEncryptionOptions);
         }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/EncryptionTestHelper.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/EncryptionTestHelper.cs
@@ -25,6 +25,7 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.TestHelpers;
+using MongoDB.TestHelpers.XunitExtensions;
 
 namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
 {
@@ -41,17 +42,17 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
             {
                 "aws" => new Dictionary<string, object>
                 {
-                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY") },
+                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrSkip("FLE_AWS_KEY") },
                     { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET") }
                 },
                 "aws:name1" => new Dictionary<string, object>
                 {
-                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY") },
+                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrSkip("FLE_AWS_KEY") },
                     { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET") }
                 },
                 "aws:name2" => new Dictionary<string, object>
                 {
-                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY2") },
+                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrSkip("FLE_AWS_KEY2") },
                     { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET2") }
                 },
                 "local" => new Dictionary<string, object>
@@ -68,24 +69,24 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
                 },
                 "azure" => new Dictionary<string, object>
                 {
-                    { "tenantId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_TENANTID") },
+                    { "tenantId", GetEnvironmentVariableOrDefaultOrSkip("FLE_AZURE_TENANTID") },
                     { "clientId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTID") },
                     { "clientSecret", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTSECRET") }
                 },
                 "azure:name1" => new Dictionary<string, object>
                 {
-                    { "tenantId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_TENANTID") },
+                    { "tenantId", GetEnvironmentVariableOrDefaultOrSkip("FLE_AZURE_TENANTID") },
                     { "clientId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTID") },
                     { "clientSecret", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTSECRET") }
                 },
                 "gcp" => new Dictionary<string, object>
                 {
-                    { "email", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_EMAIL") },
+                    { "email", GetEnvironmentVariableOrDefaultOrSkip("FLE_GCP_EMAIL") },
                     { "privateKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_PRIVATEKEY") }
                 },
                 "gcp:name1" => new Dictionary<string, object>
                 {
-                    { "email", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_EMAIL") },
+                    { "email", GetEnvironmentVariableOrDefaultOrSkip("FLE_GCP_EMAIL") },
                     { "privateKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_PRIVATEKEY") }
                 },
                 "kmip" => new Dictionary<string, object> { { "endpoint", "localhost:5698" } },
@@ -113,6 +114,14 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
                 },
                 _ => throw new ArgumentException($"Unsupported KMS provider: {name}.", nameof(name))
             };
+
+            string GetEnvironmentVariableOrDefaultOrSkip(string variableName)
+            {
+                RequireEnvironment.Check().EnvironmentVariable(variableName);
+
+                return Environment.GetEnvironmentVariable(variableName);
+
+            }
 
             string GetEnvironmentVariableOrDefaultOrThrowIfNothing(string variableName, string defaultValue = null) =>
                 Environment.GetEnvironmentVariable(variableName) ??

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/EncryptionTestHelper.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/EncryptionTestHelper.cs
@@ -260,12 +260,19 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
             return null;
         }
 
-        public static IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> GetKmsProviders(string filter)
-            => filter.Split([KmsProviderFilterDelimiter], StringSplitOptions.None).Distinct().ToDictionary(
+        public static IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> GetKmsProviders(string providerNames)
+        {
+            if (providerNames == null)
+            {
+                throw new ArgumentException("Provider name(s) must be supplied.", nameof(providerNames));
+            }
+
+            return providerNames.Split([KmsProviderFilterDelimiter], StringSplitOptions.None).Distinct().ToDictionary(
                 n => n,
                 n => (IReadOnlyDictionary<string, object>)__kmsProviders
                     .GetOrAdd(n, CreateKmsProvider)
                     .ToDictionary(k => k.Key, v => v.Value)); // ensure that inner dictionary is a new instance
+        }
 
         public static IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> ParseKmsProviders(BsonDocument kmsProviders, bool legacy = false)
         {
@@ -302,7 +309,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
                             if (legacy)
                             {
                                 kmsProviderDocument.ElementCount.Should().Be(0);
-                                kmsOptions = (Dictionary<string, object>)GetKmsProviders(kmsProvider.Name);
+                                kmsOptions = (Dictionary<string, object>)GetKmsProviders(kmsProvider.Name)[kmsProvider.Name];
                             }
                             else
                             {
@@ -333,7 +340,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
             return providers;
 
             bool IsPlaceholder(BsonValue value) => value.IsBsonDocument && value.AsBsonDocument.Contains("$$placeholder");
-            string GetFromEnvVariables(string kmsProvider, string key) => GetKmsProviders(kmsProvider)[key].ToString();
+            string GetFromEnvVariables(string kmsProvider, string key) => GetKmsProviders(kmsProvider)[kmsProvider][key].ToString();
         }
 
         // private methods
@@ -348,7 +355,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
                 var dummyNamespace = CollectionNamespace.FromFullName("db.dummy");
                 var autoEncryptionOptions = new AutoEncryptionOptions(
                     dummyNamespace,
-                    kmsProviders: GetKmsProviders(filter: "local"),
+                    kmsProviders: GetKmsProviders("local"),
                     extraOptions: new Dictionary<string, object>() { { "cryptSharedLibPath", cryptSharedLibPath } });
 
                 var mongoClientSettings = new MongoClientSettings

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/EncryptionTestHelper.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/EncryptionTestHelper.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -23,125 +24,95 @@ using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
-using MongoDB.Driver.Encryption;
 using MongoDB.Driver.TestHelpers;
 
 namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
 {
     public static class EncryptionTestHelper
     {
-        private static readonly Lazy<IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>>> __kmsProviders = new Lazy<IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>>>(ConfigureDefaultKmsProviders, isThreadSafe: true);
+        private static readonly ConcurrentDictionary<string,  IReadOnlyDictionary<string, object>> __kmsProviders = new();
         private const string KmsProviderFilterDelimiter = ";";
         private static readonly string __defaultMongocryptdPath = Environment.GetEnvironmentVariable("MONGODB_BINARIES") ?? "";
-        private static readonly Lazy<(bool IsValid, SemanticVersion Version)> __defaultCsfleSetupState = new Lazy<(bool IsValid, SemanticVersion Version)>(IsDefaultCsfleSetupValid, isThreadSafe: true);
+        private static readonly Lazy<(bool IsValid, SemanticVersion Version)> __defaultCsfleSetupState = new(IsDefaultCsfleSetupValid, isThreadSafe: true);
 
-        private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> ConfigureDefaultKmsProviders()
+        private static IReadOnlyDictionary<string, object> CreateKmsProvider(string name)
         {
-            var kmsProviders = new Dictionary<string, IReadOnlyDictionary<string, object>>
+            return name switch
             {
+                "aws" => new Dictionary<string, object>
                 {
-                    "aws", new Dictionary<string, object>
+                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY") },
+                    { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET") }
+                },
+                "aws:name1" => new Dictionary<string, object>
+                {
+                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY") },
+                    { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET") }
+                },
+                "aws:name2" => new Dictionary<string, object>
+                {
+                    { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY2") },
+                    { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET2") }
+                },
+                "local" => new Dictionary<string, object>
+                {
+                    { "key", new BsonBinaryData(Convert.FromBase64String(LocalMasterKey)).Bytes }
+                },
+                "local:name1" => new Dictionary<string, object>
+                {
+                    { "key", new BsonBinaryData(Convert.FromBase64String(LocalMasterKey)).Bytes }
+                },
+                "local:name2" => new Dictionary<string, object>
+                {
+                    { "key", new BsonBinaryData(Convert.FromBase64String(LocalMasterKey)).Bytes }
+                },
+                "azure" => new Dictionary<string, object>
+                {
+                    { "tenantId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_TENANTID") },
+                    { "clientId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTID") },
+                    { "clientSecret", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTSECRET") }
+                },
+                "azure:name1" => new Dictionary<string, object>
+                {
+                    { "tenantId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_TENANTID") },
+                    { "clientId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTID") },
+                    { "clientSecret", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTSECRET") }
+                },
+                "gcp" => new Dictionary<string, object>
+                {
+                    { "email", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_EMAIL") },
+                    { "privateKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_PRIVATEKEY") }
+                },
+                "gcp:name1" => new Dictionary<string, object>
+                {
+                    { "email", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_EMAIL") },
+                    { "privateKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_PRIVATEKEY") }
+                },
+                "kmip" => new Dictionary<string, object> { { "endpoint", "localhost:5698" } },
+                "kmip:name1" => new Dictionary<string, object> { { "endpoint", "localhost:5698" } },
+                "awsTemporary" => new Dictionary<string, object>
+                {
                     {
-                        { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY") },
-                        { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET") }
+                        "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_ACCESS_KEY_ID")
+                    },
+                    {
+                        "secretAccessKey",
+                        GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_SECRET_ACCESS_KEY")
+                    },
+                    { "sessionToken", GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_SESSION_TOKEN") }
+                },
+                "awsTemporaryNoSessionToken" => new Dictionary<string, object>
+                {
+                    {
+                        "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_ACCESS_KEY_ID")
+                    },
+                    {
+                        "secretAccessKey",
+                        GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_SECRET_ACCESS_KEY")
                     }
                 },
-                {
-                    "aws:name1", new Dictionary<string, object>
-                    {
-                        { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY") },
-                        { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET") }
-                    }
-                },
-                {
-                    "aws:name2", new Dictionary<string, object>
-                    {
-                        { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_KEY2") },
-                        { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AWS_SECRET2") }
-                    }
-                },
-                {
-                    "local", new Dictionary<string, object>
-                    {
-                        { "key", new BsonBinaryData(Convert.FromBase64String(LocalMasterKey)).Bytes }
-                    }
-                },
-                {
-                    "local:name1", new Dictionary<string, object>
-                    {
-                        { "key", new BsonBinaryData(Convert.FromBase64String(LocalMasterKey)).Bytes }
-                    }
-                },
-                {
-                    "local:name2", new Dictionary<string, object>
-                    {
-                        { "key", new BsonBinaryData(Convert.FromBase64String(LocalMasterKey)).Bytes }
-                    }
-                },
-                {
-                    "azure", new Dictionary<string, object>
-                    {
-                        { "tenantId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_TENANTID") },
-                        { "clientId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTID") },
-                        { "clientSecret", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTSECRET") }
-                    }
-                },
-                {
-                    "azure:name1", new Dictionary<string, object>
-                    {
-                        { "tenantId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_TENANTID") },
-                        { "clientId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTID") },
-                        { "clientSecret", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_AZURE_CLIENTSECRET") }
-                    }
-                },
-                {
-                    "gcp", new Dictionary<string, object>
-                    {
-                        { "email", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_EMAIL") },
-                        { "privateKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_PRIVATEKEY") }
-                    }
-                },
-                {
-                    "gcp:name1", new Dictionary<string, object>
-                    {
-                        { "email", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_EMAIL") },
-                        { "privateKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("FLE_GCP_PRIVATEKEY") }
-                    }
-                },
-                {
-                    "kmip", new Dictionary<string, object>
-                    {
-                        { "endpoint", "localhost:5698" }
-                    }
-                },
-                {
-                    "kmip:name1", new Dictionary<string, object>
-                    {
-                        { "endpoint", "localhost:5698" }
-                    }
-                }
+                _ => throw new ArgumentException($"Unsupported KMS provider: {name}.", nameof(name))
             };
-
-            if (Environment.GetEnvironmentVariable("CSFLE_AWS_TEMPORARY_CREDS_ENABLED") != null)
-            {
-                kmsProviders.Add(
-                    "awsTemporary",
-                    new Dictionary<string, object>
-                    {
-                        { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_ACCESS_KEY_ID") },
-                        { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_SECRET_ACCESS_KEY") },
-                        { "sessionToken", GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_SESSION_TOKEN") }
-                    });
-                kmsProviders.Add(
-                    "awsTemporaryNoSessionToken",
-                    new Dictionary<string, object>
-                    {
-                        { "accessKeyId", GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_ACCESS_KEY_ID") },
-                        { "secretAccessKey", GetEnvironmentVariableOrDefaultOrThrowIfNothing("CSFLE_AWS_TEMP_SECRET_ACCESS_KEY") }
-                    });
-            }
-
-            return kmsProviders;
 
             string GetEnvironmentVariableOrDefaultOrThrowIfNothing(string variableName, string defaultValue = null) =>
                 Environment.GetEnvironmentVariable(variableName) ??
@@ -289,18 +260,16 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
             return null;
         }
 
-        public static IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> GetKmsProviders(string filter = null) =>
-            __kmsProviders
-                .Value
-                .Where(kms => filter == null || filter.Split(new[] { KmsProviderFilterDelimiter }, StringSplitOptions.None).Contains(kms.Key))
-                .ToDictionary(
-                    k => k.Key,
-                    v => (IReadOnlyDictionary<string, object>)v.Value.ToDictionary(ik => ik.Key, iv => iv.Value)); // ensure that inner dictionary is a new instance
+        public static IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> GetKmsProviders(string filter)
+            => filter.Split([KmsProviderFilterDelimiter], StringSplitOptions.None).Distinct().ToDictionary(
+                n => n,
+                n => (IReadOnlyDictionary<string, object>)__kmsProviders
+                    .GetOrAdd(n, CreateKmsProvider)
+                    .ToDictionary(k => k.Key, v => v.Value)); // ensure that inner dictionary is a new instance
 
         public static IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> ParseKmsProviders(BsonDocument kmsProviders, bool legacy = false)
         {
             var providers = new Dictionary<string, IReadOnlyDictionary<string, object>>();
-            var kmsProvidersFromEnvs = GetKmsProviders();
             foreach (var kmsProvider in kmsProviders.Elements)
             {
                 var kmsOptions = new Dictionary<string, object>();
@@ -333,7 +302,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
                             if (legacy)
                             {
                                 kmsProviderDocument.ElementCount.Should().Be(0);
-                                kmsOptions = (Dictionary<string, object>)kmsProvidersFromEnvs[kmsProvider.Name];
+                                kmsOptions = (Dictionary<string, object>)GetKmsProviders(kmsProvider.Name);
                             }
                             else
                             {
@@ -364,7 +333,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption
             return providers;
 
             bool IsPlaceholder(BsonValue value) => value.IsBsonDocument && value.AsBsonDocument.Contains("$$placeholder");
-            string GetFromEnvVariables(string kmsProvider, string key) => kmsProvidersFromEnvs[kmsProvider][key].ToString();
+            string GetFromEnvVariables(string kmsProvider, string key) => GetKmsProviders(kmsProvider)[key].ToString();
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -697,11 +697,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             [Values(false, true)] bool async)
         {
             RequireServer.Check().Supports(Feature.ClientSideEncryption);
-
-            if (kmsProvider == "kmip")
-            {
-                RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
-            }
+            RequireEnvironment.Check().KmsProvider(kmsProvider);
 
             using (var client = ConfigureClient())
             using (var clientEncrypted = ConfigureClientEncrypted(BsonDocument.Parse(SchemaMap), kmsProviderFilter: kmsProvider))
@@ -789,6 +785,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             string expectedExceptionInfoForInvalidEncryption)
         {
             RequireServer.Check().Supports(Feature.ClientSideEncryption);
+            RequireEnvironment.Check().KmsProvider(kmsType);
 
             if (kmsType == "kmip")
             {
@@ -2462,10 +2459,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             // The test description requires configuring all kmsProviders in setup, but leaving only related to the provided income arguments
             // to avoid restrictions on kmip mocking setup for unrelated to kmip tests
             var kmsProviderFilter = EncryptionTestHelper.CreateKmsProviderFilter(srcProvider, dstProvider);
-            if (kmsProviderFilter.Contains("kmip"))
-            {
-                RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
-            }
+            RequireEnvironment.Check().KmsProvider(kmsProviderFilter);
 
             const string value = "test";
 

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -101,7 +101,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             RequireServer.Check().Supports(Feature.Csfle2QEv2).ClusterTypes(ClusterType.ReplicaSet, ClusterType.Sharded, ClusterType.LoadBalanced);
 
             using (var client = ConfigureClient())
-            using (var clientEncryption = ConfigureClientEncryption(client, kmsProviderFilter: kmsProvider))
+            using (var clientEncryption = ConfigureClientEncryption(client, kmsProviderNames: kmsProvider))
             {
                 var encryptedFields = BsonDocument.Parse(@"
                 {
@@ -494,7 +494,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             RequireServer.Check().Supports(Feature.Csfle2QEv2).ClusterTypes(ClusterType.ReplicaSet, ClusterType.Sharded, ClusterType.LoadBalanced);
 
             using var client = ConfigureClient(keyVaultNamespace: __keyVaultCollectionNamespace, kmsProviders: EncryptionTestHelper.GetKmsProviders("local"));
-            using var clientEncryption = ConfigureClientEncryption(client, kmsProviderFilter: "local");
+            using var clientEncryption = ConfigureClientEncryption(client, kmsProviderNames: "local");
 
             var datakeysCollection = GetCollection(client, __keyVaultCollectionNamespace);
             var externalKey = JsonFileReader.Instance.Documents["external.external-key.json"];
@@ -705,7 +705,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
             using (var client = ConfigureClient())
             using (var clientEncrypted = ConfigureClientEncrypted(BsonDocument.Parse(SchemaMap), kmsProviderFilter: kmsProvider))
-            using (var clientEncryption = ConfigureClientEncryption(clientEncrypted, kmsProviderFilter: kmsProvider))
+            using (var clientEncryption = ConfigureClientEncryption(clientEncrypted, kmsProviderNames: kmsProvider))
             {
                 var dataKeyOptions = CreateDataKeyOptions(kmsProvider);
                 var dataKey = CreateDataKey(clientEncryption, kmsProvider, dataKeyOptions, async);
@@ -796,8 +796,8 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             }
 
             using (var client = ConfigureClient())
-            using (var clientEncryption = ConfigureClientEncryption(client, ValidKmsEndpointConfigurator, kmsProviderFilter: kmsType))
-            using (var clientEncryptionInvalid = ConfigureClientEncryption(client, InvalidKmsEndpointConfigurator, kmsProviderFilter: kmsType))
+            using (var clientEncryption = ConfigureClientEncryption(client, ValidKmsEndpointConfigurator, kmsProviderNames: kmsType))
+            using (var clientEncryptionInvalid = ConfigureClientEncryption(client, InvalidKmsEndpointConfigurator, kmsProviderNames: kmsType))
             {
                 var testCaseMasterKey = kmsType switch
                 {
@@ -952,7 +952,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 var externalSchema = JsonFileReader.Instance.Documents["external.external-schema.json"];
                 CreateCollection(client_test, __collCollectionNamespace, new BsonDocument("$jsonSchema", externalSchema));
 
-                using (var client_encryption = ConfigureClientEncryption(client_test, kmsProviderFilter: "local"))
+                using (var client_encryption = ConfigureClientEncryption(client_test, kmsProviderNames: "local"))
                 {
                     var value = "string0";
                     var encryptionOptions = new EncryptOptions(
@@ -1140,7 +1140,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
             var decryptionEventsCollectionNamespace = CollectionNamespace.FromFullName("db.decryption_events");
             using (var setupClient = ConfigureClient(clearCollections: true, mainCollectionNamespace: decryptionEventsCollectionNamespace))
-            using (var clientEncryption = ConfigureClientEncryption(setupClient, kmsProviderFilter: "local"))
+            using (var clientEncryption = ConfigureClientEncryption(setupClient, kmsProviderNames: "local"))
             {
                 var keyId = CreateDataKey(clientEncryption, "local", new DataKeyOptions(), async);
 
@@ -1269,7 +1269,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 Insert(keyVaultCollection, async, key1Document);
 
                 using (var keyVaultClient = CreateMongoClient())
-                using (var clientEncryption = ConfigureClientEncryption(keyVaultClient, kmsProviderFilter: "local"))
+                using (var clientEncryption = ConfigureClientEncryption(keyVaultClient, kmsProviderNames: "local"))
                 using (var encryptedClient = ConfigureClientEncrypted(kmsProviderFilter: "local", autoEncryptionOptionsConfigurator: (options) => options.With(bypassQueryAnalysis: true)))
                 {
                     var explicitCollection = GetCollection(encryptedClient, explicitCollectionNamespace);
@@ -1395,7 +1395,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             var clientEncryptedSchema = new BsonDocument("db.coll", JsonFileReader.Instance.Documents["external.external-schema.json"]);
             using (var client = ConfigureClient())
             using (var clientEncrypted = ConfigureClientEncrypted(clientEncryptedSchema, externalKeyVaultClient: externalKeyVaultClient, kmsProviderFilter: "local"))
-            using (var clientEncryption = ConfigureClientEncryption(clientEncrypted, kmsProviderFilter: "local"))
+            using (var clientEncryption = ConfigureClientEncryption(clientEncrypted, kmsProviderNames: "local"))
             {
                 var datakeys = GetCollection(client, __keyVaultCollectionNamespace);
                 var externalKey = JsonFileReader.Instance.Documents["external.external-key.json"];
@@ -1468,7 +1468,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             using var clientEncrypted = ConfigureClientEncrypted();
             using var clientEncryption = ConfigureClientEncryption(
                 clientEncrypted,
-                kmsProviderFilter: kmsProvider,
+                kmsProviderNames: kmsProvider,
                 kmsProviderConfigurator: KmsProviderEndpointConfigurator
             );
 
@@ -1588,7 +1588,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 kmsProviderConfigurator: KmsProviderEndpointConfigurator,
                 allowClientCertificateFunc: (kmsName) => kmsName == kmsProvider && certificateType == CertificateType.TlsWithClientCert,
                 clientEncryptionOptionsConfigurator: TestRelatedClientEncryptionOptionsConfigurator,
-                kmsProviderFilter: kmsProvider))
+                kmsProviderNames: kmsProvider))
             {
                 var dataKeyOptions = CreateDataKeyOptions(
                     kmsProvider: kmsProvider,
@@ -2221,7 +2221,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 var keyVaultCollection = GetCollection(keyVaultClient, __keyVaultCollectionNamespace);
                 Insert(keyVaultCollection, async, key1Document);
 
-                using (var clientEncryption = ConfigureClientEncryption(keyVaultClient, kmsProviderFilter: kmsProvider))
+                using (var clientEncryption = ConfigureClientEncryption(keyVaultClient, kmsProviderNames: kmsProvider))
                 using (var encryptedClient = ConfigureClientEncrypted(kmsProviderFilter: kmsProvider, bypassQueryAnalysis: true))
                 {
                     var encrypted0 = ExplicitEncrypt(clientEncryption, encryptOptions, value0, async);
@@ -2470,14 +2470,14 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             const string value = "test";
 
             using (var client1 = ConfigureClient(clearCollections: true))
-            using (var clientEncryption1 = ConfigureClientEncryption(client1, kmsProviderFilter: kmsProviderFilter))
+            using (var clientEncryption1 = ConfigureClientEncryption(client1, kmsProviderNames: kmsProviderFilter))
             {
                 var datakeyOptions = CreateDataKeyOptions(srcProvider);
                 var keyID = CreateDataKey(clientEncryption1, srcProvider, datakeyOptions, async);
                 var ciphertext = ExplicitEncrypt(clientEncryption1, new EncryptOptions(keyId: keyID, algorithm: EncryptionAlgorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic), value, async);
 
                 using (var client2 = ConfigureClient(clearCollections: false))
-                using (var clientEncryption2 = ConfigureClientEncryption(client2, kmsProviderFilter: kmsProviderFilter))
+                using (var clientEncryption2 = ConfigureClientEncryption(client2, kmsProviderNames: kmsProviderFilter))
                 {
                     var rewrapManyDataKeyOptions = CreateRewrapManyDataKeyOptions(dstProvider);
                     var result = RewrapManyDataKey(clientEncryption2, rewrapManyDataKeyOptions, async);
@@ -2759,7 +2759,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
             var encryptOptions = new EncryptOptions(EncryptionAlgorithm.TextPreview, keyId: key1Id, contentionFactor: 0);
 
-            using (var clientEncryption = ConfigureClientEncryption(keyVaultClient, kmsProviderFilter: "local"))
+            using (var clientEncryption = ConfigureClientEncryption(keyVaultClient, kmsProviderNames: "local"))
             using (var encryptedClient = ConfigureClientEncrypted(kmsProviderFilter: "local", bypassQueryAnalysis: true))
             {
                 var prefixSuffixCollection = GetCollection(encryptedClient, prefixSuffixCollectionNamespace);
@@ -2997,7 +2997,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                             PartialFilterExpression = new BsonDocument("keyAltNames", new BsonDocument("$exists", true))
                         }));
 
-                using (var clientEncryption = ConfigureClientEncryption(client, kmsProviderFilter: "local"))
+                using (var clientEncryption = ConfigureClientEncryption(client, kmsProviderNames: "local"))
                 {
                     var dataKey = CreateDataKey(clientEncryption, "local", new DataKeyOptions(alternateKeyNames: new[] { "def" }), async);
                     RunTestCase(clientEncryption, dataKey, testCase);
@@ -3057,7 +3057,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             RequireServer.Check().Supports(Feature.ClientSideEncryption);
 
             using (var clientEncrypted = ConfigureClientEncrypted(kmsProviderFilter: kmsProvider))
-            using (var clientEncryption = ConfigureClientEncryption(clientEncrypted, kmsProviderFilter: kmsProvider))
+            using (var clientEncryption = ConfigureClientEncryption(clientEncrypted, kmsProviderNames: kmsProvider))
             {
                 var dataKeyOptions = CreateDataKeyOptions(kmsProvider);
                 var exception = Record.Exception(() => _ = CreateDataKey(clientEncryption, kmsProvider, dataKeyOptions, async));
@@ -3184,7 +3184,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
         private MongoClientSettings ConfigureClientEncryptedSettings(
             BsonDocument schemaMap = null,
             IMongoClient externalKeyVaultClient = null,
-            string kmsProviderFilter = null,
+            string kmsProviderNames = null,
             EventCapturer eventCapturer = null,
             Dictionary<string, object> extraOptions = null,
             bool bypassAutoEncryption = false,
@@ -3193,7 +3193,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             bool? retryReads = null,
             CollectionNamespace keyVaultCollectionNamespace = null)
         {
-            var kmsProviders = EncryptionTestHelper.GetKmsProviders(filter: kmsProviderFilter);
+            var kmsProviders = EncryptionTestHelper.GetKmsProviders(kmsProviderNames);
             var tlsOptions = EncryptionTestHelper.CreateTlsOptionsIfAllowed(
                 kmsProviders,
                 // only kmip currently requires tls configuration for ClientEncrypted
@@ -3225,14 +3225,14 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             Action<string, Dictionary<string, object>> kmsProviderConfigurator = null,
             Func<string, bool> allowClientCertificateFunc = null,
             Action<ClientEncryptionOptions> clientEncryptionOptionsConfigurator = null,
-            string kmsProviderFilter = null,
+            string kmsProviderNames = null,
             BsonDocument kmsDocument = null)
         {
             Dictionary<string, IReadOnlyDictionary<string, object>> kmsProviders;
             if (kmsDocument == null)
             {
                 kmsProviders = EncryptionTestHelper
-                    .GetKmsProviders(filter: kmsProviderFilter)
+                    .GetKmsProviders(kmsProviderNames)
                     .Select(k =>
                     {
                         if (kmsProviderConfigurator != null)
@@ -3245,7 +3245,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             }
             else
             {
-                Ensure.IsNull(kmsProviderFilter, nameof(kmsProviderFilter));
+                Ensure.IsNull(kmsProviderNames, nameof(kmsProviderNames));
 
                 kmsProviders = kmsDocument
                     .Elements

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -787,11 +787,6 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             RequireServer.Check().Supports(Feature.ClientSideEncryption);
             RequireEnvironment.Check().KmsProvider(kmsType);
 
-            if (kmsType == "kmip")
-            {
-                RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
-            }
-
             using (var client = ConfigureClient())
             using (var clientEncryption = ConfigureClientEncryption(client, ValidKmsEndpointConfigurator, kmsProviderNames: kmsType))
             using (var clientEncryptionInvalid = ConfigureClientEncryption(client, InvalidKmsEndpointConfigurator, kmsProviderNames: kmsType))

--- a/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
+++ b/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
@@ -31,6 +31,35 @@ namespace MongoDB.TestHelpers.XunitExtensions
         }
         #endregion
 
+        public RequireEnvironment KmsProvider(string kmsProviderName)
+        {
+            if (kmsProviderName?.Contains("kmip", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
+            }
+
+            if (kmsProviderName?.Contains("awsTemporary", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                Check().EnvironmentVariable("CSFLE_AWS_TEMPORARY_CREDS_ENABLED", isDefined: true);
+            }
+            else if (kmsProviderName?.Contains("aws", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                Check().EnvironmentVariable("FLE_AWS_KEY", isDefined: true);
+            }
+
+            if (kmsProviderName?.Contains("azure", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                Check().EnvironmentVariable("FLE_AZURE_TENANTID", isDefined: true);
+            }
+
+            if (kmsProviderName?.Contains("gcp", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                Check().EnvironmentVariable("FLE_GCP_EMAIL", isDefined: true);
+            }
+
+            return this;
+        }
+
         public RequireEnvironment EnvironmentVariable(string name, bool isDefined = true, bool allowEmpty = true)
         {
             var actualValue = Environment.GetEnvironmentVariable(name);

--- a/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
+++ b/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
@@ -47,7 +47,7 @@ namespace MongoDB.TestHelpers.XunitExtensions
 
             bool CheckProvider(string match, string environmentVariable)
             {
-                if (kmsProviderName?.Contains(match, StringComparison.OrdinalIgnoreCase) != true)
+                if (kmsProviderName == null || kmsProviderName.IndexOf(match, StringComparison.OrdinalIgnoreCase) < 0)
                 {
                     return false;
                 }

--- a/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
+++ b/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
@@ -33,32 +33,30 @@ namespace MongoDB.TestHelpers.XunitExtensions
 
         public RequireEnvironment KmsProvider(string kmsProviderName)
         {
-            if (kmsProviderName?.Contains("kmip", StringComparison.OrdinalIgnoreCase) == true)
+            CheckProvider("kmip", "KMS_MOCK_SERVERS_ENABLED");
+
+            if (!CheckProvider("awsTemporary", "CSFLE_AWS_TEMPORARY_CREDS_ENABLED"))
             {
-                Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
+                CheckProvider("aws", "FLE_AWS_KEY");
             }
 
-            if (kmsProviderName?.Contains("awsTemporary", StringComparison.OrdinalIgnoreCase) == true)
-            {
-                Check().EnvironmentVariable("CSFLE_AWS_TEMPORARY_CREDS_ENABLED", isDefined: true);
-            }
-            else if (kmsProviderName?.Contains("aws", StringComparison.OrdinalIgnoreCase) == true)
-            {
-                Check().EnvironmentVariable("FLE_AWS_KEY", isDefined: true);
-            }
-
-            if (kmsProviderName?.Contains("azure", StringComparison.OrdinalIgnoreCase) == true)
-            {
-                Check().EnvironmentVariable("FLE_AZURE_TENANTID", isDefined: true);
-            }
-
-            if (kmsProviderName?.Contains("gcp", StringComparison.OrdinalIgnoreCase) == true)
-            {
-                Check().EnvironmentVariable("FLE_GCP_EMAIL", isDefined: true);
-            }
+            CheckProvider("azure", "FLE_AZURE_TENANTID");
+            CheckProvider("gcp", "FLE_GCP_EMAIL");
 
             return this;
+
+            bool CheckProvider(string match, string environmentVariable)
+            {
+                if (kmsProviderName?.Contains(match, StringComparison.OrdinalIgnoreCase) != true)
+                {
+                    return false;
+                }
+
+                Check().EnvironmentVariable(environmentVariable, isDefined: true);
+                return true;
+            }
         }
+
 
         public RequireEnvironment EnvironmentVariable(string name, bool isDefined = true, bool allowEmpty = true)
         {


### PR DESCRIPTION
Such that tests that can run locally will run locally, without the AWS or other key being available.