### PR TITLE
CSHARP-5930: Update replica-set discovery and reporting in tests

### DIFF
--- a/tests/MongoDB.Driver.Examples/CausalConsistencyExamples.cs
+++ b/tests/MongoDB.Driver.Examples/CausalConsistencyExamples.cs
@@ -120,9 +120,10 @@ namespace MongoDB.Driver.Examples
             DropCollection(CreateClient(), "myDatabase", "myCollection");
 
             // Start Tunable Consistency Controls Example
-            var connectionString = "mongodb://localhost/?readPreference=secondaryPreferred";
+            var settings = MongoClientSettings.FromConnectionString(CoreTestConfiguration.ConnectionString.ToString());
+            settings.ReadPreference = ReadPreference.SecondaryPreferred;
 
-            var client = new MongoClient(connectionString);
+            var client = new MongoClient(settings);
             var database = client.GetDatabase("myDatabase");
             var collection = database.GetCollection<BsonDocument>("myCollection");
 

--- a/tests/MongoDB.Driver.Examples/CausalConsistencyExamples.cs
+++ b/tests/MongoDB.Driver.Examples/CausalConsistencyExamples.cs
@@ -75,7 +75,7 @@ namespace MongoDB.Driver.Examples
         [Fact]
         public void Causal_Consistency_Example_2()
         {
-            RequireServer.Check().SupportsCausalConsistency();
+            RequireServer.Check().SupportsCausalConsistency().ReplicaSetDataBearingMembers(2);
 
             string testDatabaseName = "test";
             string itemsCollectionName = "items";
@@ -120,9 +120,10 @@ namespace MongoDB.Driver.Examples
             DropCollection(CreateClient(), "myDatabase", "myCollection");
 
             // Start Tunable Consistency Controls Example
-            var connectionString = "mongodb://localhost/?readPreference=secondaryPreferred";
+            var settings = MongoClientSettings.FromConnectionString(CoreTestConfiguration.ConnectionString.ToString());
+            settings.ReadPreference = ReadPreference.SecondaryPreferred;
 
-            var client = new MongoClient(connectionString);
+            var client = new MongoClient(settings);
             var database = client.GetDatabase("myDatabase");
             var collection = database.GetCollection<BsonDocument>("myCollection");
 

--- a/tests/MongoDB.Driver.Examples/ClientSideEncryption2Examples.cs
+++ b/tests/MongoDB.Driver.Examples/ClientSideEncryption2Examples.cs
@@ -38,6 +38,10 @@ namespace MongoDB.Driver.Examples
         public void FLE2AutomaticEncryption()
         {
             RequireServer.Check().Supports(Feature.Csfle2).ClusterTypes(ClusterType.ReplicaSet, ClusterType.Sharded, ClusterType.LoadBalanced);
+            if (CoreTestConfiguration.GetCryptSharedLibPath() == null)
+            {
+                throw new Xunit.Sdk.SkipException("Test skipped because CRYPT_SHARED_LIB_PATH is not set.");
+            }
 
             var unencryptedClient = DriverTestConfiguration.Client;
 
@@ -52,7 +56,7 @@ namespace MongoDB.Driver.Examples
             };
             kmsProviders.Add("local", localKey);
 
-            var keyVaultClient = new MongoClient();
+            var keyVaultClient = new MongoClient(CoreTestConfiguration.ConnectionString.ToString());
 
             // Create two data keys.
             var clientEncryptionOptions = new ClientEncryptionOptions(keyVaultClient, KeyVaultNamespace, kmsProviders);
@@ -92,7 +96,9 @@ namespace MongoDB.Driver.Examples
             };
 
             var autoEncryptionOptions = new AutoEncryptionOptions(KeyVaultNamespace, kmsProviders, encryptedFieldsMap: encryptedFieldsMap);
-            var encryptedClient = new MongoClient(new MongoClientSettings { AutoEncryptionOptions = autoEncryptionOptions });
+            var encryptedClientSettings = MongoClientSettings.FromConnectionString(CoreTestConfiguration.ConnectionString.ToString());
+            encryptedClientSettings.AutoEncryptionOptions = autoEncryptionOptions;
+            var encryptedClient = new MongoClient(encryptedClientSettings);
 
             // Create an FLE 2 collection.
             var database = encryptedClient.GetDatabase(CollectionNamespace.DatabaseNamespace.DatabaseName);

