### PR TITLE
CSHARP-6023: Update libmongocrypt URLs for 1.18.0+

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1757,13 +1757,13 @@ tasks:
               echo "Copying files ... begin"
               export AZUREKMS_PRIVATEKEYPATH=/tmp/testazurekms_privatekey
               source $DRIVERS_TOOLS/.evergreen/csfle/azurekms/secrets-export.sh
-              tar czf /tmp/mongo-csharp-driver.tgz .
+              evergreen/compile-sources.sh
+              tar czf /tmp/mongo-csharp-driver.tgz tests/*.Tests/bin/Release/net6.0/ evergreen/install-dotnet.sh evergreen/run-csfle-azure-tests.sh
               AZUREKMS_SRC=/tmp/mongo-csharp-driver.tgz AZUREKMS_DST="~/" $DRIVERS_TOOLS/.evergreen/csfle/azurekms/copy-file.sh
               echo "Copying files ... end"
               echo "Untarring file ... begin"
               AZUREKMS_CMD="tar xf mongo-csharp-driver.tgz" $DRIVERS_TOOLS/.evergreen/csfle/azurekms/run-command.sh
               echo "Untarring file ... end"
-
         - command: shell.exec
           type: test
           params:
@@ -2099,6 +2099,7 @@ task_groups:
       - func: init-test-results
       - func: make-files-executable
       - func: assume-aws-test-secrets-role
+      - func: configure-framework
       - command: subprocess.exec
         params:
           binary: bash

--- a/evergreen/run-csfle-azure-tests.sh
+++ b/evergreen/run-csfle-azure-tests.sh
@@ -24,5 +24,4 @@ export CSFLE_AZURE_KMS_TESTS_ENABLED=true
 export FRAMEWORK=net6.0
 . ./evergreen/install-dotnet.sh
 
-./evergreen/compile-sources.sh
-TEST_CATEGORY=CsfleAZUREKMS ./evergreen/execute-tests.sh
+dotnet test --no-build -c Release --framework net6.0 --filter Category=CsfleAZUREKMS -e MONGODB_URI="$MONGODB_URI" --results-directory ./build/test-results --logger "console;verbosity=detailed" ./tests/**/*.Tests.dll

--- a/purls.txt
+++ b/purls.txt
@@ -1,1 +1,1 @@
-pkg:github/mongodb/libmongocrypt@1.15.2
+pkg:github/mongodb/libmongocrypt@1.18.2

--- a/sbom.json
+++ b/sbom.json
@@ -1,74 +1,33 @@
 {
   "components": [
     {
-      "bom-ref": "pkg:github/mongodb/libmongocrypt@1.15.2",
+      "bom-ref": "pkg:github/mongodb/libmongocrypt@1.18.2",
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://github.com/mongodb/libmongocrypt/archive/1.15.2.tar.gz"
+          "url": "https://github.com/mongodb/libmongocrypt/archive/1.18.2.tar.gz"
         },
         {
           "type": "website",
-          "url": "https://github.com/mongodb/libmongocrypt/tree/1.15.2"
+          "url": "https://github.com/mongodb/libmongocrypt/tree/1.18.2"
         }
       ],
       "group": "mongodb",
       "name": "libmongocrypt",
-      "purl": "pkg:github/mongodb/libmongocrypt@1.15.2",
+      "purl": "pkg:github/mongodb/libmongocrypt@1.18.2",
       "type": "library",
-      "version": "1.15.2"
+      "version": "1.18.2"
     }
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/mongodb/libmongocrypt@1.15.2"
+      "ref": "pkg:github/mongodb/libmongocrypt@1.18.2"
     }
   ],
   "metadata": {
-    "timestamp": "2026-01-15T21:04:19.144270+00:00",
-    "tools": [
-      {
-        "externalReferences": [
-          {
-            "type": "build-system",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
-          },
-          {
-            "type": "distribution",
-            "url": "https://pypi.org/project/cyclonedx-python-lib/"
-          },
-          {
-            "type": "documentation",
-            "url": "https://cyclonedx-python-library.readthedocs.io/"
-          },
-          {
-            "type": "issue-tracker",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
-          },
-          {
-            "type": "license",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
-          },
-          {
-            "type": "release-notes",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
-          },
-          {
-            "type": "vcs",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
-          },
-          {
-            "type": "website",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
-          }
-        ],
-        "name": "cyclonedx-python-lib",
-        "vendor": "CycloneDX",
-        "version": "6.4.4"
-      }
-    ]
+    "timestamp": "2026-05-26T14:17:27.299760+00:00"
   },
