### PR TITLE
📦 update snappier version with vulnerability

### DIFF
--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="DnsClient" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
-    <PackageReference Include="Snappier" Version="1.0.0" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>


### PR DESCRIPTION
New vulnerability has been detected with [CVE-2026-44302](https://www.tenable.com/cve/CVE-2026-44302) this pr updates the snappier to the fixed version of this new vulnerability