### PR TITLE
CSHARP-5992: Add LINQ translation benchmark suite

### DIFF
--- a/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkHelper.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkHelper.cs
@@ -37,18 +37,16 @@ public static class BenchmarkHelper
         }
     }
 
-    public static double CalculateCompositeScore(IEnumerable<BenchmarkResult> benchmarkResults, string benchmarkCategory)
+    public static (double Score, string Unit, string MetricName) CalculateComposite(IEnumerable<BenchmarkResult> benchmarkResults, string benchmarkCategory)
     {
-        var identifiedBenchmarksScores = benchmarkResults
-            .Where(benchmark => benchmark.Categories.Contains(benchmarkCategory))
-            .Select(benchmark => benchmark.Score).ToArray();
+        var members = benchmarkResults
+            .Where(benchmark => benchmark.Categories.Contains(benchmarkCategory)
+                && !benchmark.Categories.Contains(DriverBenchmarkCategory.ExcludeFromComposite))
+            .ToArray();
 
-        if (identifiedBenchmarksScores.Any())
-        {
-            return identifiedBenchmarksScores.Average();
-        }
-
-        return 0;
+        return members.Length == 0
+            ? (0, "ops/s", "operations_per_second")
+            : (members.Average(benchmark => benchmark.Score), members[0].Unit, members[0].MetricName);
     }
 
     public static void CreateEmptyDirectory(string path)

--- a/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkHelper.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkHelper.cs
@@ -44,9 +44,16 @@ public static class BenchmarkHelper
                 && !benchmark.Categories.Contains(DriverBenchmarkCategory.ExcludeFromComposite))
             .ToArray();
 
-        return members.Length == 0
-            ? (0, "ops/s", "operations_per_second")
-            : (members.Average(benchmark => benchmark.Score), members[0].Unit, members[0].MetricName);
+        if (members.Length == 0)
+        {
+            // No members to derive the unit from; fall back to the category's normal unit so the
+            // composite's metric name is stable whether or not the category ran this time.
+            return benchmarkCategory == DriverBenchmarkCategory.LinqBench
+                ? (0, "ops/s", "operations_per_second")
+                : (0, "MB/s", "megabytes_per_second");
+        }
+
+        return (members.Average(benchmark => benchmark.Score), members[0].Unit, members[0].MetricName);
     }
 
     public static void CreateEmptyDirectory(string path)

--- a/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkHelper.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkHelper.cs
@@ -78,14 +78,14 @@ public static class BenchmarkHelper
         public const string PerfTestDatabaseName = "perftest";
         public const string PerfTestCollectionName = "corpus";
 
-        public static IMongoClient CreateClient()
+        public static IMongoClient CreateClient(string databaseToDrop = PerfTestDatabaseName)
         {
             var mongoUri = Environment.GetEnvironmentVariable("MONGODB_URI");
             var settings = mongoUri != null ? MongoClientSettings.FromConnectionString(mongoUri) : new();
             settings.ClusterSource = DisposingClusterSource.Instance;
 
             var client = new MongoClient(settings);
-            client.DropDatabase(PerfTestDatabaseName);
+            client.DropDatabase(databaseToDrop);
 
             return client;
         }

--- a/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkResult.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkResult.cs
@@ -33,36 +33,32 @@ public sealed class BenchmarkResult
         var methodName = benchmarkCaseDescriptor.WorkloadMethod.Name;
         Categories = new HashSet<string>(benchmarkCaseDescriptor.Categories);
 
+        var median = benchmarkReport.ResultStatistics.Median;
+
         if (Categories.Contains(DriverBenchmarkCategory.BsonBench))
         {
             var bsonBenchmarkData = (BsonBenchmarkData)benchmarkReport.BenchmarkCase.Parameters["BenchmarkData"];
             Name = bsonBenchmarkData.DataSetName + benchmarkCaseDescriptor.Type.Name;
-
-            var dataSetSize = bsonBenchmarkData.DataSetSize;
-            // dataSetSize is in bytes, median is in nanoseconds — score is MB/s
-            Score = (dataSetSize / (benchmarkReport.ResultStatistics.Median / 1_000_000_000D)) / 1_000_000D;
+            Score = MegabytesPerSecond(bsonBenchmarkData.DataSetSize, median);
             Unit = "MB/s";
             MetricName = "megabytes_per_second";
         }
-        else if (Categories.Contains(DriverBenchmarkCategory.LinqBench))
-        {
-            Name = methodName;
-            // median is in nanoseconds — score is translations/second
-            Score = 1_000_000_000D / benchmarkReport.ResultStatistics.Median;
-            Unit = "translations/s";
-            MetricName = "translations_per_second";
-        }
-        else
+        else if (benchmarkReport.BenchmarkCase.Parameters["BenchmarkDataSetSize"] is int dataSetSize)
         {
             Name = Categories.Contains(DriverBenchmarkCategory.BulkWriteBench)
                 ? methodName
                 : benchmarkCaseDescriptor.Type.Name;
-
-            var dataSetSize = (int)benchmarkReport.BenchmarkCase.Parameters["BenchmarkDataSetSize"];
-            // dataSetSize is in bytes, median is in nanoseconds — score is MB/s
-            Score = (dataSetSize / (benchmarkReport.ResultStatistics.Median / 1_000_000_000D)) / 1_000_000D;
+            Score = MegabytesPerSecond(dataSetSize, median);
             Unit = "MB/s";
             MetricName = "megabytes_per_second";
+        }
+        else
+        {
+            // No dataset size: this is a time-throughput benchmark scored as operations/second.
+            Name = methodName;
+            Score = 1_000_000_000D / median;
+            Unit = "ops/s";
+            MetricName = "operations_per_second";
         }
 
         if (methodName.EndsWith("Poco") || methodName.EndsWith("PocoBenchmark"))
@@ -70,4 +66,8 @@ public sealed class BenchmarkResult
             Name = Name.Replace("Benchmark", "PocoBenchmark");
         }
     }
+
+    // dataSetSize is in bytes, medianNanoseconds is in nanoseconds — result is MB/s
+    private static double MegabytesPerSecond(int dataSetSize, double medianNanoseconds)
+        => (dataSetSize / (medianNanoseconds / 1_000_000_000D)) / 1_000_000D;
 }

--- a/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkResult.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/BenchmarkResult.cs
@@ -24,6 +24,8 @@ public sealed class BenchmarkResult
     public HashSet<string> Categories { get; }
     public string Name { get; }
     public double Score { get; }
+    public string Unit { get; }
+    public string MetricName { get; }
 
     public BenchmarkResult(BenchmarkReport benchmarkReport)
     {
@@ -31,13 +33,24 @@ public sealed class BenchmarkResult
         var methodName = benchmarkCaseDescriptor.WorkloadMethod.Name;
         Categories = new HashSet<string>(benchmarkCaseDescriptor.Categories);
 
-        int dataSetSize;
         if (Categories.Contains(DriverBenchmarkCategory.BsonBench))
         {
             var bsonBenchmarkData = (BsonBenchmarkData)benchmarkReport.BenchmarkCase.Parameters["BenchmarkData"];
             Name = bsonBenchmarkData.DataSetName + benchmarkCaseDescriptor.Type.Name;
 
-            dataSetSize = bsonBenchmarkData.DataSetSize;
+            var dataSetSize = bsonBenchmarkData.DataSetSize;
+            // dataSetSize is in bytes, median is in nanoseconds — score is MB/s
+            Score = (dataSetSize / (benchmarkReport.ResultStatistics.Median / 1_000_000_000D)) / 1_000_000D;
+            Unit = "MB/s";
+            MetricName = "megabytes_per_second";
+        }
+        else if (Categories.Contains(DriverBenchmarkCategory.LinqBench))
+        {
+            Name = methodName;
+            // median is in nanoseconds — score is translations/second
+            Score = 1_000_000_000D / benchmarkReport.ResultStatistics.Median;
+            Unit = "translations/s";
+            MetricName = "translations_per_second";
         }
         else
         {
@@ -45,16 +58,16 @@ public sealed class BenchmarkResult
                 ? methodName
                 : benchmarkCaseDescriptor.Type.Name;
 
-            dataSetSize = (int)benchmarkReport.BenchmarkCase.Parameters["BenchmarkDataSetSize"];
+            var dataSetSize = (int)benchmarkReport.BenchmarkCase.Parameters["BenchmarkDataSetSize"];
+            // dataSetSize is in bytes, median is in nanoseconds — score is MB/s
+            Score = (dataSetSize / (benchmarkReport.ResultStatistics.Median / 1_000_000_000D)) / 1_000_000D;
+            Unit = "MB/s";
+            MetricName = "megabytes_per_second";
         }
 
         if (methodName.EndsWith("Poco") || methodName.EndsWith("PocoBenchmark"))
         {
             Name = Name.Replace("Benchmark", "PocoBenchmark");
         }
-
-        // change the median from nanoseconds to seconds for calculating the score.
-        // since dataSetSize is in bytes, divide the score to convert to MB/s
-        Score = (dataSetSize / (benchmarkReport.ResultStatistics.Median / 1_000_000_000D)) / 1_000_000D;
     }
 }

--- a/benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs
@@ -23,12 +23,12 @@ public static class DriverBenchmarkCategory
     public const string BsonBench = "BSONBench";
     public const string DriverBench = "DriverBench";
     public const string ExcludeFromComposite = "ExcludeFromComposite";
+    public const string LinqBench = "LinqBench";
     public const string MultiBench = "MultiBench";
     public const string ParallelBench = "ParallelBench";
     public const string ReadBench = "ReadBench";
     public const string SingleBench = "SingleBench";
     public const string WriteBench = "WriteBench";
-    public const string LinqBench = "LinqBench";
 
     public static readonly IEnumerable<string> AllCategories = [BsonBench, ReadBench, WriteBench, MultiBench, SingleBench, ParallelBench, DriverBench, BulkWriteBench, LinqBench];
 }

--- a/benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs
@@ -26,9 +26,8 @@ public static class DriverBenchmarkCategory
     public const string ReadBench = "ReadBench";
     public const string SingleBench = "SingleBench";
     public const string WriteBench = "WriteBench";
-
-    // not included in AllCategories as it's not part of the benchmarking spec
     public const string BulkWriteBench = "BulkWriteBench";
+    public const string LinqBench = "LinqBench";
 
-    public static readonly IEnumerable<string> AllCategories = [BsonBench, ReadBench, WriteBench, MultiBench, SingleBench, ParallelBench, DriverBench];
+    public static readonly IEnumerable<string> AllCategories = [BsonBench, ReadBench, WriteBench, MultiBench, SingleBench, ParallelBench, DriverBench, BulkWriteBench, LinqBench];
 }

--- a/benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs
@@ -19,14 +19,15 @@ namespace MongoDB.Benchmarks;
 
 public static class DriverBenchmarkCategory
 {
+    public const string BulkWriteBench = "BulkWriteBench";
     public const string BsonBench = "BSONBench";
     public const string DriverBench = "DriverBench";
+    public const string ExcludeFromComposite = "ExcludeFromComposite";
     public const string MultiBench = "MultiBench";
     public const string ParallelBench = "ParallelBench";
     public const string ReadBench = "ReadBench";
     public const string SingleBench = "SingleBench";
     public const string WriteBench = "WriteBench";
-    public const string BulkWriteBench = "BulkWriteBench";
     public const string LinqBench = "LinqBench";
 
     public static readonly IEnumerable<string> AllCategories = [BsonBench, ReadBench, WriteBench, MultiBench, SingleBench, ParallelBench, DriverBench, BulkWriteBench, LinqBench];

--- a/benchmarks/MongoDB.Driver.Benchmarks/Exporters/EvergreenExporter.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Exporters/EvergreenExporter.cs
@@ -53,7 +53,10 @@ public sealed class EvergreenExporter : IExporter
             // write composite scores e.g ReadBench
             foreach (var category in DriverBenchmarkCategory.AllCategories)
             {
-                WriteScoreToResults(jsonWriter, category, CalculateCompositeScore(benchmarkResults, category));
+                var metricName = category == DriverBenchmarkCategory.LinqBench
+                    ? "translations_per_second"
+                    : "megabytes_per_second";
+                WriteScoreToResults(jsonWriter, category, CalculateCompositeScore(benchmarkResults, category), metricName);
             }
 
             // write individual benchmarks results

--- a/benchmarks/MongoDB.Driver.Benchmarks/Exporters/EvergreenExporter.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Exporters/EvergreenExporter.cs
@@ -59,7 +59,7 @@ public sealed class EvergreenExporter : IExporter
             // write individual benchmarks results
             foreach (var benchmark in benchmarkResults)
             {
-                WriteScoreToResults(jsonWriter, benchmark.Name, benchmark.Score);
+                WriteScoreToResults(jsonWriter, benchmark.Name, benchmark.Score, benchmark.MetricName);
             }
 
             jsonWriter.WriteEndArray();
@@ -68,7 +68,7 @@ public sealed class EvergreenExporter : IExporter
         return new[] { resultsPath };
     }
 
-    private static void WriteScoreToResults(JsonWriter jsonWriter, string name, double score)
+    private static void WriteScoreToResults(JsonWriter jsonWriter, string name, double score, string metricName = "megabytes_per_second")
     {
         jsonWriter.WriteStartDocument();
         jsonWriter.WriteStartDocument("info");
@@ -77,7 +77,7 @@ public sealed class EvergreenExporter : IExporter
 
         jsonWriter.WriteStartArray("metrics");
         jsonWriter.WriteStartDocument();
-        jsonWriter.WriteString("name", "megabytes_per_second");
+        jsonWriter.WriteString("name", metricName);
         jsonWriter.WriteDouble("value", score);
         jsonWriter.WriteEndDocument();
         jsonWriter.WriteEndArray();

--- a/benchmarks/MongoDB.Driver.Benchmarks/Exporters/EvergreenExporter.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Exporters/EvergreenExporter.cs
@@ -53,10 +53,8 @@ public sealed class EvergreenExporter : IExporter
             // write composite scores e.g ReadBench
             foreach (var category in DriverBenchmarkCategory.AllCategories)
             {
-                var metricName = category == DriverBenchmarkCategory.LinqBench
-                    ? "translations_per_second"
-                    : "megabytes_per_second";
-                WriteScoreToResults(jsonWriter, category, CalculateCompositeScore(benchmarkResults, category), metricName);
+                var composite = CalculateComposite(benchmarkResults, category);
+                WriteScoreToResults(jsonWriter, category, composite.Score, composite.MetricName);
             }
 
             // write individual benchmarks results
@@ -71,7 +69,7 @@ public sealed class EvergreenExporter : IExporter
         return new[] { resultsPath };
     }
 