-  "serialNumber": "urn:uuid:d12e361f-cdab-4028-82ee-5c93bc628cfc",
+  "serialNumber": "urn:uuid:ee36e806-bcad-4568-9f1a-9ea3d7c70953",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",

--- a/src/MongoDB.Driver.Encryption/MongoDB.Driver.Encryption.csproj
+++ b/src/MongoDB.Driver.Encryption/MongoDB.Driver.Encryption.csproj
@@ -14,130 +14,142 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LibMongoCryptVersionPath>r1.15/2807bca63631a5b6b8affcb7f4402e351166659e</LibMongoCryptVersionPath>
+    <LibMongoCryptVersion>1.18.2</LibMongoCryptVersion>
+    <LibMongoCryptBaseUrl>https://github.com/mongodb/libmongocrypt/releases/download/$(LibMongoCryptVersion)</LibMongoCryptBaseUrl>
   </PropertyGroup>
 
   <Target Name="DownloadNativeBinaries_MacOS"
-          BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/osx/native/libmongocrypt.dylib')">
+          BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/osx/native/libmongocrypt.dylib')">
     <PropertyGroup>
-      <LibMongoCryptSourceUrl>https://mciuploads.s3.amazonaws.com/libmongocrypt-release/macos/$(LibMongoCryptVersionPath)/libmongocrypt.tar.gz</LibMongoCryptSourceUrl>
+      <LibMongoCryptTarball>libmongocrypt-macos-universal-$(LibMongoCryptVersion).tar.gz</LibMongoCryptTarball>
+      <LibMongoCryptSourceUrl>$(LibMongoCryptBaseUrl)/$(LibMongoCryptTarball)</LibMongoCryptSourceUrl>
       <LibMongoCryptSourcePath>lib/libmongocrypt.dylib</LibMongoCryptSourcePath>
-      <LibMongoCryptPackagePath>$(LibMongoCryptVersionPath)/runtimes/osx/native</LibMongoCryptPackagePath>
+      <LibMongoCryptPackagePath>$(LibMongoCryptVersion)/runtimes/osx/native</LibMongoCryptPackagePath>
     </PropertyGroup>
 
     <MSBuild Projects ="$(MSBuildProjectFullPath)"
-             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
+             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptTarball=$(LibMongoCryptTarball);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
              Targets="DownloadNativeBinary" />
   </Target>
 
-  <Target Name="DownloadNativeBinaries_UbuntuX64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/linux-x64/native/libmongocrypt.so')">
+  <Target Name="DownloadNativeBinaries_UbuntuX64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/linux-x64/native/libmongocrypt.so')">
     <PropertyGroup>
-      <LibMongoCryptSourceUrl>https://mciuploads.s3.amazonaws.com/libmongocrypt-release/ubuntu1804-64/$(LibMongoCryptVersionPath)/libmongocrypt.tar.gz</LibMongoCryptSourceUrl>
-      <LibMongoCryptSourcePath>nocrypto/lib/libmongocrypt.so</LibMongoCryptSourcePath>
-      <LibMongoCryptPackagePath>$(LibMongoCryptVersionPath)/runtimes/linux-x64/native/</LibMongoCryptPackagePath>
+      <LibMongoCryptTarball>libmongocrypt-linux-x86_64-glibc_2_7-nocrypto-$(LibMongoCryptVersion).tar.gz</LibMongoCryptTarball>
+      <LibMongoCryptSourceUrl>$(LibMongoCryptBaseUrl)/$(LibMongoCryptTarball)</LibMongoCryptSourceUrl>
+      <LibMongoCryptSourcePath>lib64/libmongocrypt.so</LibMongoCryptSourcePath>
+      <LibMongoCryptPackagePath>$(LibMongoCryptVersion)/runtimes/linux-x64/native/</LibMongoCryptPackagePath>
     </PropertyGroup>
 
     <MSBuild Projects ="$(MSBuildProjectFullPath)"
