### PR TITLE
CSHARP-6010: Simplify FailPoint setup in tests

### DIFF
--- a/tests/MongoDB.Driver.TestHelpers/Core/FailPoint.cs
+++ b/tests/MongoDB.Driver.TestHelpers/Core/FailPoint.cs
@@ -24,6 +24,7 @@ using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Operations;
 using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
+using MongoDB.Driver.Tests;
 
 namespace MongoDB.Driver.Core.TestHelpers
 {
@@ -32,7 +33,6 @@ namespace MongoDB.Driver.Core.TestHelpers
         // public constants
         public const string FailCommand = "failCommand";
         public const string MaxTimeAlwaysTimeout = "maxTimeAlwaysTimeOut";
-        public const string OnPrimaryTransactionalWrite = "onPrimaryTransactionalWrite";
     }
 
     internal sealed class FailPoint : IDisposable
@@ -41,15 +41,17 @@ namespace MongoDB.Driver.Core.TestHelpers
 
         #region static
 
-        public static FailPoint Configure(IClusterInternal cluster, ICoreSessionHandle session, BsonDocument command, bool? withAsync = null)
+        public static FailPoint Configure(BsonDocument command, bool? withAsync = null, IClusterInternal cluster = null)
         {
-            var server = GetWriteableServer(cluster);
-            return FailPoint.Configure(server, session, command, withAsync);
+            return Configure(WritableServerSelector.Instance, command, withAsync, cluster);
         }
 
-        public static FailPoint Configure(IServer server, ICoreSessionHandle session, BsonDocument command, bool? withAsync = null)
+        public static FailPoint Configure(IServerSelector serverSelector, BsonDocument command, bool? withAsync = null, IClusterInternal cluster = null)
         {
-            var binding = new SingleServerReadWriteBinding(server, session.Fork());
+            cluster ??= DriverTestConfiguration.Client.GetClusterInternal();
+            DriverTestConfiguration.WaitForAllServersToBeConnected(cluster);
+            var server = cluster.SelectServer(OperationContext.NoTimeout, serverSelector);
+            var binding = new SingleServerReadWriteBinding(server, NoCoreSession.NewHandle());
             if (withAsync.HasValue)
             {
                 MakeFailPointApplicationNameTestableIfConfigured(command, withAsync.Value);
@@ -68,29 +70,23 @@ namespace MongoDB.Driver.Core.TestHelpers
             }
         }
 
-        public static FailPoint Configure(IClusterInternal cluster, ICoreSessionHandle session, string name, BsonDocument args, bool? withAsync = null)
+        public static FailPoint Configure(string name, BsonDocument args, bool? withAsync = null)
         {
             Ensure.IsNotNull(name, nameof(name));
             Ensure.IsNotNull(args, nameof(args));
             var command = new BsonDocument("configureFailPoint", name).Merge(args, overwriteExistingElements: false);
-            return Configure(cluster, session, command, withAsync);
+            return Configure(command, withAsync);
         }
 
-        public static FailPoint ConfigureAlwaysOn(IClusterInternal cluster, ICoreSessionHandle session, string name, bool? withAsync = null)
+        public static FailPoint ConfigureAlwaysOn(string name, bool? withAsync = null)
         {
             var args = new BsonDocument("mode", "alwaysOn");
-            return Configure(cluster, session, name, args, withAsync);
+            return Configure(name, args, withAsync);
         }
 
         public static string DecorateApplicationName(string applicationName, bool async) => $"{applicationName}{ApplicationNameTestableSuffix}{async}";
 
         // private static methods
-        private static IServer GetWriteableServer(IClusterInternal cluster)
-        {
-            var selector = WritableServerSelector.Instance;
-            return cluster.SelectServer(OperationContext.NoTimeout, selector);
-        }
-
         private static void MakeFailPointApplicationNameTestableIfConfigured(BsonDocument command, bool async)
         {
             if (command.TryGetValue("data", out var dataBsonValue))
@@ -132,14 +128,7 @@ namespace MongoDB.Driver.Core.TestHelpers
         /// <value>The binding is a single server binding.</value>
         internal IReadWriteBinding Binding => _binding;
 
-        // public methods
-        /// <summary>
-        /// Configures the failpoint on the server.
-        /// </summary>
-        public void Configure()
-        {
-            Configure(_command);
-        }
+        public IServer Server => _server;
 
         public void Dispose()
         {
@@ -152,10 +141,8 @@ namespace MongoDB.Driver.Core.TestHelpers
         }
 
         // private methods
-        private void Configure(BsonDocument command, bool waitForConnected = false)
-        {
-            ExecuteCommand(command, waitForConnected);
-        }
+        private void Configure()
+            => ExecuteCommand(_command, false);
 
         private void ConfigureOff()
         {
@@ -165,7 +152,7 @@ namespace MongoDB.Driver.Core.TestHelpers
                 { "configureFailPoint", name },
                 { "mode", "off" }
             };
-            Configure(command, true);
+            ExecuteCommand(command, true);
         }
 
         private void ExecuteCommand(BsonDocument command, bool waitForConnected)

--- a/tests/MongoDB.Driver.TestHelpers/Core/FailPoint.cs
+++ b/tests/MongoDB.Driver.TestHelpers/Core/FailPoint.cs
@@ -41,10 +41,8 @@ namespace MongoDB.Driver.Core.TestHelpers
 
         #region static
 
-        public static FailPoint Configure(BsonDocument command, bool? withAsync = null, IClusterInternal cluster = null)
-        {
-            return Configure(WritableServerSelector.Instance, command, withAsync, cluster);
-        }
+        public static FailPoint Configure(BsonDocument command, bool? withAsync = null, IClusterInternal cluster = null) =>
+            Configure(WritableServerSelector.Instance, command, withAsync, cluster);
 
         public static FailPoint Configure(IServerSelector serverSelector, BsonDocument command, bool? withAsync = null, IClusterInternal cluster = null)
         {

--- a/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
+++ b/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
@@ -127,7 +127,8 @@ namespace MongoDB.Driver.Tests
 
         public static IMongoClient CreateMongoClient(
             Action<MongoClientSettings> clientSettingsConfigurator = null,
-            bool useMultipleShardRouters = false)
+            bool useMultipleShardRouters = false,
+            bool waitForAllServersToBeConnected = false)
         {
             var clusterType = CoreTestConfiguration.Cluster.Description.Type;
             if (clusterType != ClusterType.Sharded && clusterType != ClusterType.LoadBalanced)
@@ -152,7 +153,13 @@ namespace MongoDB.Driver.Tests
                 OidcCallbackAdapterCachingFactory.Instance.Reset();
             }
 
