### PR TITLE
CSHARP-5930: Skip tests on Mac with Cloudflare WARP due to DnsClient bug

### DIFF
--- a/tests/MongoDB.Driver.Tests/Core/Clusters/DnsClientWrapperTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Clusters/DnsClientWrapperTests.cs
@@ -22,6 +22,7 @@ using DnsClient;
 using FluentAssertions;
 using MongoDB.Bson.TestHelpers;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Core.Clusters
@@ -49,6 +50,8 @@ namespace MongoDB.Driver.Core.Clusters
         [InlineData("_mongodb._tcp.test5.test.build.10gen.cc", new[] { "localhost.test.build.10gen.cc.:27017" }, true)]
         public void ResolveSrvRecords_should_return_expected_result(string service, string[] expectedEndPoints, bool async)
         {
+            RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+
             var subject = CreateSubject();
 
             List<SrvRecord> result;
@@ -114,6 +117,8 @@ namespace MongoDB.Driver.Core.Clusters
         [InlineData("test5.test.build.10gen.cc", "replicaSet=repl0&authSource=thisDB", true)]
         public void ResolveTxtRecords_should_return_expected_result(string domainName, string expectedString, bool async)
         {
+            RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+
             var subject = CreateSubject();
 
             List<TxtRecord> result;

--- a/tests/MongoDB.Driver.Tests/MongoCredentialTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCredentialTests.cs
@@ -15,6 +15,7 @@
 
 using FluentAssertions;
 using MongoDB.Driver.Authentication.Oidc;
+using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;
 
@@ -161,6 +162,8 @@ namespace MongoDB.Driver.Tests
         [InlineData("mongodb+srv://<cluster>/?retryWrites=true&authMechanism=MONGODB-OIDC&authSource=%24external&authMechanismProperties=ENVIRONMENT:azure,prop:ab%2Ccd%2Cef%2Cjh,TOKEN_RESOURCE:mongodb://test-cluster,ANOTHER:test")]
         public void TestMechanismPropertyFromUnresolvedConnectionString(string url)
         {
+            RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+
             var mongoConnection = MongoClientSettings.FromConnectionString(url);
             mongoConnection.Credential.GetMechanismProperty("ENVIRONMENT", "").Should().Be("azure");
             mongoConnection.Credential.GetMechanismProperty("prop", "").Should().Be("ab,cd,ef,jh");

--- a/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
@@ -66,6 +66,8 @@ namespace MongoDB.Driver.Tests
         [InlineData("mongodb+srv://test2.test.build.10gen.cc")]
         public void constructor_with_resolved_connection_string_should_initialize_resolved_instance(string url)
         {
+            RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+
             var connectionString = new ConnectionString(url);
             var resolvedConnectionString = connectionString.Resolve();
             var builder = new MongoUrlBuilder(resolvedConnectionString);
@@ -126,6 +128,8 @@ namespace MongoDB.Driver.Tests
         [InlineData("mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2", true, 2, true)]
         public void Resolve_with_srvMaxHosts_should_return_expected_result(string url, bool resolveHosts, int expectedSrvMaxHosts, bool async)
         {
+            RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+
             var subject = new MongoUrl(url);
 
             MongoUrl result;

--- a/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoUrlTests.cs
@@ -66,7 +66,10 @@ namespace MongoDB.Driver.Tests
         [InlineData("mongodb+srv://test2.test.build.10gen.cc")]
         public void constructor_with_resolved_connection_string_should_initialize_resolved_instance(string url)
         {
-            RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+            if (url.StartsWith("mongodb+srv://", StringComparison.OrdinalIgnoreCase))
+            {
+                RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+            }
 
             var connectionString = new ConnectionString(url);
             var resolvedConnectionString = connectionString.Resolve();

--- a/tests/MongoDB.Driver.Tests/Specifications/initial-dns-seedlist-discovery/InitialDnsSeedlistDiscoveryTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/initial-dns-seedlist-discovery/InitialDnsSeedlistDiscoveryTestRunner.cs
@@ -39,6 +39,8 @@ namespace MongoDB.Driver.Tests.Specifications.initial_dns_seedlist_discovery
         [ClassData(typeof(TestCaseFactory))]
         public void RunTestDefinition(TestCase testCase)
         {
+            RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+
             ConnectionString connectionString = null;
             Exception resolveException = Record.Exception(() => connectionString = new ConnectionString((string)testCase.Definition["uri"]).Resolve());
             Assert(connectionString, resolveException, testCase.Definition);
@@ -48,6 +50,8 @@ namespace MongoDB.Driver.Tests.Specifications.initial_dns_seedlist_discovery
         [ClassData(typeof(TestCaseFactory))]
         public async Task RunTestDefinitionAsync(TestCase testCase)
         {
+            RequireEnvironment.Check().NoDuplicateIpv4MappedNameServers();
+
             ConnectionString connectionString = null;
             Exception resolveException = await Record.ExceptionAsync(async () => connectionString = await new ConnectionString((string)testCase.Definition["uri"]).ResolveAsync());
             Assert(connectionString, resolveException, testCase.Definition);

--- a/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
+++ b/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
@@ -14,10 +14,13 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using Xunit.Sdk;
 
 namespace MongoDB.TestHelpers.XunitExtensions
@@ -63,6 +66,57 @@ namespace MongoDB.TestHelpers.XunitExtensions
                 return this;
             }
             throw new SkipException($"Test skipped because an OS process {processName} has not been detected.");
+        }
+
+        // Cloudflare WARP (and similar VPN software) can write both plain IPv4 and IPv4-mapped IPv6
+        // forms of the same loopback address into /etc/resolv.conf (e.g. 127.0.2.3 and ::ffff:127.0.2.3).
+        // DnsClient reads /etc/resolv.conf directly and may select the ::ffff: form for UDP queries,
+        // which macOS does not route correctly, causing a socket timeout. Skip DNS-dependent tests
+        // when this configuration is detected.
+        public RequireEnvironment NoDuplicateIpv4MappedNameServers()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return this;
+            }
+
+            const string resolveConfPath = "/etc/resolv.conf";
+            if (!File.Exists(resolveConfPath))
+            {
+                return this;
+            }
+
+            var ipv4Addresses = new HashSet<IPAddress>();
+            var allAddresses = new List<IPAddress>();
+
+            foreach (var line in File.ReadAllLines(resolveConfPath))
+            {
+                var trimmed = line.Trim();
+                if (!trimmed.StartsWith("nameserver", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var parts = trimmed.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length >= 2 && IPAddress.TryParse(parts[1], out var ip))
+                {
+                    allAddresses.Add(ip);
+                    if (ip.AddressFamily == AddressFamily.InterNetwork)
+                    {
+                        ipv4Addresses.Add(ip);
+                    }
+                }
+            }
+
+            if (allAddresses.Any(ip => ip.IsIPv4MappedToIPv6 && ipv4Addresses.Contains(ip.MapToIPv4())))
+            {
+                throw new SkipException(
+                    "Test skipped because /etc/resolv.conf contains both an IPv4 nameserver address and its IPv4-mapped " +
+                    "IPv6 equivalent (e.g. Cloudflare WARP). DnsClient may time out when it selects the ::ffff: form " +
+                    "for a UDP query on this platform. See CSHARP-5930.");
+            }
+
+            return this;
         }
 
         public RequireEnvironment HostReachable(DnsEndPoint endPoint)

--- a/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
+++ b/tests/MongoDB.TestHelpers/XunitExtensions/RequireEnvironment.cs
@@ -70,12 +70,13 @@ namespace MongoDB.TestHelpers.XunitExtensions
 
         // Cloudflare WARP (and similar VPN software) can write both plain IPv4 and IPv4-mapped IPv6
         // forms of the same loopback address into /etc/resolv.conf (e.g. 127.0.2.3 and ::ffff:127.0.2.3).
-        // DnsClient reads /etc/resolv.conf directly and may select the ::ffff: form for UDP queries,
-        // which macOS does not route correctly, causing a socket timeout. Skip DNS-dependent tests
+        // DnsClient reads /etc/resolv.conf directly and may select the ::ffff: form for UDP queries.
+        // On macOS, the kernel does not route IPv4-mapped IPv6 loopback addresses via UDP correctly,
+        // causing a socket timeout. Linux handles this correctly. Skip DNS-dependent tests on macOS
         // when this configuration is detected.
         public RequireEnvironment NoDuplicateIpv4MappedNameServers()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 return this;
             }
@@ -89,23 +90,30 @@ namespace MongoDB.TestHelpers.XunitExtensions
             var ipv4Addresses = new HashSet<IPAddress>();
             var allAddresses = new List<IPAddress>();
 
-            foreach (var line in File.ReadAllLines(resolveConfPath))
+            try
             {
-                var trimmed = line.Trim();
-                if (!trimmed.StartsWith("nameserver", StringComparison.OrdinalIgnoreCase))
+                foreach (var line in File.ReadAllLines(resolveConfPath))
                 {
-                    continue;
-                }
-
-                var parts = trimmed.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length >= 2 && IPAddress.TryParse(parts[1], out var ip))
-                {
-                    allAddresses.Add(ip);
-                    if (ip.AddressFamily == AddressFamily.InterNetwork)
+                    var trimmed = line.Trim();
+                    if (!trimmed.StartsWith("nameserver", StringComparison.OrdinalIgnoreCase))
                     {
-                        ipv4Addresses.Add(ip);
+                        continue;
+                    }
+
+                    var parts = trimmed.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 2 && IPAddress.TryParse(parts[1], out var ip))
+                    {
+                        allAddresses.Add(ip);
+                        if (ip.AddressFamily == AddressFamily.InterNetwork && IPAddress.IsLoopback(ip))
+                        {
+                            ipv4Addresses.Add(ip);
+                        }
                     }
                 }
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            {
+                return this;
             }
 
             if (allAddresses.Any(ip => ip.IsIPv4MappedToIPv6 && ipv4Addresses.Contains(ip.MapToIPv4())))


### PR DESCRIPTION
Original change attempting to fix the bug in the product was rejected. This change detects the condition and skips the tests instead.

- RequireEnvironment.cs — added NoDuplicateIpv4MappedNameServers(). On non-Windows it reads /etc/resolv.conf, parses nameserver lines, and throws SkipException if any IPv4-mapped IPv6 address (::ffff:x.x.x.x) is present alongside its plain IPv4 equivalent. On Windows or when /etc/resolv.conf doesn't exist it's a no-op.