### PR TITLE
add asp commands

### DIFF
--- a/src/MongoDB.Driver/StreamProcessing/CreateStreamProcessorOptions.cs
+++ b/src/MongoDB.Driver/StreamProcessing/CreateStreamProcessorOptions.cs
@@ -1,0 +1,37 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Options for <see cref="StreamProcessors.Create(string, System.Collections.Generic.IEnumerable{BsonDocument}, CreateStreamProcessorOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    public sealed class CreateStreamProcessorOptions
+    {
+        /// <summary>Dead letter queue configuration.</summary>
+        public BsonDocument Dlq { get; set; }
+
+        /// <summary>Field name used for stream metadata.</summary>
+        public string StreamMetaFieldName { get; set; }
+
+        /// <summary>Compute tier (e.g. "SP2", "SP5", "SP10", "SP30", "SP50").</summary>
+        public string Tier { get; set; }
+
+        /// <summary>Whether failover is enabled.</summary>
+        public bool? Failover { get; set; }
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/FailoverOptions.cs
+++ b/src/MongoDB.Driver/StreamProcessing/FailoverOptions.cs
@@ -1,0 +1,32 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Failover configuration for <see cref="StartStreamProcessorOptions.Failover"/>.
+    /// </summary>
+    public sealed class FailoverOptions
+    {
+        /// <summary>Target region for failover. Required when failover is sent.</summary>
+        public string Region { get; set; }
+
+        /// <summary>Failover mode. Valid values: "GRACEFUL" (default), "FORCED".</summary>
+        public string Mode { get; set; }
+
+        /// <summary>If true, validates the failover request without executing it.</summary>
+        public bool? DryRun { get; set; }
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/GetStreamProcessorSamplesOptions.cs
+++ b/src/MongoDB.Driver/StreamProcessing/GetStreamProcessorSamplesOptions.cs
@@ -1,0 +1,42 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Options for <see cref="StreamProcessor.Samples(GetStreamProcessorSamplesOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    public sealed class GetStreamProcessorSamplesOptions
+    {
+        /// <summary>
+        /// The cursor id from a previous call. If null or zero, a new sample
+        /// cursor is opened via <c>startSampleStreamProcessor</c>. If non-zero,
+        /// the next batch is fetched via <c>getMoreSampleStreamProcessor</c>.
+        /// </summary>
+        public long? CursorId { get; set; }
+
+        /// <summary>
+        /// Maximum number of documents to sample. Only sent on the initial
+        /// call (when CursorId is null or zero). Ignored on subsequent calls.
+        /// </summary>
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// Number of documents to return per batch. Only sent on subsequent
+        /// calls (when CursorId is non-zero). Ignored on the initial call.
+        /// </summary>
+        public int? BatchSize { get; set; }
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/GetStreamProcessorStatsOptions.cs
+++ b/src/MongoDB.Driver/StreamProcessing/GetStreamProcessorStatsOptions.cs
@@ -1,0 +1,26 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Options for <see cref="StreamProcessor.Stats(GetStreamProcessorStatsOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    public sealed class GetStreamProcessorStatsOptions
+    {
+        /// <summary>If true, includes per-operator statistics.</summary>
+        public bool? Verbose { get; set; }
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/StartStreamProcessorOptions.cs
+++ b/src/MongoDB.Driver/StreamProcessing/StartStreamProcessorOptions.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Options for <see cref="StreamProcessor.Start(StartStreamProcessorOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    /// <remarks>
+    /// The spec's <c>startAfter</c> option is RESERVED for future use and is
+    /// not yet accepted by the server; the driver MUST NOT send it.
+    /// </remarks>
+    public sealed class StartStreamProcessorOptions
+    {
+        /// <summary>Number of workers.</summary>
+        public int? Workers { get; set; }
+
+        /// <summary>Clear checkpoints before starting.</summary>
+        public bool? ClearCheckpoints { get; set; }
+
+        /// <summary>Resume from a specific operation time.</summary>
+        public BsonTimestamp StartAtOperationTime { get; set; }
+
+        /// <summary>Compute tier. Valid values: "SP2", "SP5", "SP10", "SP30", "SP50".</summary>
+        public string Tier { get; set; }
+
+        /// <summary>Enable auto-scaling.</summary>
+        public bool? EnableAutoScaling { get; set; }
+
+        /// <summary>Failover configuration. The Region property is required when failover is sent.</summary>
+        public FailoverOptions Failover { get; set; }
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/StreamProcessingClient.cs
+++ b/src/MongoDB.Driver/StreamProcessing/StreamProcessingClient.cs
@@ -1,0 +1,167 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Client for an Atlas Stream Processing workspace.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="MongoClient"/> so that connection intent is
+    /// explicit and ASP commands cannot be accidentally routed to a standard
+    /// <c>mongod</c>. The underlying <see cref="MongoClient"/> is still
+    /// available via <see cref="Client"/> for advanced uses such as
+    /// <c>RunCommand</c> against admin.
+    ///
+    /// Workspace endpoints share the <c>mongodb://</c> URI scheme with
+    /// standard MongoDB clusters but follow a distinct hostname pattern:
+    ///
+    /// <c>mongodb://atlas-stream-&lt;workspaceId&gt;-&lt;suffix&gt;.&lt;region&gt;.a.query.mongodb.net/</c>
+    ///
+    /// Atlas staging endpoints use <c>.a.query.mongodb-stage.net</c>; both are
+    /// accepted. Per the ASP spec, TLS is required and the authentication
+    /// source defaults to "admin".
+    /// </remarks>
+    public sealed class StreamProcessingClient : IDisposable
+    {
+        private readonly MongoClient _client;
+        private readonly IMongoDatabase _admin;
+        private readonly string _uri;
+        private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new <see cref="StreamProcessingClient"/>.
+        /// </summary>
+        /// <param name="uri">Workspace connection string.</param>
+        public StreamProcessingClient(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+            if (!IsWorkspaceUri(uri))
+            {
+                throw new ArgumentException(
+                    "StreamProcessingClient requires a workspace endpoint URI " +
+                    "(atlas-stream-*.a.query.mongodb.net or .mongodb-<env>.net). " +
+                    "For standard MongoDB clusters, use MongoClient instead.",
+                    nameof(uri));
+            }
+
+            if (uri.StartsWith("mongodb+srv://", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException(
+                    "mongodb+srv:// is not supported for workspace endpoints; use mongodb://.",
+                    nameof(uri));
+            }
+
+            var settings = MongoClientSettings.FromConnectionString(uri);
+
+            // TLS is required and MUST NOT be disabled.
+            if (!settings.UseTls)
+            {
+                settings.UseTls = true;
+            }
+
+            // authSource defaults to "admin" but MAY be overridden by the caller.
+            if (settings.Credential != null && string.IsNullOrEmpty(settings.Credential.Source))
+            {
+                settings.Credential = settings.Credential.WithMechanismProperty("SOURCE", "admin");
+            }
+
+            _uri = uri;
+            _client = new MongoClient(settings);
+            _admin = _client.GetDatabase("admin");
+        }
+
+        /// <summary>The underlying <see cref="MongoClient"/>.</summary>
+        public MongoClient Client => _client;
+
+        /// <summary>The workspace URI passed to the constructor.</summary>
+        public string Uri => _uri;
+
+        /// <summary>Returns a handle for managing stream processors in this workspace.</summary>
+        public StreamProcessors StreamProcessorsView => new StreamProcessors(_admin);
+
+        /// <summary>Disposes the underlying <see cref="MongoClient"/>.</summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _client.Dispose();
+            _disposed = true;
+        }
+
+        /// <summary>
+        /// Returns true when the supplied URI targets an Atlas Stream
+        /// Processing workspace endpoint.
+        /// </summary>
+        /// <remarks>
+        /// Matches hostnames that begin with <c>atlas-stream-</c> and end with
+        /// <c>.a.query.mongodb.net</c> (production) or
+        /// <c>.a.query.mongodb-&lt;env&gt;.net</c> (e.g. <c>mongodb-stage.net</c>
+        /// for Atlas staging).
+        /// </remarks>
+        public static bool IsWorkspaceUri(string uri)
+        {
+            if (string.IsNullOrEmpty(uri)) return false;
+
+            var lower = uri.ToLowerInvariant();
+            if (!lower.StartsWith("mongodb://", StringComparison.Ordinal)) return false;
+
+            var afterScheme = lower.Substring("mongodb://".Length);
+
+            // Strip userinfo: if "@" appears before any path/query, take everything after.
+            var pathOrQueryIdx = IndexOfAny(afterScheme, '/', '?');
+            var searchEnd = pathOrQueryIdx == -1 ? afterScheme.Length : pathOrQueryIdx;
+            var atIdx = afterScheme.LastIndexOf('@', searchEnd > 0 ? searchEnd - 1 : 0);
+            var hostSection = atIdx >= 0 ? afterScheme.Substring(atIdx + 1) : afterScheme;
+
+            // Strip path/query/port.
+            var endIdx = IndexOfAny(hostSection, '/', '?', ':');
+            var host = endIdx == -1 ? hostSection : hostSection.Substring(0, endIdx);
+
+            if (!host.StartsWith("atlas-stream-", StringComparison.Ordinal)) return false;
+            if (host.EndsWith(".a.query.mongodb.net", StringComparison.Ordinal)) return true;
+
+            // Accept .a.query.mongodb-<env>.net
+            var envMarker = ".a.query.mongodb-";
+            var markerIdx = host.LastIndexOf(envMarker, StringComparison.Ordinal);
+            if (markerIdx >= 0 && host.EndsWith(".net", StringComparison.Ordinal))
+            {
+                var envStart = markerIdx + envMarker.Length;
+                var envLength = host.Length - envStart - ".net".Length;
+                if (envLength > 0)
+                {
+                    for (var i = envStart; i < envStart + envLength; i++)
+                    {
+                        var c = host[i];
+                        var ok = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-';
+                        if (!ok) return false;
+                    }
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static int IndexOfAny(string s, params char[] chars)
+        {
+            return s.IndexOfAny(chars);
+        }
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/StreamProcessor.cs
+++ b/src/MongoDB.Driver/StreamProcessing/StreamProcessor.cs
@@ -1,0 +1,249 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Handle for a specific named stream processor.
+    /// </summary>
+    /// <remarks>
+    /// Holding a handle does not imply the processor currently exists on the
+    /// server. Obtained via <see cref="StreamProcessors.Get"/>.
+    /// </remarks>
+    public sealed class StreamProcessor
+    {
+        private static readonly HashSet<string> ValidFailoverModes = new HashSet<string>(StringComparer.Ordinal) { "GRACEFUL", "FORCED" };
+
+        private readonly IMongoDatabase _admin;
+        private readonly string _name;
+
+        internal StreamProcessor(IMongoDatabase admin, string name)
+        {
+            if (admin == null) throw new ArgumentNullException(nameof(admin));
+            if (string.IsNullOrEmpty(name)) throw new ArgumentException("name must be non-empty.", nameof(name));
+
+            _admin = admin;
+            _name = name;
+        }
+
+        /// <summary>The processor name.</summary>
+        public string Name => _name;
+
+        /// <summary>Starts the processor.</summary>
+        public void Start(StartStreamProcessorOptions options = null, CancellationToken cancellationToken = default)
+        {
+            _admin.RunCommand(new BsonDocumentCommand<BsonDocument>(BuildStartCommand(options)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>Starts the processor asynchronously.</summary>
+        public Task StartAsync(StartStreamProcessorOptions options = null, CancellationToken cancellationToken = default)
+        {
+            return _admin.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(BuildStartCommand(options)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>Stops the processor. The processor remains in STOPPED and can be restarted.</summary>
+        public void Stop(CancellationToken cancellationToken = default)
+        {
+            _admin.RunCommand(new BsonDocumentCommand<BsonDocument>(new BsonDocument("stopStreamProcessor", _name)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>Stops the processor asynchronously.</summary>
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            return _admin.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(new BsonDocument("stopStreamProcessor", _name)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>Drops the processor permanently. A dropped processor cannot be recovered.</summary>
+        public void Drop(CancellationToken cancellationToken = default)
+        {
+            _admin.RunCommand(new BsonDocumentCommand<BsonDocument>(new BsonDocument("dropStreamProcessor", _name)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>Drops the processor asynchronously.</summary>
+        public Task DropAsync(CancellationToken cancellationToken = default)
+        {
+            return _admin.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(new BsonDocument("dropStreamProcessor", _name)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>Returns runtime statistics for the processor. The processor must be in STARTED.</summary>
+        public BsonDocument Stats(GetStreamProcessorStatsOptions options = null, CancellationToken cancellationToken = default)
+        {
+            return _admin.RunCommand(new BsonDocumentCommand<BsonDocument>(BuildStatsCommand(options)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>Returns runtime statistics asynchronously.</summary>
+        public Task<BsonDocument> StatsAsync(GetStreamProcessorStatsOptions options = null, CancellationToken cancellationToken = default)
+        {
+            return _admin.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(BuildStatsCommand(options)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves a batch of sampled documents.
+        /// </summary>
+        /// <remarks>
+        /// Routes to <c>startSampleStreamProcessor</c> when no CursorId is supplied (or
+        /// CursorId is 0); otherwise routes to <c>getMoreSampleStreamProcessor</c> with
+        /// the supplied cursor id. The caller MUST stop iterating when the
+        /// returned <see cref="StreamProcessorSamples.CursorId"/> is 0.
+        /// </remarks>
+        public StreamProcessorSamples Samples(GetStreamProcessorSamplesOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var cursorId = options?.CursorId ?? 0;
+            if (cursorId == 0)
+            {
+                var doc = _admin.RunCommand(new BsonDocumentCommand<BsonDocument>(BuildStartSampleCommand(options)), cancellationToken: cancellationToken);
+                return new StreamProcessorSamples(ReadCursorId(doc), new List<BsonDocument>());
+            }
+
+            var more = _admin.RunCommand(new BsonDocumentCommand<BsonDocument>(BuildGetMoreSampleCommand(cursorId, options)), cancellationToken: cancellationToken);
+            return BuildSamplesResult(more);
+        }
+
+        /// <summary>Retrieves a batch of sampled documents asynchronously.</summary>
+        public async Task<StreamProcessorSamples> SamplesAsync(GetStreamProcessorSamplesOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var cursorId = options?.CursorId ?? 0;
+            if (cursorId == 0)
+            {
+                var doc = await _admin.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(BuildStartSampleCommand(options)), cancellationToken: cancellationToken).ConfigureAwait(false);
+                return new StreamProcessorSamples(ReadCursorId(doc), new List<BsonDocument>());
+            }
+
+            var more = await _admin.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(BuildGetMoreSampleCommand(cursorId, options)), cancellationToken: cancellationToken).ConfigureAwait(false);
+            return BuildSamplesResult(more);
+        }
+
+        private BsonDocument BuildStartCommand(StartStreamProcessorOptions options)
+        {
+            var cmd = new BsonDocument("startStreamProcessor", _name);
+            if (options == null)
+            {
+                return cmd;
+            }
+
+            if (options.Workers.HasValue)
+            {
+                cmd["workers"] = options.Workers.Value;
+            }
+
+            // Spec puts these option fields under a nested "options" document.
+            var sub = new BsonDocument();
+            if (options.ClearCheckpoints.HasValue) sub["clearCheckpoints"] = options.ClearCheckpoints.Value;
+            if (options.StartAtOperationTime != null) sub["startAtOperationTime"] = options.StartAtOperationTime;
+            if (options.Tier != null) sub["tier"] = options.Tier;
+            if (options.EnableAutoScaling.HasValue) sub["enableAutoScaling"] = options.EnableAutoScaling.Value;
+            if (sub.ElementCount > 0) cmd["options"] = sub;
+
+            if (options.Failover != null)
+            {
+                if (string.IsNullOrEmpty(options.Failover.Region))
+                {
+                    throw new ArgumentException("Failover.Region is required when Failover is set.", nameof(options));
+                }
+
+                if (options.Failover.Mode != null && !ValidFailoverModes.Contains(options.Failover.Mode))
+                {
+                    throw new ArgumentException(
+                        $"Invalid Failover.Mode \"{options.Failover.Mode}\"; expected one of: GRACEFUL, FORCED.",
+                        nameof(options));
+                }
+
+                var f = new BsonDocument("region", options.Failover.Region);
+                if (options.Failover.Mode != null) f["mode"] = options.Failover.Mode;
+                if (options.Failover.DryRun.HasValue) f["dryRun"] = options.Failover.DryRun.Value;
+                cmd["failover"] = f;
+            }
+
+            return cmd;
+        }
+
+        private BsonDocument BuildStatsCommand(GetStreamProcessorStatsOptions options)
+        {
+            var cmd = new BsonDocument("getStreamProcessorStats", _name);
+            if (options?.Verbose.HasValue == true)
+            {
+                cmd["options"] = new BsonDocument("verbose", options.Verbose.Value);
+            }
+            return cmd;
+        }
+
+        private BsonDocument BuildStartSampleCommand(GetStreamProcessorSamplesOptions options)
+        {
+            var cmd = new BsonDocument("startSampleStreamProcessor", _name);
+            if (options?.Limit.HasValue == true)
+            {
+                cmd["limit"] = options.Limit.Value;
+            }
+            return cmd;
+        }
+
+        private BsonDocument BuildGetMoreSampleCommand(long cursorId, GetStreamProcessorSamplesOptions options)
+        {
+            var cmd = new BsonDocument
+            {
+                { "getMoreSampleStreamProcessor", _name },
+                { "cursorId", cursorId }
+            };
+            if (options?.BatchSize.HasValue == true)
+            {
+                cmd["batchSize"] = options.BatchSize.Value;
+            }
+            return cmd;
+        }
+
+        private static long ReadCursorId(BsonDocument doc)
+        {
+            if (doc == null || !doc.TryGetValue("cursorId", out var value))
+            {
+                throw new InvalidOperationException("startSampleStreamProcessor did not return a cursorId.");
+            }
+            return value.ToInt64();
+        }
+
+        private static StreamProcessorSamples BuildSamplesResult(BsonDocument response)
+        {
+            var cursorId = response.TryGetValue("cursorId", out var cidValue) ? cidValue.ToInt64() : 0L;
+
+            // Dev-server deviation: some server builds use "messages" instead of
+            // "nextBatch". Prefer the spec-defined "nextBatch" but fall back to
+            // "messages" when present.
+            BsonValue batchValue;
+            if (!response.TryGetValue("nextBatch", out batchValue))
+            {
+                response.TryGetValue("messages", out batchValue);
+            }
+
+            var documents = new List<BsonDocument>();
+            if (batchValue != null && batchValue.IsBsonArray)
+            {
+                foreach (var item in batchValue.AsBsonArray)
+                {
+                    if (item.IsBsonDocument)
+                    {
+                        documents.Add(item.AsBsonDocument);
+                    }
+                }
+            }
+
+            return new StreamProcessorSamples(cursorId, documents);
+        }
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/StreamProcessorInfo.cs
+++ b/src/MongoDB.Driver/StreamProcessing/StreamProcessorInfo.cs
@@ -1,0 +1,119 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Information about a single stream processor, returned by the
+    /// getStreamProcessor command.
+    /// </summary>
+    /// <remarks>
+    /// Fields the spec marks as optional may be absent depending on server
+    /// version; the corresponding accessors return <c>null</c> in that case.
+    /// Drivers MUST surface unknown state values as-is rather than mapping them
+    /// to a closed set, so <see cref="State"/> is a plain string.
+    /// </remarks>
+    public sealed class StreamProcessorInfo
+    {
+        private readonly BsonDocument _raw;
+
+        internal StreamProcessorInfo(BsonDocument raw)
+        {
+            _raw = raw ?? new BsonDocument();
+        }
+
+        /// <summary>The raw response document.</summary>
+        public BsonDocument Raw => _raw;
+
+        /// <summary>Processor id. Optional: not returned by all server versions.</summary>
+        public string Id => _raw.GetValue("id", BsonNull.Value).IsBsonNull ? null : _raw["id"].AsString;
+
+        /// <summary>Processor name.</summary>
+        public string Name => _raw.GetValue("name", BsonNull.Value).IsBsonNull ? null : _raw["name"].AsString;
+
+        /// <summary>Current state.</summary>
+        public string State => _raw.GetValue("state", BsonNull.Value).IsBsonNull ? null : _raw["state"].AsString;
+
+        /// <summary>Aggregation pipeline of the processor.</summary>
+        public IReadOnlyList<BsonDocument> Pipeline
+        {
+            get
+            {
+                if (!_raw.TryGetValue("pipeline", out var v) || !v.IsBsonArray)
+                {
+                    return new List<BsonDocument>();
+                }
+                var array = v.AsBsonArray;
+                var list = new List<BsonDocument>(array.Count);
+                foreach (var item in array)
+                {
+                    if (item.IsBsonDocument)
+                    {
+                        list.Add(item.AsBsonDocument);
+                    }
+                }
+                return list;
+            }
+        }
+
+        /// <summary>Pipeline version. Optional: not returned by all server versions.</summary>
+        public int? PipelineVersion => _raw.TryGetValue("pipelineVersion", out var v) && v.IsInt32 ? v.AsInt32 : (int?)null;
+
+        /// <summary>Compute tier.</summary>
+        public string Tier => _raw.GetValue("tier", BsonNull.Value).IsBsonNull ? null : _raw["tier"].AsString;
+
+        /// <summary>Dead letter queue configuration.</summary>
+        public BsonDocument Dlq => _raw.TryGetValue("dlq", out var v) && v.IsBsonDocument ? v.AsBsonDocument : null;
+
+        /// <summary>Field name used for stream metadata.</summary>
+        public string StreamMetaFieldName => _raw.GetValue("streamMetaFieldName", BsonNull.Value).IsBsonNull ? null : _raw["streamMetaFieldName"].AsString;
+
+        /// <summary>Whether auto-scaling is enabled.</summary>
+        public bool AutoScalingEnabled => _raw.GetValue("enableAutoScaling", false).ToBoolean();
+
+        /// <summary>Whether failover is enabled.</summary>
+        public bool FailoverEnabled => _raw.GetValue("failoverEnabled", false).ToBoolean();
+
+        /// <summary>Active region for the processor.</summary>
+        public string ActiveRegion => _raw.GetValue("activeRegion", BsonNull.Value).IsBsonNull ? null : _raw["activeRegion"].AsString;
+
+        /// <summary>Workspace default region.</summary>
+        public string WorkspaceDefaultRegion => _raw.GetValue("workspaceDefaultRegion", BsonNull.Value).IsBsonNull ? null : _raw["workspaceDefaultRegion"].AsString;
+
+        /// <summary>Timestamp of the last state change.</summary>
+        public BsonValue LastStateChange => _raw.TryGetValue("lastStateChange", out var v) ? v : null;
+
+        /// <summary>Timestamp of the last modification.</summary>
+        public BsonValue LastModifiedAt => _raw.TryGetValue("lastModifiedAt", out var v) ? v : null;
+
+        /// <summary>User who last modified the processor.</summary>
+        public string ModifiedBy => _raw.GetValue("modifiedBy", BsonNull.Value).IsBsonNull ? null : _raw["modifiedBy"].AsString;
+
+        /// <summary>Whether the processor has been started at least once.</summary>
+        public bool HasStarted => _raw.GetValue("hasStarted", false).ToBoolean();
+
+        /// <summary>Error message. Always present; empty string indicates no error has occurred.</summary>
+        public string ErrorMessage => _raw.GetValue("errorMsg", "").AsString;
+
+        /// <summary>Whether the most recent error is retryable.</summary>
+        public bool ErrorRetryable => _raw.GetValue("errorRetryable", false).ToBoolean();
+
+        /// <summary>Error code from the most recent error.</summary>
+        public int? ErrorCode => _raw.TryGetValue("errorCode", out var v) && v.IsInt32 ? v.AsInt32 : (int?)null;
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/StreamProcessorSamples.cs
+++ b/src/MongoDB.Driver/StreamProcessing/StreamProcessorSamples.cs
@@ -1,0 +1,46 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// The result of a call to <see cref="StreamProcessor.Samples"/> or
+    /// <see cref="StreamProcessor.SamplesAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Callers MUST stop iterating when <see cref="CursorId"/> is 0 — the
+    /// cursor is exhausted and no further calls should be made.
+    /// </remarks>
+    public sealed class StreamProcessorSamples
+    {
+        internal StreamProcessorSamples(long cursorId, IReadOnlyList<BsonDocument> documents)
+        {
+            CursorId = cursorId;
+            Documents = documents ?? new List<BsonDocument>();
+        }
+
+        /// <summary>The cursor id to pass to the next call. 0 means the cursor is exhausted.</summary>
+        public long CursorId { get; }
+
+        /// <summary>The batch of sampled documents.</summary>
+        public IReadOnlyList<BsonDocument> Documents { get; }
+
+        /// <summary>Whether the cursor is exhausted (cursor id is 0).</summary>
+        public bool IsExhausted => CursorId == 0;
+    }
+}

--- a/src/MongoDB.Driver/StreamProcessing/StreamProcessors.cs
+++ b/src/MongoDB.Driver/StreamProcessing/StreamProcessors.cs
@@ -1,0 +1,123 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.StreamProcessing
+{
+    /// <summary>
+    /// Handle for managing stream processors in a workspace. Obtained from
+    /// <see cref="StreamProcessingClient.StreamProcessorsView"/>.
+    /// </summary>
+    public sealed class StreamProcessors
+    {
+        private readonly IMongoDatabase _admin;
+
+        internal StreamProcessors(IMongoDatabase admin)
+        {
+            _admin = admin ?? throw new ArgumentNullException(nameof(admin));
+        }
+
+        /// <summary>Creates a new stream processor.</summary>
+        public void Create(string name, IEnumerable<BsonDocument> pipeline, CreateStreamProcessorOptions options = null, CancellationToken cancellationToken = default)
+        {
+            _admin.RunCommand(new BsonDocumentCommand<BsonDocument>(BuildCreateCommand(name, pipeline, options)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>Creates a new stream processor asynchronously.</summary>
+        public Task CreateAsync(string name, IEnumerable<BsonDocument> pipeline, CreateStreamProcessorOptions options = null, CancellationToken cancellationToken = default)
+        {
+            return _admin.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(BuildCreateCommand(name, pipeline, options)), cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns a handle for the named processor. Does not imply that the
+        /// processor currently exists on the server.
+        /// </summary>
+        public StreamProcessor Get(string name)
+        {
+            return new StreamProcessor(_admin, name);
+        }
+
+        /// <summary>Returns information about a single stream processor.</summary>
+        public StreamProcessorInfo GetInfo(string name, CancellationToken cancellationToken = default)
+        {
+            ValidateName(name);
+            var response = _admin.RunCommand(new BsonDocumentCommand<BsonDocument>(new BsonDocument("getStreamProcessor", name)), cancellationToken: cancellationToken);
+            return new StreamProcessorInfo(UnwrapResult(response));
+        }
+
+        /// <summary>Returns information about a single stream processor asynchronously.</summary>
+        public async Task<StreamProcessorInfo> GetInfoAsync(string name, CancellationToken cancellationToken = default)
+        {
+            ValidateName(name);
+            var response = await _admin.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(new BsonDocument("getStreamProcessor", name)), cancellationToken: cancellationToken).ConfigureAwait(false);
+            return new StreamProcessorInfo(UnwrapResult(response));
+        }
+
+        private static BsonDocument BuildCreateCommand(string name, IEnumerable<BsonDocument> pipeline, CreateStreamProcessorOptions options)
+        {
+            ValidateName(name);
+            if (pipeline == null) throw new ArgumentNullException(nameof(pipeline));
+
+            var pipelineArray = new BsonArray();
+            foreach (var stage in pipeline)
+            {
+                if (stage != null) pipelineArray.Add(stage);
+            }
+
+            var cmd = new BsonDocument
+            {
+                { "createStreamProcessor", name },
+                { "pipeline", pipelineArray }
+            };
+
+            if (options == null) return cmd;
+
+            var sub = new BsonDocument();
+            if (options.Dlq != null) sub["dlq"] = options.Dlq;
+            if (options.StreamMetaFieldName != null) sub["streamMetaFieldName"] = options.StreamMetaFieldName;
+            if (options.Tier != null) sub["tier"] = options.Tier;
+            if (options.Failover.HasValue) sub["failover"] = options.Failover.Value;
+            if (sub.ElementCount > 0) cmd["options"] = sub;
+
+            return cmd;
+        }
+
+        private static BsonDocument UnwrapResult(BsonDocument response)
+        {
+            // Dev-server deviation: some server builds wrap the processor
+            // document in a top-level "result" key. Unwrap if present so the
+            // caller sees a flat document matching the spec.
+            if (response != null && response.TryGetValue("result", out var resultValue) && resultValue.IsBsonDocument)
+            {
+                return resultValue.AsBsonDocument;
+            }
+            return response ?? new BsonDocument();
+        }
+
+        private static void ValidateName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("name must be non-empty.", nameof(name));
+            }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Examples/StreamProcessingExample.cs
+++ b/tests/MongoDB.Driver.Examples/StreamProcessingExample.cs
@@ -1,0 +1,172 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver.StreamProcessing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MongoDB.Driver.Examples
+{
+    /// <summary>
+    /// Demonstrates the full lifecycle of an Atlas Stream Processing (ASP)
+    /// stream processor: create, start, sample, stop, drop.
+    ///
+    /// Requirements:
+    ///   - An Atlas Stream Processing workspace endpoint.
+    ///   - A user with the atlasAdmin role.
+    ///   - Two connections registered: sample_stream_solar (source) and __testLog (sink).
+    ///
+    /// Run with:
+    ///   MONGODB_STREAM_PROCESSING_URI='mongodb://user:pass@atlas-stream-….a.query.mongodb.net/' \
+    ///     dotnet test tests/MongoDB.Driver.Examples/MongoDB.Driver.Examples.csproj \
+    ///     --filter "FullyQualifiedName~StreamProcessingExample"
+    ///
+    /// Self-skips when the env var is unset.
+    /// </summary>
+    [Trait("Category", "Integration")]
+    public class StreamProcessingExample
+    {
+        private readonly ITestOutputHelper _output;
+
+        public StreamProcessingExample(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task Lifecycle()
+        {
+            var uri = Environment.GetEnvironmentVariable("MONGODB_STREAM_PROCESSING_URI");
+            if (string.IsNullOrEmpty(uri) || !StreamProcessingClient.IsWorkspaceUri(uri))
+            {
+                _output.WriteLine("Skipping: MONGODB_STREAM_PROCESSING_URI is not configured to a workspace endpoint.");
+                return;
+            }
+
+            var client = new StreamProcessingClient(uri);
+            var processors = client.StreamProcessorsView;
+            var name = "csharpdriver_demo_" + ObjectId.GenerateNewId();
+
+            _output.WriteLine($"Workspace: {uri}");
+            _output.WriteLine($"Processor: {name}");
+            _output.WriteLine("");
+
+            var created = false;
+            try
+            {
+                var pipeline = new List<BsonDocument>
+                {
+                    new BsonDocument("$source", new BsonDocument("connectionName", "sample_stream_solar")),
+                    new BsonDocument("$emit", new BsonDocument
+                    {
+                        { "connectionName", "__testLog" },
+                        { "topic", "csharp-driver-demo" }
+                    })
+                };
+
+                // 1. create
+                _output.WriteLine($"[1/6] create({name})");
+                await processors.CreateAsync(name, pipeline).ConfigureAwait(false);
+                created = true;
+                var info = await processors.GetInfoAsync(name).ConfigureAwait(false);
+                _output.WriteLine($"      state={info.State}");
+                _output.WriteLine("");
+
+                // 2. start
+                _output.WriteLine("[2/6] start()");
+                var processor = processors.Get(name);
+                await processor.StartAsync().ConfigureAwait(false);
+
+                var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+                string state;
+                do
+                {
+                    await Task.Delay(500).ConfigureAwait(false);
+                    state = (await processors.GetInfoAsync(name).ConfigureAwait(false)).State;
+                } while (state != "STARTED" && DateTime.UtcNow < deadline);
+
+                _output.WriteLine($"      state={state}");
+                _output.WriteLine("");
+                if (state != "STARTED")
+                {
+                    throw new InvalidOperationException($"processor did not reach STARTED within 30s (got {state})");
+                }
+
+                // 3. stats
+                _output.WriteLine("[3/6] stats()");
+                var stats = await processor.StatsAsync().ConfigureAwait(false);
+                _output.WriteLine($"      {stats.ToJson()}");
+                _output.WriteLine("");
+
+                // 4. sample
+                _output.WriteLine("[4/6] samples()");
+                var opened = await processor.SamplesAsync(new GetStreamProcessorSamplesOptions { Limit = 5 }).ConfigureAwait(false);
+                _output.WriteLine($"      open  cursorId={opened.CursorId} docs={opened.Documents.Count}");
+
+                if (!opened.IsExhausted)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                    var batch = await processor.SamplesAsync(new GetStreamProcessorSamplesOptions
+                    {
+                        CursorId = opened.CursorId,
+                        BatchSize = 5
+                    }).ConfigureAwait(false);
+                    _output.WriteLine($"      batch cursorId={batch.CursorId} docs={batch.Documents.Count}");
+                    for (var i = 0; i < batch.Documents.Count; i++)
+                    {
+                        _output.WriteLine($"          [{i}] {batch.Documents[i].ToJson()}");
+                    }
+                }
+                _output.WriteLine("");
+
+                // 5. stop
+                _output.WriteLine("[5/6] stop()");
+                await processor.StopAsync().ConfigureAwait(false);
+                _output.WriteLine($"      state={(await processors.GetInfoAsync(name).ConfigureAwait(false)).State}");
+                _output.WriteLine("");
+
+                // 6. drop
+                _output.WriteLine("[6/6] drop()");
+                await processor.DropAsync().ConfigureAwait(false);
+                _output.WriteLine("      dropped");
+                _output.WriteLine("");
+
+                _output.WriteLine("OK.");
+            }
+            catch (Exception e)
+            {
+                _output.WriteLine("");
+                _output.WriteLine($"FAILED: {e.GetType().Name}: {e.Message}");
+                if (created)
+                {
+                    try
+                    {
+                        await processors.Get(name).DropAsync().ConfigureAwait(false);
+                        _output.WriteLine($"(cleaned up processor {name})");
+                    }
+                    catch
+                    {
+                        // best-effort
+                    }
+                }
+                throw;
+            }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/StreamProcessing/StreamProcessingClientTests.cs
+++ b/tests/MongoDB.Driver.Tests/StreamProcessing/StreamProcessingClientTests.cs
@@ -1,0 +1,71 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using FluentAssertions;
+using MongoDB.Driver.StreamProcessing;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.StreamProcessing
+{
+    public class StreamProcessingClientTests
+    {
+        [Theory]
+        [InlineData("mongodb://atlas-stream-699c842ef433fe6001480b17-etif1.virginia-usa.a.query.mongodb.net/")]
+        [InlineData("mongodb://user:pass@atlas-stream-xyz.us-east-1.a.query.mongodb.net:27017/?retryWrites=true")]
+        [InlineData("mongodb://user:pass@atlas-stream-699c842ef433fe6001480b17-etif1.virginia-usa.a.query.mongodb-stage.net")]
+        [InlineData("MONGODB://atlas-stream-xyz.us-east-1.a.query.mongodb.net/")]
+        public void IsWorkspaceUri_returns_true_for_workspace_endpoints(string uri)
+        {
+            StreamProcessingClient.IsWorkspaceUri(uri).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("mongodb://localhost:27017/")]
+        [InlineData("mongodb+srv://cluster0.example.mongodb.net/")]
+        [InlineData("mongodb://atlas-stream-x.example.com/")]
+        [InlineData("mongodb://abc.virginia-usa.a.query.mongodb.net/")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void IsWorkspaceUri_returns_false_for_other_endpoints(string uri)
+        {
+            StreamProcessingClient.IsWorkspaceUri(uri).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Constructor_rejects_non_workspace_uri()
+        {
+            var ex = Record.Exception(() => new StreamProcessingClient("mongodb://localhost:27017/"));
+            ex.Should().BeOfType<ArgumentException>()
+                .Which.Message.Should().Contain("workspace endpoint URI");
+        }
+
+        [Fact]
+        public void Constructor_rejects_srv_scheme()
+        {
+            var ex = Record.Exception(() => new StreamProcessingClient(
+                "mongodb+srv://atlas-stream-x.us-east-1.a.query.mongodb.net/"));
+            ex.Should().BeOfType<ArgumentException>()
+                .Which.Message.Should().Contain("workspace endpoint URI");
+        }
+
+        [Fact]
+        public void Constructor_rejects_null_uri()
+        {
+            var ex = Record.Exception(() => new StreamProcessingClient(null));
+            ex.Should().BeOfType<ArgumentNullException>();
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/StreamProcessing/StreamProcessingLifecycleTests.cs
+++ b/tests/MongoDB.Driver.Tests/StreamProcessing/StreamProcessingLifecycleTests.cs
@@ -1,0 +1,127 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver.StreamProcessing;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.StreamProcessing
+{
+    /// <summary>
+    /// Functional smoke test for Atlas Stream Processing. Skipped unless
+    /// <c>MONGODB_STREAM_PROCESSING_URI</c> is set to a workspace endpoint
+    /// (<c>atlas-stream-*.&lt;region&gt;.a.query.mongodb{,-stage}.net</c>)
+    /// with valid credentials.
+    /// </summary>
+    [Trait("Category", "Integration")]
+    public class StreamProcessingLifecycleTests
+    {
+        private static string WorkspaceUri => Environment.GetEnvironmentVariable("MONGODB_STREAM_PROCESSING_URI");
+
+        private static bool ShouldRun
+        {
+            get
+            {
+                var uri = WorkspaceUri;
+                return !string.IsNullOrEmpty(uri) && StreamProcessingClient.IsWorkspaceUri(uri);
+            }
+        }
+
+        [Fact]
+        public async Task Lifecycle_create_start_stats_sample_stop_drop()
+        {
+            if (!ShouldRun)
+            {
+                // MONGODB_STREAM_PROCESSING_URI not configured to a workspace endpoint; skip.
+                return;
+            }
+
+            var client = new StreamProcessingClient(WorkspaceUri);
+            var processors = client.StreamProcessorsView;
+            var name = "csharpdriver_test_" + ObjectId.GenerateNewId();
+
+            var pipeline = new List<BsonDocument>
+            {
+                new BsonDocument("$source", new BsonDocument("connectionName", "sample_stream_solar")),
+                new BsonDocument("$emit", new BsonDocument
+                {
+                    { "connectionName", "__testLog" },
+                    { "topic", "csharp-driver-demo" }
+                })
+            };
+
+            try
+            {
+                // create
+                await processors.CreateAsync(name, pipeline).ConfigureAwait(false);
+                var info = await processors.GetInfoAsync(name).ConfigureAwait(false);
+                info.Name.Should().Be(name);
+                new[] { "CREATED", "VALIDATING", "CREATING" }.Should().Contain(info.State);
+
+                // start
+                var processor = processors.Get(name);
+                await processor.StartAsync().ConfigureAwait(false);
+
+                var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+                string state;
+                do
+                {
+                    await Task.Delay(500).ConfigureAwait(false);
+                    state = (await processors.GetInfoAsync(name).ConfigureAwait(false)).State;
+                } while (state != "STARTED" && DateTime.UtcNow < deadline);
+
+                state.Should().Be("STARTED");
+
+                // stats
+                var stats = await processor.StatsAsync().ConfigureAwait(false);
+                stats.Should().NotBeNull();
+
+                // sample: open + fetch one batch
+                var opened = await processor.SamplesAsync(new GetStreamProcessorSamplesOptions { Limit = 5 }).ConfigureAwait(false);
+                opened.CursorId.Should().BeGreaterThan(0);
+                opened.Documents.Should().BeEmpty();
+
+                var batch = await processor.SamplesAsync(new GetStreamProcessorSamplesOptions
+                {
+                    CursorId = opened.CursorId,
+                    BatchSize = 5
+                }).ConfigureAwait(false);
+                batch.CursorId.Should().BeGreaterOrEqualTo(0);
+
+                // stop + drop
+                await processor.StopAsync().ConfigureAwait(false);
+                await processor.DropAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // best-effort cleanup
+                try
+                {
+                    await processors.Get(name).DropAsync(CancellationToken.None).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // ignore
+                }
+                throw;
+            }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/StreamProcessing/StreamProcessorInfoTests.cs
+++ b/tests/MongoDB.Driver.Tests/StreamProcessing/StreamProcessorInfoTests.cs
@@ -1,0 +1,123 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Reflection;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver.StreamProcessing;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.StreamProcessing
+{
+    public class StreamProcessorInfoTests
+    {
+        private static StreamProcessorInfo CreateFrom(BsonDocument raw)
+        {
+            // Constructor is internal; use reflection so tests don't depend on
+            // a public hook just for unit tests.
+            var ctor = typeof(StreamProcessorInfo).GetConstructor(
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                new[] { typeof(BsonDocument) },
+                null);
+            ctor.Should().NotBeNull();
+            return (StreamProcessorInfo)ctor.Invoke(new object[] { raw });
+        }
+
+        [Fact]
+        public void Getters_expose_populated_fields()
+        {
+            var raw = new BsonDocument
+            {
+                { "id", "proc-1" },
+                { "name", "smokeTestProcessor" },
+                { "state", "CREATED" },
+                { "pipeline", new BsonArray { new BsonDocument("$source", new BsonDocument("connectionName", "sample_stream_solar")) } },
+                { "pipelineVersion", 2 },
+                { "tier", "SP2" },
+                { "streamMetaFieldName", "_stream_meta" },
+                { "enableAutoScaling", true },
+                { "failoverEnabled", false },
+                { "activeRegion", "us-east-1" },
+                { "workspaceDefaultRegion", "us-east-1" },
+                { "modifiedBy", "user-1" },
+                { "hasStarted", false },
+                { "errorMsg", "" },
+                { "errorRetryable", false }
+            };
+
+            var info = CreateFrom(raw);
+            info.Id.Should().Be("proc-1");
+            info.Name.Should().Be("smokeTestProcessor");
+            info.State.Should().Be("CREATED");
+            info.PipelineVersion.Should().Be(2);
+            info.Tier.Should().Be("SP2");
+            info.StreamMetaFieldName.Should().Be("_stream_meta");
+            info.AutoScalingEnabled.Should().BeTrue();
+            info.FailoverEnabled.Should().BeFalse();
+            info.ActiveRegion.Should().Be("us-east-1");
+            info.WorkspaceDefaultRegion.Should().Be("us-east-1");
+            info.ModifiedBy.Should().Be("user-1");
+            info.HasStarted.Should().BeFalse();
+            info.ErrorMessage.Should().BeEmpty();
+            info.ErrorRetryable.Should().BeFalse();
+            info.Pipeline.Should().HaveCount(1);
+            info.Pipeline[0]["$source"]["connectionName"].AsString.Should().Be("sample_stream_solar");
+        }
+
+        [Fact]
+        public void Getters_return_defaults_when_fields_missing()
+        {
+            var info = CreateFrom(new BsonDocument
+            {
+                { "name", "p" },
+                { "state", "CREATED" }
+            });
+
+            info.Id.Should().BeNull();
+            info.PipelineVersion.Should().NotHaveValue();
+            info.Tier.Should().BeNull();
+            info.Dlq.Should().BeNull();
+            info.StreamMetaFieldName.Should().BeNull();
+            info.ActiveRegion.Should().BeNull();
+            info.WorkspaceDefaultRegion.Should().BeNull();
+            info.ModifiedBy.Should().BeNull();
+            info.AutoScalingEnabled.Should().BeFalse();
+            info.FailoverEnabled.Should().BeFalse();
+            info.HasStarted.Should().BeFalse();
+            info.ErrorMessage.Should().BeEmpty();
+            info.ErrorRetryable.Should().BeFalse();
+            info.ErrorCode.Should().NotHaveValue();
+            info.Pipeline.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Error_fields_exposed_when_set()
+        {
+            var info = CreateFrom(new BsonDocument
+            {
+                { "name", "p" },
+                { "state", "FAILED" },
+                { "errorMsg", "something went wrong" },
+                { "errorRetryable", true },
+                { "errorCode", 125 }
+            });
+
+            info.ErrorMessage.Should().Be("something went wrong");
+            info.ErrorRetryable.Should().BeTrue();
+            info.ErrorCode.Should().Be(125);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/StreamProcessing/StreamProcessorSamplesTests.cs
+++ b/tests/MongoDB.Driver.Tests/StreamProcessing/StreamProcessorSamplesTests.cs
@@ -1,0 +1,62 @@
+﻿/* Copyright 2026-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Reflection;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver.StreamProcessing;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.StreamProcessing
+{
+    public class StreamProcessorSamplesTests
+    {
+        private static StreamProcessorSamples CreateFrom(long cursorId, IReadOnlyList<BsonDocument> docs)
+        {
+            var ctor = typeof(StreamProcessorSamples).GetConstructor(
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                new[] { typeof(long), typeof(IReadOnlyList<BsonDocument>) },
+                null);
+            ctor.Should().NotBeNull();
+            return (StreamProcessorSamples)ctor.Invoke(new object[] { cursorId, docs });
+        }
+
+        [Fact]
+        public void IsExhausted_returns_true_when_cursor_id_is_zero()
+        {
+            CreateFrom(0, new List<BsonDocument>()).IsExhausted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsExhausted_returns_false_when_cursor_id_is_non_zero()
+        {
+            CreateFrom(42, new List<BsonDocument>()).IsExhausted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Documents_returns_the_documents_passed_in()
+        {
+            var docs = new List<BsonDocument>
+            {
+                new BsonDocument("x", 1),
+                new BsonDocument("x", 2)
+            };
+            var samples = CreateFrom(7, docs);
+            samples.Documents.Should().BeEquivalentTo(docs);
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary

  Adds first-class driver support for Atlas Stream Processing (ASP), implementing the [ASP driver spec](https://docs.google.com/document/d/1ORSCgQCwB0wo54egVPUwvuY6egcvjaJpYf965IywKjs/edit). Users currently have to drop down to
  `client.GetDatabase("admin").RunCommand(...)` against a workspace endpoint; this PR adds a dedicated client / handles layer matching what's already shipped for PHP, Rust, and Ruby.

  ## What's new

  **Public API** (`src/MongoDB.Driver/StreamProcessing/`)
  - `StreamProcessingClient` — workspace-scoped client distinct from `MongoClient`. Validates the workspace URI (`atlas-stream-*.<region>.a.query.mongodb.net` and the `.mongodb-<env>.net` staging variants), enforces TLS, defaults `authSource` to
  `admin`. Implements `IDisposable` and disposes the underlying `MongoClient`. Static `StreamProcessingClient.IsWorkspaceUri(uri)` exposed for callers that want to gate before connecting.
  - `StreamProcessors` — `Create` / `Get` / `GetInfo` (plus `Async` pairs) for managing processors in a workspace.
  - `StreamProcessor` — `Start` / `Stop` / `Drop` / `Stats` / `Samples` (plus `Async` pairs) for a named processor.
  - `StreamProcessorInfo` — typed accessor over the `getStreamProcessor` response. Fields the spec marks as optional (e.g. `Id`, `PipelineVersion`) are `Nullable<T>` / nullable reference types.
  - `StreamProcessorSamples` — result of `Samples` / `SamplesAsync`, exposes `CursorId`, `Documents`, `IsExhausted`.
  - Options: `CreateStreamProcessorOptions`, `StartStreamProcessorOptions`, `FailoverOptions`, `GetStreamProcessorStatsOptions`, `GetStreamProcessorSamplesOptions`. POCO classes following the existing options-class convention.

  **Wire commands**
  All 8 ASP commands routed through `IMongoDatabase.RunCommand` / `RunCommandAsync` against the `admin` database: `createStreamProcessor`, `startStreamProcessor`, `stopStreamProcessor`, `dropStreamProcessor`, `getStreamProcessor`,
  `getStreamProcessorStats`, `startSampleStreamProcessor`, `getMoreSampleStreamProcessor`.

  ## Notable spec / server alignment

  - **`startAfter` (in `StartStreamProcessorOptions`) is intentionally not exposed** — the spec marks it RESERVED for future use and explicitly forbids drivers from sending it.
  - **Dev-server response shape deviations are accommodated**, matching the workarounds in the PHP / Rust / Ruby PRs:
    - `StreamProcessors.GetInfo` unwraps a top-level `result` wrapper when the server returns `{ ok: 1, result: { … } }`.
    - `StreamProcessor.Samples` accepts both `nextBatch` (spec) and `messages` (current dev server).
    - `StreamProcessorInfo.Id` and `PipelineVersion` return `null` when the server omits them.
  - **`Samples` is a single-call dispatch:** null/zero `CursorId` → `startSampleStreamProcessor` (returns `StreamProcessorSamples` with cursor id, empty docs); non-zero → `getMoreSampleStreamProcessor`. Callers stop when `CursorId == 0` (or use
  the `IsExhausted` predicate).
  - **State strings returned as plain strings**, not enums — per the spec, drivers MUST surface unknown state values as-is rather than mapping to a closed set.
  - **Internal-only fields** (`tenantID`, `projectId`, `processorId`) are not surfaced in the public API.

  ## Test plan

  - [x] `dotnet build CSharpDriver.sln` — 0 errors (14 pre-existing warnings: `SharpCompress` vulnerability + `netcoreapp3.1` TFM support notices, neither introduced by this PR)
  - [x] `dotnet test tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj -f net10.0 --filter "FullyQualifiedName~StreamProcessing"` — all unit tests pass (URI detection for prod / staging / creds-and-port / case-insensitivity / four reject
  cases; constructor rejection paths; full `StreamProcessorInfo` getter coverage including defaults and error fields; `StreamProcessorSamples` predicates)
  - [x] `dotnet test ... --filter "FullyQualifiedName~StreamProcessingLifecycle"` (no env var) — self-skips cleanly
  - [x] Full lifecycle exercised against an Atlas staging workspace via `tests/MongoDB.Driver.Examples/StreamProcessingExample.cs` — create → start → stats → samples (cursor opened + telemetry docs returned in second call) → stop → drop. All
  transitions clean.