-            return new MongoClient(clientSettings);
+            var client = new MongoClient(clientSettings);
+            if (waitForAllServersToBeConnected)
+            {
+                WaitForAllServersToBeConnected(client.GetClusterInternal());
+            }
+
+            return client;
         }
 
         public static IMongoClient CreateMongoClient(EventCapturer capturer, LoggingSettings loggingSettings = null) =>

--- a/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
+++ b/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
@@ -34,6 +34,7 @@ namespace MongoDB.Driver.Tests
     /// </summary>
     public static class DriverTestConfiguration
     {
+        private const string DefaultClientAppName = "DefaultClient";
         // private static fields
         private static Lazy<IMongoClient> __client;
         private static Lazy<IMongoClient> __clientWithMultipleShardRouters;
@@ -44,8 +45,8 @@ namespace MongoDB.Driver.Tests
         // static constructor
         static DriverTestConfiguration()
         {
-            __client = new Lazy<IMongoClient>(CreateMongoClient, isThreadSafe: true);
-            __clientWithMultipleShardRouters = new Lazy<IMongoClient>(() => CreateMongoClient(useMultipleShardRouters: true), true);
+            __client = new Lazy<IMongoClient>(() => CreateMongoClient(settings => settings.ApplicationName = DefaultClientAppName), isThreadSafe: true);
+            __clientWithMultipleShardRouters = new Lazy<IMongoClient>(() => CreateMongoClient(settings => settings.ApplicationName = DefaultClientAppName, useMultipleShardRouters: true), true);
             __databaseNamespace = CoreTestConfiguration.DatabaseNamespace;
             __directClientsToShardRouters = new Lazy<IReadOnlyList<IMongoClient>>(
                 () => CreateDirectClientsToHostsInConnectionString(CoreTestConfiguration.ConnectionStringWithMultipleShardRouters).ToList().AsReadOnly(),
@@ -176,9 +177,6 @@ namespace MongoDB.Driver.Tests
 
             return new MongoClient(settings);
         }
-
-        private static IMongoClient CreateMongoClient() =>
-            CreateMongoClient(GetClientSettings());
 
         public static MongoClientSettings GetClientSettings()
         {

--- a/tests/MongoDB.Driver.Tests/ClusterTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterTests.cs
@@ -87,11 +87,10 @@ namespace MongoDB.Driver.Tests
             var eventCapturer = CreateEventCapturer();
             using (var client = CreateMongoClient(eventCapturer, applicationName))
             {
-                var slowServerSelector = WritableServerSelector.Instance;
-                var slowServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, slowServerSelector);
+                using var failPoint = FailPoint.Configure(WritableServerSelector.Instance, failCommand, async, client.GetClusterInternal());
+                var slowServer = failPoint.Server;
                 var fastServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new DelegateServerSelector((_, servers) => servers.Where(s => s.ServerId != slowServer.ServerId)));
 
-                using var failPoint = FailPoint.Configure(slowServerSelector, failCommand, async, client.GetClusterInternal());
                 var database = client.GetDatabase(_databaseName);
                 CreateCollection();
                 var collection = database.GetCollection<BsonDocument>(_collectionName);

--- a/tests/MongoDB.Driver.Tests/ClusterTests.cs
+++ b/tests/MongoDB.Driver.Tests/ClusterTests.cs
@@ -87,10 +87,11 @@ namespace MongoDB.Driver.Tests
             var eventCapturer = CreateEventCapturer();
             using (var client = CreateMongoClient(eventCapturer, applicationName))
             {
-                var slowServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, WritableServerSelector.Instance);
+                var slowServerSelector = WritableServerSelector.Instance;
+                var slowServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, slowServerSelector);
                 var fastServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new DelegateServerSelector((_, servers) => servers.Where(s => s.ServerId != slowServer.ServerId)));
 
-                using var failPoint = FailPoint.Configure(slowServer, NoCoreSession.NewHandle(), failCommand, async);
+                using var failPoint = FailPoint.Configure(slowServerSelector, failCommand, async, client.GetClusterInternal());
                 var database = client.GetDatabase(_databaseName);
                 CreateCollection();
                 var collection = database.GetCollection<BsonDocument>(_collectionName);

--- a/tests/MongoDB.Driver.Tests/ConnectionsSurvivePrimaryStepDownTests.cs
+++ b/tests/MongoDB.Driver.Tests/ConnectionsSurvivePrimaryStepDownTests.cs
@@ -19,7 +19,6 @@ using System.Net;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
@@ -57,7 +56,7 @@ namespace MongoDB.Driver.Tests
                 var collection = database.GetCollection<BsonDocument>(_collectionName, new MongoCollectionSettings { WriteConcern = WriteConcern.WMajority });
                 eventCapturer.Clear();
 
