### PR TITLE
CSHARP-5746: Update $lookup prose test for MONGOCRYPT-793

### DIFF
--- a/specifications/client-side-encryption/prose-tests/etc/data/lookup/schema-non-csfle.json
+++ b/specifications/client-side-encryption/prose-tests/etc/data/lookup/schema-non-csfle.json
@@ -1,0 +1,3 @@
+{
+   "bsonType": "object"
+}

--- a/src/MongoDB.Driver/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver/Core/Misc/Feature.cs
@@ -55,6 +55,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __createObjectIdExpression = new Feature("CreateObjectIdExpression", WireVersion.Server83);
         private static readonly Feature __csfleRangeAlgorithm = new Feature("CsfleRangeAlgorithm", WireVersion.Server62);
         private static readonly Feature __csfle2Qev2Lookup = new Feature("csfle2Qev2Lookup", WireVersion.Server81);
+        private static readonly Feature __csfle2Qev2LookupNonCsfleSchema = new Feature("csfle2Qev2LookupNonCsfleSchema", WireVersion.Server82);
         private static readonly Feature __csfle2Qev2RangeAlgorithm = new Feature("csfle2Qev2RangeAlgorithm", WireVersion.Server80);
         private static readonly Feature __csfle2Qev2TextPreviewAlgorithm = new Feature("csfle2Qev2TextPreviewAlgorithm", WireVersion.Server82);
         private static readonly Feature __csfle2 = new Feature("Csfle2", WireVersion.Server60);
@@ -279,6 +280,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the csfle2 $lookup support feature.
         /// </summary>
         public static Feature Csfle2QEv2Lookup => __csfle2Qev2Lookup;
+
+        /// <summary>
+        /// Gets the csfle2 $lookup support feature for mixing a queryable encryption schema with a non-CSFLE JSON schema validator.
+        /// </summary>
+        public static Feature Csfle2QEv2LookupNonCsfleSchema => __csfle2Qev2LookupNonCsfleSchema;
 
         /// <summary>
         /// Gets the csfle2 range algorithm feature.

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -2723,6 +2723,46 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             }
         }
 
+        // 25. Test $lookup (case 10)
+        [Fact]
+        public void TestLookupQeJoinsNonCsfleSchema()
+        {
+            RequireServer.Check().Supports(Feature.Csfle2QEv2LookupNonCsfleSchema)
+                .ClusterTypes(ClusterType.ReplicaSet, ClusterType.Sharded, ClusterType.LoadBalanced);
+
+            TestLookupSetup();
+
+            var keyVaultCollectionNamespace = new CollectionNamespace("db", "keyvault");
+            var qeNamespace = new CollectionNamespace("db", "qe");
+
+            // Case 10: db.qe joins db.non_csfle_schema
+            var pipeline10 = """
+                             [
+                                 {"$match" : {"qe" : "qe"}},
+                                 {
+                                     "$lookup" : {
+                                         "from" : "non_csfle_schema",
+                                         "as" : "matched",
+                                         "pipeline" : [ {"$match" : {"non_csfle_schema" : "non_csfle_schema"}}, {"$project" : {"_id" : 0, "__safeContent__" : 0}} ]
+                                     }
+                                 },
+                                 {"$project" : {"_id" : 0, "__safeContent__" : 0}}
+                             ]
+                             """;
+            var expectedResult10 = """{"qe" : "qe", "matched" : [ {"non_csfle_schema" : "non_csfle_schema"} ]}""";
+
+            using var mongoClient = ConfigureClientEncrypted(kmsProviderFilter: "local",
+                keyVaultCollectionNamespace: keyVaultCollectionNamespace);
+            var collection = GetCollection(mongoClient, qeNamespace);
+            var result = collection.Aggregate(CreatePipeline(pipeline10)).Single();
+            result.Should().Be(BsonDocument.Parse(expectedResult10));
+
+            PipelineDefinition<BsonDocument, BsonDocument> CreatePipeline(string pipelineJson)
+            {
+                return Bson.Serialization.BsonSerializer.Deserialize<List<BsonDocument>>(pipelineJson);
+            }
+        }
+
         // https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#27-text-explicit-encryption
         [Theory]
         [ParameterAttributeData]