-    private static void WriteScoreToResults(JsonWriter jsonWriter, string name, double score, string metricName = "megabytes_per_second")
+    private static void WriteScoreToResults(JsonWriter jsonWriter, string name, double score, string metricName)
     {
         jsonWriter.WriteStartDocument();
         jsonWriter.WriteStartDocument("info");

--- a/benchmarks/MongoDB.Driver.Benchmarks/Exporters/LocalExporter.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Exporters/LocalExporter.cs
@@ -53,7 +53,7 @@ public sealed class LocalExporter : IExporter
 
             foreach (var benchmark in benchmarkResults)
             {
-                WriteScore(writer, benchmark.Name, benchmark.Score);
+                WriteScore(writer, benchmark.Name, benchmark.Score, benchmark.Unit);
             }
 
             exportedFiles.Add(path);
@@ -62,10 +62,10 @@ public sealed class LocalExporter : IExporter
         return exportedFiles;
     }
 
-    private static void WriteScore(StreamWriter writer, string benchName, double score)
+    private static void WriteScore(StreamWriter writer, string benchName, double score, string unit = "MB/s")
     {
         writer.WriteLine(score != 0
-            ? $"Executed {benchName}, score: {score:F3} MB/s"
+            ? $"Executed {benchName}, score: {score:F3} {unit}"
             : $"Skipped {benchName}");
     }
 }

--- a/benchmarks/MongoDB.Driver.Benchmarks/Exporters/LocalExporter.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Exporters/LocalExporter.cs
@@ -48,10 +48,8 @@ public sealed class LocalExporter : IExporter
             writer.WriteLine("Scores Summary: ");
             foreach (var category in DriverBenchmarkCategory.AllCategories)
             {
-                var unit = category == DriverBenchmarkCategory.LinqBench
-                    ? "translations/s"
-                    : "MB/s";
-                WriteScore(writer, category, CalculateCompositeScore(benchmarkResults, category), unit);
+                var composite = CalculateComposite(benchmarkResults, category);
+                WriteScore(writer, category, composite.Score, composite.Unit);
             }
 
             foreach (var benchmark in benchmarkResults)
@@ -65,7 +63,7 @@ public sealed class LocalExporter : IExporter
         return exportedFiles;
     }
 
-    private static void WriteScore(StreamWriter writer, string benchName, double score, string unit = "MB/s")
+    private static void WriteScore(StreamWriter writer, string benchName, double score, string unit)
     {
         writer.WriteLine(score != 0
             ? $"Executed {benchName}, score: {score:F3} {unit}"

--- a/benchmarks/MongoDB.Driver.Benchmarks/Exporters/LocalExporter.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Exporters/LocalExporter.cs
@@ -48,7 +48,10 @@ public sealed class LocalExporter : IExporter
             writer.WriteLine("Scores Summary: ");
             foreach (var category in DriverBenchmarkCategory.AllCategories)
             {
-                WriteScore(writer, category, CalculateCompositeScore(benchmarkResults, category));
+                var unit = category == DriverBenchmarkCategory.LinqBench
+                    ? "translations/s"
+                    : "MB/s";
+                WriteScore(writer, category, CalculateCompositeScore(benchmarkResults, category), unit);
             }
 
             foreach (var benchmark in benchmarkResults)

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqBenchmarkDataTypes.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqBenchmarkDataTypes.cs
@@ -1,0 +1,85 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace MongoDB.Benchmarks.Linq;
+
+public class OrderDocument
+{
+    public int Id { get; set; }
+    public string CustomerName { get; set; }
+    public string Status { get; set; }
+    public decimal Total { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public string Currency { get; set; }
+    public decimal Subtotal { get; set; }
+    public decimal Tax { get; set; }
+    public decimal Discount { get; set; }
+    public string Notes { get; set; }
+    public int ItemCount { get; set; }
+    public bool IsPaid { get; set; }
+    public string PaymentMethod { get; set; }
+    public string ShippingMethod { get; set; }
+    public Address ShippingAddress { get; set; }
+#pragma warning disable CA2227 // Collection properties should be read only
+    public List<OrderItem> Items { get; set; }
+#pragma warning restore CA2227
+}
+
+public class Address
+{
+    public string Street { get; set; }
+    public string City { get; set; }
+    public string State { get; set; }
+    public string Zip { get; set; }
+    public string Country { get; set; }
+}
+
+public class OrderItem
+{
+    public string ProductId { get; set; }
+    public decimal Price { get; set; }
+}
+
+public class OrderProjection
+{
+    public int Id { get; set; }
+    public string Customer { get; set; }
+    public decimal Total { get; set; }
+    public IEnumerable<string> ProductIds { get; set; }
+}
+
+public class OrderSummary
+{
+    public string CustomerName { get; set; }
+    public decimal Total { get; set; }
+}
+
+public class SetFields
+{
+    public string Status { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public decimal Total { get; set; }
+}
+
+public class GroupResult
+{
+    public string Status { get; set; }
+    public int Count { get; set; }
+    public decimal TotalRevenue { get; set; }
+}

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
@@ -1,0 +1,185 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using static MongoDB.Benchmarks.BenchmarkHelper;
+using static MongoDB.Benchmarks.Linq.LinqTranslationBenchmark;
+
+namespace MongoDB.Benchmarks.Linq;
+
+[MemoryDiagnoser]
+public class LinqEndToEndBenchmark
+{
+    private const string DatabaseName = "linqbench";
+    private const string CollectionName = "orders";
+    private const int SeedCount = 500;
+
+    private IMongoClient _client;
+    private IMongoCollection<OrderDocument> _collection;
+
+    private readonly string _statusFilter = "Active";
+    private readonly string _prefix = "Acme";
+    private readonly string _city = "Seattle";
+    private readonly DateTime _cutoff = new(2025, 1, 1);
+
+    private BsonDocument _multiFieldFilter;
+    private BsonDocument _orStatusFilter;
+    private BsonDocument[] _groupByPipeline;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _client = MongoConfiguration.CreateClient();
+        var db = _client.GetDatabase(DatabaseName);
+        _collection = db.GetCollection<OrderDocument>(CollectionName);
+
+        SeedData();
+        PreBuildQueries();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _client.DropDatabase(DatabaseName);
+        _client.Dispose();
+    }
+
+    // --- MultiFieldSearch: compound filter ---
+
+    [Benchmark]
+    public List<OrderDocument> MultiFieldSearchLinq()
+    {
+        return _collection.Find(x =>
+            x.Status == _statusFilter &&
+            x.CustomerName.StartsWith(_prefix) &&
+            x.ShippingAddress.City == _city &&
+            x.CreatedAt > _cutoff &&
+            !x.IsPaid).ToList();
+    }
+
+    [Benchmark]
+    public List<OrderDocument> MultiFieldSearchRaw()
+    {
+        return _collection.Find(_multiFieldFilter).ToList();
+    }
+
+    // --- OrStatusFilter: simple OR filter ---
+
+    [Benchmark]
+    public List<OrderDocument> OrStatusFilterLinq()
+    {
+        return _collection.Find(x =>
+            x.Status == "Active" || x.Status == "Pending" || x.Status == "Processing" || x.Status == "Shipped").ToList();
+    }
+
+    [Benchmark]
+    public List<OrderDocument> OrStatusFilterRaw()
+    {
+        return _collection.Find(_orStatusFilter).ToList();
+    }
+
+    // --- GroupBy aggregate ---
+
+    [Benchmark]
+    public List<BsonDocument> GroupByLinq()
+    {
+        return _collection.Aggregate()
+            .Group(x => x.Status, g => new { Status = g.Key, Count = g.Count(), TotalRevenue = g.Sum(x => x.Total) })
+            .As<BsonDocument>()
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<BsonDocument> GroupByRaw()
+    {
+        var pipeline = PipelineDefinition<OrderDocument, BsonDocument>.Create(_groupByPipeline);
+        return _collection.Aggregate(pipeline).ToList();
+    }
+
+    private void PreBuildQueries()
+    {
+        _multiFieldFilter = new BsonDocument
+        {
+            { "Status", _statusFilter },
+            { "CustomerName", new BsonDocument("$regex", $"^{_prefix}") },
+            { "ShippingAddress.City", _city },
+            { "CreatedAt", new BsonDocument("$gt", _cutoff) },
+            { "IsPaid", new BsonDocument("$ne", true) }
+        };
+
+        _orStatusFilter = new BsonDocument("$or", new BsonArray
+        {
+            new BsonDocument("Status", "Active"),
+            new BsonDocument("Status", "Pending"),
+            new BsonDocument("Status", "Processing"),
+            new BsonDocument("Status", "Shipped")
+        });
+
+        _groupByPipeline = new[]
+        {
+            new BsonDocument("$group", new BsonDocument
+            {
+                { "_id", "$Status" },
+                { "Count", new BsonDocument("$sum", 1) },
+                { "TotalRevenue", new BsonDocument("$sum", "$Total") }
+            })
+        };
+    }
+
+    private void SeedData()
+    {
+        var statuses = new[] { "Active", "Pending", "Processing", "Shipped", "Cancelled" };
+        var cities = new[] { "Seattle", "Portland", "Denver", "Austin", "Boston" };
+        var names = new[] { "Acme Corp", "Acme Inc", "Globex", "Initech", "Umbrella" };
+        var random = new Random(42);
+
+        var documents = Enumerable.Range(0, SeedCount).Select(i => new OrderDocument
+        {
+            Id = i,
+            CustomerName = names[i % names.Length],
+            Status = statuses[i % statuses.Length],
+            Total = random.Next(10, 1000),
+            Subtotal = random.Next(10, 900),
+            Tax = random.Next(1, 100),
+            Discount = random.Next(0, 50),
+            CreatedAt = new DateTime(2024, 1, 1).AddDays(random.Next(0, 730)),
+            IsPaid = i % 3 != 0,
+            Currency = "USD",
+            ItemCount = random.Next(1, 10),
+            PaymentMethod = "Card",
+            ShippingMethod = "Standard",
+            ShippingAddress = new Address
+            {
+                Street = $"{i} Main St",
+                City = cities[i % cities.Length],
+                State = "WA",
+                Zip = "98101",
+                Country = "US"
+            },
+            Items = Enumerable.Range(0, random.Next(1, 5)).Select(j => new OrderItem
+            {
+                ProductId = $"prod-{j}",
+                Price = random.Next(5, 200)
+            }).ToList()
+        }).ToList();
+
+        _collection.InsertMany(documents);
+    }
+}

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
@@ -24,13 +24,12 @@ using static MongoDB.Benchmarks.BenchmarkHelper;
 namespace MongoDB.Benchmarks.Linq;
 
 [MemoryDiagnoser]
+[BenchmarkCategory(DriverBenchmarkCategory.LinqBench, DriverBenchmarkCategory.ExcludeFromComposite)]
 public class LinqEndToEndBenchmark
 {
     private const string DatabaseName = "linqbench";
     private const string CollectionName = "orders";
-    // 500 is intentional: the broad-scan vs. selective contrast (e.g. OrFilter's ~700 KB
-    // result dominating its LINQ-Raw delta) needs enough documents to make serialization
-    // a visible cost. Translation-only timing lives in LinqTranslationBenchmark, not here.
+    // Enough documents to return a realistic result size; see the README for why.
     private const int SeedCount = 500;
 
     private IMongoClient _client;
@@ -64,9 +63,7 @@ public class LinqEndToEndBenchmark
         PreBuildQueries();
     }
 
-    // Indexes minimize server-side filter/group time so cross-benchmark deltas reflect
-    // translation cost rather than COLLSCAN variance. Without indexes, ~95% of e2e time
-    // on the heavier benchmarks goes to the server, and translator changes are invisible.
+    // Indexed so server-side filter/group time stays small; see the README for why.
     private void CreateIndexes()
     {
         _collection.Indexes.CreateMany(new[]

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
@@ -39,9 +39,16 @@ public class LinqEndToEndBenchmark
     private readonly string _city = "Seattle";
     private readonly DateTime _cutoff = new(2025, 1, 1);
 
+    private readonly int[] _lookupIds = { 1, 50, 100, 200, 400 };
+    private const int PageSize = 10;
+
     private BsonDocument _multiFieldFilter;
-    private BsonDocument _orStatusFilter;
+    private BsonDocument _orFilter;
     private BsonDocument[] _groupByPipeline;
+    private BsonDocument _projectionFilter;
+    private BsonDocument _projectionDoc;
+    private BsonDocument _inFilter;
+    private BsonDocument[] _pagedQueryPipeline;
 
     [GlobalSetup]
     public void Setup()
@@ -51,7 +58,21 @@ public class LinqEndToEndBenchmark
         _collection = db.GetCollection<OrderDocument>(CollectionName);
 
         SeedData();
+        CreateIndexes();
         PreBuildQueries();
+    }
+
+    // Indexes minimize server-side filter/group time so cross-benchmark deltas reflect
+    // translation cost rather than COLLSCAN variance. Without indexes, ~95% of e2e time
+    // on the heavier benchmarks goes to the server, and translator changes are invisible.
+    private void CreateIndexes()
+    {
+        _collection.Indexes.CreateMany(new[]
+        {
+            new CreateIndexModel<OrderDocument>(Builders<OrderDocument>.IndexKeys.Ascending(x => x.Status)),
+            new CreateIndexModel<OrderDocument>(Builders<OrderDocument>.IndexKeys.Ascending(x => x.CreatedAt)),
+            new CreateIndexModel<OrderDocument>(Builders<OrderDocument>.IndexKeys.Ascending("ShippingAddress.City")),
+        });
     }
 
     [GlobalCleanup]
@@ -80,19 +101,19 @@ public class LinqEndToEndBenchmark
         return _collection.Find(_multiFieldFilter).ToList();
     }
 
-    // --- OrStatusFilter: simple OR filter ---
+    // --- OrFilter: simple OR filter ---
 
     [Benchmark]
-    public List<OrderDocument> OrStatusFilterLinq()
+    public List<OrderDocument> OrFilterLinq()
     {
         return _collection.Find(x =>
             x.Status == "Active" || x.Status == "Pending" || x.Status == "Processing" || x.Status == "Shipped").ToList();
     }
 
     [Benchmark]
-    public List<OrderDocument> OrStatusFilterRaw()
+    public List<OrderDocument> OrFilterRaw()
     {
-        return _collection.Find(_orStatusFilter).ToList();
+        return _collection.Find(_orFilter).ToList();
     }
 
     // --- GroupBy aggregate ---
@@ -113,18 +134,77 @@ public class LinqEndToEndBenchmark
         return _collection.Aggregate(pipeline).ToList();
     }
 
+    // --- Projection: Find with .Project to a typed DTO ---
+
+    [Benchmark]
+    public List<OrderSummary> ProjectionLinq()
+    {
+        return _collection.Find(x => x.Status == _statusFilter)
+            .Project(x => new OrderSummary { CustomerName = x.CustomerName, Total = x.Total })
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<OrderSummary> ProjectionRaw()
+    {
+        return _collection.Find(_projectionFilter)
+            .Project<OrderSummary>(_projectionDoc)
+            .ToList();
+    }
+
+    // --- InFilter: array Contains → $in ---
+
+    [Benchmark]
+    public List<OrderDocument> InFilterLinq()
+    {
+        return _collection.Find(x => _lookupIds.Contains(x.Id)).ToList();
+    }
+
+    [Benchmark]
+    public List<OrderDocument> InFilterRaw()
+    {
+        return _collection.Find(_inFilter).ToList();
+    }
+
+    // --- PagedQuery: AsQueryable Where → OrderBy → ThenBy → Take, translates to a pipeline ---
+
+    [Benchmark]
+    public List<OrderDocument> PagedQueryLinq()
+    {
+        return _collection.AsQueryable()
+            .Where(x => x.Status == _statusFilter)
+            .OrderBy(x => x.CreatedAt)
+            .ThenBy(x => x.CustomerName)
+            .Take(PageSize)
+            .ToList();
+    }
+
+    [Benchmark]
+    public List<OrderDocument> PagedQueryRaw()
+    {
+        var pipeline = PipelineDefinition<OrderDocument, OrderDocument>.Create(_pagedQueryPipeline);
+        return _collection.Aggregate(pipeline).ToList();
+    }
+
     private void PreBuildQueries()
     {
+        // The Raw filter shapes below mirror exactly what the LINQ provider emits
+        // for the matching Linq benchmark — verified by translating the LINQ expressions
+        // with LinqProviderAdapter and comparing the rendered BSON. Equivalence matters
+        // because LINQ-vs-Raw deltas are meant to isolate translation cost, not query-shape cost.
+
+        // StartsWith translates to BsonRegularExpression with "s" (dot-matches-all) option,
+        // serialized as { "$regularExpression": { "pattern": ..., "options": "s" } }
         _multiFieldFilter = new BsonDocument
         {
             { "Status", _statusFilter },
-            { "CustomerName", new BsonDocument("$regex", $"^{_prefix}") },
+            { "CustomerName", new BsonRegularExpression($"^{_prefix}", "s") },
             { "ShippingAddress.City", _city },
             { "CreatedAt", new BsonDocument("$gt", _cutoff) },
             { "IsPaid", new BsonDocument("$ne", true) }
         };
 
-        _orStatusFilter = new BsonDocument("$or", new BsonArray
+        _orFilter = new BsonDocument("$or", new BsonArray
         {
             new BsonDocument("Status", "Active"),
             new BsonDocument("Status", "Pending"),
@@ -132,14 +212,46 @@ public class LinqEndToEndBenchmark
             new BsonDocument("Status", "Shipped")
         });
 
+        // The LINQ Group(keySelector, resultSelector) emits two stages: a $group with
+        // auto-generated __agg0/__agg1 aliases, and a $project that renames them back
+        // and the key to the user-visible field names.
         _groupByPipeline = new[]
         {
             new BsonDocument("$group", new BsonDocument
             {
                 { "_id", "$Status" },
-                { "Count", new BsonDocument("$sum", 1) },
-                { "TotalRevenue", new BsonDocument("$sum", "$Total") }
+                { "__agg0", new BsonDocument("$sum", 1) },
+                { "__agg1", new BsonDocument("$sum", "$Total") }
+            }),
+            new BsonDocument("$project", new BsonDocument
+            {
+                { "Status", "$_id" },
+                { "Count", "$__agg0" },
+                { "TotalRevenue", "$__agg1" },
+                { "_id", 0 }
             })
+        };
+
+        // Find().Project(x => new OrderSummary { ... }) emits a server-side inclusion projection.
+        // The exact shape is verified against LinqProviderAdapter.TranslateExpressionToFindProjection.
+        _projectionFilter = new BsonDocument("Status", _statusFilter);
+        _projectionDoc = new BsonDocument
+        {
+            { "CustomerName", 1 },
+            { "Total", 1 },
+            { "_id", 0 }
+        };
+
+        // ids.Contains(x.Id) translates to { "_id": { "$in": [...] } } since Id maps to _id by convention.
+        _inFilter = new BsonDocument("_id", new BsonDocument("$in", new BsonArray(_lookupIds.Select(id => (BsonValue)id))));
+
+        // AsQueryable().Where(...).OrderBy(...).ThenBy(...).Take(n) translates to a pipeline:
+        // $match, then $sort with the two keys, then $limit. Verified via translator dump.
+        _pagedQueryPipeline = new[]
+        {
+            new BsonDocument("$match", new BsonDocument("Status", _statusFilter)),
+            new BsonDocument("$sort", new BsonDocument { { "CreatedAt", 1 }, { "CustomerName", 1 } }),
+            new BsonDocument("$limit", PageSize)
         };
     }
 
@@ -182,4 +294,10 @@ public class LinqEndToEndBenchmark
 
         _collection.InsertMany(documents);
     }
+}
+
+public class OrderSummary
+{
+    public string CustomerName { get; set; }
+    public decimal Total { get; set; }
 }

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
@@ -20,7 +20,6 @@ using BenchmarkDotNet.Attributes;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using static MongoDB.Benchmarks.BenchmarkHelper;
-using static MongoDB.Benchmarks.Linq.LinqTranslationBenchmark;
 
 namespace MongoDB.Benchmarks.Linq;
 
@@ -85,8 +84,6 @@ public class LinqEndToEndBenchmark
         _client.Dispose();
     }
 
-    // --- MultiFieldSearch: compound filter ---
-
     [Benchmark]
     public List<OrderDocument> MultiFieldSearchLinq()
     {
@@ -104,8 +101,6 @@ public class LinqEndToEndBenchmark
         return _collection.Find(_multiFieldFilter).ToList();
     }
 
-    // --- OrFilter: simple OR filter ---
-
     [Benchmark]
     public List<OrderDocument> OrFilterLinq()
     {
@@ -118,8 +113,6 @@ public class LinqEndToEndBenchmark
     {
         return _collection.Find(_orFilter).ToList();
     }
-
-    // --- GroupBy aggregate ---
 
     [Benchmark]
     public List<BsonDocument> GroupByLinq()
@@ -137,8 +130,6 @@ public class LinqEndToEndBenchmark
         return _collection.Aggregate(pipeline).ToList();
     }
 
-    // --- Projection: Find with .Project to a typed DTO ---
-
     [Benchmark]
     public List<OrderSummary> ProjectionLinq()
     {
@@ -155,8 +146,6 @@ public class LinqEndToEndBenchmark
             .ToList();
     }
 
-    // --- InFilter: array Contains → $in ---
-
     [Benchmark]
     public List<OrderDocument> InFilterLinq()
     {
@@ -168,8 +157,6 @@ public class LinqEndToEndBenchmark
     {
         return _collection.Find(_inFilter).ToList();
     }
-
-    // --- PagedQuery: AsQueryable Where → OrderBy → ThenBy → Take, translates to a pipeline ---
 
     [Benchmark]
     public List<OrderDocument> PagedQueryLinq()
@@ -297,10 +284,4 @@ public class LinqEndToEndBenchmark
 
         _collection.InsertMany(documents);
     }
-}
-
-public class OrderSummary
-{
-    public string CustomerName { get; set; }
-    public decimal Total { get; set; }
 }

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
@@ -29,6 +29,9 @@ public class LinqEndToEndBenchmark
 {
     private const string DatabaseName = "linqbench";
     private const string CollectionName = "orders";
+    // 500 is intentional: the broad-scan vs. selective contrast (e.g. OrFilter's ~700 KB
+    // result dominating its LINQ-Raw delta) needs enough documents to make serialization
+    // a visible cost. Translation-only timing lives in LinqTranslationBenchmark, not here.
     private const int SeedCount = 500;
 
     private IMongoClient _client;

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
@@ -70,7 +70,7 @@ public class LinqEndToEndBenchmark
         {
             new CreateIndexModel<OrderDocument>(Builders<OrderDocument>.IndexKeys.Ascending(x => x.Status)),
             new CreateIndexModel<OrderDocument>(Builders<OrderDocument>.IndexKeys.Ascending(x => x.CreatedAt)),
-            new CreateIndexModel<OrderDocument>(Builders<OrderDocument>.IndexKeys.Ascending("ShippingAddress.City")),
+            new CreateIndexModel<OrderDocument>(Builders<OrderDocument>.IndexKeys.Ascending(x => x.ShippingAddress.City)),
         });
     }
 

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs
@@ -53,7 +53,7 @@ public class LinqEndToEndBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        _client = MongoConfiguration.CreateClient();
+        _client = MongoConfiguration.CreateClient(DatabaseName);
         var db = _client.GetDatabase(DatabaseName);
         _collection = db.GetCollection<OrderDocument>(CollectionName);
 

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
@@ -14,7 +14,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using BenchmarkDotNet.Attributes;
@@ -235,68 +234,4 @@ public class LinqTranslationBenchmark
             .Select(g => new GroupResult { Status = g.Key, Count = g.Count(), TotalRevenue = g.Sum(x => x.Total) })
             .Expression;
     }