-                using (ConfigureFailPoint(client, errorCode))
+                using (ConfigureFailPoint(errorCode))
                 {
                     var exception = Record.Exception(() => { collection.InsertOne(new BsonDocument("test", 1)); });
 
@@ -158,7 +157,7 @@ namespace MongoDB.Driver.Tests
                 var collection = database.GetCollection<BsonDocument>(_collectionName, new MongoCollectionSettings { WriteConcern = WriteConcern.WMajority });
                 eventCapturer.Clear();
 
-                using (ConfigureFailPoint(client, 10107))
+                using (ConfigureFailPoint(10107))
                 {
                     var exception = Record.Exception(() => { collection.InsertOne(new BsonDocument("test", 1)); });
 
@@ -186,12 +185,10 @@ namespace MongoDB.Driver.Tests
         }
 
         // private methods
-        private FailPoint ConfigureFailPoint(IMongoClient client, int errorCode)
+        private FailPoint ConfigureFailPoint(int errorCode)
         {
-            var session = NoCoreSession.NewHandle();
-
             var args = BsonDocument.Parse($"{{ mode : {{ times : 1 }}, data : {{ failCommands : [\"insert\"], errorCode : {errorCode} }} }}");
-            return FailPoint.Configure(client.GetClusterInternal(), session, "failCommand", args);
+            return FailPoint.Configure("failCommand", args);
         }
 
         private IMongoClient CreateMongoClient(EventCapturer capturedEvents) =>

--- a/tests/MongoDB.Driver.Tests/Core/Operations/AggregateOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/AggregateOperationTests.cs
@@ -624,7 +624,7 @@ namespace MongoDB.Driver.Core.Operations
 
             var subject = new AggregateOperation<BsonDocument>(_collectionNamespace, __pipeline, __resultSerializer, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/AggregateToCollectionOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/AggregateToCollectionOperationTests.cs
@@ -751,7 +751,7 @@ namespace MongoDB.Driver.Core.Operations
                 MaxTime = TimeSpan.FromSeconds(9001)
             };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/CountDocumentsOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/CountDocumentsOperationTests.cs
@@ -257,7 +257,7 @@ namespace MongoDB.Driver.Core.Operations
             RequireServer.Check().ClusterTypes(ClusterType.Standalone, ClusterType.ReplicaSet);
             var subject = new CountDocumentsOperation(_collectionNamespace, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/CountOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/CountOperationTests.cs
@@ -512,7 +512,7 @@ namespace MongoDB.Driver.Core.Operations
             RequireServer.Check().ClusterTypes(ClusterType.Standalone, ClusterType.ReplicaSet);
             var subject = new CountOperation(_collectionNamespace, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/CreateIndexesOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/CreateIndexesOperationTests.cs
@@ -277,7 +277,7 @@ namespace MongoDB.Driver.Core.Operations
             var requests = new[] { new CreateIndexRequest(new BsonDocument("x", 1)) };
             var subject = new CreateIndexesOperation(_collectionNamespace, requests, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/DistinctOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/DistinctOperationTests.cs
@@ -462,7 +462,7 @@ namespace MongoDB.Driver.Core.Operations
             RequireServer.Check().ClusterTypes(ClusterType.Standalone, ClusterType.ReplicaSet);
             var subject = new DistinctOperation<int>(_collectionNamespace, _valueSerializer, _fieldName, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/DropIndexOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/DropIndexOperationTests.cs
@@ -292,7 +292,7 @@ namespace MongoDB.Driver.Core.Operations
             var indexName = "x_1";
             var subject = new DropIndexOperation(_collectionNamespace, indexName, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/EstimatedDocumentCountOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/EstimatedDocumentCountOperationTests.cs
@@ -240,7 +240,7 @@ namespace MongoDB.Driver.Core.Operations
 
             var subject = new EstimatedDocumentCountOperation(_collectionNamespace, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/FindOneAndDeleteOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/FindOneAndDeleteOperationTests.cs
@@ -481,7 +481,7 @@ namespace MongoDB.Driver.Core.Operations
             var subject = new FindOneAndDeleteOperation<BsonDocument>(_collectionNamespace, filter, _findAndModifyValueDeserializer, _messageEncoderSettings);
             subject.MaxTime = TimeSpan.FromSeconds(9001);
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/FindOneAndReplaceOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/FindOneAndReplaceOperationTests.cs
@@ -721,7 +721,7 @@ namespace MongoDB.Driver.Core.Operations
             var subject = new FindOneAndReplaceOperation<BsonDocument>(_collectionNamespace, _filter, _replacement, _findAndModifyValueDeserializer, _messageEncoderSettings);
             subject.MaxTime = TimeSpan.FromSeconds(9001);
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/FindOneAndUpdateOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/FindOneAndUpdateOperationTests.cs
@@ -723,7 +723,7 @@ namespace MongoDB.Driver.Core.Operations
                 MaxTime = TimeSpan.FromSeconds(9001)
             };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/FindOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/FindOperationTests.cs
@@ -896,7 +896,7 @@ namespace MongoDB.Driver.Core.Operations
             RequireServer.Check().ClusterTypes(ClusterType.Standalone, ClusterType.ReplicaSet);
             var subject = new FindOperation<BsonDocument>(_collectionNamespace, BsonDocumentSerializer.Instance, _messageEncoderSettings) { MaxTime = TimeSpan.FromSeconds(9001) };
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/MapReduceOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/MapReduceOperationTests.cs
@@ -469,7 +469,7 @@ namespace MongoDB.Driver.Core.Operations
 #pragma warning restore CS0618 // Type or member is obsolete
             subject.MaxTime = TimeSpan.FromSeconds(9001);
 
-            using (var failPoint = FailPoint.ConfigureAlwaysOn(_cluster, _session, FailPointName.MaxTimeAlwaysTimeout))
+            using (var failPoint = FailPoint.ConfigureAlwaysOn(FailPointName.MaxTimeAlwaysTimeout))
             {
                 var exception = Record.Exception(() => ExecuteOperation(subject, failPoint.Binding, async));
 

--- a/tests/MongoDB.Driver.Tests/IJsonDrivenTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/IJsonDrivenTestRunner.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MongoDB.Bson;
+using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.TestHelpers;
 
@@ -24,6 +25,7 @@ namespace MongoDB.Driver.Tests
 {
     internal interface IJsonDrivenTestRunner
     {
+        IClusterInternal FailPointCluster { get; }
         void ConfigureFailPoint(IServerSelector serverSelector, BsonDocument failCommand);
         Task ConfigureFailPointAsync(IServerSelector serverSelector, BsonDocument failCommand);
     }
@@ -32,15 +34,27 @@ namespace MongoDB.Driver.Tests
     {
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
 
+        public IClusterInternal FailPointCluster
+        {
+            get
+            {
+                var regularClient = DriverTestConfiguration.Client;
+                var client = regularClient.Cluster.Description.Type == ClusterType.Sharded
+                    ? DriverTestConfiguration.ClientWithMultipleShardRouters
+                    : regularClient;
+                return client.GetClusterInternal();
+            }
+        }
+
         public void ConfigureFailPoint(IServerSelector serverSelector, BsonDocument failCommand)
         {
-            var failPoint = FailPoint.Configure(serverSelector, failCommand, withAsync: false);
+            var failPoint = FailPoint.Configure(serverSelector, failCommand, withAsync: false, cluster: FailPointCluster);
             _disposables.Add(failPoint);
         }
 
         public async Task ConfigureFailPointAsync(IServerSelector serverSelector, BsonDocument failCommand)
         {
-            var failPoint = await Task.Run(() => FailPoint.Configure(serverSelector, failCommand, withAsync: true)).ConfigureAwait(false);
+            var failPoint = await Task.Run(() => FailPoint.Configure(serverSelector, failCommand, withAsync: true, cluster: FailPointCluster)).ConfigureAwait(false);
             _disposables.Add(failPoint);
         }
 

--- a/tests/MongoDB.Driver.Tests/IJsonDrivenTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/IJsonDrivenTestRunner.cs
@@ -17,45 +17,30 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MongoDB.Bson;
-using MongoDB.Driver.Core.Bindings;
-using MongoDB.Driver.Core.Clusters;
-using MongoDB.Driver.Core.Servers;
+using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.TestHelpers;
 
 namespace MongoDB.Driver.Tests
 {
     internal interface IJsonDrivenTestRunner
     {
-        IClusterInternal FailPointCluster { get; }
-        void ConfigureFailPoint(IServer server, ICoreSessionHandle session, BsonDocument failCommand);
-        Task ConfigureFailPointAsync(IServer server, ICoreSessionHandle session, BsonDocument failCommand);
+        void ConfigureFailPoint(IServerSelector serverSelector, BsonDocument failCommand);
+        Task ConfigureFailPointAsync(IServerSelector serverSelector, BsonDocument failCommand);
     }
 
     internal sealed class JsonDrivenTestRunner : IJsonDrivenTestRunner, IDisposable
     {
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
 
-        public IClusterInternal FailPointCluster
+        public void ConfigureFailPoint(IServerSelector serverSelector, BsonDocument failCommand)
         {
-            get
-            {
-                var regularClient = DriverTestConfiguration.Client;
-                var client = regularClient.Cluster.Description.Type == ClusterType.Sharded
-                    ? DriverTestConfiguration.ClientWithMultipleShardRouters
-                    : regularClient;
-                return client.GetClusterInternal();
-            }
-        }
-
-        public void ConfigureFailPoint(IServer server, ICoreSessionHandle session, BsonDocument failCommand)
-        {
-            var failPoint = FailPoint.Configure(server, session, failCommand, withAsync: false);
+            var failPoint = FailPoint.Configure(serverSelector, failCommand, withAsync: false);
             _disposables.Add(failPoint);
         }
 
-        public async Task ConfigureFailPointAsync(IServer server, ICoreSessionHandle session, BsonDocument failCommand)
+        public async Task ConfigureFailPointAsync(IServerSelector serverSelector, BsonDocument failCommand)
         {
-            var failPoint = await Task.Run(() => FailPoint.Configure(server, session, failCommand, withAsync: true)).ConfigureAwait(false);
+            var failPoint = await Task.Run(() => FailPoint.Configure(serverSelector, failCommand, withAsync: true)).ConfigureAwait(false);
             _disposables.Add(failPoint);
         }
 

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenConfigureFailPointTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenConfigureFailPointTest.cs
@@ -17,9 +17,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
-using MongoDB.Driver.Core.Servers;
 
 namespace MongoDB.Driver.Tests.JsonDrivenTests
 {
@@ -34,27 +32,18 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
 
         protected override void CallMethod(CancellationToken cancellationToken)
         {
-            var server = GetFailPointServer();
-            TestRunner.ConfigureFailPoint(server, NoCoreSession.NewHandle(), _failCommand);
+            var serverSelector = GetFailPointServerSelector();
+            TestRunner.ConfigureFailPoint(serverSelector, _failCommand);
         }
 
         protected override async Task CallMethodAsync(CancellationToken cancellationToken)
         {
-            var server = await GetFailPointServerAsync().ConfigureAwait(false);
-            await TestRunner.ConfigureFailPointAsync(server, NoCoreSession.NewHandle(), _failCommand).ConfigureAwait(false);
+            var serverSelector = GetFailPointServerSelector();
+            await TestRunner.ConfigureFailPointAsync(serverSelector, _failCommand).ConfigureAwait(false);
         }
 
-        protected virtual IServer GetFailPointServer()
-        {
-            var cluster = TestRunner.FailPointCluster;
-            return cluster.SelectServer(OperationContext.NoTimeout, WritableServerSelector.Instance);
-        }
-
-        protected async virtual Task<IServer> GetFailPointServerAsync()
-        {
-            var cluster = TestRunner.FailPointCluster;
-            return await cluster.SelectServerAsync(OperationContext.NoTimeout, WritableServerSelector.Instance).ConfigureAwait(false);
-        }
+        protected virtual IServerSelector GetFailPointServerSelector() =>
+            WritableServerSelector.Instance;
 
         protected override void SetArgument(string name, BsonValue value)
         {

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenTargetedFailPointTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenTargetedFailPointTest.cs
@@ -15,10 +15,8 @@
 
 using System.Collections.Generic;
 using System.Net;
-using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
-using MongoDB.Driver.Core.Servers;
 
 namespace MongoDB.Driver.Tests.JsonDrivenTests
 {
@@ -29,18 +27,10 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         {
         }
 
-        protected override IServer GetFailPointServer()
+        protected override IServerSelector GetFailPointServerSelector()
         {
             var pinnedServerEndpoint = GetPinnedServerEndpointAndAssertNotNull();
-            var pinnedServerSelector = CreateServerSelector(pinnedServerEndpoint);
-            return TestRunner.FailPointCluster.SelectServer(OperationContext.NoTimeout, pinnedServerSelector);
-        }
-
-        protected async override Task<IServer> GetFailPointServerAsync()
-        {
-            var pinnedServerEndpoint = GetPinnedServerEndpointAndAssertNotNull();
-            var pinnedServerSelector = CreateServerSelector(pinnedServerEndpoint);
-            return await TestRunner.FailPointCluster.SelectServerAsync(OperationContext.NoTimeout, pinnedServerSelector).ConfigureAwait(false);
+            return CreateServerSelector(pinnedServerEndpoint);
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
+++ b/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
@@ -17,7 +17,6 @@ using System;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
@@ -250,12 +249,8 @@ namespace MongoDB.Driver.Tests
             return GetClient(cb => cb.Subscribe(capturer));
         }
 
-        private FailPoint ConfigureFailPoint(string failpointCommand)
-        {
-            var cluster = DriverTestConfiguration.Client.GetClusterInternal();
-            var session = NoCoreSession.NewHandle();
-            return FailPoint.Configure(cluster, session, BsonDocument.Parse(failpointCommand));
-        }
+        private FailPoint ConfigureFailPoint(string failpointCommand) =>
+            FailPoint.Configure(BsonDocument.Parse(failpointCommand));
 
         private void RequireSupportForRetryableWrites()
         {

--- a/tests/MongoDB.Driver.Tests/Specifications/Runner/MongoClientJsonDrivenTestRunnerBase.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/Runner/MongoClientJsonDrivenTestRunnerBase.cs
@@ -23,7 +23,6 @@ using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
@@ -446,27 +445,22 @@ namespace MongoDB.Driver.Tests.Specifications.Runner
             {
                 Logger.LogDebug("Configuring failpoint");
 
-                var cluster = client.GetClusterInternal();
-
                 var settings = client.Settings.Clone();
                 ConfigureClientSettings(settings, test);
 
-                if (settings.DirectConnection == true)
+                IServerSelector failPointServerSelector;
+                if (settings.DirectConnection)
                 {
                     var serverAddress = EndPointHelper.Parse(settings.Server.ToString());
-
-                    var selector = new EndPointServerSelector(serverAddress);
-                    _failPointServer = cluster.SelectServer(OperationContext.NoTimeout, selector);
+                    failPointServerSelector = new EndPointServerSelector(serverAddress);
                 }
                 else
                 {
-                    _failPointServer = cluster.SelectServer(OperationContext.NoTimeout, WritableServerSelector.Instance);
+                    failPointServerSelector = WritableServerSelector.Instance;
                 }
 
-                var session = NoCoreSession.NewHandle();
                 var command = failPoint.AsBsonDocument;
-
-                return FailPoint.Configure(_failPointServer, session, command, _async);
+                return FailPoint.Configure(failPointServerSelector, command, _async);
             }
 
             return null;

--- a/tests/MongoDB.Driver.Tests/Specifications/Runner/MongoClientJsonDrivenTestRunnerBase.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/Runner/MongoClientJsonDrivenTestRunnerBase.cs
@@ -460,7 +460,7 @@ namespace MongoDB.Driver.Tests.Specifications.Runner
                 }
 
                 var command = failPoint.AsBsonDocument;
-                return FailPoint.Configure(failPointServerSelector, command, _async);
+                return FailPoint.Configure(failPointServerSelector, command, _async, client.GetClusterInternal());
             }
 
             return null;

--- a/tests/MongoDB.Driver.Tests/Specifications/auth/OidcAuthenticationProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/auth/OidcAuthenticationProseTests.cs
@@ -25,7 +25,6 @@ using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Authentication;
 using MongoDB.Driver.Authentication.Oidc;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
@@ -591,11 +590,8 @@ namespace MongoDB.Driver.Tests.Specifications.auth
                 }
             };
 
-            var cluster = DriverTestConfiguration.Client.GetClusterInternal();
-            var server = cluster.SelectServer(OperationContext.NoTimeout, new ReadPreferenceServerSelector(ReadPreference.Primary));
-            var session = NoCoreSession.NewHandle();
-
-            return FailPoint.Configure(server, session, failPointCommand);
+            var failPointServerSelector = new ReadPreferenceServerSelector(ReadPreference.Primary);
+            return FailPoint.Configure(failPointServerSelector, failPointCommand);
         }
 
         private (MongoClientSettings MongoClientSettings, EventCapturer EventCapturer, Mock<IOidcCallback> CustomCallback) GetMongoClientSettings(string userName = null)

--- a/tests/MongoDB.Driver.Tests/Specifications/client-backpressure/prose-tests/ClientBackpressureProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-backpressure/prose-tests/ClientBackpressureProseTests.cs
@@ -218,7 +218,7 @@ public class ClientBackpressureProseTestsIntegration
 
         var eventCapturer = new EventCapturer().CaptureCommandEvents("find");
 
-        using var failPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), failPointCommand);
+        using var failPoint = FailPoint.Configure(failPointCommand);
         using var client = DriverTestConfiguration.CreateMongoClient(s =>
         {
             s.RetryReads = true;
@@ -261,7 +261,7 @@ public class ClientBackpressureProseTestsIntegration
 
         var eventCapturer = new EventCapturer().CaptureCommandEvents("find");
 
-        using var failPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), failPointCommand);
+        using var failPoint = FailPoint.Configure(failPointCommand);
         using var client = DriverTestConfiguration.CreateMongoClient(s =>
         {
             s.RetryReads = true;

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -1177,7 +1177,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                                     ""failCommands"": [ ""aggregate"" ]
                                 }
                             }");
-                            using (FailPoint.Configure(_cluster, NoCoreSession.NewHandle(), failPointCommand))
+                            using (FailPoint.Configure(failPointCommand))
                             {
                                 var exception = Record.Exception(() => Aggregate(decryptionEventsCollection, async));
                                 exception.Should().BeOfType<MongoCommandException>();
@@ -1200,7 +1200,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                                     ""failCommands"" : [ ""aggregate"" ]
                                 }
                             }");
-                            using (FailPoint.Configure(_cluster, NoCoreSession.NewHandle(), failPointCommand))
+                            using (FailPoint.Configure(failPointCommand))
                             {
                                 var exception = Record.Exception(() => Aggregate(decryptionEventsCollection, async));
                                 exception.Should().BeOfType<MongoConnectionException>().Which.IsNetworkException.Should().BeTrue();

--- a/tests/MongoDB.Driver.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
@@ -723,7 +723,7 @@ namespace MongoDB.Driver.Tests.Specifications.connection_monitoring_and_pooling
                     }
 
                     var failPointServerSelector = new EndPointServerSelector(server.EndPoint);
-                    failPoint = FailPoint.Configure(failPointServerSelector, failPointDocument.AsBsonDocument, withAsync: async, cluster: cluster);
+                    failPoint = FailPoint.Configure(failPointServerSelector, failPointDocument.AsBsonDocument, withAsync: async);
 
                     if (resetPool)
                     {

--- a/tests/MongoDB.Driver.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
@@ -723,7 +723,7 @@ namespace MongoDB.Driver.Tests.Specifications.connection_monitoring_and_pooling
                     }
 
                     var failPointServerSelector = new EndPointServerSelector(server.EndPoint);
-                    failPoint = FailPoint.Configure(failPointServerSelector, failPointDocument.AsBsonDocument, withAsync: async);
+                    failPoint = FailPoint.Configure(failPointServerSelector, failPointDocument.AsBsonDocument, withAsync: async, cluster: cluster);
 
                     if (resetPool)
                     {

--- a/tests/MongoDB.Driver.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/connection-monitoring-and-pooling/ConnectionMonitoringAndPoolingTestRunner.cs
@@ -26,7 +26,6 @@ using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Configuration;
@@ -723,8 +722,8 @@ namespace MongoDB.Driver.Tests.Specifications.connection_monitoring_and_pooling
                         eventCapturer.WaitForOrThrowIfTimeout(events => events.Any(e => e is ConnectionPoolClearedEvent), TimeSpan.FromMilliseconds(500));
                     }
 
-                    var failPointServer = CoreTestConfiguration.Cluster.SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(server.EndPoint));
-                    failPoint = FailPoint.Configure(failPointServer, NoCoreSession.NewHandle(), failPointDocument.AsBsonDocument, withAsync: async);
+                    var failPointServerSelector = new EndPointServerSelector(server.EndPoint);
+                    failPoint = FailPoint.Configure(failPointServerSelector, failPointDocument.AsBsonDocument, withAsync: async);
 
                     if (resetPool)
                     {

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/prose-tests/CrudProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/prose-tests/CrudProseTests.cs
@@ -20,7 +20,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
@@ -696,13 +695,8 @@ namespace MongoDB.Driver.Tests.Specifications.crud.prose_tests
         }
 
         // private methods
-        private FailPoint ConfigureFailPoint(string failpointCommand)
-        {
-            var cluster = DriverTestConfiguration.Client.GetClusterInternal();
-            var session = NoCoreSession.NewHandle();
-
-            return FailPoint.Configure(cluster, session, BsonDocument.Parse(failpointCommand));
-        }
+        private FailPoint ConfigureFailPoint(string failpointCommand) =>
+            FailPoint.Configure(BsonDocument.Parse(failpointCommand));
 
         private IMongoClient CreateMongoClient(EventCapturer eventCapturer = null)
         {

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsProseTests.cs
@@ -21,7 +21,6 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Events;
@@ -81,8 +80,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                .Capture<ConnectionPoolCheckingOutConnectionFailedEvent>()
                .CaptureCommandEvents("find");
 
-            var failpointServer = DriverTestConfiguration.Client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, failPointSelector);
-            using var failPoint = FailPoint.Configure(failpointServer, NoCoreSession.NewHandle(), failPointCommand);
+            using var failPoint = FailPoint.Configure(failPointSelector, failPointCommand);
 
             using var client = CreateClient(settings, eventCapturer, heartbeatInterval);
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
@@ -149,11 +147,11 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                 },
                 useMultipleShardRouters: true);
 
-            var failPointServer1 = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(client.Cluster.Description.Servers[0].EndPoint));
-            var failPointServer2 = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(client.Cluster.Description.Servers[1].EndPoint));
+            var failPointServerSelector1 = new EndPointServerSelector(client.Cluster.Description.Servers[0].EndPoint);
+            var failPointServerSelector2 = new EndPointServerSelector(client.Cluster.Description.Servers[1].EndPoint);
 
-            using var failPoint1 = FailPoint.Configure(failPointServer1, NoCoreSession.NewHandle(), failPointCommand);
-            using var failPoint2 = FailPoint.Configure(failPointServer2, NoCoreSession.NewHandle(), failPointCommand);
+            using var failPoint1 = FailPoint.Configure(failPointServerSelector1, failPointCommand, cluster: client.GetClusterInternal());
+            using var failPoint2 = FailPoint.Configure(failPointServerSelector2, failPointCommand, cluster: client.GetClusterInternal());
 
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
             var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
@@ -201,9 +199,9 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                 useMultipleShardRouters: false);
             DriverTestConfiguration.WaitForAllServersToBeConnected(client.GetClusterInternal());
 
-            var failPointServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(client.Cluster.Description.Servers[0].EndPoint));
+            var failPointServerSelector = new EndPointServerSelector(client.Cluster.Description.Servers[0].EndPoint);
 