-             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
+             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptTarball=$(LibMongoCryptTarball);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
              Targets="DownloadNativeBinary" />
   </Target>
 
-  <Target Name="DownloadNativeBinaries_UbuntuARM64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/linux-arm64/native/libmongocrypt.so')">
+  <Target Name="DownloadNativeBinaries_UbuntuARM64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/linux-arm64/native/libmongocrypt.so')">
     <PropertyGroup>
-      <LibMongoCryptSourceUrl>https://mciuploads.s3.amazonaws.com/libmongocrypt-release/ubuntu1804-arm64/$(LibMongoCryptVersionPath)/libmongocrypt.tar.gz</LibMongoCryptSourceUrl>
-      <LibMongoCryptSourcePath>nocrypto/lib/libmongocrypt.so</LibMongoCryptSourcePath>
-      <LibMongoCryptPackagePath>$(LibMongoCryptVersionPath)/runtimes/linux-arm64/native/</LibMongoCryptPackagePath>
+      <LibMongoCryptTarball>libmongocrypt-linux-arm64-glibc_2_17-nocrypto-$(LibMongoCryptVersion).tar.gz</LibMongoCryptTarball>
+      <LibMongoCryptSourceUrl>$(LibMongoCryptBaseUrl)/$(LibMongoCryptTarball)</LibMongoCryptSourceUrl>
+      <LibMongoCryptSourcePath>lib64/libmongocrypt.so</LibMongoCryptSourcePath>
+      <LibMongoCryptPackagePath>$(LibMongoCryptVersion)/runtimes/linux-arm64/native/</LibMongoCryptPackagePath>
     </PropertyGroup>
 
     <MSBuild Projects ="$(MSBuildProjectFullPath)"
-             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
+             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptTarball=$(LibMongoCryptTarball);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
              Targets="DownloadNativeBinary" />
   </Target>
 
-
-  <Target Name="DownloadNativeBinaries_AlpineAMD64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/linux-musl-x64/native/libmongocrypt.so')">
+  <Target Name="DownloadNativeBinaries_AlpineAMD64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/linux-musl-x64/native/libmongocrypt.so')">
     <PropertyGroup>
-        <LibMongoCryptSourceUrl>https://mciuploads.s3.amazonaws.com/libmongocrypt-release/alpine-amd64-earthly/$(LibMongoCryptVersionPath)/libmongocrypt.tar.gz</LibMongoCryptSourceUrl>
-        <LibMongoCryptSourcePath>nocrypto/lib/libmongocrypt.so</LibMongoCryptSourcePath>
-        <LibMongoCryptPackagePath>$(LibMongoCryptVersionPath)/runtimes/linux-musl-x64/native/</LibMongoCryptPackagePath>
+      <LibMongoCryptTarball>libmongocrypt-linux-x86_64-musl_1_2-nocrypto-$(LibMongoCryptVersion).tar.gz</LibMongoCryptTarball>
+      <LibMongoCryptSourceUrl>$(LibMongoCryptBaseUrl)/$(LibMongoCryptTarball)</LibMongoCryptSourceUrl>
+      <LibMongoCryptSourcePath>lib/libmongocrypt.so</LibMongoCryptSourcePath>
+      <LibMongoCryptPackagePath>$(LibMongoCryptVersion)/runtimes/linux-musl-x64/native/</LibMongoCryptPackagePath>
     </PropertyGroup>
 
     <MSBuild Projects ="$(MSBuildProjectFullPath)"
-             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
+             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptTarball=$(LibMongoCryptTarball);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
              Targets="DownloadNativeBinary" />
   </Target>
 
-  <Target Name="DownloadNativeBinaries_AlpineARM64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/linux-musl-arm64/native/libmongocrypt.so')">
+  <Target Name="DownloadNativeBinaries_AlpineARM64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/linux-musl-arm64/native/libmongocrypt.so')">
     <PropertyGroup>