@@ -3638,12 +3678,14 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             var qe2Namespace = new CollectionNamespace("db", "qe2");
             var noSchemaNamespace = new CollectionNamespace("db", "no_schema");
             var noSchema2Namespace = new CollectionNamespace("db", "no_schema2");
+            var nonCsfleSchemaNamespace = new CollectionNamespace("db", "non_csfle_schema");
 
             var keyDoc = JsonFileReader.Instance.Documents["etc.data.lookup.key-doc.json"];
             var schemaCsfle = JsonFileReader.Instance.Documents["etc.data.lookup.schema-csfle.json"];
             var schemaCsfle2 = JsonFileReader.Instance.Documents["etc.data.lookup.schema-csfle2.json"];
             var schemaQe = JsonFileReader.Instance.Documents["etc.data.lookup.schema-qe.json"];
             var schemaQe2 = JsonFileReader.Instance.Documents["etc.data.lookup.schema-qe2.json"];
+            var schemaNonCsfle = JsonFileReader.Instance.Documents["etc.data.lookup.schema-non-csfle.json"];
 
             // Setup
             using var clientEncrypted = ConfigureClientEncrypted(kmsProviderFilter: "local",
@@ -3657,6 +3699,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             DropCollection(qe2Namespace);
             DropCollection(noSchemaNamespace);
             DropCollection(noSchema2Namespace);
+            DropCollection(nonCsfleSchemaNamespace);
 
             CreateCollection(clientEncrypted, csfleNamespace,
                 validatorSchema: new BsonDocument("$jsonSchema", schemaCsfle));
@@ -3666,6 +3709,8 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             CreateCollection(clientEncrypted, qe2Namespace, encryptedFields: schemaQe2);
             CreateCollection(clientEncrypted, noSchemaNamespace);
             CreateCollection(clientEncrypted, noSchema2Namespace);
+            CreateCollection(clientEncrypted, nonCsfleSchemaNamespace,
+                validatorSchema: new BsonDocument("$jsonSchema", schemaNonCsfle));
 
             // Collections from encrypted client
             var keyVaultCollectionEncrypted = GetCollection(clientEncrypted, keyVaultCollectionNamespace);
@@ -3675,6 +3720,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             var qe2CollectionEncrypted = GetCollection(clientEncrypted, qe2Namespace);
             var noSchemaCollectionEncrypted = GetCollection(clientEncrypted, noSchemaNamespace);
             var noSchema2CollectionEncrypted = GetCollection(clientEncrypted, noSchema2Namespace);
+            var nonCsfleSchemaCollectionEncrypted = GetCollection(clientEncrypted, nonCsfleSchemaNamespace);
 
             // Collections from plain (unencrypted) client
             var csfleCollection = GetCollection(client, csfleNamespace);
@@ -3705,6 +3751,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
             noSchemaCollectionEncrypted.InsertOne(BsonDocument.Parse("""{"no_schema": "no_schema"}"""));
             noSchema2CollectionEncrypted.InsertOne(BsonDocument.Parse("""{"no_schema2": "no_schema2"}"""));
+            nonCsfleSchemaCollectionEncrypted.InsertOne(BsonDocument.Parse("""{"non_csfle_schema": "non_csfle_schema"}"""));
         }
 
         // nested types


### PR DESCRIPTION
## Summary
- Adds Case 10 (`db.qe` joins `db.non_csfle_schema`) from the client-side-encryption prose tests; server 8.2 + libmongocrypt 1.17 (MONGOCRYPT-793 / SERVER-100260) now permit mixing a QE schema with a non-CSFLE JSON Schema validator in `$lookup`.
- Case 8's assertion already accepts both the old (`not supported`) and the new (`Cannot specify both encryptionInformation and csfleEncryptionSchemas...`) error substrings, so no change there.

JIRA: https://jira.mongodb.org/browse/CSHARP-5746
Spec: https://github.com/mongodb/specifications/commit/d41d48b90ef22aedae934dd22f3a21c65b5a13bc