-            using var failPoint = FailPoint.Configure(failPointServer, NoCoreSession.NewHandle(), failPointCommand);
+            using var failPoint = FailPoint.Configure(failPointServerSelector, failPointCommand);
 
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
             var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
@@ -254,10 +252,9 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                     s.ReadPreference = ReadPreference.PrimaryPreferred;
                 },
                 useMultipleShardRouters: false);
-            DriverTestConfiguration.WaitForAllServersToBeConnected(client.GetClusterInternal());
 
-            var failPointServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new ReadPreferenceServerSelector(ReadPreference.Primary));
-            using var failPoint = FailPoint.Configure(failPointServer, NoCoreSession.NewHandle(), failPointCommand);
+            var failPointServerSelector = new ReadPreferenceServerSelector(ReadPreference.Primary);
+            using var failPoint = FailPoint.Configure(failPointServerSelector, failPointCommand);
 
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
             var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
@@ -266,9 +263,9 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                 await collection.FindAsync(Builders<BsonDocument>.Filter.Empty) :
                 collection.FindSync(Builders<BsonDocument>.Filter.Empty);
 
-            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>().Subject.ConnectionId.ServerId.Should().Be(failPointServer.ServerId);
+            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>().Subject.ConnectionId.ServerId.EndPoint.Should().Be(failPoint.Server.ServerId.EndPoint);
             eventCapturer.Next().Should().BeOfType<CommandFailedEvent>();