-      <LibMongoCryptSourceUrl>https://mciuploads.s3.amazonaws.com/libmongocrypt-release/alpine-arm64-earthly/$(LibMongoCryptVersionPath)/libmongocrypt.tar.gz</LibMongoCryptSourceUrl>
-      <LibMongoCryptSourcePath>nocrypto/lib/libmongocrypt.so</LibMongoCryptSourcePath>
-      <LibMongoCryptPackagePath>$(LibMongoCryptVersionPath)/runtimes/linux-musl-arm64/native/</LibMongoCryptPackagePath>
+      <LibMongoCryptTarball>libmongocrypt-linux-arm64-musl_1_2-nocrypto-$(LibMongoCryptVersion).tar.gz</LibMongoCryptTarball>
+      <LibMongoCryptSourceUrl>$(LibMongoCryptBaseUrl)/$(LibMongoCryptTarball)</LibMongoCryptSourceUrl>
+      <LibMongoCryptSourcePath>lib/libmongocrypt.so</LibMongoCryptSourcePath>
+      <LibMongoCryptPackagePath>$(LibMongoCryptVersion)/runtimes/linux-musl-arm64/native/</LibMongoCryptPackagePath>
     </PropertyGroup>
 
     <MSBuild Projects ="$(MSBuildProjectFullPath)"
-             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
+             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptTarball=$(LibMongoCryptTarball);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
              Targets="DownloadNativeBinary" />
   </Target>
 
-  <Target Name="DownloadNativeBinaries_WindowsX64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/win-x64/native/mongocrypt.dll')">
+  <Target Name="DownloadNativeBinaries_WindowsX64" BeforeTargets="BeforeBuild" Condition="!Exists('$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/win-x64/native/mongocrypt.dll')">
     <PropertyGroup>
-      <LibMongoCryptSourceUrl>https://mciuploads.s3.amazonaws.com/libmongocrypt-release/windows-test/$(LibMongoCryptVersionPath)/libmongocrypt.tar.gz</LibMongoCryptSourceUrl>
+      <LibMongoCryptTarball>libmongocrypt-windows-x86_64-$(LibMongoCryptVersion).tar.gz</LibMongoCryptTarball>
+      <LibMongoCryptSourceUrl>$(LibMongoCryptBaseUrl)/$(LibMongoCryptTarball)</LibMongoCryptSourceUrl>
       <LibMongoCryptSourcePath>bin/mongocrypt.dll</LibMongoCryptSourcePath>
-      <LibMongoCryptPackagePath>$(LibMongoCryptVersionPath)/runtimes/win-x64/native</LibMongoCryptPackagePath>
+      <LibMongoCryptPackagePath>$(LibMongoCryptVersion)/runtimes/win-x64/native</LibMongoCryptPackagePath>
     </PropertyGroup>
 
     <MSBuild Projects ="$(MSBuildProjectFullPath)"
