### PR TITLE
CSHARP-6034: Update Snappier to fix a security issue (Backport for v2.x)

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -30,9 +30,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.12.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
-    <PackageReference Include="Snappier" Version="1.0.0" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Buffers" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
Backport of [PR #1989](https://github.com/mongodb/mongo-csharp-driver/pull/1989) to the v2.x maintenance branch.

Snappier 1.0.0 is affected by [GHSA-pggp-6c3x-2xmx](https://github.com/advisories/GHSA-pggp-6c3x-2xmx) (NU1903 build warning). On v2.x the Snappier and System.Buffers references live in `MongoDB.Driver.Core.csproj` rather than `MongoDB.Driver.csproj`, so this could not be a clean cherry-pick of #1989 — the version bumps are identical:

- Snappier 1.0.0 → 1.3.1
- System.Buffers 4.5.1 → 4.6.1

Targeting a 2.30.1 patch release.

Evergreen patch: https://evergreen.mongodb.com/version/69fe472a2df8bb0007b2505b