### PR TITLE
CSHARP-6038: Suppress SharpCompress NU1902 audit warning

### DIFF
--- a/benchmarks/MongoDB.Driver.Benchmarks/MongoDB.Driver.Benchmarks.csproj
+++ b/benchmarks/MongoDB.Driver.Benchmarks/MongoDB.Driver.Benchmarks.csproj
@@ -34,4 +34,11 @@
     <ProjectReference Include="..\..\src\MongoDB.Driver.Encryption\MongoDB.Driver.Encryption.csproj" />
     <ProjectReference Include="..\..\tests\MongoDB.Driver.TestHelpers\MongoDB.Driver.TestHelpers.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- CSHARP-6038: SharpCompress directory-traversal advisory does not affect the driver,
+         which only uses in-memory ZLib stream compression and never calls IArchive.WriteToDirectory.
+         Remove once the SharpCompress dependency is dropped. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-6c8g-7p36-r338" />
+  </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -57,6 +57,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- CSHARP-6038: SharpCompress directory-traversal advisory does not affect the driver,
+         which only uses in-memory ZLib stream compression and never calls IArchive.WriteToDirectory.
+         Remove once the SharpCompress dependency is dropped. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-6c8g-7p36-r338" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\MongoDB.Shared\IsExternalInit.cs" Visible="false" />
   </ItemGroup>
 

--- a/tests/BuildProps/Tests.Build.props
+++ b/tests/BuildProps/Tests.Build.props
@@ -63,4 +63,11 @@
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- CSHARP-6038: SharpCompress directory-traversal advisory does not affect the driver,
+         which only uses in-memory ZLib stream compression and never calls IArchive.WriteToDirectory.
+         Remove once the SharpCompress dependency is dropped. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-6c8g-7p36-r338" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The 3.8.1 release build is blocked by a transitive-dependency advisory against `SharpCompress 0.30.1`:

- Advisory: [GHSA-6c8g-7p36-r338](https://github.com/advisories/GHSA-6c8g-7p36-r338) (CVE-2026-44788)
- Severity: Moderate
- Vulnerable code path: `IArchive.WriteToDirectory()` — directory traversal during archive extraction

The driver does not exercise the vulnerable API. SharpCompress is only used in `ZlibCompressor.cs` for in-memory ZLib stream compression of MongoDB wire-protocol messages; `WriteToDirectory` is never called. However, `TreatWarningsAsErrors=true` in our build props promotes NU1902 to an error and breaks the release pipeline.

This PR adds a targeted `<NuGetAuditSuppress>` for this specific advisory URL in:

- `src/Directory.Build.props` — covers driver projects
- `tests/BuildProps/Tests.Build.props` — covers test projects

This is intentionally narrow (one advisory URL) so other future advisories are still surfaced. 

Will be cherry-picked to v3.8.x to unblock the 3.8.1 release.