### PR TITLE
CSHARP-6034: Update Snappier to fix a security issue

### DIFF
--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="DnsClient" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
-    <PackageReference Include="Snappier" Version="1.0.0" />
+    <PackageReference Include="Snappier" Version="1.2.0" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Buffers" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'netstandard2.1'">

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="DnsClient" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
-    <PackageReference Include="Snappier" Version="1.2.0" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>


### PR DESCRIPTION
Snappier 1.0.0 is affected by a security issue and builds are failing:
`warning NU1903: Package 'Snappier' 1.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-pggp-6c3x-2xmx`

This PR upgrades Snappier to the latest 1.3.1