-
-    #region Models
-
-    public class OrderDocument
-    {
-        public int Id { get; set; }
-        public string CustomerName { get; set; }
-        public string Status { get; set; }
-        public decimal Total { get; set; }
-        public DateTime CreatedAt { get; set; }
-        public DateTime? UpdatedAt { get; set; }
-        public string Currency { get; set; }
-        public decimal Subtotal { get; set; }
-        public decimal Tax { get; set; }
-        public decimal Discount { get; set; }
-        public string Notes { get; set; }
-        public int ItemCount { get; set; }
-        public bool IsPaid { get; set; }
-        public string PaymentMethod { get; set; }
-        public string ShippingMethod { get; set; }
-        public Address ShippingAddress { get; set; }
-#pragma warning disable CA2227 // Collection properties should be read only
-        public List<OrderItem> Items { get; set; }
-#pragma warning restore CA2227
-    }
-
-    public class Address
-    {
-        public string Street { get; set; }
-        public string City { get; set; }
-        public string State { get; set; }
-        public string Zip { get; set; }
-        public string Country { get; set; }
-    }
-
-    public class OrderItem
-    {
-        public string ProductId { get; set; }
-        public decimal Price { get; set; }
-    }
-
-    public class OrderProjection
-    {
-        public int Id { get; set; }
-        public string Customer { get; set; }
-        public decimal Total { get; set; }
-        public IEnumerable<string> ProductIds { get; set; }
-    }
-
-    public class SetFields
-    {
-        public string Status { get; set; }
-        public DateTime? UpdatedAt { get; set; }
-        public decimal Total { get; set; }
-    }
-
-    public class GroupResult
-    {
-        public string Status { get; set; }
-        public int Count { get; set; }
-        public decimal TotalRevenue { get; set; }
-    }
-
-    #endregion
 }

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
@@ -41,7 +41,6 @@ public class LinqTranslationBenchmark
     private Expression<Func<OrderDocument, string>> _fieldSelectionExpression;
 
     private Expression<Func<OrderDocument, OrderProjection>> _aggregationProjectionExpression;
-    private Expression<Func<OrderDocument, OrderDocument>> _projectionSentinelExpression;
 
     private Expression<Func<OrderDocument, SetFields>> _updatePipelineExpression;
 
@@ -86,8 +85,6 @@ public class LinqTranslationBenchmark
             Total = x.Subtotal + x.Tax - x.Discount,
             ProductIds = x.Items.Select(i => i.ProductId)
         };