-            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>().Subject.ConnectionId.ServerId.Should().NotBe(failPointServer.ServerId);
+            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>().Subject.ConnectionId.ServerId.EndPoint.Should().NotBe(failPoint.Server.ServerId.EndPoint);
             eventCapturer.Next().Should().BeOfType<CommandSucceededEvent>();
         }
 
@@ -301,10 +298,11 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                     s.ClusterConfigurator = b => b.Subscribe(eventCapturer);
                     s.ReadPreference = ReadPreference.PrimaryPreferred;
                 },
-                useMultipleShardRouters: false);
+                useMultipleShardRouters: false,
+                waitForAllServersToBeConnected: true);
 
-            var failPointServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new ReadPreferenceServerSelector(ReadPreference.Primary));
-            using var failPoint = FailPoint.Configure(failPointServer, NoCoreSession.NewHandle(), failPointCommand);
+            var failPointServerSelector = new ReadPreferenceServerSelector(ReadPreference.Primary);
+            using var failPoint = FailPoint.Configure(failPointServerSelector, failPointCommand);
 
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
             var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
@@ -313,9 +311,9 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                 await collection.FindAsync(Builders<BsonDocument>.Filter.Empty) :
                 collection.FindSync(Builders<BsonDocument>.Filter.Empty);
 
