### PR TITLE
ci: declare contents:read on PR validation workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,9 @@ on:
       - unlabeled
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   pull-request-validation:
     name: Pull Request validation.


### PR DESCRIPTION
Pins `.github/workflows/pr.yml` to `permissions: contents: read` at the workflow level. The job is unusually narrow: it never checks out the repo, never sets up any toolchain, and only runs three guard steps against `github.event.pull_request` (label presence, title prefix, no trailing period). All three reads come from the event payload itself, not the API, so no token scope above the default is required.

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is the supply-chain case for being explicit. A tampered third-party action - even one composed in via a `uses:` entry added later - exfiltrates `GITHUB_TOKEN` from workflow logs and the leaked token carries whatever scope was issued at the workflow level. Capping the token to `contents: read` keeps any future third-party action added here bounded to the lowest scope, gives drift protection if the org default ever widens, and registers with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