-
-        _projectionSentinelExpression = x => x;
 
         _updatePipelineExpression = x => new SetFields
         {
@@ -161,22 +158,6 @@ public class LinqTranslationBenchmark
     {
         return LinqProviderAdapter.TranslateExpressionToProjection(
             _aggregationProjectionExpression,
-            _orderSerializer,
-            BsonSerializer.SerializerRegistry,
-            _translationOptions);
-    }
-
-    // x => x takes the early-return special case in LinqProviderAdapter
-    // and bypasses the translation pipeline. Movement here means the fast-path
-    // detection itself regressed, not the translator.
-    // Excluded from the LinqBench composite: its ~17ns timing would dominate the
-    // averaged translations/second score and mask regressions in the real benchmarks.
-    [Benchmark]
-    [BenchmarkCategory(DriverBenchmarkCategory.ExcludeFromComposite)]
-    public RenderedProjectionDefinition<OrderDocument> ProjectionSentinel()
-    {
-        return LinqProviderAdapter.TranslateExpressionToProjection(
-            _projectionSentinelExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
@@ -170,7 +170,10 @@ public class LinqTranslationBenchmark
     // x => x takes the early-return special case in LinqProviderAdapter
     // and bypasses the translation pipeline. Movement here means the fast-path
     // detection itself regressed, not the translator.
+    // Excluded from the LinqBench composite: its ~17ns timing would dominate the
+    // averaged translations/second score and mask regressions in the real benchmarks.
     [Benchmark]
+    [BenchmarkCategory(DriverBenchmarkCategory.ExcludeFromComposite)]
     public RenderedProjectionDefinition<OrderDocument> ProjectionSentinel()
     {
         return LinqProviderAdapter.TranslateExpressionToProjection(

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
@@ -35,7 +35,7 @@ public class LinqTranslationBenchmark
     private ExpressionTranslationOptions _translationOptions;
 
     private Expression<Func<OrderDocument, bool>> _multiFieldSearchExpression;
-    private Expression<Func<OrderDocument, bool>> _orStatusFilterExpression;
+    private Expression<Func<OrderDocument, bool>> _orFilterExpression;
     private Expression<Func<OrderDocument, bool>> _batchLookupExpression;
     private Expression<Func<OrderDocument, bool>> _arrayElementQueryExpression;
 
@@ -71,7 +71,7 @@ public class LinqTranslationBenchmark
             x.CreatedAt > cutoff &&
             !x.IsPaid;
 
-        _orStatusFilterExpression = x =>
+        _orFilterExpression = x =>
             x.Status == "Active" || x.Status == "Pending" || x.Status == "Processing" || x.Status == "Shipped";
 
         _batchLookupExpression = x => ids.Contains(x.Id);
@@ -117,10 +117,10 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public BsonDocument OrStatusFilter()
+    public BsonDocument OrFilter()
     {
         return LinqProviderAdapter.TranslateExpressionToFilter(
-            _orStatusFilterExpression,
+            _orFilterExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
@@ -1,0 +1,365 @@
+/* Copyright 2010-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using BenchmarkDotNet.Attributes;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+using MongoDB.Driver.Linq.Linq3Implementation;
+using MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecutableQueryTranslators;
+
+namespace MongoDB.Benchmarks.Linq;
+
+[MemoryDiagnoser]
+[BenchmarkCategory(DriverBenchmarkCategory.LinqBench)]
+public class LinqTranslationBenchmark
+{
+    private readonly string _activeStatus = "Active";
+
+    private IBsonSerializer<OrderDocument> _orderSerializer;
+    private ExpressionTranslationOptions _translationOptions;
+
+    private Expression<Func<OrderDocument, bool>> _equalityByIdExpression;
+    private Expression<Func<OrderDocument, bool>> _compoundFilterExpression;
+    private Expression<Func<OrderDocument, bool>> _inListFilterExpression;
+    private Expression<Func<OrderDocument, bool>> _stringMethodFilterExpression;
+    private Expression<Func<OrderDocument, bool>> _arrayAnyExpression;
+    private Expression<Func<OrderDocument, bool>> _nestedMemberFilterExpression;
+    private Expression<Func<OrderDocument, bool>> _orChainFilterExpression;
+    private Expression<Func<OrderDocument, bool>> _dateTimeMethodFilterExpression;
+    private Expression<Func<OrderDocument, bool>> _instanceFieldCaptureExpression;
+
+    private Expression<Func<OrderDocument, OrderDocument>> _wholeDocumentProjectionExpression;
+    private Expression<Func<OrderDocument, OrderSummary>> _pocoProjectionExpression;
+    private Expression<Func<OrderDocument, WideOrderProjection>> _widePocoProjectionExpression;
+    private Expression<Func<OrderDocument, OrderItemIds>> _nestedTransformProjectionExpression;
+
+    private MongoClient _queryClient;
+    private MongoQueryProvider<OrderDocument> _queryProvider;
+    private Expression _queryableChainExpression;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _orderSerializer = BsonSerializer.LookupSerializer<OrderDocument>();
+        _translationOptions = new ExpressionTranslationOptions();
+
+        var targetId = 42;
+        var statusFilter = "Active";
+        var cutoff = new DateTime(2025, 1, 1);
+        var ids = new[] { 1, 2, 3, 4, 5 };
+        var prefix = "Acme";
+        var priceThreshold = 100m;
+        var city = "Seattle";
+        var year = 2025;
+
+        _equalityByIdExpression = x => x.Id == targetId;
+        _compoundFilterExpression = x => x.Status == statusFilter && x.CreatedAt > cutoff;
+        _inListFilterExpression = x => ids.Contains(x.Id);
+        _stringMethodFilterExpression = x => x.CustomerName.StartsWith(prefix);
+        _arrayAnyExpression = x => x.Items.Any(i => i.Price > priceThreshold);
+        _nestedMemberFilterExpression = x => x.ShippingAddress.City == city;
+        _orChainFilterExpression = x => x.Status == "Active" || x.Status == "Pending" || x.Status == "Processing" || x.Status == "Shipped";
+        _dateTimeMethodFilterExpression = x => x.CreatedAt.Year == year;
+        _instanceFieldCaptureExpression = x => x.Status == _activeStatus;
+
+        _wholeDocumentProjectionExpression = x => x;
+        _pocoProjectionExpression = x => new OrderSummary { Id = x.Id, Customer = x.CustomerName, Total = x.Total };
+        _widePocoProjectionExpression = x => new WideOrderProjection
+        {
+            Id = x.Id,
+            CustomerName = x.CustomerName,
+            Status = x.Status,
+            Total = x.Total,
+            CreatedAt = x.CreatedAt,
+            UpdatedAt = x.UpdatedAt,
+            Currency = x.Currency,
+            Subtotal = x.Subtotal,
+            Tax = x.Tax,
+            Discount = x.Discount,
+            Notes = x.Notes,
+            ItemCount = x.ItemCount,
+            IsPaid = x.IsPaid,
+            PaymentMethod = x.PaymentMethod,
+            ShippingMethod = x.ShippingMethod
+        };
+        _nestedTransformProjectionExpression = x => new OrderItemIds { Id = x.Id, ProductIds = x.Items.Select(i => i.ProductId) };
+
+        SetupQueryableChain(statusFilter);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _queryClient?.Dispose();
+    }
+
+    [Benchmark]
+    public void EqualityById()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _equalityByIdExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void CompoundFilter()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _compoundFilterExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void InListFilter()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _inListFilterExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void StringMethodFilter()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _stringMethodFilterExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void ArrayAnyWithPredicate()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _arrayAnyExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void NestedMemberFilter()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _nestedMemberFilterExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void OrChainFilter()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _orChainFilterExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void DateTimeMethodFilter()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _dateTimeMethodFilterExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    // Captures an instance field instead of a stack-local. The expression tree
+    // contains a member access on captured `this`, exercising a different
+    // partial-evaluation path than the other filter benchmarks above.
+    [Benchmark]
+    public void InstanceFieldCaptureFilter()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+            _instanceFieldCaptureExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    // Sentinel: x => x takes the early-return special case in LinqProviderAdapter
+    // and bypasses the translation pipeline. Movement here means the fast-path
+    // detection itself regressed, not the translator.
+    [Benchmark]
+    public void WholeDocumentProjectionSentinel()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToProjection(
+            _wholeDocumentProjectionExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void PocoProjection()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToProjection(
+            _pocoProjectionExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    // Same expression as PocoProjection but goes through the find-projection
+    // simplifier (AstFindProjectionSimplifier), exercising a separate code path.
+    [Benchmark]
+    public void FindProjection()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToFindProjection(
+            _pocoProjectionExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void WidePocoProjection()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToProjection(
+            _widePocoProjectionExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    [Benchmark]
+    public void ProjectionWithNestedTransform()
+    {
+        _ = LinqProviderAdapter.TranslateExpressionToProjection(
+            _nestedTransformProjectionExpression,
+            _orderSerializer,
+            BsonSerializer.SerializerRegistry,
+            _translationOptions);
+    }
+
+    // Exercises the IQueryable composition path through MongoQueryProvider —
+    // a different code path from the adapter shortcuts above, used when callers
+    // write collection.AsQueryable().Where(...).Select(...) chains.
+    [Benchmark]
+    public void IQueryableComposition()
+    {
+        _ = ExpressionToExecutableQueryTranslator.Translate<OrderDocument, OrderSummary>(
+            _queryProvider,
+            _queryableChainExpression,
+            _translationOptions);
+    }
+
+    private void SetupQueryableChain(string statusFilter)
+    {
+        var mongoUri = Environment.GetEnvironmentVariable("MONGODB_URI");
+        var settings = mongoUri != null ? MongoClientSettings.FromConnectionString(mongoUri) : new MongoClientSettings();
+        settings.ClusterSource = DisposingClusterSource.Instance;
+        _queryClient = new MongoClient(settings);
+
+        var collection = _queryClient.GetDatabase("linqbench").GetCollection<OrderDocument>("orders");
+        var queryable = collection.AsQueryable();
+
+        _queryProvider = (MongoQueryProvider<OrderDocument>)queryable.Provider;
+        _queryableChainExpression = queryable
+            .Where(x => x.Status == statusFilter)
+            .Select(x => new OrderSummary { Id = x.Id, Customer = x.CustomerName, Total = x.Total })
+            .OrderBy(s => s.Total)
+            .Take(10)
+            .Expression;
+    }
+
+    #region Test Models
+
+    public class OrderDocument
+    {
+        public int Id { get; set; }
+        public string CustomerName { get; set; }
+        public string Status { get; set; }
+        public decimal Total { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+        public string Currency { get; set; }
+        public decimal Subtotal { get; set; }
+        public decimal Tax { get; set; }
+        public decimal Discount { get; set; }
+        public string Notes { get; set; }
+        public int ItemCount { get; set; }
+        public bool IsPaid { get; set; }
+        public string PaymentMethod { get; set; }
+        public string ShippingMethod { get; set; }
+        public Address ShippingAddress { get; set; }
+#pragma warning disable CA2227 // Collection properties should be read only
+        public List<OrderItem> Items { get; set; }
+#pragma warning restore CA2227
+    }
+
+    public class Address
+    {
+        public string Street { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+        public string Zip { get; set; }
+        public string Country { get; set; }
+    }
+
+    public class OrderItem
+    {
+        public string ProductId { get; set; }
+        public decimal Price { get; set; }
+    }
+
+    public class OrderSummary
+    {
+        public int Id { get; set; }
+        public string Customer { get; set; }
+        public decimal Total { get; set; }
+    }
+
+    public class WideOrderProjection
+    {
+        public int Id { get; set; }
+        public string CustomerName { get; set; }
+        public string Status { get; set; }
+        public decimal Total { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+        public string Currency { get; set; }
+        public decimal Subtotal { get; set; }
+        public decimal Tax { get; set; }
+        public decimal Discount { get; set; }
+        public string Notes { get; set; }
+        public int ItemCount { get; set; }
+        public bool IsPaid { get; set; }
+        public string PaymentMethod { get; set; }
+        public string ShippingMethod { get; set; }
+    }
+
+    public class OrderItemIds
+    {
+        public int Id { get; set; }
+        public IEnumerable<string> ProductIds { get; set; }
+    }
+
+    #endregion
+}

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
@@ -31,29 +31,25 @@ namespace MongoDB.Benchmarks.Linq;
 [BenchmarkCategory(DriverBenchmarkCategory.LinqBench)]
 public class LinqTranslationBenchmark
 {
-    private readonly string _activeStatus = "Active";
-
     private IBsonSerializer<OrderDocument> _orderSerializer;
     private ExpressionTranslationOptions _translationOptions;
 
-    private Expression<Func<OrderDocument, bool>> _equalityByIdExpression;
-    private Expression<Func<OrderDocument, bool>> _compoundFilterExpression;
-    private Expression<Func<OrderDocument, bool>> _inListFilterExpression;
-    private Expression<Func<OrderDocument, bool>> _stringMethodFilterExpression;
-    private Expression<Func<OrderDocument, bool>> _arrayAnyExpression;
-    private Expression<Func<OrderDocument, bool>> _nestedMemberFilterExpression;
-    private Expression<Func<OrderDocument, bool>> _orChainFilterExpression;
-    private Expression<Func<OrderDocument, bool>> _dateTimeMethodFilterExpression;
-    private Expression<Func<OrderDocument, bool>> _instanceFieldCaptureExpression;
+    private Expression<Func<OrderDocument, bool>> _multiFieldSearchExpression;
+    private Expression<Func<OrderDocument, bool>> _orStatusFilterExpression;
+    private Expression<Func<OrderDocument, bool>> _batchLookupExpression;
+    private Expression<Func<OrderDocument, bool>> _arrayElementQueryExpression;
 
-    private Expression<Func<OrderDocument, OrderDocument>> _wholeDocumentProjectionExpression;
-    private Expression<Func<OrderDocument, OrderSummary>> _pocoProjectionExpression;
-    private Expression<Func<OrderDocument, WideOrderProjection>> _widePocoProjectionExpression;
-    private Expression<Func<OrderDocument, OrderItemIds>> _nestedTransformProjectionExpression;
+    private Expression<Func<OrderDocument, string>> _fieldSelectionExpression;
+
+    private Expression<Func<OrderDocument, OrderProjection>> _aggregationProjectionExpression;
+    private Expression<Func<OrderDocument, OrderDocument>> _projectionSentinelExpression;
+
+    private Expression<Func<OrderDocument, SetFields>> _updatePipelineExpression;
 
     private MongoClient _queryClient;
-    private MongoQueryProvider<OrderDocument> _queryProvider;
-    private Expression _queryableChainExpression;
+    private MongoQueryProvider<OrderDocument> _queryableProvider;
+    private Expression _queryablePipelineExpression;
+    private Expression _groupByAggregationExpression;
 
     [GlobalSetup]
     public void Setup()
@@ -61,48 +57,47 @@ public class LinqTranslationBenchmark
         _orderSerializer = BsonSerializer.LookupSerializer<OrderDocument>();
         _translationOptions = new ExpressionTranslationOptions();
 
-        var targetId = 42;
         var statusFilter = "Active";
         var cutoff = new DateTime(2025, 1, 1);
-        var ids = new[] { 1, 2, 3, 4, 5 };
         var prefix = "Acme";
-        var priceThreshold = 100m;
         var city = "Seattle";
-        var year = 2025;
+        var ids = new[] { 1, 2, 3, 4, 5 };
+        var priceThreshold = 100m;
 
-        _equalityByIdExpression = x => x.Id == targetId;
-        _compoundFilterExpression = x => x.Status == statusFilter && x.CreatedAt > cutoff;
-        _inListFilterExpression = x => ids.Contains(x.Id);
-        _stringMethodFilterExpression = x => x.CustomerName.StartsWith(prefix);
-        _arrayAnyExpression = x => x.Items.Any(i => i.Price > priceThreshold);
-        _nestedMemberFilterExpression = x => x.ShippingAddress.City == city;
-        _orChainFilterExpression = x => x.Status == "Active" || x.Status == "Pending" || x.Status == "Processing" || x.Status == "Shipped";
-        _dateTimeMethodFilterExpression = x => x.CreatedAt.Year == year;
-        _instanceFieldCaptureExpression = x => x.Status == _activeStatus;
+        _multiFieldSearchExpression = x =>
+            x.Status == statusFilter &&
+            x.CustomerName.StartsWith(prefix) &&
+            x.ShippingAddress.City == city &&
+            x.CreatedAt > cutoff &&
+            !x.IsPaid;
 
-        _wholeDocumentProjectionExpression = x => x;
-        _pocoProjectionExpression = x => new OrderSummary { Id = x.Id, Customer = x.CustomerName, Total = x.Total };
-        _widePocoProjectionExpression = x => new WideOrderProjection
+        _orStatusFilterExpression = x =>
+            x.Status == "Active" || x.Status == "Pending" || x.Status == "Processing" || x.Status == "Shipped";
+
+        _batchLookupExpression = x => ids.Contains(x.Id);
+
+        _arrayElementQueryExpression = x => x.Items.Any(i => i.Price > priceThreshold);
+
+        _fieldSelectionExpression = x => x.Items[0].ProductId;
+
+        _aggregationProjectionExpression = x => new OrderProjection
         {
             Id = x.Id,
-            CustomerName = x.CustomerName,
-            Status = x.Status,
-            Total = x.Total,
-            CreatedAt = x.CreatedAt,
-            UpdatedAt = x.UpdatedAt,
-            Currency = x.Currency,
-            Subtotal = x.Subtotal,
-            Tax = x.Tax,
-            Discount = x.Discount,
-            Notes = x.Notes,
-            ItemCount = x.ItemCount,
-            IsPaid = x.IsPaid,
-            PaymentMethod = x.PaymentMethod,
-            ShippingMethod = x.ShippingMethod
+            Customer = x.CustomerName,
+            Total = x.Subtotal + x.Tax - x.Discount,
+            ProductIds = x.Items.Select(i => i.ProductId)
         };
-        _nestedTransformProjectionExpression = x => new OrderItemIds { Id = x.Id, ProductIds = x.Items.Select(i => i.ProductId) };
 
-        SetupQueryableChain(statusFilter);
+        _projectionSentinelExpression = x => x;
+
+        _updatePipelineExpression = x => new SetFields
+        {
+            Status = "Shipped",
+            UpdatedAt = DateTime.UtcNow,
+            Total = x.Subtotal + x.Tax - x.Discount
+        };
+
+        SetupQueryableExpressions(statusFilter);
     }
 
     [GlobalCleanup]
@@ -112,166 +107,108 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public BsonDocument EqualityById()
+    public BsonDocument MultiFieldSearch()
     {
         return LinqProviderAdapter.TranslateExpressionToFilter(
-            _equalityByIdExpression,
+            _multiFieldSearchExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);
     }
 
     [Benchmark]
-    public BsonDocument CompoundFilter()
+    public BsonDocument OrStatusFilter()
     {
         return LinqProviderAdapter.TranslateExpressionToFilter(
-            _compoundFilterExpression,
+            _orStatusFilterExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);
     }
 
     [Benchmark]
-    public BsonDocument InListFilter()
+    public BsonDocument BatchLookup()
     {
         return LinqProviderAdapter.TranslateExpressionToFilter(
-            _inListFilterExpression,
+            _batchLookupExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);
     }
 
     [Benchmark]
-    public BsonDocument StringMethodFilter()
+    public BsonDocument ArrayElementQuery()
     {
         return LinqProviderAdapter.TranslateExpressionToFilter(
-            _stringMethodFilterExpression,
+            _arrayElementQueryExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);
     }
 
     [Benchmark]
-    public BsonDocument ArrayAnyWithPredicate()
+    public RenderedFieldDefinition FieldSelection()
     {
-        return LinqProviderAdapter.TranslateExpressionToFilter(
-            _arrayAnyExpression,
+        return LinqProviderAdapter.TranslateExpressionToField(
+            _fieldSelectionExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
-            _translationOptions);
+            _translationOptions,
+            subPathRoot: null);
     }
 
     [Benchmark]
-    public BsonDocument NestedMemberFilter()
+    public RenderedProjectionDefinition<OrderProjection> AggregationProjection()
     {
-        return LinqProviderAdapter.TranslateExpressionToFilter(
-            _nestedMemberFilterExpression,
+        return LinqProviderAdapter.TranslateExpressionToProjection(
+            _aggregationProjectionExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);
     }
 
-    [Benchmark]
-    public BsonDocument OrChainFilter()
-    {
-        return LinqProviderAdapter.TranslateExpressionToFilter(
-            _orChainFilterExpression,
-            _orderSerializer,
-            BsonSerializer.SerializerRegistry,
-            _translationOptions);
-    }
-
-    [Benchmark]
-    public BsonDocument DateTimeMethodFilter()
-    {
-        return LinqProviderAdapter.TranslateExpressionToFilter(
-            _dateTimeMethodFilterExpression,
-            _orderSerializer,
-            BsonSerializer.SerializerRegistry,
-            _translationOptions);
-    }
-
-    // Captures an instance field instead of a stack-local. The expression tree
-    // contains a member access on captured `this`, exercising a different
-    // partial-evaluation path than the other filter benchmarks above.
-    [Benchmark]
-    public BsonDocument InstanceFieldCaptureFilter()
-    {
-        return LinqProviderAdapter.TranslateExpressionToFilter(
-            _instanceFieldCaptureExpression,
-            _orderSerializer,
-            BsonSerializer.SerializerRegistry,
-            _translationOptions);
-    }
-
-    // Sentinel: x => x takes the early-return special case in LinqProviderAdapter
+    // x => x takes the early-return special case in LinqProviderAdapter
     // and bypasses the translation pipeline. Movement here means the fast-path
     // detection itself regressed, not the translator.
     [Benchmark]
-    public RenderedProjectionDefinition<OrderDocument> WholeDocumentProjectionSentinel()
+    public RenderedProjectionDefinition<OrderDocument> ProjectionSentinel()
     {
         return LinqProviderAdapter.TranslateExpressionToProjection(
-            _wholeDocumentProjectionExpression,
+            _projectionSentinelExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);
     }
 
     [Benchmark]
-    public RenderedProjectionDefinition<OrderSummary> PocoProjection()
+    public BsonDocument UpdatePipeline()
     {
-        return LinqProviderAdapter.TranslateExpressionToProjection(
-            _pocoProjectionExpression,
-            _orderSerializer,
-            BsonSerializer.SerializerRegistry,
-            _translationOptions);
-    }
-
-    // Same expression as PocoProjection but goes through the find-projection
-    // simplifier (AstFindProjectionSimplifier), exercising a separate code path.
-    [Benchmark]
-    public RenderedProjectionDefinition<OrderSummary> FindProjection()
-    {
-        return LinqProviderAdapter.TranslateExpressionToFindProjection(
-            _pocoProjectionExpression,
+        return LinqProviderAdapter.TranslateExpressionToSetStage(
+            _updatePipelineExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
             _translationOptions);
     }
 
     [Benchmark]
-    public RenderedProjectionDefinition<WideOrderProjection> WidePocoProjection()
+    public object QueryablePipeline()
     {
-        return LinqProviderAdapter.TranslateExpressionToProjection(
-            _widePocoProjectionExpression,
-            _orderSerializer,
-            BsonSerializer.SerializerRegistry,
+        return ExpressionToExecutableQueryTranslator.Translate<OrderDocument, OrderProjection>(
+            _queryableProvider,
+            _queryablePipelineExpression,
             _translationOptions);
     }
 
     [Benchmark]
-    public RenderedProjectionDefinition<OrderItemIds> ProjectionWithNestedTransform()
+    public object GroupByAggregation()
     {
-        return LinqProviderAdapter.TranslateExpressionToProjection(
-            _nestedTransformProjectionExpression,
-            _orderSerializer,
-            BsonSerializer.SerializerRegistry,
+        return ExpressionToExecutableQueryTranslator.Translate<OrderDocument, GroupResult>(
+            _queryableProvider,
+            _groupByAggregationExpression,
             _translationOptions);
     }
 
-    // Exercises the IQueryable composition path through MongoQueryProvider —
-    // a different code path from the adapter shortcuts above, used when callers
-    // write collection.AsQueryable().Where(...).Select(...) chains.
-    [Benchmark]
-    public object IQueryableComposition()
-    {
-        return ExpressionToExecutableQueryTranslator.Translate<OrderDocument, OrderSummary>(
-            _queryProvider,
-            _queryableChainExpression,
-            _translationOptions);
-    }
-
-    private void SetupQueryableChain(string statusFilter)
+    private void SetupQueryableExpressions(string statusFilter)
     {
         var mongoUri = Environment.GetEnvironmentVariable("MONGODB_URI");
         var settings = mongoUri != null ? MongoClientSettings.FromConnectionString(mongoUri) : new MongoClientSettings();
@@ -281,16 +218,22 @@ public class LinqTranslationBenchmark
         var collection = _queryClient.GetDatabase("linqbench").GetCollection<OrderDocument>("orders");
         var queryable = collection.AsQueryable();
 
-        _queryProvider = (MongoQueryProvider<OrderDocument>)queryable.Provider;
-        _queryableChainExpression = queryable
+        _queryableProvider = (MongoQueryProvider<OrderDocument>)queryable.Provider;
+
+        _queryablePipelineExpression = queryable
             .Where(x => x.Status == statusFilter)
-            .Select(x => new OrderSummary { Id = x.Id, Customer = x.CustomerName, Total = x.Total })
+            .Select(x => new OrderProjection { Id = x.Id, Customer = x.CustomerName, Total = x.Total, ProductIds = x.Items.Select(i => i.ProductId) })
             .OrderBy(s => s.Total)
             .Take(10)
             .Expression;
+
+        _groupByAggregationExpression = queryable
+            .GroupBy(x => x.Status)
+            .Select(g => new GroupResult { Status = g.Key, Count = g.Count(), TotalRevenue = g.Sum(x => x.Total) })
+            .Expression;
     }
 
-    #region Test Models
+    #region Models
 
     public class OrderDocument
     {
@@ -330,36 +273,26 @@ public class LinqTranslationBenchmark
         public decimal Price { get; set; }
     }
 
-    public class OrderSummary
+    public class OrderProjection
     {
         public int Id { get; set; }
         public string Customer { get; set; }
         public decimal Total { get; set; }
-    }
-
-    public class WideOrderProjection
-    {
-        public int Id { get; set; }
-        public string CustomerName { get; set; }
-        public string Status { get; set; }
-        public decimal Total { get; set; }
-        public DateTime CreatedAt { get; set; }
-        public DateTime? UpdatedAt { get; set; }
-        public string Currency { get; set; }
-        public decimal Subtotal { get; set; }
-        public decimal Tax { get; set; }
-        public decimal Discount { get; set; }
-        public string Notes { get; set; }
-        public int ItemCount { get; set; }
-        public bool IsPaid { get; set; }
-        public string PaymentMethod { get; set; }
-        public string ShippingMethod { get; set; }
-    }
-
-    public class OrderItemIds
-    {
-        public int Id { get; set; }
         public IEnumerable<string> ProductIds { get; set; }
+    }
+
+    public class SetFields
+    {
+        public string Status { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+        public decimal Total { get; set; }
+    }
+
+    public class GroupResult
+    {
+        public string Status { get; set; }
+        public int Count { get; set; }
+        public decimal TotalRevenue { get; set; }
     }
 
     #endregion

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
@@ -61,6 +61,7 @@ public class LinqTranslationBenchmark
         var city = "Seattle";
         var ids = new[] { 1, 2, 3, 4, 5 };
         var priceThreshold = 100m;
+        var updatedAt = new DateTime(2025, 6, 1);
 
         _multiFieldSearchExpression = x =>
             x.Status == statusFilter &&
@@ -89,7 +90,7 @@ public class LinqTranslationBenchmark
         _updatePipelineExpression = x => new SetFields
         {
             Status = "Shipped",
-            UpdatedAt = DateTime.UtcNow,
+            UpdatedAt = updatedAt,
             Total = x.Subtotal + x.Tax - x.Discount
         };
 

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using BenchmarkDotNet.Attributes;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
@@ -111,9 +112,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void EqualityById()
+    public BsonDocument EqualityById()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _equalityByIdExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -121,9 +122,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void CompoundFilter()
+    public BsonDocument CompoundFilter()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _compoundFilterExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -131,9 +132,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void InListFilter()
+    public BsonDocument InListFilter()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _inListFilterExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -141,9 +142,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void StringMethodFilter()
+    public BsonDocument StringMethodFilter()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _stringMethodFilterExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -151,9 +152,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void ArrayAnyWithPredicate()
+    public BsonDocument ArrayAnyWithPredicate()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _arrayAnyExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -161,9 +162,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void NestedMemberFilter()
+    public BsonDocument NestedMemberFilter()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _nestedMemberFilterExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -171,9 +172,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void OrChainFilter()
+    public BsonDocument OrChainFilter()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _orChainFilterExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -181,9 +182,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void DateTimeMethodFilter()
+    public BsonDocument DateTimeMethodFilter()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _dateTimeMethodFilterExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -194,9 +195,9 @@ public class LinqTranslationBenchmark
     // contains a member access on captured `this`, exercising a different
     // partial-evaluation path than the other filter benchmarks above.
     [Benchmark]
-    public void InstanceFieldCaptureFilter()
+    public BsonDocument InstanceFieldCaptureFilter()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFilter(
+        return LinqProviderAdapter.TranslateExpressionToFilter(
             _instanceFieldCaptureExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -207,9 +208,9 @@ public class LinqTranslationBenchmark
     // and bypasses the translation pipeline. Movement here means the fast-path
     // detection itself regressed, not the translator.
     [Benchmark]
-    public void WholeDocumentProjectionSentinel()
+    public RenderedProjectionDefinition<OrderDocument> WholeDocumentProjectionSentinel()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToProjection(
+        return LinqProviderAdapter.TranslateExpressionToProjection(
             _wholeDocumentProjectionExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -217,9 +218,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void PocoProjection()
+    public RenderedProjectionDefinition<OrderSummary> PocoProjection()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToProjection(
+        return LinqProviderAdapter.TranslateExpressionToProjection(
             _pocoProjectionExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -229,9 +230,9 @@ public class LinqTranslationBenchmark
     // Same expression as PocoProjection but goes through the find-projection
     // simplifier (AstFindProjectionSimplifier), exercising a separate code path.
     [Benchmark]
-    public void FindProjection()
+    public RenderedProjectionDefinition<OrderSummary> FindProjection()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToFindProjection(
+        return LinqProviderAdapter.TranslateExpressionToFindProjection(
             _pocoProjectionExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -239,9 +240,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void WidePocoProjection()
+    public RenderedProjectionDefinition<WideOrderProjection> WidePocoProjection()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToProjection(
+        return LinqProviderAdapter.TranslateExpressionToProjection(
             _widePocoProjectionExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -249,9 +250,9 @@ public class LinqTranslationBenchmark
     }
 
     [Benchmark]
-    public void ProjectionWithNestedTransform()
+    public RenderedProjectionDefinition<OrderItemIds> ProjectionWithNestedTransform()
     {
-        _ = LinqProviderAdapter.TranslateExpressionToProjection(
+        return LinqProviderAdapter.TranslateExpressionToProjection(
             _nestedTransformProjectionExpression,
             _orderSerializer,
             BsonSerializer.SerializerRegistry,
@@ -262,9 +263,9 @@ public class LinqTranslationBenchmark
     // a different code path from the adapter shortcuts above, used when callers
     // write collection.AsQueryable().Where(...).Select(...) chains.
     [Benchmark]
-    public void IQueryableComposition()
+    public object IQueryableComposition()
     {
-        _ = ExpressionToExecutableQueryTranslator.Translate<OrderDocument, OrderSummary>(
+        return ExpressionToExecutableQueryTranslator.Translate<OrderDocument, OrderSummary>(
             _queryProvider,
             _queryableChainExpression,
             _translationOptions);

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
@@ -71,7 +71,7 @@ This selectivity has been validated via targeted injection tests (see `workdocs/
 
 **Allocation changes** are often more actionable than time changes. A new allocation in a hot path is a real regression even if the time delta is within noise. The `[MemoryDiagnoser]` columns (`Gen0`, `Allocated`) make allocation regressions visible.
 
-**`OrChainFilter`** is intentionally the only filter without captured locals. It's ~5x faster than other filters because closure capture dominates filter translation cost. Treat it as a "raw translation baseline" — if it regresses but others don't, the regression is in the expression translator itself, not in closure handling.
+**`OrChainFilter`** is the fastest filter at ~7µs (~5x faster than others) because it uses literal constants instead of captured variables, producing a simpler expression tree with less work at every stage. This makes it the most sensitive filter benchmark — small translator regressions that would be lost in the noise on slower benchmarks show up clearly here.
 
 **`WholeDocumentProjectionSentinel`** at ~17ns is not measuring translation. It validates that `LinqProviderAdapter` still short-circuits `x => x` projections. Movement here means the fast-path detection broke, not that translation got slower.
 

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
@@ -26,7 +26,7 @@ Each calls `LinqProviderAdapter.TranslateExpressionToFilter`, exercising: prepro
 | Benchmark | Expression | Translator path exercised |
 |---|---|---|
 | `MultiFieldSearch` | `x.Status == s && x.CustomerName.StartsWith(prefix) && x.ShippingAddress.City == city && x.CreatedAt > cutoff && !x.IsPaid` | And → Comparison, MethodCall (StartsWith), nested MemberAccess, Not + boolean MemberAccess |
-| `OrStatusFilter` | 4-way `==` OR with literal constants | Or → Comparison. No closures — fastest filter, most sensitive to small regressions |
+| `OrFilter` | 4-way `==` OR with literal constants | Or → Comparison. No closures — fastest filter, most sensitive to small regressions |
 | `BatchLookup` | `ids.Contains(x.Id)` | MethodCall → ContainsMethodToFilterTranslator → `$in` |
 | `ArrayElementQuery` | `x.Items.Any(i => i.Price > t)` | MethodCall → AllOrAnyMethodToFilterTranslator → `$elemMatch`, `@<elem>` symbol |
 
@@ -80,7 +80,7 @@ This selectivity has been validated via targeted injection tests.
 
 **Allocation changes** are often more actionable than time changes. A new allocation in a hot path is a real regression even if the time delta is within noise. The `[MemoryDiagnoser]` columns (`Gen0`, `Allocated`) make allocation regressions visible.
 
-**`OrStatusFilter`** is the fastest filter (~7µs, ~5x faster than others) because it uses literal constants instead of captured variables, producing a simpler expression tree with less work at every stage. This makes it the most sensitive filter benchmark — small translator regressions that would be lost in the noise on slower benchmarks show up clearly here.
+**`OrFilter`** is the fastest filter (~7µs, ~5x faster than others) because it uses literal constants instead of captured variables, producing a simpler expression tree with less work at every stage. This makes it the most sensitive filter benchmark — small translator regressions that would be lost in the noise on slower benchmarks show up clearly here.
 
 **`ProjectionSentinel`** at ~17ns is not measuring translation. It validates that `LinqProviderAdapter` still short-circuits `x => x` projections. Movement here means the fast-path detection broke, not that translation got slower.
 
@@ -93,7 +93,7 @@ Three drift clusters emerged from characterization:
 | Bucket | Threshold | Benchmarks | Observed range |
 |---|---|---|---|
 | Tight | 15% | `MultiFieldSearch`, `UpdatePipeline`, `BatchLookup`, `ArrayElementQuery` | 9–15% |
-| Wider | 30% | `OrStatusFilter`, `FieldSelection`, `AggregationProjection`, `QueryablePipeline`, `GroupByAggregation` | 20–29% |
+| Wider | 30% | `OrFilter`, `FieldSelection`, `AggregationProjection`, `QueryablePipeline`, `GroupByAggregation` | 20–29% |
 | Sentinel | 100% | `ProjectionSentinel` | 5% |
 
-`OrStatusFilter` and `FieldSelection` land in the wider bucket for different reasons: `OrStatusFilter` is ~7µs and proportional noise is large at that scale; `FieldSelection` is ~2µs with similar characteristics. The three complex benchmarks (`AggregationProjection`, `QueryablePipeline`, `GroupByAggregation`) show higher drift because they allocate more and exercise more GC pressure.
+`OrFilter` and `FieldSelection` land in the wider bucket for different reasons: `OrFilter` is ~7µs and proportional noise is large at that scale; `FieldSelection` is ~2µs with similar characteristics. The three complex benchmarks (`AggregationProjection`, `QueryablePipeline`, `GroupByAggregation`) show higher drift because they allocate more and exercise more GC pressure.

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
@@ -1,6 +1,6 @@
 # LINQ Translation Benchmarks
 
-Measures the performance of the LINQ-to-aggregation translation layer — the CPU work the driver does to convert a C# expression tree into a MongoDB query/pipeline document. No database I/O is involved; these benchmarks isolate translator regressions from network and serialization noise.
+Measures the performance of the LINQ-to-aggregation translation layer — the CPU work the driver does to convert a C# expression tree into a MongoDB query/pipeline document. The benchmarks themselves execute no queries; they isolate translator regressions from network and serialization noise. (The two `IQueryable` benchmarks — `QueryablePipeline` and `GroupByAggregation` — create a `MongoClient` in `[GlobalSetup]` because `MongoQueryProvider<T>` is obtained via `collection.AsQueryable()`. No queries are executed against that client; its background cluster monitor is the only DB-side activity, and the measurement impact is expected to sit below the 2-4% drift floor.)
 
 ## Running
 

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
@@ -11,7 +11,7 @@ cd benchmarks/MongoDB.Driver.Benchmarks
 dotnet run -c Release -- --filter "*LinqTranslation*"
 
 # Specific benchmark
-dotnet run -c Release -- --filter "*EqualityById*"
+dotnet run -c Release -- --filter "*MultiFieldSearch*"
 
 # As part of the full perf suite (also runs DriverBench, BsonBench, etc.)
 dotnet run -c Release -- --driverBenchmarks --anyCategories "LinqBench"
@@ -19,68 +19,81 @@ dotnet run -c Release -- --driverBenchmarks --anyCategories "LinqBench"
 
 ## Benchmark Inventory
 
-### Filter benchmarks (9)
+### Filter benchmarks (4)
 
 Each calls `LinqProviderAdapter.TranslateExpressionToFilter`, exercising: preprocessor → SerializerFinder → ExpressionToFilterTranslator → AstSimplifier → render.
 
-| Benchmark | Expression | Notes |
+| Benchmark | Expression | Translator path exercised |
 |---|---|---|
-| `EqualityById` | `x => x.Id == id` | Most common filter pattern |
-| `CompoundFilter` | `x.Status == s && x.CreatedAt > cutoff` | Multi-condition with AND |
-| `InListFilter` | `ids.Contains(x.Id)` | Batch-fetch pattern |
-| `StringMethodFilter` | `x.CustomerName.StartsWith(prefix)` | String method translation |
-| `ArrayAnyWithPredicate` | `x.Items.Any(i => i.Price > t)` | Array sub-document filtering |
-| `NestedMemberFilter` | `x.ShippingAddress.City == c` | Embedded document navigation |
-| `OrChainFilter` | 4-way `==` OR with literal constants | No closure capture — measures raw translation cost |
-| `DateTimeMethodFilter` | `x.CreatedAt.Year == y` | DateTime member method |
-| `InstanceFieldCaptureFilter` | `x.Status == _activeStatus` | Captures `this`-field instead of stack-local |
+| `MultiFieldSearch` | `x.Status == s && x.CustomerName.StartsWith(prefix) && x.ShippingAddress.City == city && x.CreatedAt > cutoff && !x.IsPaid` | And → Comparison, MethodCall (StartsWith), nested MemberAccess, Not + boolean MemberAccess |
+| `OrStatusFilter` | 4-way `==` OR with literal constants | Or → Comparison. No closures — fastest filter, most sensitive to small regressions |
+| `BatchLookup` | `ids.Contains(x.Id)` | MethodCall → ContainsMethodToFilterTranslator → `$in` |
+| `ArrayElementQuery` | `x.Items.Any(i => i.Price > t)` | MethodCall → AllOrAnyMethodToFilterTranslator → `$elemMatch`, `@<elem>` symbol |
 
-### Projection benchmarks (5)
+### Field benchmark (1)
+
+| Benchmark | Expression | Translator path exercised |
+|---|---|---|
+| `FieldSelection` | `x => x.Items[0].ProductId` | `TranslateExpressionToField` → ExpressionToFilterFieldTranslator (MethodCall/get_Item, MemberAccess, Parameter sub-translators) |
+
+### Projection benchmarks (2)
 
 | Benchmark | Entry Point | Notes |
 |---|---|---|
-| `WholeDocumentProjectionSentinel` | `TranslateExpressionToProjection` | `x => x` — fast-path early return. Sentinel for fast-path breakage, not translator perf. |
-| `PocoProjection` | `TranslateExpressionToProjection` | 3-field DTO via MemberInit |
-| `FindProjection` | `TranslateExpressionToFindProjection` | Same expression as PocoProjection, but through `AstFindProjectionSimplifier` |
-| `WidePocoProjection` | `TranslateExpressionToProjection` | 15-field DTO — scaling behavior |
-| `ProjectionWithNestedTransform` | `TranslateExpressionToProjection` | `Items.Select(i => i.ProductId)` inside projection |
+| `AggregationProjection` | `TranslateExpressionToProjection` | 4-field DTO with computed arithmetic (`Subtotal + Tax - Discount`) and nested `Items.Select(i => i.ProductId)` transform |
+| `ProjectionSentinel` | `TranslateExpressionToProjection` | `x => x` — fast-path early return. Sentinel for fast-path breakage, not translator perf. |
 
-### Composition benchmark (1)
+### Update benchmark (1)
 
 | Benchmark | Entry Point | Notes |
 |---|---|---|
-| `IQueryableComposition` | `ExpressionToExecutableQueryTranslator.Translate` | `Where → Select → OrderBy → Take` via MongoQueryProvider. Covers the IQueryable code path users write with `collection.AsQueryable()`. |
+| `UpdatePipeline` | `TranslateExpressionToSetStage` | Sets 3 fields including a computed expression (`Subtotal + Tax - Discount`). Exercises `ExpressionToSetStageTranslator` with MemberInit pattern matching. |
+
+### IQueryable benchmarks (2)
+
+Both use `ExpressionToExecutableQueryTranslator.Translate` via `MongoQueryProvider` — the pipeline composition path users write with `collection.AsQueryable()`.
+
+| Benchmark | Expression chain | Notes |
+|---|---|---|
+| `QueryablePipeline` | `Where → Select → OrderBy → Take` | Exercises filter, projection, sort, and limit pipeline stages |
+| `GroupByAggregation` | `GroupBy → Select` with Count + Sum | Exercises `GroupByMethodToPipelineTranslator`, `$group` stage, IGroupingSerializer, accumulators |
 
 ## Code Path Coverage
 
 Each benchmark exercises a specific subset of the translation pipeline:
 
-| Component | Filters | Projections | Sentinel | IQueryable |
-|---|:---:|:---:|:---:|:---:|
-| `LinqExpressionPreprocessor` | ✓ | ✓ | — | ✓ |
-| `SerializerFinder` | ✓ | ✓ | — | ✓ |
-| `ExpressionToFilterTranslator` | ✓ | — | — | ✓ (Where) |
-| `ExpressionToAggregationExpressionTranslator` | — | ✓ | — | ✓ (Select) |
-| `AstSimplifier` | ✓ | ✓ | — | ✓ |
-| `AstFindProjectionSimplifier` | — | FindProjection only | — | — |
-| `AstPipelineOptimizer` | — | — | — | ✓ |
+| Component | Filters | FieldSelection | Projections | Sentinel | Update | IQueryable |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| `LinqExpressionPreprocessor` | ✓ | ✓ | ✓ | — | values only | ✓ |
+| `SerializerFinder` | ✓ | ✓ | ✓ | — | ✓ | ✓ |
+| `ExpressionToFilterTranslator` (incl. Not, MemberAccess) | ✓ | — | — | — | — | ✓ (Where) |
+| `ExpressionToFilterFieldTranslator` | — | ✓ | — | — | — | — |
+| `ExpressionToAggregationExpressionTranslator` | — | — | ✓ | — | ✓ (values) | ✓ (Select) |
+| `ExpressionToSetStageTranslator` | — | — | — | — | ✓ | — |
+| `GroupByMethodToPipelineTranslator` | — | — | — | — | — | GroupBy only |
+| `AstSimplifier` | ✓ | — | ✓ | — | ✓ | ✓ |
+| `AstPipelineOptimizer` | — | — | — | — | — | ✓ |
 
-This selectivity has been validated via targeted injection tests (see `workdocs/LINQ-benchmarks/work_context.md`).
+This selectivity has been validated via targeted injection tests.
 
 ## Interpreting Results
 
 **Allocation changes** are often more actionable than time changes. A new allocation in a hot path is a real regression even if the time delta is within noise. The `[MemoryDiagnoser]` columns (`Gen0`, `Allocated`) make allocation regressions visible.
 
-**`OrChainFilter`** is the fastest filter at ~7µs (~5x faster than others) because it uses literal constants instead of captured variables, producing a simpler expression tree with less work at every stage. This makes it the most sensitive filter benchmark — small translator regressions that would be lost in the noise on slower benchmarks show up clearly here.
+**`OrStatusFilter`** is the fastest filter (~7µs, ~5x faster than others) because it uses literal constants instead of captured variables, producing a simpler expression tree with less work at every stage. This makes it the most sensitive filter benchmark — small translator regressions that would be lost in the noise on slower benchmarks show up clearly here.
 
-**`WholeDocumentProjectionSentinel`** at ~17ns is not measuring translation. It validates that `LinqProviderAdapter` still short-circuits `x => x` projections. Movement here means the fast-path detection broke, not that translation got slower.
+**`ProjectionSentinel`** at ~17ns is not measuring translation. It validates that `LinqProviderAdapter` still short-circuits `x => x` projections. Movement here means the fast-path detection broke, not that translation got slower.
 
 ## Regression Thresholds
 
-Provisional thresholds based on M1 Max local characterization. These should be tightened once calibrated on the perf-job hardware (`rhel90-dbx-perf-large`).
+Provisional thresholds based on 7-run M1 Max characterization (min/max range as a % of median). These should be tightened once calibrated on the perf-job hardware (`rhel90-dbx-perf-large`).
 
-| Bucket | Threshold | Benchmarks |
-|---|---|---|
-| Default | 15% | Most filters, `PocoProjection`, `FindProjection`, `IQueryableComposition` |
-| Wider | 30% | `OrChainFilter` (very fast, proportional noise is large), `WidePocoProjection`, `ProjectionWithNestedTransform` |
-| Sentinel | 100% | `WholeDocumentProjectionSentinel` |
+Three drift clusters emerged from characterization:
+
+| Bucket | Threshold | Benchmarks | Observed range |
+|---|---|---|---|
+| Tight | 15% | `MultiFieldSearch`, `UpdatePipeline`, `BatchLookup`, `ArrayElementQuery` | 9–15% |
+| Wider | 30% | `OrStatusFilter`, `FieldSelection`, `AggregationProjection`, `QueryablePipeline`, `GroupByAggregation` | 20–29% |
+| Sentinel | 100% | `ProjectionSentinel` | 5% |
+
+`OrStatusFilter` and `FieldSelection` land in the wider bucket for different reasons: `OrStatusFilter` is ~7µs and proportional noise is large at that scale; `FieldSelection` is ~2µs with similar characteristics. The three complex benchmarks (`AggregationProjection`, `QueryablePipeline`, `GroupByAggregation`) show higher drift because they allocate more and exercise more GC pressure.

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
@@ -1,23 +1,29 @@
-# LINQ Translation Benchmarks
+# LINQ Benchmarks
 
-Measures the performance of the LINQ-to-aggregation translation layer — the CPU work the driver does to convert a C# expression tree into a MongoDB query/pipeline document. The benchmarks themselves execute no queries; they isolate translator regressions from network and serialization noise. (The two `IQueryable` benchmarks — `QueryablePipeline` and `GroupByAggregation` — create a `MongoClient` in `[GlobalSetup]` because `MongoQueryProvider<T>` is obtained via `collection.AsQueryable()`. No queries are executed against that client; its background cluster monitor is the only DB-side activity, and the measurement impact is expected to sit below the 2-4% drift floor.)
+This directory contains two LINQ benchmark suites with different goals:
+
+- **Translation** (`LinqTranslationBenchmark`, category `LinqBench`) — measures the CPU work the driver does to convert a C# expression tree into a MongoDB query/pipeline document. These benchmarks execute no queries; they isolate translator regressions from network and serialization noise. (The two `IQueryable` benchmarks — `QueryablePipeline` and `GroupByAggregation` — create a `MongoClient` in `[GlobalSetup]` because `MongoQueryProvider<T>` is obtained via `collection.AsQueryable()`. No queries are executed against that client; its background cluster monitor is the only DB-side activity, and the measurement impact is expected to sit below the 2-4% drift floor.)
+- **End-to-end** (`LinqEndToEndBenchmark`, also category `LinqBench` but excluded from its composite) — runs real queries against a server and measures how much of user-visible latency the translator accounts for under realistic result sizes. See [End-to-End Benchmarks](#end-to-end-benchmarks) below.
 
 ## Running
 
 ```bash
 cd benchmarks/MongoDB.Driver.Benchmarks
 
-# All LINQ benchmarks
+# All translation benchmarks (no server needed)
 dotnet run -c Release -- --filter "*LinqTranslation*"
+
+# All end-to-end benchmarks (requires a reachable server; seeds and drops the linqbench database)
+dotnet run -c Release -- --filter "*LinqEndToEnd*"
 
 # Specific benchmark
 dotnet run -c Release -- --filter "*MultiFieldSearch*"
 
-# As part of the full perf suite (also runs DriverBench, BsonBench, etc.)
+# As part of the full perf suite (also runs DriverBench, BsonBench, etc.); LinqBench covers both LINQ suites
 dotnet run -c Release -- --driverBenchmarks --anyCategories "LinqBench"
 ```
 
-## Benchmark Inventory
+## Translation Benchmark Inventory
 
 ### Filter benchmarks (4)
 
@@ -36,12 +42,11 @@ Each calls `LinqProviderAdapter.TranslateExpressionToFilter`, exercising: prepro
 |---|---|---|
 | `FieldSelection` | `x => x.Items[0].ProductId` | `TranslateExpressionToField` → ExpressionToFilterFieldTranslator (MethodCall/get_Item, MemberAccess, Parameter sub-translators) |
 
-### Projection benchmarks (2)
+### Projection benchmark (1)
 
 | Benchmark | Entry Point | Notes |
 |---|---|---|
 | `AggregationProjection` | `TranslateExpressionToProjection` | 4-field DTO with computed arithmetic (`Subtotal + Tax - Discount`) and nested `Items.Select(i => i.ProductId)` transform |
-| `ProjectionSentinel` | `TranslateExpressionToProjection` | `x => x` — fast-path early return. Sentinel for fast-path breakage, not translator perf. |
 
 ### Update benchmark (1)
 
@@ -58,42 +63,40 @@ Both use `ExpressionToExecutableQueryTranslator.Translate` via `MongoQueryProvid
 | `QueryablePipeline` | `Where → Select → OrderBy → Take` | Exercises filter, projection, sort, and limit pipeline stages |
 | `GroupByAggregation` | `GroupBy → Select` with Count + Sum | Exercises `GroupByMethodToPipelineTranslator`, `$group` stage, IGroupingSerializer, accumulators |
 
-## Code Path Coverage
-
-Each benchmark exercises a specific subset of the translation pipeline:
-
-| Component | Filters | FieldSelection | Projections | Sentinel | Update | IQueryable |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|
-| `LinqExpressionPreprocessor` | ✓ | ✓ | ✓ | — | values only | ✓ |
-| `SerializerFinder` | ✓ | ✓ | ✓ | — | ✓ | ✓ |
-| `ExpressionToFilterTranslator` (incl. Not, MemberAccess) | ✓ | — | — | — | — | ✓ (Where) |
-| `ExpressionToFilterFieldTranslator` | — | ✓ | — | — | — | — |
-| `ExpressionToAggregationExpressionTranslator` | — | — | ✓ | — | ✓ (values) | ✓ (Select) |
-| `ExpressionToSetStageTranslator` | — | — | — | — | ✓ | — |
-| `GroupByMethodToPipelineTranslator` | — | — | — | — | — | GroupBy only |
-| `AstSimplifier` | ✓ | — | ✓ | — | ✓ | ✓ |
-| `AstPipelineOptimizer` | — | — | — | — | — | ✓ |
-
-This selectivity has been validated via targeted injection tests.
-
 ## Interpreting Results
 
 **Allocation changes** are often more actionable than time changes. A new allocation in a hot path is a real regression even if the time delta is within noise. The `[MemoryDiagnoser]` columns (`Gen0`, `Allocated`) make allocation regressions visible.
 
 **`OrFilter`** is the fastest filter (~7µs, ~5x faster than others) because it uses literal constants instead of captured variables, producing a simpler expression tree with less work at every stage. This makes it the most sensitive filter benchmark — small translator regressions that would be lost in the noise on slower benchmarks show up clearly here.
 
-**`ProjectionSentinel`** at ~17ns is not measuring translation. It validates that `LinqProviderAdapter` still short-circuits `x => x` projections. Movement here means the fast-path detection broke, not that translation got slower.
+## End-to-End Benchmarks
+
+`LinqEndToEndBenchmark` executes real queries against a server. Each operation appears as a pair: a `*Linq` variant that translates the expression on every call, and a `*Raw` variant that sends a pre-built BSON document and skips translation. Both issue the same query shape (the raw shapes are built in `[GlobalSetup]` to match what the provider emits), so everything downstream — server execution, network, serialization, deserialization — is common to both, and the Linq−Raw delta approximates translation's contribution to that operation's end-to-end time.
+
+The collection is seeded with 500 documents and indexed so server-side filter/group time stays small. This keeps the cross-benchmark deltas dominated by translation and serialization rather than COLLSCAN variance, while still returning a realistic result size so serialization is a visible part of the total.
+
+| Pair | Operation |
+|---|---|
+| `MultiFieldSearch{Linq,Raw}` | compound `Find` filter |
+| `OrFilter{Linq,Raw}` | 4-way `$or` `Find` filter |
+| `GroupBy{Linq,Raw}` | `$group` aggregate (count + sum) |
+| `Projection{Linq,Raw}` | `Find` with server-side inclusion projection |
+| `InFilter{Linq,Raw}` | `$in` over a set of ids |
+| `PagedQuery{Linq,Raw}` | `Where → OrderBy → ThenBy → Take` pipeline |
+
+**What this suite is for — and what it is not.** Translation is a low-single-digit fraction of end-to-end latency (for `OrFilter`, whose result set serializes hundreds of KB, the translator's share is ~1.2%). That sits well under the suite's drift floor, so a *translator regression is not reliably visible here* — those are caught directly by the translation suite above. What the end-to-end suite uniquely shows, tracked over time, is movement in the *non-translation* costs — serialization, deserialization, server, network — that changes how large a share translation represents. The translation suite is blind to those by construction.
+
+Because the numbers are dominated by server and network time, they carry confounds the translation suite does not (server version, hardware, network). They are tracked as a **trend**, not a pass/fail gate: read the series for how the translator's share drifts, not for single-run regressions.
 
 ## Regression Thresholds
 
-Provisional thresholds based on 7-run M1 Max characterization (min/max range as a % of median). These should be tightened once calibrated on the perf-job hardware (`rhel90-dbx-perf-large`).
+Provisional thresholds for the **translation** benchmarks, based on local characterization (min/max range as a % of median). These should be tightened once calibrated on the perf-job hardware. The end-to-end benchmarks are tracked as a trend rather than gated — their server- and network-dominated timings make single-run thresholds unreliable, and translator regressions surface in the translation suite, not here.
 
-Three drift clusters emerged from characterization:
+Two drift clusters emerged from characterization:
 
 | Bucket | Threshold | Benchmarks | Observed range |
 |---|---|---|---|
 | Tight | 15% | `MultiFieldSearch`, `UpdatePipeline`, `BatchLookup`, `ArrayElementQuery` | 9–15% |
 | Wider | 30% | `OrFilter`, `FieldSelection`, `AggregationProjection`, `QueryablePipeline`, `GroupByAggregation` | 20–29% |
-| Sentinel | 100% | `ProjectionSentinel` | 5% |
 
 `OrFilter` and `FieldSelection` land in the wider bucket for different reasons: `OrFilter` is ~7µs and proportional noise is large at that scale; `FieldSelection` is ~2µs with similar characteristics. The three complex benchmarks (`AggregationProjection`, `QueryablePipeline`, `GroupByAggregation`) show higher drift because they allocate more and exercise more GC pressure.

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
@@ -1,0 +1,86 @@
+# LINQ Translation Benchmarks
+
+Measures the performance of the LINQ-to-aggregation translation layer — the CPU work the driver does to convert a C# expression tree into a MongoDB query/pipeline document. No database I/O is involved; these benchmarks isolate translator regressions from network and serialization noise.
+
+## Running
+
+```bash
+cd benchmarks/MongoDB.Driver.Benchmarks
+
+# All LINQ benchmarks
+dotnet run -c Release -- --filter "*LinqTranslation*"
+
+# Specific benchmark
+dotnet run -c Release -- --filter "*EqualityById*"
+
+# As part of the full perf suite (also runs DriverBench, BsonBench, etc.)
+dotnet run -c Release -- --driverBenchmarks --anyCategories "LinqBench"
+```
+
+## Benchmark Inventory
+
+### Filter benchmarks (9)
+
+Each calls `LinqProviderAdapter.TranslateExpressionToFilter`, exercising: preprocessor → SerializerFinder → ExpressionToFilterTranslator → AstSimplifier → render.
+
+| Benchmark | Expression | Notes |
+|---|---|---|
+| `EqualityById` | `x => x.Id == id` | Most common filter pattern |
+| `CompoundFilter` | `x.Status == s && x.CreatedAt > cutoff` | Multi-condition with AND |
+| `InListFilter` | `ids.Contains(x.Id)` | Batch-fetch pattern |
+| `StringMethodFilter` | `x.CustomerName.StartsWith(prefix)` | String method translation |
+| `ArrayAnyWithPredicate` | `x.Items.Any(i => i.Price > t)` | Array sub-document filtering |
+| `NestedMemberFilter` | `x.ShippingAddress.City == c` | Embedded document navigation |
+| `OrChainFilter` | 4-way `==` OR with literal constants | No closure capture — measures raw translation cost |
+| `DateTimeMethodFilter` | `x.CreatedAt.Year == y` | DateTime member method |
+| `InstanceFieldCaptureFilter` | `x.Status == _activeStatus` | Captures `this`-field instead of stack-local |
+
+### Projection benchmarks (5)
+
+| Benchmark | Entry Point | Notes |
+|---|---|---|
+| `WholeDocumentProjectionSentinel` | `TranslateExpressionToProjection` | `x => x` — fast-path early return. Sentinel for fast-path breakage, not translator perf. |
+| `PocoProjection` | `TranslateExpressionToProjection` | 3-field DTO via MemberInit |
+| `FindProjection` | `TranslateExpressionToFindProjection` | Same expression as PocoProjection, but through `AstFindProjectionSimplifier` |
+| `WidePocoProjection` | `TranslateExpressionToProjection` | 15-field DTO — scaling behavior |
+| `ProjectionWithNestedTransform` | `TranslateExpressionToProjection` | `Items.Select(i => i.ProductId)` inside projection |
+
+### Composition benchmark (1)
+
+| Benchmark | Entry Point | Notes |
+|---|---|---|
+| `IQueryableComposition` | `ExpressionToExecutableQueryTranslator.Translate` | `Where → Select → OrderBy → Take` via MongoQueryProvider. Covers the IQueryable code path users write with `collection.AsQueryable()`. |
+
+## Code Path Coverage
+
+Each benchmark exercises a specific subset of the translation pipeline:
+
+| Component | Filters | Projections | Sentinel | IQueryable |
+|---|:---:|:---:|:---:|:---:|
+| `LinqExpressionPreprocessor` | ✓ | ✓ | — | ✓ |
+| `SerializerFinder` | ✓ | ✓ | — | ✓ |
+| `ExpressionToFilterTranslator` | ✓ | — | — | ✓ (Where) |
+| `ExpressionToAggregationExpressionTranslator` | — | ✓ | — | ✓ (Select) |
+| `AstSimplifier` | ✓ | ✓ | — | ✓ |
+| `AstFindProjectionSimplifier` | — | FindProjection only | — | — |
+| `AstPipelineOptimizer` | — | — | — | ✓ |
+
+This selectivity has been validated via targeted injection tests (see `workdocs/LINQ-benchmarks/work_context.md`).
+
+## Interpreting Results
+
+**Allocation changes** are often more actionable than time changes. A new allocation in a hot path is a real regression even if the time delta is within noise. The `[MemoryDiagnoser]` columns (`Gen0`, `Allocated`) make allocation regressions visible.
+
+**`OrChainFilter`** is intentionally the only filter without captured locals. It's ~5x faster than other filters because closure capture dominates filter translation cost. Treat it as a "raw translation baseline" — if it regresses but others don't, the regression is in the expression translator itself, not in closure handling.
+
+**`WholeDocumentProjectionSentinel`** at ~17ns is not measuring translation. It validates that `LinqProviderAdapter` still short-circuits `x => x` projections. Movement here means the fast-path detection broke, not that translation got slower.
+
+## Regression Thresholds
+
+Provisional thresholds based on M1 Max local characterization. These should be tightened once calibrated on the perf-job hardware (`rhel90-dbx-perf-large`).
+
+| Bucket | Threshold | Benchmarks |
+|---|---|---|
+| Default | 15% | Most filters, `PocoProjection`, `FindProjection`, `IQueryableComposition` |
+| Wider | 30% | `OrChainFilter` (very fast, proportional noise is large), `WidePocoProjection`, `ProjectionWithNestedTransform` |
+| Sentinel | 100% | `WholeDocumentProjectionSentinel` |

--- a/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
+++ b/benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md
@@ -86,17 +86,4 @@ The collection is seeded with 500 documents and indexed so server-side filter/gr
 
 **What this suite is for — and what it is not.** Translation is a low-single-digit fraction of end-to-end latency (for `OrFilter`, whose result set serializes hundreds of KB, the translator's share is ~1.2%). That sits well under the suite's drift floor, so a *translator regression is not reliably visible here* — those are caught directly by the translation suite above. What the end-to-end suite uniquely shows, tracked over time, is movement in the *non-translation* costs — serialization, deserialization, server, network — that changes how large a share translation represents. The translation suite is blind to those by construction.
 
-Because the numbers are dominated by server and network time, they carry confounds the translation suite does not (server version, hardware, network). They are tracked as a **trend**, not a pass/fail gate: read the series for how the translator's share drifts, not for single-run regressions.
-
-## Regression Thresholds
-
-Provisional thresholds for the **translation** benchmarks, based on local characterization (min/max range as a % of median). These should be tightened once calibrated on the perf-job hardware. The end-to-end benchmarks are tracked as a trend rather than gated — their server- and network-dominated timings make single-run thresholds unreliable, and translator regressions surface in the translation suite, not here.
-
-Two drift clusters emerged from characterization:
-
-| Bucket | Threshold | Benchmarks | Observed range |
-|---|---|---|---|
-| Tight | 15% | `MultiFieldSearch`, `UpdatePipeline`, `BatchLookup`, `ArrayElementQuery` | 9–15% |
-| Wider | 30% | `OrFilter`, `FieldSelection`, `AggregationProjection`, `QueryablePipeline`, `GroupByAggregation` | 20–29% |
-
-`OrFilter` and `FieldSelection` land in the wider bucket for different reasons: `OrFilter` is ~7µs and proportional noise is large at that scale; `FieldSelection` is ~2µs with similar characteristics. The three complex benchmarks (`AggregationProjection`, `QueryablePipeline`, `GroupByAggregation`) show higher drift because they allocate more and exercise more GC pressure.
+Because the numbers are dominated by server and network time, they carry confounds the translation suite does not (server version, hardware, network) and are noisier run-to-run. Read them as a **trend** in the translator's share rather than as single-run pass/fail signals.

--- a/evergreen/run-perf-tests.sh
+++ b/evergreen/run-perf-tests.sh
@@ -9,4 +9,4 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # Download the data to be used in the performance tests
 ./scripts/download-data.sh .
 
-dotnet run -c Release -- --driverBenchmarks --evergreen --anyCategories "DriverBench" "BsonBench" "RunBench" --a ./Benchmark.Artifacts
+dotnet run -c Release -- --driverBenchmarks --evergreen --anyCategories "DriverBench" "BsonBench" "RunBench" "LinqBench" --a ./Benchmark.Artifacts


### PR DESCRIPTION
## Summary

Adds a 9-benchmark `LinqBench` suite that exercises the LINQ-to-aggregation translation layer in isolation (no queries executed at benchmark time), plus a `LinqEndToEnd` suite that compares LINQ vs hand-built `BsonDocument` query plans end-to-end. Wires `LinqBench` into the perf-job category filter and the composite-score path, giving us a defensible signal when the translator (especially `SerializerFinder`, `AstSimplifier`, and the method-call sub-translators) moves.

Cross-commit runs against pre-/post-SerializerFinder and an in-flight optimization PR (#1961) show the suite catches the regressions and improvements we'd want it to — see Validation.

## Motivation

The driver has spec-driven benchmarks for I/O-heavy patterns (`Find`, `BulkWrite`, `GridFS`, BSON encode/decode) but nothing for the LINQ translator. As internal paths shift — `SerializerFinder` overhauls, `AstSimplifier` changes, new visitor support — we have no signal on translation-cost movement. When CSHARP-5572 introduced `SerializerFinder` (#1700), we couldn't quantify what it cost. This closes that gap.

## What this adds

| File | Purpose |
|---|---|
| `benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqTranslationBenchmark.cs` | 9-benchmark translation suite (filter / field / projection / update / IQueryable entry points) |
| `benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqEndToEndBenchmark.cs` | 12 LINQ-vs-raw end-to-end benchmarks (6 patterns × {LINQ, Raw}) against a mongod |
| `benchmarks/MongoDB.Driver.Benchmarks/Linq/LinqBenchmarkDataTypes.cs` | Shared POCO models for both LINQ suites |
| `benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md` | Suite docs: full benchmark inventory and how to interpret |
| `benchmarks/MongoDB.Driver.Benchmarks/DriverBenchmarkCategory.cs` | New `LinqBench` and `ExcludeFromComposite` consts; `LinqBench` and `BulkWriteBench` added to `AllCategories`. `ExcludeFromComposite` keeps the end-to-end benchmarks out of the `LinqBench` composite while still running them |
| `benchmarks/MongoDB.Driver.Benchmarks/BenchmarkResult.cs` + `Exporters/*.cs` | Scores time-throughput benchmarks as operations/second; composite derives its unit from members and skips `ExcludeFromComposite` benchmarks |
| `evergreen/run-perf-tests.sh` | Adds `LinqBench` to the `--anyCategories` filter |

Cedar/SPS auto-discovers new composite categories — no dashboard config required.

## Design decisions

- **Translation-only as the primary suite.** `LinqTranslationBenchmark` calls translator entry points directly (`LinqProviderAdapter.TranslateExpressionTo*`, `ExpressionToExecutableQueryTranslator.Translate`); no queries run at benchmark time, isolating translator regressions from network and serialization noise. (Caveat: `QueryablePipeline` and `GroupByAggregation` need a `MongoQueryProvider<T>`, obtained from `collection.AsQueryable()` on a real `MongoClient` in `[GlobalSetup]`; its background cluster monitor is the only DB-side activity, expected below the 2-4% drift floor.) End-to-end coverage lives in `LinqEndToEndBenchmark`; it shares the `LinqBench` category so it runs in the perf job, and is marked `ExcludeFromComposite` so it stays out of the composite.
- **Representative user queries, not a visitor matrix.** An earlier proposal organized benchmarks by which `SerializerFinderVisit*.cs` file they exercised; reframed to "what users actually write." Matrix coverage stays an option for targeted gaps.
- **`LinqBench` does not cross-tag with the spec categories** (`DriverBench`, `BsonBench`, etc.), keeping LINQ numbers out of the spec composite averages. It lands in `AllCategories` so its own composite is emitted.
- **`BulkWriteBench` composite bundled here.** Previously excluded with a "not part of the benchmarking spec" comment; team wanted its composite tracked, done here to avoid a tiny standalone PR.
- **`[MemoryDiagnoser]` on everything.** Allocation regressions matter independently of time and surface earlier than time regressions on noisy hardware.

## Benchmark inventory

Translation suite: 9 benchmarks across filter (4), field (1), projection (1), update (1), and IQueryable (2) entry points. End-to-end suite: 12 benchmarks — 6 patterns (`MultiFieldSearch`, `OrFilter`, `GroupBy`, `Projection`, `InFilter`, `PagedQuery`) each run LINQ vs hand-built raw. The full per-benchmark breakdown (patterns, translator paths exercised) lives in [`Linq/README.md`](benchmarks/MongoDB.Driver.Benchmarks/Linq/README.md).

The e2e suite seeds 500 documents with secondary indexes on `Status`, `CreatedAt`, and `ShippingAddress.City` in `[GlobalSetup]`; each LINQ/Raw pair renders to byte-equivalent BSON (verified via `LinqProviderAdapter`), so the LINQ−Raw delta isolates translator + provider overhead from query-shape differences.

## Validation

Five lines of evidence that the suite produces actionable signal.

### 1. Within-run noise

Across all perf-hw runs (n=10 each, multiple commits), BDN-reported within-run StdDev is <1% on most benchmarks (typically 0.2-0.9%), with the fastest micro-benchmarks at 0.3-1.4%. Each individual run is a well-converged measurement.

### 2. Selectivity — targeted regression injection

`Thread.SpinWait(300)` (~10 µs on M1) injected into four translator code paths in turn:

| Injection point | Expected affected benchmarks |
|---|---|
| `SerializerFinder.FindSerializers()` | All benchmarks (universal path) |
| `GetItemMethodToFilterFieldTranslator` | `FieldSelection` only |
| `NotExpressionToFilterTranslator` | `MultiFieldSearch` (Not), `OrFilter` (chains Comparison dispatch) |
| `GroupByMethodToPipelineTranslator` | `GroupByAggregation` only |

Each injection moved only the benchmarks that should have moved — clean per-path selectivity, so when something regresses the benchmarks that move tell you *which translator* moved.

### 3. Cross-run drift on the perf-job hardware (n=10 on `rhel90-dbx-perf-large`)

.NET 8.0, X64 RyuJit, single perf-task invocation on the same host.

| Benchmark | Min | Median | Max | Range% | CV% | Within-run StdDev% |
|---|---:|---:|---:|---:|---:|---:|
| `MultiFieldSearch` | 494.0 µs | 497.2 µs | 507.8 µs | 2.8% | 1.03% | 0.23% |
| `OrFilter` | 13.3 µs | 13.5 µs | 13.7 µs | 3.1% | 1.01% | 0.23% |
| `BatchLookup` | 144.9 µs | 145.8 µs | 148.1 µs | 2.2% | 0.74% | 0.88% |
| `ArrayElementQuery` | 177.4 µs | 179.4 µs | 181.4 µs | 2.2% | 0.77% | 0.51% |
| `FieldSelection` | 5,610 ns | 5,795 ns | 6,025 ns | 7.1% | 2.30% | 0.32% |
| `AggregationProjection` | 406.5 µs | 412.6 µs | 420.1 µs | 3.3% | 1.07% | 0.47% |
| `UpdatePipeline` | 95.5 µs | 96.3 µs | 98.4 µs | 3.0% | 1.06% | 0.59% |
| `QueryablePipeline` | 874.5 µs | 890.7 µs | 913.6 µs | 4.4% | 1.38% | 0.52% |
| `GroupByAggregation` | 489.7 µs | 495.1 µs | 506.6 µs | 3.4% | 0.94% | 0.77% |

Every benchmark but `FieldSelection` lands in 2-4.5% range, CV ≤1.5% — a ~5× compression of the M1 drift bands characterized during development. `FieldSelection` (~6µs) drifts wider (7.1%), fast enough that small absolute drift looks proportionally large. Sub-10% deltas are individually resolvable, which matters for the optimization comparison below.

### 4. Cross-commit reality check

Transplanted onto pinned commits and run on `rhel90-dbx-perf-large` (n=10 per commit), the suite caught both a known historical regression and an in-flight optimization:

- **SerializerFinder introduction (#1700)** — parent (`46640eac98`) vs the merge (`59c9d34180`): every benchmark moved well above its drift band, most 2-3× slower. `UpdatePipeline` was a +626% time / +898% allocation outlier because `TranslateExpressionToSetStage` runs `SerializerFinder` on the un-preprocessed lambda, unlike the other entry points which preprocess first (root cause in the follow-up below). Confirms the suite surfaces real translator regressions.
- **Optimization #1961** (`SerializerFinderVisitMethodCall` switch → `MethodInfo`-keyed lookup), base `66780341e7` vs head `54973d039a` — measurable allocation wins on the method-call / IQueryable benchmarks (`ArrayElementQuery` -12.4%, `QueryablePipeline` -4.5%, `BatchLookup` / `GroupByAggregation` -3.3%) with smaller time effects at the edge of the drift bands. The suite resolves what *kind* of change this is — an allocation reduction — which was invisible at M1 noise levels.

### 5. End-to-end overhead — Atlas dev cluster, perf-hardware, n=10

Six patterns run twice each (LINQ-translated vs hand-built `BsonDocument` / pipeline), 500 docs with secondary indexes, against a live Atlas dev cluster from the perf host. Each LINQ/Raw pair renders to byte-equivalent BSON, so the LINQ−Raw delta reflects translator and provider overhead, not query-shape differences.

| Pattern | LINQ median | Raw median | LINQ−Raw | LINQ/Raw | **Translator share** | LINQ alloc | Raw alloc | Alloc ratio |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `MultiFieldSearch` | 1,966 µs | 1,185 µs | +782 µs | 1.66× | **39.7%** | 74.2 KB | 43.6 KB | 1.70× |
| `OrFilter` | 7,321 µs | 7,230 µs | +91 µs | 1.01× | **1.2%** | 719.1 KB | 711.1 KB | 1.01× |
| `GroupBy` | 2,034 µs | 1,476 µs | +558 µs | 1.38× | **27.4%** | 65.4 KB | 20.6 KB | 3.18× |
| `Projection` | 2,160 µs | 1,051 µs | +1,109 µs | 2.05× | **51.3%** | 124.8 KB | 35.5 KB | 3.52× |
| `InFilter` | 1,100 µs | 784 µs | +315 µs | 1.40× | **28.7%** | 41.5 KB | 28.8 KB | 1.44× |
| `PagedQuery` | 1,645 µs | 1,213 µs | +432 µs | 1.36× | **26.3%** | 63.3 KB | 34.8 KB | 1.82× |

**Translator share** is the fraction of user-visible LINQ time that disappears if you write raw `BsonDocument` instead — an *upper bound* on translator cost (the delta also includes provider overhead like cursor construction and command serialization).

- Projection-heavy patterns (`Projection` 51%, `MultiFieldSearch` 40%): translator is ~40-50% of user-visible latency on indexed selective queries; a 10% translator regression is a ~5% user-visible one.
- Filter/aggregation patterns (`GroupBy` 27%, `InFilter` 29%, `PagedQuery` 26%): translator is ~25-30%; meaningful server-side work (`$group`, `$in`, sort-skip-limit) partially offsets it.
- Broad scans (`OrFilter` 1.2%): translator is ~1% because the 4-way OR matches many documents and serializes ~700 KB, so a 10% translator regression is invisible to users.
- Allocation ratios isolate LINQ-side overhead: `Projection` 3.5×, `GroupBy` 3.2× — projected-type-serializer and `IGroupingSerializer` construction is allocation-heavy, and catches translator-side allocation regressions even when network time masks the time delta.

Caveat: Atlas dev cluster across the internet from the perf host; per-run absolute times range ±15-30% (up to ±50% where server time dominates), but the translator-share *ratios* are more stable because LINQ and Raw on the same iteration see correlated network noise. Single-batch result, 500 docs.

## Regression-alert thresholds (perf-hardware-calibrated)

Calibrated to observed drift on `rhel90-dbx-perf-large`:

| Bucket | Threshold | Benchmarks | Rationale |
|---|---|---|---|
| Tight | 8% | `MultiFieldSearch`, `BatchLookup`, `ArrayElementQuery`, `AggregationProjection`, `UpdatePipeline`, `QueryablePipeline`, `GroupByAggregation`, `OrFilter` | Observed range 2.2–4.4%; 8% gives ~2× headroom. |
| Wider | 12% | `FieldSelection` | ~6µs benchmark; observed range 7.1%. |

Allocation thresholds should be even tighter — observed allocation drift is 0-1.2%.

## Follow-ups (not in this PR)

- File a ticket for the `TranslateExpressionToSetStage` preprocessing asymmetry surfaced above (SerializerFinder runs on the un-preprocessed tree; `UpdatePipeline` +626% time, +898% alloc). The design is intentional — dispatch pattern-matches on `NewExpression`/`MemberInitExpression`, which `PartialEvaluator` would collapse if applied at the top — so any fix must preserve that dispatch shape. Not a one-line change.
- Sub-3% time-delta detection on real changes hasn't been measured end-to-end (current experiments validate large deltas and 3-12% alloc deltas); the perf-hw drift bands suggest it's feasible.
- Coverage gaps: `Lookup`/`Join`, `Distinct`, `SelectMany`, `Cast`, `$expr` fallback paths.
- Quantify the background cluster-monitor's noise contribution to `QueryablePipeline`/`GroupByAggregation` (expected sub-1%, absorbed by the 2-4% drift floor).
- Runtime equivalence guard for the e2e suite: assert each LINQ expression's translated BSON equals its pre-built Raw doc in `[GlobalSetup]`, so a future translator shape change fails the benchmark loudly instead of silently shifting the share numbers.
