### PR TITLE
CSHARP-5895: Deprecate mongo-orchestration in favor of mongodb-runner - follow up fix

### DIFF
--- a/evergreen/run-tests.sh
+++ b/evergreen/run-tests.sh
@@ -71,6 +71,8 @@ echo "CRYPT_SHARED_LIB_PATH:" $CRYPT_SHARED_LIB_PATH
 echo "Initial MongoDB URI:" $MONGODB_URI
 echo "Framework: " $FRAMEWORK
 
+MONGODB_URI="${MONGODB_URI%/}" # remove trailing slash if present
+
 # Provision the correct connection string and set up SSL if needed
 if [ "$TOPOLOGY" == "sharded_cluster" ]; then
        export MONGODB_URI_WITH_MULTIPLE_MONGOSES="${MONGODB_URI}"


### PR DESCRIPTION
`mongodb-runner` produces MONGO_URL with the trailing slash, what collides with the url manipulation logic in `run-tests.sh`. Fix removes that slash if present.