--- a/tests/MongoDB.Driver.Examples/ClientSideEncryption2Examples.cs
+++ b/tests/MongoDB.Driver.Examples/ClientSideEncryption2Examples.cs
@@ -38,6 +38,10 @@ namespace MongoDB.Driver.Examples
         public void FLE2AutomaticEncryption()
         {
             RequireServer.Check().Supports(Feature.Csfle2).ClusterTypes(ClusterType.ReplicaSet, ClusterType.Sharded, ClusterType.LoadBalanced);
+            if (string.IsNullOrWhiteSpace(CoreTestConfiguration.GetCryptSharedLibPath()))
+            {
+                throw new Xunit.Sdk.SkipException("Test skipped because CRYPT_SHARED_LIB_PATH is not set.");
+            }
 
             var unencryptedClient = DriverTestConfiguration.Client;
 
@@ -52,7 +56,7 @@ namespace MongoDB.Driver.Examples
             };
             kmsProviders.Add("local", localKey);
 
-            var keyVaultClient = new MongoClient();
+            var keyVaultClient = new MongoClient(CoreTestConfiguration.ConnectionString.ToString());
 
             // Create two data keys.
             var clientEncryptionOptions = new ClientEncryptionOptions(keyVaultClient, KeyVaultNamespace, kmsProviders);
@@ -92,7 +96,9 @@ namespace MongoDB.Driver.Examples
             };
 
             var autoEncryptionOptions = new AutoEncryptionOptions(KeyVaultNamespace, kmsProviders, encryptedFieldsMap: encryptedFieldsMap);
-            var encryptedClient = new MongoClient(new MongoClientSettings { AutoEncryptionOptions = autoEncryptionOptions });
+            var encryptedClientSettings = MongoClientSettings.FromConnectionString(CoreTestConfiguration.ConnectionString.ToString());
+            encryptedClientSettings.AutoEncryptionOptions = autoEncryptionOptions;
+            var encryptedClient = new MongoClient(encryptedClientSettings);
 
             // Create an FLE 2 collection.
             var database = encryptedClient.GetDatabase(CollectionNamespace.DatabaseNamespace.DatabaseName);

--- a/tests/MongoDB.Driver.TestHelpers/Core/XunitExtensions/RequireServer.cs
+++ b/tests/MongoDB.Driver.TestHelpers/Core/XunitExtensions/RequireServer.cs
@@ -18,7 +18,9 @@ using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Encryption;
+using MongoDB.Driver.Tests;
 using Xunit.Sdk;
 
 namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