-            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>().Subject.ConnectionId.ServerId.Should().Be(failPointServer.ServerId);
+            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>().Subject.ConnectionId.ServerId.EndPoint.Should().Be(failPoint.Server.ServerId.EndPoint);
             eventCapturer.Next().Should().BeOfType<CommandFailedEvent>();
-            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>().Subject.ConnectionId.ServerId.Should().Be(failPointServer.ServerId);
+            eventCapturer.Next().Should().BeOfType<CommandStartedEvent>().Subject.ConnectionId.ServerId.EndPoint.Should().Be(failPoint.Server.ServerId.EndPoint);
             eventCapturer.Next().Should().BeOfType<CommandSucceededEvent>();
         }
 
@@ -354,7 +352,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
             var secondFailPointConfigured = false;
             FailPoint secondFailPoint = null;
 
-            using var firstFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), firstFailPointCommand);
+            using var firstFailPoint = FailPoint.Configure(firstFailPointCommand);
 
             var eventCapturer = new EventCapturer().CaptureCommandEvents("find");
             using var client = DriverTestConfiguration.CreateMongoClient(s =>
@@ -367,7 +365,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                     {
                         if (e is { CommandName: "find", Failure: MongoCommandException { Code: 91 } } && !secondFailPointConfigured)
                         {
-                            secondFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), secondFailPointCommand);
+                            secondFailPoint = FailPoint.Configure(secondFailPointCommand);
                             secondFailPointConfigured = true;
                         }
                     });
