### PR TITLE
CSHARP-6056: Remove duplicated tasks from Azure and GCP KMS test matrices

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -2859,23 +2859,21 @@ buildvariants:
           - test-csfle-with-mocked-kms-tls-netstandard21
           - test-csfle-with-mongocryptd-netstandard21
 
-- matrix_name: "csfle-with-azure-kms-tests-linux"
-  matrix_spec: { ssl: "nossl", os: "ubuntu-2004" }
-  display_name: "CSFLE with AZURE KMS ${os}"
+- name: "csfle-with-azure-kms-tests"
+  display_name: "CSFLE with AZURE KMS"
   batchtime: 20160 # 14 days
+  run_on:
+    - ubuntu2004-small
   tasks:
     - name: testazurekms-task-group
-    - name: test-csfle-with-mongocryptd-netstandard21
-    - name: test-csfle-with-mongocryptd-net60
 
-- matrix_name: "csfle-with-gcp-kms-tests-linux"
-  matrix_spec: { ssl: "nossl", os: "ubuntu-2004" }
-  display_name: "CSFLE with GCP KMS ${os}"
+- name: "csfle-with-gcp-kms-tests"
+  display_name: "CSFLE with GCP KMS"
   batchtime: 20160 # 14 days
+  run_on:
+    - ubuntu2004-small
   tasks:
     - name: testgcpkms-task-group
-    - name: test-csfle-with-mongocryptd-netstandard21
-    - name: test-csfle-with-mongocryptd-net60
 
 # Smoke tests
 - matrix_name: "smoke-tests"


### PR DESCRIPTION
What changed: Two matrix build variants (`csfle-with-azure-kms-tests-linux`, `csfle-with-gcp-kms-tests-linux`) are converted to simple named variants, and `test-csfle-with-mongocryptd-netstandard21` + `test-csfle-with-mongocryptd-net60` are removed from both.

Observations:

1. Matrix → named variant conversion looks correct. The old matrix had a single spec (ssl: nossl, os: ubuntu-2004), so it only ever produced one build variant. Converting to an explicit named variant with run_on: ubuntu2004-small is equivalent. No coverage loss here.
2. Removed `mongocryptd` tasks from Azure/GCP KMS variants. `test-csfle-with-mongocryptd-netstandard21` and `test-csfle-with-mongocryptd-net60` are still present in other build variants (lines 2833–2834, 2842–2843, 2852–2853, 2860 of the file). These KMS-specific build variants presumably require Azure/GCP credentials, so the `mongocryptd` tasks (which don't need those credentials) are redundant duplicates here. Removing them makes sense.
3. `testazurekms-task-group` and `testgcpkms-task-group` are kept intact, so actual KMS-specific testing is unaffected.
