### PR TITLE
CSHARP-6055: Update SharpCompress to remedy vulnerability

### DIFF
--- a/src/MongoDB.Driver/Core/Compression/ZlibCompressor.cs
+++ b/src/MongoDB.Driver/Core/Compression/ZlibCompressor.cs
@@ -44,7 +44,7 @@ namespace MongoDB.Driver.Core.Compression
         /// <inheritdoc />
         public void Compress(Stream input, Stream output)
         {
-            using (var zlibStream = new ZlibStream(new NonDisposingStream(output), CompressionMode.Compress, _compressionLevel))
+            using (var zlibStream = new ZlibStream(SharpCompressStream.CreateNonDisposing(output), CompressionMode.Compress, _compressionLevel))
             {
                 zlibStream.FlushMode = FlushType.Sync;
                 input.EfficientCopyTo(zlibStream);
@@ -54,7 +54,7 @@ namespace MongoDB.Driver.Core.Compression
         /// <inheritdoc />
         public void Decompress(Stream input, Stream output)
         {
-            using (var zlibStream = new ZlibStream(new NonDisposingStream(input), CompressionMode.Decompress))
+            using (var zlibStream = new ZlibStream(SharpCompressStream.CreateNonDisposing(input), CompressionMode.Decompress))
             {
                 zlibStream.CopyTo(output);
             }

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="DnsClient" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="SharpCompress" Version="0.30.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.1" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />
     <PackageReference Include="System.Buffers" Version="4.6.1" />

--- a/tests/MongoDB.Driver.Tests/Core/Compression/CompressorsTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Compression/CompressorsTests.cs
@@ -222,8 +222,8 @@ namespace MongoDB.Driver.Core.Tests.Core.Compression
             {
                 var memoryStream = new MemoryStream();
                 var byteBufferStream = new ByteBufferStream(buffer);
-                using (new NonDisposingStream(memoryStream))
-                using (new NonDisposingStream(byteBufferStream))
+                using (SharpCompressStream.CreateNonDisposing(memoryStream))
+                using (SharpCompressStream.CreateNonDisposing(byteBufferStream))
                 {
                     test(byteBufferStream, memoryStream);
                     assertResult?.Invoke(byteBufferStream, memoryStream);


### PR DESCRIPTION
Alternative to #1997 that has a much reduced chance of potential regressions by simply upgrading to latest and compensating for lack of NonDisposingStream class.

Fixes [CSHARP-6055](https://jira.mongodb.org/browse/CSHARP-6055)