@@ -426,7 +424,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
             var secondFailPointConfigured = false;
             FailPoint secondFailPoint = null;
 
-            using var firstFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), firstFailPointCommand);
+            using var firstFailPoint = FailPoint.Configure(firstFailPointCommand);
 
             var eventCapturer = new EventCapturer().CaptureCommandEvents("find");
             using var client = DriverTestConfiguration.CreateMongoClient(s =>
@@ -439,7 +437,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                     {
                         if (e is { CommandName: "find", Failure: MongoCommandException { Code: 91 } } && !secondFailPointConfigured)
                         {
-                            secondFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), secondFailPointCommand);
+                            secondFailPoint = FailPoint.Configure(secondFailPointCommand);
                             secondFailPointConfigured = true;
                         }
                     });

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-reads/RetryableReadsProseTests.cs
@@ -251,7 +251,8 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_reads
                     s.ClusterConfigurator = b => b.Subscribe(eventCapturer);
                     s.ReadPreference = ReadPreference.PrimaryPreferred;
                 },
-                useMultipleShardRouters: false);
+                useMultipleShardRouters: false,
+                waitForAllServersToBeConnected: true);
 
             var failPointServerSelector = new ReadPreferenceServerSelector(ReadPreference.Primary);
             using var failPoint = FailPoint.Configure(failPointServerSelector, failPointCommand);

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/ErrorPropagationAfterMultipleErrors.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/ErrorPropagationAfterMultipleErrors.cs
@@ -13,13 +13,10 @@
 * limitations under the License.
 */
 
-using System.Threading;
 using FluentAssertions;
 using MongoDB.Bson;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Events;
-using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Operations;
 using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
@@ -66,7 +63,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
             var secondFailPointConfigured = false;
             FailPoint secondFailPoint = null;
 
-            using var firstFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), firstFailPointCommand);
+            using var firstFailPoint = FailPoint.Configure(firstFailPointCommand);
 
             using var client = DriverTestConfiguration.CreateMongoClient(s =>
             {
@@ -75,7 +72,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
                 {
                     if (e is { CommandName: "insert", Failure: MongoCommandException { Code: 91 } } && !secondFailPointConfigured)
                     {
-                        secondFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), secondFailPointCommand);
+                        secondFailPoint = FailPoint.Configure(secondFailPointCommand);
                         secondFailPointConfigured = true;
                     }
                 });
@@ -130,7 +127,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
             var secondFailPointConfigured = false;
             FailPoint secondFailPoint = null;
 
-            using var firstFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), firstFailPointCommand);
+            using var firstFailPoint = FailPoint.Configure(firstFailPointCommand);
 
             using var client = DriverTestConfiguration.CreateMongoClient(s =>
             {
@@ -139,7 +136,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
                 {
                     if (e is { CommandName: "insert", Failure: MongoCommandException { Code: 91 } } && !secondFailPointConfigured)
                     {
-                        secondFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), secondFailPointCommand);
+                        secondFailPoint = FailPoint.Configure(secondFailPointCommand);
                         secondFailPointConfigured = true;
                     }
                 });
@@ -194,7 +191,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
             var secondFailPointConfigured = false;
             FailPoint secondFailPoint = null;
 
-            using var firstFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), firstFailPointCommand);
+            using var firstFailPoint = FailPoint.Configure(firstFailPointCommand);
 
             using var client = DriverTestConfiguration.CreateMongoClient(s =>
             {
@@ -203,7 +200,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
                 {
                     if (e is { CommandName: "insert", Failure: MongoCommandException { Code: 91 } } && !secondFailPointConfigured)
                     {
-                        secondFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), secondFailPointCommand);
+                        secondFailPoint = FailPoint.Configure(secondFailPointCommand);
                         secondFailPointConfigured = true;
                     }
                 });

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/PoolClearRetryability.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/PoolClearRetryability.cs
@@ -21,7 +21,6 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Events;
@@ -83,8 +82,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
                .Capture<ConnectionPoolCheckingOutConnectionFailedEvent>()
                .CaptureCommandEvents("insert");
 
-            var failpointServer = DriverTestConfiguration.Client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, failPointSelector);
-            using var failPoint = FailPoint.Configure(failpointServer, NoCoreSession.NewHandle(), failPointCommand);
+            using var failPoint = FailPoint.Configure(failPointSelector, failPointCommand);
 
             using var client = CreateClient(settings, eventCapturer, heartbeatInterval);
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/RetryBehaviorWithMixedErrors.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/RetryBehaviorWithMixedErrors.cs
@@ -17,10 +17,8 @@ using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Events;
-using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Operations;
 using MongoDB.Driver.Core.TestHelpers;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
@@ -66,7 +64,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
             var secondFailPointConfigured = false;
             FailPoint secondFailPoint = null;
 
-            using var firstFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), firstFailPointCommand);
+            using var firstFailPoint = FailPoint.Configure(firstFailPointCommand);
 
             var eventCapturer = new EventCapturer().CaptureCommandEvents("insert");
             using var client = DriverTestConfiguration.CreateMongoClient(s =>
@@ -79,7 +77,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
                     {
                         if (e is { CommandName: "insert", Failure: MongoCommandException { Code: 91 } } && !secondFailPointConfigured)
                         {
-                            secondFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), secondFailPointCommand);
+                            secondFailPoint = FailPoint.Configure(secondFailPointCommand);
                             secondFailPointConfigured = true;
                         }
                     });
@@ -138,7 +136,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
             var secondFailPointConfigured = false;
             FailPoint secondFailPoint = null;
 