@@ -67,7 +69,7 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
 
         public RequireServer ClusterType(ClusterType clusterType)
         {
-            var actualClusterType = CoreTestConfiguration.Cluster.Description.Type;
+            var actualClusterType = GetActualClusterType();
             if (actualClusterType == clusterType)
             {
                 return this;
@@ -77,7 +79,7 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
 
         public RequireServer ClusterTypes(params ClusterType[] clusterTypes)
         {
-            var actualClusterType = CoreTestConfiguration.Cluster.Description.Type;
+            var actualClusterType = GetActualClusterType();
             if (clusterTypes.Contains(actualClusterType))
             {
                 return this;
@@ -239,6 +241,16 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
             throw new SkipException($"Test skipped because the cluster does not have multiple mongoses.");
         }
 
+        public RequireServer ReplicaSetDataBearingMembers(int minimum)
+        {
+            var actualCount = DriverTestConfiguration.GetReplicaSetNumberOfDataBearingMembers(CoreTestConfiguration.Cluster);
+            if (actualCount >= minimum)
+            {
+                return this;
+            }
+            throw new SkipException($"Test skipped because replica set has {actualCount} data-bearing member(s) and at least {minimum} are required.");
+        }
+
         public RequireServer VersionGreaterThanOrEqualTo(SemanticVersion version)
         {
             var actualVersion = CoreTestConfiguration.ServerVersion;
@@ -285,6 +297,19 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
         }
 
         // private methods
+        private ClusterType GetActualClusterType()
+        {
+            var description = CoreTestConfiguration.Cluster.Description;
+            // For direct connections, Description.Type is always Standalone regardless of the actual
+            // server type. Use the server's reported type to get the true effective cluster type.
+            if (description.DirectConnection)
+            {
+                var serverType = description.Servers.FirstOrDefault()?.Type ?? ServerType.Unknown;
+                return serverType.ToClusterType();
+            }
+            return description.Type;
+        }
+
         private bool CanRunOn(BsonDocument requirements)
         {
             return requirements.All(IsRequirementSatisfied);
@@ -335,9 +360,8 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
                     return true;
                 case "topologies":
                 case "topology":
-                    var actualClusterType = CoreTestConfiguration.Cluster.Description.Type;
-                    var runOnClusterTypes = requirement.Value.AsBsonArray.Select(topology => MapTopologyToClusterType(topology.AsString)).ToList();
-                    return runOnClusterTypes.Contains(actualClusterType);
+                    var actualServerType = CoreTestConfiguration.Cluster.Description.Servers.FirstOrDefault()?.Type ?? ServerType.Unknown;
+                    return requirement.Value.AsBsonArray.Any(topology => IsTopologyMatch(topology.AsString, actualServerType));
                 case "csfle":
                     return IsCsfleRequirementSatisfied(requirement);
                 default:
@@ -365,15 +389,15 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
             return SemanticVersionCompareToAsReleased(actualLibmongocryptVersion, minLibmongocryptVersion) >= 0;
         }
 
-        private ClusterType MapTopologyToClusterType(string topology)
+        private bool IsTopologyMatch(string topology, ServerType serverType)
         {
             switch (topology)
             {
-                case "single": return Clusters.ClusterType.Standalone;
-                case "replicaset": return Clusters.ClusterType.ReplicaSet;
+                case "single": return serverType == ServerType.Standalone;
+                case "replicaset": return serverType.IsReplicaSetMember();
                 case "sharded-replicaset":
-                case "sharded": return Clusters.ClusterType.Sharded;
-                case "load-balanced": return Clusters.ClusterType.LoadBalanced;
+                case "sharded": return serverType == ServerType.ShardRouter;
+                case "load-balanced": return serverType == ServerType.LoadBalanced;
                 default: throw new ArgumentException($"Invalid topology: \"{topology}\".", nameof(topology));
             }
         }

--- a/tests/MongoDB.Driver.TestHelpers/Core/XunitExtensions/RequireServer.cs
+++ b/tests/MongoDB.Driver.TestHelpers/Core/XunitExtensions/RequireServer.cs
@@ -19,7 +19,9 @@ using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Encryption;
+using MongoDB.Driver.Tests;
 using Xunit.Sdk;
+using ClusterTypeEnum = MongoDB.Driver.Core.Clusters.ClusterType;
 
 namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
 {
@@ -67,7 +69,7 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
 
         public RequireServer ClusterType(ClusterType clusterType)
         {
-            var actualClusterType = CoreTestConfiguration.Cluster.Description.Type;
+            var actualClusterType = GetActualClusterType();
             if (actualClusterType == clusterType)
             {
                 return this;
@@ -77,7 +79,7 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
 
         public RequireServer ClusterTypes(params ClusterType[] clusterTypes)
         {
-            var actualClusterType = CoreTestConfiguration.Cluster.Description.Type;
+            var actualClusterType = GetActualClusterType();
             if (clusterTypes.Contains(actualClusterType))
             {
                 return this;
@@ -172,13 +174,13 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
 
         public RequireServer SupportsCausalConsistency()
         {
-            return ClusterTypes(Clusters.ClusterType.Sharded, Clusters.ClusterType.ReplicaSet).SupportsSessions();
+            return ClusterTypes(ClusterTypeEnum.Sharded, ClusterTypeEnum.ReplicaSet).SupportsSessions();
         }
 
         public RequireServer SupportsSessions()
         {
             var clusterDescription = CoreTestConfiguration.Cluster.Description;
-            if (clusterDescription.LogicalSessionTimeout != null || clusterDescription.Type == Clusters.ClusterType.LoadBalanced)
+            if (clusterDescription.LogicalSessionTimeout != null || GetActualClusterType() == ClusterTypeEnum.LoadBalanced)
             {
                 return this;
             }
@@ -220,8 +222,8 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
 
         public RequireServer MultipleMongosesIfSharded(bool required)
         {
-            var clusterType = CoreTestConfiguration.Cluster.Description.Type;
-            if (clusterType == Clusters.ClusterType.Sharded || clusterType == Clusters.ClusterType.LoadBalanced)
+            var clusterType = GetActualClusterType();
+            if (clusterType == ClusterTypeEnum.Sharded || clusterType == ClusterTypeEnum.LoadBalanced)
             {
                 MultipleMongoses(required);
             }
@@ -237,6 +239,31 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
             }
 
             throw new SkipException($"Test skipped because the cluster does not have multiple mongoses.");
+        }
+
+        public RequireServer ReplicaSetDataBearingMembers(int minimum)
+        {
+            // Only meaningful on replica-set topologies; on sharded/standalone/load-balanced the
+            // "data-bearing members" concept doesn't translate to a useful constraint. No-op on
+            // non-RS so callers can chain this onto a multi-topology allowlist (e.g. after
+            // SupportsCausalConsistency, which permits RS or Sharded) without inadvertently
+            // skipping sharded runs. Callers who want RS-only must chain ClusterType(ReplicaSet)
+            // explicitly.
+            if (GetActualClusterType() != ClusterTypeEnum.ReplicaSet)
+            {
+                return this;
+            }
+            // GetReplicaSetNumberOfDataBearingMembers waits for the cluster to connect and then
+            // counts, so it returns promptly with the real count rather than spinning the full
+            // timeout when the count can never reach `minimum` (e.g. a directConnection only ever
+            // sees its single targeted server, so the count tops out at 1).
+            var cluster = CoreTestConfiguration.Cluster;
+            var actualCount = DriverTestConfiguration.GetReplicaSetNumberOfDataBearingMembers(cluster);
+            if (actualCount >= minimum)
+            {
+                return this;
+            }
+            throw new SkipException($"Test skipped because replica set has {actualCount} data-bearing member(s) and at least {minimum} are required: {cluster.Description}.");
         }
 
         public RequireServer VersionGreaterThanOrEqualTo(SemanticVersion version)
@@ -285,6 +312,8 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
         }
 
         // private methods
+        private ClusterType GetActualClusterType() => DriverTestConfiguration.GetActualClusterType(CoreTestConfiguration.Cluster);
+
         private bool CanRunOn(BsonDocument requirements)
         {
             return requirements.All(IsRequirementSatisfied);
@@ -335,9 +364,10 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
                     return true;
                 case "topologies":
                 case "topology":
-                    var actualClusterType = CoreTestConfiguration.Cluster.Description.Type;
-                    var runOnClusterTypes = requirement.Value.AsBsonArray.Select(topology => MapTopologyToClusterType(topology.AsString)).ToList();
-                    return runOnClusterTypes.Contains(actualClusterType);
+                    {
+                        var actualClusterType = GetActualClusterType();
+                        return requirement.Value.AsBsonArray.Any(topology => IsTopologyMatch(topology.AsString, actualClusterType));
+                    }
                 case "csfle":
                     return IsCsfleRequirementSatisfied(requirement);
                 default:
@@ -359,15 +389,15 @@ namespace MongoDB.Driver.Core.TestHelpers.XunitExtensions
             return SemanticVersionCompareToAsReleased(actualLibmongocryptVersion, minLibmongocryptVersion) >= 0;
         }
 
-        private ClusterType MapTopologyToClusterType(string topology)
+        private bool IsTopologyMatch(string topology, ClusterTypeEnum clusterType)
         {
             switch (topology)
             {
-                case "single": return Clusters.ClusterType.Standalone;
-                case "replicaset": return Clusters.ClusterType.ReplicaSet;
+                case "single": return clusterType == ClusterTypeEnum.Standalone;
+                case "replicaset": return clusterType == ClusterTypeEnum.ReplicaSet;
                 case "sharded-replicaset":
-                case "sharded": return Clusters.ClusterType.Sharded;
-                case "load-balanced": return Clusters.ClusterType.LoadBalanced;
+                case "sharded": return clusterType == ClusterTypeEnum.Sharded;
+                case "load-balanced": return clusterType == ClusterTypeEnum.LoadBalanced;
                 default: throw new ArgumentException($"Invalid topology: \"{topology}\".", nameof(topology));
             }
         }

--- a/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
+++ b/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
@@ -221,12 +221,14 @@ namespace MongoDB.Driver.Tests
 
         internal static bool IsReplicaSet(IClusterInternal cluster)
         {
-            var clusterTypeIsKnown = SpinWait.SpinUntil(() => cluster.Description.Type != ClusterType.Unknown, TimeSpan.FromSeconds(10));
-            if (!clusterTypeIsKnown)
+            var serverIsKnown = SpinWait.SpinUntil(
+                () => cluster.Description.Servers.Any(s => s.Type != ServerType.Unknown),
+                TimeSpan.FromSeconds(10));
+            if (!serverIsKnown)
             {
                 throw new InvalidOperationException($"Unable to determine cluster type: {cluster.Description}.");
             }
-            return cluster.Description.Type == ClusterType.ReplicaSet;
+            return cluster.Description.Servers.Any(s => s.Type.IsReplicaSetMember());
         }
 
         internal static int GetReplicaSetNumberOfDataBearingMembers(IClusterInternal cluster)

--- a/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
+++ b/tests/MongoDB.Driver.TestHelpers/DriverTestConfiguration.cs
@@ -223,14 +223,19 @@ namespace MongoDB.Driver.Tests
             };
         }
 
+        // Returns true if any server reports an RS member type (Primary, Secondary, Arbiter,
+        // Other, or Ghost). Callers that need specifically a data-bearing member should use
+        // GetReplicaSetNumberOfDataBearingMembers instead.
         internal static bool IsReplicaSet(IClusterInternal cluster)
         {
-            var clusterTypeIsKnown = SpinWait.SpinUntil(() => cluster.Description.Type != ClusterType.Unknown, TimeSpan.FromSeconds(10));
-            if (!clusterTypeIsKnown)
+            var serverIsKnown = SpinWait.SpinUntil(
+                () => cluster.Description.Servers.Any(s => s.Type != ServerType.Unknown),
+                TimeSpan.FromSeconds(10));
+            if (!serverIsKnown)
             {
                 throw new InvalidOperationException($"Unable to determine cluster type: {cluster.Description}.");
             }
-            return cluster.Description.Type == ClusterType.ReplicaSet;
+            return cluster.Description.Servers.Any(s => s.Type.IsReplicaSetMember());
         }
 
         internal static int GetReplicaSetNumberOfDataBearingMembers(IClusterInternal cluster)
@@ -241,7 +246,56 @@ namespace MongoDB.Driver.Tests
             }
 
             WaitForAllServersToBeConnected(cluster);
+            // Under a directConnect the description only includes the single node being targeted,
+            // so this count reflects only that server. RequireServer.ReplicaSetDataBearingMembers(2)
+            // therefore correctly skips tests that need multiple members when connected directly.
             return cluster.Description.Servers.Count(s => s.IsDataBearing);
+        }
+
+        // Returns the effective cluster type. For direct connections Description.Type is always
+        // Standalone regardless of the actual server type, so the server's reported type is used
+        // instead. Throws (rather than skips) if the type cannot be determined: an undeterminable
+        // topology is an environment failure, not a "this topology isn't applicable" skip.
+        internal static ClusterType GetActualClusterType(IClusterInternal cluster)
+        {
+            var description = cluster.Description;
+            if (description.DirectConnection)
+            {
+                var serverIsKnown = SpinWait.SpinUntil(
+                    () => cluster.Description.Servers.Any(s => s.Type != ServerType.Unknown),
+                    TimeSpan.FromSeconds(10));
+                if (!serverIsKnown)
+                {
+                    throw new InvalidOperationException($"Unable to determine cluster type: {cluster.Description}.");
+                }
+                return cluster.Description.Servers.First(s => s.Type != ServerType.Unknown).Type.ToClusterType();
+            }
+            // For non-direct connections the cluster machinery resolves Description.Type before tests
+            // run, but spin briefly here as well so early-startup invocations don't race against the
+            // initial SDAM rounds.
+            var typeIsKnown = SpinWait.SpinUntil(
+                () => cluster.Description.Type != ClusterType.Unknown,
+                TimeSpan.FromSeconds(10));
+            if (!typeIsKnown)
+            {
+                throw new InvalidOperationException($"Unable to determine cluster type: {cluster.Description}.");
+            }
+            return cluster.Description.Type;
+        }
+
+        internal static bool IsSingleNodeReplicaSet(IClusterInternal cluster)
+        {
+            // IsReplicaSet spins until at least one server type is known (throwing if it never
+            // resolves), so a transient empty / all-Unknown snapshot is never mistaken for "not a
+            // replica set".
+            if (!IsReplicaSet(cluster))
+            {
+                return false;
+            }
+            // Matches both a directConnection to a single RS member and a non-directConnection
+            // single-node RS.
+            var servers = cluster.Description.Servers;
+            return servers.Count == 1 && servers[0].Type.IsReplicaSetMember();
         }
 
         internal static void WaitForAllServersToBeConnected(IClusterInternal cluster)

--- a/tests/MongoDB.Driver.Tests/ConnectionsSurvivePrimaryStepDownTests.cs
+++ b/tests/MongoDB.Driver.Tests/ConnectionsSurvivePrimaryStepDownTests.cs
@@ -78,7 +78,7 @@ namespace MongoDB.Driver.Tests
         [ParameterAttributeData]
         public void Connection_pool_should_not_be_cleared_when_replSetStepDown_and_GetMore([Values(false, true)] bool async)
         {
-            RequireServer.Check().Supports(Feature.KeepConnectionPoolWhenReplSetStepDown).ClusterType(ClusterType.ReplicaSet);
+            RequireServer.Check().Supports(Feature.KeepConnectionPoolWhenReplSetStepDown).ClusterType(ClusterType.ReplicaSet).ReplicaSetDataBearingMembers(2);
 
             var eventCapturer = new EventCapturer().Capture<ConnectionPoolClearedEvent>();
             using (var client = CreateMongoClient(eventCapturer))

--- a/tests/MongoDB.Driver.Tests/ConnectionsSurvivePrimaryStepDownTests.cs
+++ b/tests/MongoDB.Driver.Tests/ConnectionsSurvivePrimaryStepDownTests.cs
@@ -76,7 +76,7 @@ namespace MongoDB.Driver.Tests
         [ParameterAttributeData]
         public void Connection_pool_should_not_be_cleared_when_replSetStepDown_and_GetMore([Values(false, true)] bool async)
         {
-            RequireServer.Check().ClusterType(ClusterType.ReplicaSet);
+            RequireServer.Check().ClusterType(ClusterType.ReplicaSet).ReplicaSetDataBearingMembers(2);
 
             var eventCapturer = new EventCapturer().Capture<ConnectionPoolClearedEvent>();
             using (var client = CreateMongoClient(eventCapturer))

--- a/tests/MongoDB.Driver.Tests/Specifications/UnifiedTestSpecRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/UnifiedTestSpecRunner.cs
@@ -15,10 +15,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Core.Logging;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.Logging;
@@ -210,11 +212,31 @@ namespace MongoDB.Driver.Tests.Specifications
         [Category("SDAM", "SupportLoadBalancing")]
         [UnifiedTestsTheory("server_discovery_and_monitoring.tests.unified")]
         public void ServerDiscoveryAndMonitoring(JsonDrivenTestCase testCase)
-            => Run(testCase, IsSdamLogValid, new SdamRunnerEventsProcessor(testCase.Name));
+        {
+            // These tests require full RS topology discovery (multiple topology change events).
+            // A directConnect single-node RS only fires 2 topology events, never the RS discovery sequence.
+            if (IsDirectConnectionToReplicaSet())
+            {
+                SkipNotSupportedTestCases(testCase, "logging-replicaset.json");
+                SkipNotSupportedTestCases(testCase, "replicaset-emit-topology-changed-before-close.json");
+                SkipNotSupportedTestCases(testCase, "rediscover-quickly-after-step-down.json");
+            }
+
+            Run(testCase, IsSdamLogValid, new SdamRunnerEventsProcessor(testCase.Name));
+        }
 
         [Category("SupportLoadBalancing")]
         [UnifiedTestsTheory("server_selection.tests.logging")]
-        public void ServerSelection(JsonDrivenTestCase testCase) => Run(testCase);
+        public void ServerSelection(JsonDrivenTestCase testCase)
+        {
+            // replica-set.json expects full RS topology discovery events not available on directConnect RS.
+            if (IsDirectConnectionToReplicaSet())
+            {
+                SkipNotSupportedTestCases(testCase, "replica-set.json");
+            }
+
+            Run(testCase);
+        }
 
         [UnifiedTestsTheory("sessions.tests")]
         public void Sessions(JsonDrivenTestCase testCase) => Run(testCase);
@@ -276,6 +298,17 @@ namespace MongoDB.Driver.Tests.Specifications
 
         private static void RequireKmsMock() =>
             RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED");
+
+        private static bool IsDirectConnectionToReplicaSet()
+        {
+            var description = CoreTestConfiguration.Cluster.Description;
+            if (!description.DirectConnection)
+            {
+                return false;
+            }
+            var serverType = description.Servers.FirstOrDefault()?.Type ?? ServerType.Unknown;
+            return serverType.IsReplicaSetMember();
+        }
 
         private static void SkipNotSupportedTestCases(JsonDrivenTestCase testCase, string operationName)
         {

--- a/tests/MongoDB.Driver.Tests/Specifications/UnifiedTestSpecRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/UnifiedTestSpecRunner.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.Clusters;
@@ -210,11 +211,34 @@ namespace MongoDB.Driver.Tests.Specifications
         [Category("SDAM", "SupportLoadBalancing")]
         [UnifiedTestsTheory("server_discovery_and_monitoring.tests.unified")]
         public void ServerDiscoveryAndMonitoring(JsonDrivenTestCase testCase)
-            => Run(testCase, IsSdamLogValid, new SdamRunnerEventsProcessor(testCase.Name));
+        {
+            // These tests require full RS topology discovery (multiple topology change events).
+            // A single-node RS (whether via directConnect or replicaSet= with one member) only fires 2 topology
+            // events, never the full RS discovery sequence with secondary discovery. CSHARP-6008.
+            if (IsSingleNodeReplicaSet())
+            {
+                const string singleNodeRsReason = "Test skipped because single-node replica set does not produce full RS topology discovery events (CSHARP-6008).";
+                SkipFile(testCase, "logging-replicaset.json", singleNodeRsReason);
+                SkipFile(testCase, "replicaset-emit-topology-changed-before-close.json", singleNodeRsReason);
+                SkipFile(testCase, "rediscover-quickly-after-step-down.json", singleNodeRsReason);
+            }
+
+            Run(testCase, IsSdamLogValid, new SdamRunnerEventsProcessor(testCase.Name));
+        }
 
         [Category("SupportLoadBalancing")]
         [UnifiedTestsTheory("server_selection.tests.logging")]
-        public void ServerSelection(JsonDrivenTestCase testCase) => Run(testCase);
+        public void ServerSelection(JsonDrivenTestCase testCase)
+        {
+            // replica-set.json expects full RS topology discovery events and a secondary, not available on a
+            // single-node RS (whether via directConnect or replicaSet= with one member). CSHARP-6008.
+            if (IsSingleNodeReplicaSet())
+            {
+                SkipFile(testCase, "replica-set.json", "Test skipped because single-node replica set does not have a secondary (CSHARP-6008).");
+            }
+
+            Run(testCase);
+        }
 
         [UnifiedTestsTheory("sessions.tests")]
         public void Sessions(JsonDrivenTestCase testCase) => Run(testCase);
@@ -277,6 +301,25 @@ namespace MongoDB.Driver.Tests.Specifications
         private static void RequireKmsMock() =>
             RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED");
 
+        private static bool IsSingleNodeReplicaSet() => DriverTestConfiguration.IsSingleNodeReplicaSet(CoreTestConfiguration.Cluster);
+
+
+        /// <summary>
+        /// Skip all tests sourced from a specific JSON spec file. The source file is identified via
+        /// the "_fileName" value the discoverer stamps onto every test case (see
+        /// UnifiedTestsDiscoverer), rather than by parsing the composite test-case name.
+        /// </summary>
+        private static void SkipFile(JsonDrivenTestCase testCase, string fileName, string reason)
+        {
+            if (testCase.Shared.GetValue("_fileName", null)?.AsString == fileName)
+            {
+                throw new SkipException(reason);
+            }
+        }
+
+        /// <summary>
+        /// Skip tests whose name contains the given operation substring.
+        /// </summary>
         private static void SkipNotSupportedTestCases(JsonDrivenTestCase testCase, string operationName)
         {
             if (testCase.Name.Contains(operationName))
@@ -285,7 +328,9 @@ namespace MongoDB.Driver.Tests.Specifications
             }
         }
 
-        // used by SkippedTestsProvider property in UnifiedTests attribute.
+        /// <summary>
+        /// Used by SkippedTestsProvider property in UnifiedTests attribute.
+        /// </summary>
         private static readonly HashSet<string> __ignoredTests = new(
         [
             // CMAP

--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/prose-tests/ServerDiscoveryProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/prose-tests/ServerDiscoveryProseTests.cs
@@ -30,6 +30,7 @@ using MongoDB.Driver.Core.TestHelpers.Logging;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
+using Xunit.Sdk;
 using Xunit.Abstractions;
 
 namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring.prose_tests
@@ -64,7 +65,7 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring.pr
             var secondary = clusterDescription.Servers.FirstOrDefault(s => s.State == ServerState.Connected && s.Type == ServerType.ReplicaSetSecondary);
             if (secondary == null)
             {
-                throw new Exception("No secondary was found.");
+                throw new SkipException("Test skipped because no secondary was found.");
             }
 
             var dnsEndpoint = (DnsEndPoint)secondary.EndPoint;

--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/prose-tests/ServerDiscoveryProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/prose-tests/ServerDiscoveryProseTests.cs
@@ -52,19 +52,30 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring.pr
                 .Check()
                 .Supports(Feature.DirectConnectionSetting)
                 .ClusterTypes(ClusterType.ReplicaSet)
+                .ReplicaSetDataBearingMembers(2)
                 .Authentication(false); // we don't use auth connection string in this test
 
             var setupClient = DriverTestConfiguration.Client;
             setupClient.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName).RunCommand<BsonDocument>("{ ping : 1 }");
 
             var setupCluster = setupClient.Cluster;
-            SpinWait.SpinUntil(() => setupCluster.Description.State == ClusterState.Connected, TimeSpan.FromSeconds(3));
+            // ReplicaSetDataBearingMembers(2) confirms a secondary exists in the topology but not that it
+            // has finished its individual connection handshake. ClusterState.Connected only requires *any*
+            // server to be connected (typically the primary), so waiting on that predicate doesn't help
+            // here. Spin directly on the predicate we actually need: a Connected ReplicaSetSecondary.
+            SpinWait.SpinUntil(
+                () => setupCluster.Description.Servers.Any(s => s.State == ServerState.Connected && s.Type == ServerType.ReplicaSetSecondary),
+                TimeSpan.FromSeconds(10));
 
             var clusterDescription = setupCluster.Description;
             var secondary = clusterDescription.Servers.FirstOrDefault(s => s.State == ServerState.Connected && s.Type == ServerType.ReplicaSetSecondary);
             if (secondary == null)
             {
-                throw new Exception("No secondary was found.");
+                // Intentionally a hard failure (not SkipException): ReplicaSetDataBearingMembers(2) already
+                // gated on >=2 data-bearing members, and the spin above gave the secondary a generous
+                // window to connect. Hitting this branch indicates the data-bearing spin is undercounting
+                // or a real topology bug — surface it as a failure with the cluster description.
+                throw new Exception($"No connected secondary found despite RequireServer.ReplicaSetDataBearingMembers(2) guard. Cluster: {clusterDescription}.");
             }
 
             var dnsEndpoint = (DnsEndPoint)secondary.EndPoint;


### PR DESCRIPTION
See CSHARP-6008 for details about why this change is needed.

There were multiple iterations getting to this point:

## Iteration 1

RequireServer.cs
- ClusterType()/ClusterTypes(): Now use GetActualClusterType() which maps a directConnect RS member to ClusterType.ReplicaSet (instead of the misleading Standalone)
- topology/topologies case: Uses actual server type — single matches only Standalone, replicaset matches IsReplicaSetMember()

DriverTestConfiguration.cs
- IsReplicaSet(): Checks server.Type.IsReplicaSetMember() instead of cluster.Description.Type == ClusterType.ReplicaSet, so a directConnect RS is correctly identified

ReadPreferenceOnStandaloneTests.cs (from earlier)
- Uses ServerType.Standalone instead of ClusterType.Standalone to decide whether $readPreference is expected

ServerDiscoveryProseTests.cs
- Missing secondary now throws SkipException instead of a plain Exception

UnifiedTestSpecRunner.cs
- Added IsDirectConnectionToReplicaSet() helper
- ServerDiscoveryAndMonitoring: Skips logging-replicaset.json, replicaset-emit-topology-changed-before-close.json, rediscover-quickly-after-step-down.json when on directConnect RS (these require full multi-server topology discovery events)
- ServerSelection: Skips replica-set.json when on directConnect RS (same reason)

## Iteration 2

- Root cause: My GetActualClusterType() change made RequireServer.ClusterType(ClusterType.ReplicaSet) pass for a directConnect RSPrimary. This caused Connection_pool_should_not_be_cleared_when_replSetStepDown_and_GetMore to run — a test that was previously always skipped on this setup. That test calls { replSetStepDown: 30, force: true }, which makes the single-node RS step down and refuse writes for up to 30 seconds. All subsequent write operations in other tests (like DropCollection in fixture setup) then fail with MongoNotPrimaryException.
- Fix: Added RequireServer.ReplicaSetDataBearingMembers(int minimum) — a new check that counts how many data-bearing RS members the cluster has

## Iteration 3

- Applied .ReplicaSetDataBearingMembers(2) to Connection_pool_should_not_be_cleared_when_replSetStepDown_and_GetMore — the step-down test only makes sense (and is safe) with at least 2 RS members so a new primary can be elected after the step-down

## Iteration 4

- CausalConsistencyExamples.cs — Causal_Consistency_Example_3: Replaced the hardcoded "mongodb://localhost/?readPreference=secondaryPreferred" with settings built from CoreTestConfiguration.ConnectionString plus ReadPreference.SecondaryPreferred. The example intent is preserved.
- ClientSideEncryption2Examples.cs — FLE2AutomaticEncryption: Added an explicit skip when CRYPT_SHARED_LIB_PATH is not set (CSFLE/auto-encryption requires it), and fixed two new MongoClient() calls to use CoreTestConfiguration.ConnectionString.ToString() instead of the default localhost:27017.