### PR TITLE
CSHARP-5762: Avoid changing "filter" to "parentFilter" in previously supported case

### DIFF
--- a/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/PipelineStageDefinitionBuilder.cs
@@ -2319,7 +2319,7 @@ namespace MongoDB.Driver
                         { "limit", limit },
                         { "numCandidates", options?.NumberOfCandidates ?? limit * 10, options?.Exact != true },
                         { "index", options?.IndexName ?? "default" },
-                        { nestedRoot != null ? "parentFilter" : "filter", () => options?.Filter.Render(args with { RenderDollarForm = true }), options?.Filter != null },
+                        { options?.NestedFilter != null ? "parentFilter" : "filter", () => options?.Filter.Render(args with { RenderDollarForm = true }), options?.Filter != null },
                         { "exact", true, options?.Exact == true },
                         { "returnStoredSource", true, options?.ReturnStoredSource == true },
                     };

--- a/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/PipelineDefinitionBuilderTests.cs
@@ -777,6 +777,22 @@ namespace MongoDB.Driver.Tests
             stages[0].Should().BeEquivalentTo("{ $vectorSearch: { queryVector: [1.0, 2.0, 3.0], path: 'Plot.PlotEmbedding', limit: 1, numCandidates: 10, index: 'index_name', filter: { '$and' : [{ Rating: { '$lt' : 6 } }, { Synced: { '$eq' : true } }] }, parentFilter: { 'Year' : { '$gt' : 1900 } } } }");
         }
 
+        [Fact]
+        public void VectorSearch_should_add_expected_stage_with_filter_but_no_nested_filters()
+        {
+            var result = new EmptyPipelineDefinition<MovieWithPlot>().VectorSearch(m => m.Plot.PlotEmbedding,
+                new[] { 1.0, 2.0, 3.0 }, 1, new VectorSearchOptions<MovieWithPlot>()
+                {
+                    IndexName = "index_name",
+                    Filter = Builders<MovieWithPlot>.Filter.Lt("Plot.Rating", 6)
+                             & Builders<MovieWithPlot>.Filter.Eq("Plot.Synced", true)
+                });
+
+            var stages = RenderStages(result, BsonSerializer.SerializerRegistry.GetSerializer<MovieWithPlot>());
+            stages[0].Should().BeEquivalentTo(
+                "{ $vectorSearch: { queryVector: [1.0, 2.0, 3.0], path: 'Plot.PlotEmbedding', limit: 1, numCandidates: 10, index: 'index_name', filter: { '$and' : [{ 'Plot.Rating': { '$lt' : 6 } }, { 'Plot.Synced': { '$eq' : true } }] } } }");
+        }
+
         private class MovieWithPlot
         {
             public string Title { get; set; }


### PR DESCRIPTION
This was caught by running the EF tests, which already had a test for this. It appears that "filter" or "parentFilter" works on 8.3, but only "filter" works on 8.0.