-            using var firstFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), firstFailPointCommand);
+            using var firstFailPoint = FailPoint.Configure(firstFailPointCommand);
 
             var eventCapturer = new EventCapturer().CaptureCommandEvents("insert");
             using var client = DriverTestConfiguration.CreateMongoClient(s =>
@@ -151,7 +149,7 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
                     {
                         if (e is { CommandName: "insert", Failure: MongoCommandException { Code: 91 } } && !secondFailPointConfigured)
                         {
-                            secondFailPoint = FailPoint.Configure(DriverTestConfiguration.Client.GetClusterInternal(), NoCoreSession.NewHandle(), secondFailPointCommand);
+                            secondFailPoint = FailPoint.Configure(secondFailPointCommand);
                             secondFailPointConfigured = true;
                         }
                     });

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/RetryWriteOnOtherMongos.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/prose-tests/RetryWriteOnOtherMongos.cs
@@ -17,7 +17,6 @@ using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Events;
@@ -61,11 +60,11 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
                 },
                 useMultipleShardRouters: true);
 
-            var failPointServer1 = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(client.Cluster.Description.Servers[0].EndPoint));
-            var failPointServer2 = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(client.Cluster.Description.Servers[1].EndPoint));
+            var failPointServerSelector1 = new EndPointServerSelector(client.Cluster.Description.Servers[0].EndPoint);
+            var failPointServerSelector2 = new EndPointServerSelector(client.Cluster.Description.Servers[1].EndPoint);
 
-            using var failPoint1 = FailPoint.Configure(failPointServer1, NoCoreSession.NewHandle(), failPointCommand);
-            using var failPoint2 = FailPoint.Configure(failPointServer2, NoCoreSession.NewHandle(), failPointCommand);
+            using var failPoint1 = FailPoint.Configure(failPointServerSelector1, failPointCommand, cluster: client.GetClusterInternal());
+            using var failPoint2 = FailPoint.Configure(failPointServerSelector2, failPointCommand, cluster: client.GetClusterInternal());
 
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
             var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
@@ -112,9 +111,8 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes.prose_tests
                 },
                 useMultipleShardRouters: false);
 
-            var failPointServer = client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(client.Cluster.Description.Servers[0].EndPoint));
-
-            using var failPoint = FailPoint.Configure(failPointServer, NoCoreSession.NewHandle(), failPointCommand);
+            var failPointServerSelector = new EndPointServerSelector(client.Cluster.Description.Servers[0].EndPoint);
+            using var failPoint = FailPoint.Configure(failPointServerSelector, failPointCommand);
 
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
             var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);

--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/ServerDiscoveryAndMonitoringProseTests.cs
@@ -24,7 +24,6 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Events;
@@ -165,8 +164,8 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring
             settings.ApplicationName = appName;
             settings.ServerSelectionTimeout = TimeSpan.FromSeconds(5);
 
-            var server = DriverTestConfiguration.Client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(new DnsEndPoint(serverAddress.Host, serverAddress.Port)));
-            using var failPoint = FailPoint.Configure(server, NoCoreSession.NewHandle(), failPointCommand);
+            var failPointServerSelector = new EndPointServerSelector(new DnsEndPoint(serverAddress.Host, serverAddress.Port));
+            using var failPoint = FailPoint.Configure(failPointServerSelector, failPointCommand);
             using var client = DriverTestConfiguration.CreateMongoClient(settings);
 
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
@@ -216,7 +215,7 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring
                         }}
                     }}");
 
-                using (FailPoint.Configure(client.GetClusterInternal(), NoCoreSession.NewHandle(), failPointCommand))
+                using (FailPoint.Configure(failPointCommand))
                 {
                     // Note that the Server Description Equality rule means that ServerDescriptionChangedEvents will not be published.
                     // So we use reflection to obtain the latest RTT instead.
@@ -273,8 +272,8 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring
                 eventsWaitTimeout);
             eventCapturer.Clear();
 
-            var failpointServer = DriverTestConfiguration.Client.GetClusterInternal().SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(new DnsEndPoint(serverAddress.Host, serverAddress.Port)));
-            using var failPoint = FailPoint.Configure(failpointServer, NoCoreSession.NewHandle(), failPointCommand);
+            var failPointServerSelector = new EndPointServerSelector(new DnsEndPoint(serverAddress.Host, serverAddress.Port));
+            using var failPoint = FailPoint.Configure(failPointServerSelector, failPointCommand);
 
             eventCapturer.WaitForEventOrThrowIfTimeout<ConnectionPoolReadyEvent>(eventsWaitTimeout);
             var events = eventCapturer.Events

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFailPointOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedFailPointOperation.cs
@@ -15,7 +15,6 @@
 
 using System;
 using MongoDB.Bson;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers;
 
@@ -43,9 +42,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         public void Execute()
         {
             var cluster = _client.GetClusterInternal();
-            var session = NoCoreSession.NewHandle();
-
-            var failPoint = FailPoint.Configure(cluster, session, _failPointCommand, _async);
+            var failPoint = FailPoint.Configure(_failPointCommand, _async, cluster);
             _entityMap.RegisterForDispose(failPoint);
         }
     }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTargetedFailPointOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTargetedFailPointOperation.cs
@@ -15,7 +15,6 @@
 
 using System;
 using MongoDB.Bson;
-using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
 using MongoDB.Driver.Core.TestHelpers;
 
@@ -51,12 +50,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             var client = DriverTestConfiguration.CreateMongoClient(useMultipleShardRouters: true);
             _entityMap.RegisterForDispose(client);
 
-            var cluster = client.GetClusterInternal();
-            var server = cluster.SelectServer(OperationContext.NoTimeout, new EndPointServerSelector(pinnedServer));
-
-            var session = NoCoreSession.NewHandle();
-
-            var failPoint = FailPoint.Configure(server, session, _failPointCommand, withAsync: _async);
+            var failPoint = FailPoint.Configure(new EndPointServerSelector(pinnedServer), _failPointCommand, withAsync: _async, client.GetClusterInternal());
             _entityMap.RegisterForDispose(failPoint);
         }
     }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTargetedFailPointOperation.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTargetedFailPointOperation.cs
@@ -50,7 +50,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             var client = DriverTestConfiguration.CreateMongoClient(useMultipleShardRouters: true);
             _entityMap.RegisterForDispose(client);
 
-            var failPoint = FailPoint.Configure(new EndPointServerSelector(pinnedServer), _failPointCommand, withAsync: _async, client.GetClusterInternal());
+            var failPoint = FailPoint.Configure(new EndPointServerSelector(pinnedServer), _failPointCommand, _async, client.GetClusterInternal());
             _entityMap.RegisterForDispose(failPoint);
         }
     }


### PR DESCRIPTION
This PR simplifies the FailPoint test helper API by removing the requirement for callers to explicitly pass `IClusterInternal` and `ICoreSessionHandle`.
It's a prerequisite for [CSHARP-6011](https://jira.mongodb.org/browse/CSHARP-6011): Remove Session from IBinding by moving it to OperationContext.