-             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
+             Properties="TargetFramework=once;LibMongoCryptSourceUrl=$(LibMongoCryptSourceUrl);LibMongoCryptTarball=$(LibMongoCryptTarball);LibMongoCryptSourcePath=$(LibMongoCryptSourcePath);LibMongoCryptPackagePath=$(LibMongoCryptPackagePath)"
              Targets="DownloadNativeBinary" />
   </Target>
 
   <Target Name="DownloadNativeBinary">
     <PropertyGroup>
       <LibMongoCryptTmpPath>$(IntermediateOutputPath.Replace('\', '/'))$(LibMongoCryptPackagePath)</LibMongoCryptTmpPath>
+      <LibMongoCryptAscUrl>$(LibMongoCryptSourceUrl.Replace('.tar.gz','.asc'))</LibMongoCryptAscUrl>
+      <LibMongoCryptAscFile>$(LibMongoCryptTarball.Replace('.tar.gz','.asc'))</LibMongoCryptAscFile>
     </PropertyGroup>
     <DownloadFile SourceUrl="$(LibMongoCryptSourceUrl)" DestinationFolder="$(LibMongoCryptTmpPath)"/>
-    <Exec Command="tar -zxvf $(LibMongoCryptTmpPath)/libmongocrypt.tar.gz -C $(LibMongoCryptTmpPath) $(LibMongoCryptSourcePath)" />
+    <DownloadFile SourceUrl="$(LibMongoCryptAscUrl)" DestinationFolder="$(LibMongoCryptTmpPath)"/>
+    <DownloadFile SourceUrl="https://pgp.mongodb.com/libmongocrypt.pub" DestinationFolder="$(LibMongoCryptTmpPath)"/>
+    <Exec Command='gpg --batch --import "$(LibMongoCryptTmpPath)/libmongocrypt.pub"' Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
+    <Exec Command='gpg --batch --verify "$(LibMongoCryptTmpPath)/$(LibMongoCryptAscFile)" "$(LibMongoCryptTmpPath)/$(LibMongoCryptTarball)"' Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
+    <Exec Command='tar -zxvf "$(LibMongoCryptTmpPath)/$(LibMongoCryptTarball)" -C "$(LibMongoCryptTmpPath)" $(LibMongoCryptSourcePath)' />
     <Copy SourceFiles="$(LibMongoCryptTmpPath)/$(LibMongoCryptSourcePath)" DestinationFolder="$(MSBuildProjectDirectory)/$(LibMongoCryptPackagePath)" />
     <RemoveDir Directories="$(LibMongoCryptTmpPath)" />
   </Target>
 
   <ItemGroup>
-    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/osx/native/libmongocrypt.dylib">
+    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/osx/native/libmongocrypt.dylib">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>runtimes\osx\native\libmongocrypt.dylib</Link>
       <Pack>true</Pack>
       <PackagePath>runtimes\osx\native</PackagePath>
     </Content>
 
-    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/linux-x64/native/libmongocrypt.so">
+    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/linux-x64/native/libmongocrypt.so">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>runtimes\linux-x64\native\libmongocrypt.so</Link>
       <Pack>true</Pack>
       <PackagePath>runtimes\linux-x64\native</PackagePath>
     </Content>
 
-    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/linux-arm64/native/libmongocrypt.so">
+    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/linux-arm64/native/libmongocrypt.so">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>runtimes\linux-arm64\native\libmongocrypt.so</Link>
       <Pack>true</Pack>
       <PackagePath>runtimes\linux-arm64\native</PackagePath>
     </Content>
 
-    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/linux-musl-arm64/native/libmongocrypt.so">
+    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/linux-musl-arm64/native/libmongocrypt.so">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>runtimes\linux-musl-arm64\native\libmongocrypt.so</Link>
       <Pack>true</Pack>
       <PackagePath>runtimes\linux-musl-arm64\native</PackagePath>
     </Content>
 
-    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/linux-musl-x64/native/libmongocrypt.so">
+    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/linux-musl-x64/native/libmongocrypt.so">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>runtimes\linux-musl-x64\native\libmongocrypt.so</Link>
       <Pack>true</Pack>
       <PackagePath>runtimes\linux-musl-x64\native</PackagePath>
     </Content>
 
-    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersionPath)/runtimes/win-x64/native/mongocrypt.dll">
+    <Content Include="$(MSBuildProjectDirectory)/$(LibMongoCryptVersion)/runtimes/win-x64/native/mongocrypt.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>runtimes\win-x64\native\mongocrypt.dll</Link>
       <Pack>true</Pack>

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -2658,7 +2658,9 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
             var exception = Record.Exception(() => RunTestCase(csfleNamespace, pipeline8, null));
             exception.Should().NotBeNull();
-            exception.Message.Should().Contain("not supported");
+            (exception.Message.Contains("not supported") ||
+             exception.Message.Contains("Cannot specify both encryptionInformation and csfleEncryptionSchemas"))
+                .Should().BeTrue("expected error indicating that mixing CSFLE and QE in $lookup is not permitted");
 
             void RunTestCase(CollectionNamespace collectionNamespace, string pipeline, string expectedResult)
             {


### PR DESCRIPTION
## Summary
- Updates libmongocrypt from 1.15.2 to 1.18.2
- Switches all download URLs from S3 (`mciuploads.s3.amazonaws.com`) to GitHub releases (`github.com/mongodb/libmongocrypt/releases`)
- Adds GPG signature verification of downloaded tarballs on Linux and macOS (skipped on Windows where `gpg` is not guaranteed to be available)
- Updates `purls.txt` and `sbom.json` to reflect the new version