### PR TITLE
CSHARP-6004: Fix flaky Aggregate_with__out_includes_read_preference_for_5.0 test

### DIFF
--- a/src/MongoDB.Driver/Core/Bindings/SingleServerReadBinding.cs
+++ b/src/MongoDB.Driver/Core/Bindings/SingleServerReadBinding.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Clusters.ServerSelectors;
@@ -33,11 +34,10 @@ namespace MongoDB.Driver.Core.Bindings
         private readonly IServerSelector _serverSelector;
         private readonly ICoreSessionHandle _session;
 
-        public SingleServerReadBinding(IClusterInternal cluster, IServer server, ReadPreference readPreference, ICoreSessionHandle session)
+        public SingleServerReadBinding(IClusterInternal cluster, EndPoint serverEndpoint, ReadPreference readPreference, ICoreSessionHandle session)
         {
             _cluster = Ensure.IsNotNull(cluster, nameof(cluster));
-            Ensure.IsNotNull(server, nameof(server));
-            _serverSelector = new EndPointServerSelector(server.EndPoint);
+            _serverSelector = new EndPointServerSelector(Ensure.IsNotNull(serverEndpoint, nameof(serverEndpoint)));
             _readPreference = Ensure.IsNotNull(readPreference, nameof(readPreference));
             _session = Ensure.IsNotNull(session, nameof(session));
         }

--- a/src/MongoDB.Driver/GridFS/GridFSBucket.cs
+++ b/src/MongoDB.Driver/GridFS/GridFSBucket.cs
@@ -1041,7 +1041,7 @@ namespace MongoDB.Driver.GridFS
             var readPreference = _options.ReadPreference ?? _database.Settings.ReadPreference;
             var selector = new ReadPreferenceServerSelector(readPreference);
             var server = _cluster.SelectServer(operationContext, selector);
-            var binding = new SingleServerReadBinding(_cluster, server, readPreference, NoCoreSession.NewHandle());
+            var binding = new SingleServerReadBinding(_cluster, server.EndPoint, readPreference, NoCoreSession.NewHandle());
             return new ReadBindingHandle(binding);
         }
 
@@ -1050,7 +1050,7 @@ namespace MongoDB.Driver.GridFS
             var readPreference = _options.ReadPreference ?? _database.Settings.ReadPreference;
             var selector = new ReadPreferenceServerSelector(readPreference);
             var server = await _cluster.SelectServerAsync(operationContext, selector).ConfigureAwait(false);
-            var binding = new SingleServerReadBinding(_cluster, server, readPreference, NoCoreSession.NewHandle());
+            var binding = new SingleServerReadBinding(_cluster, server.EndPoint, readPreference, NoCoreSession.NewHandle());
             return new ReadBindingHandle(binding);
         }
 

--- a/tests/MongoDB.Driver.Tests/Core/Bindings/ChannelChannelSourceTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Bindings/ChannelChannelSourceTests.cs
@@ -42,7 +42,7 @@ namespace MongoDB.Driver.Core.Bindings
         }
 
         [Fact]
-        public void constructor_should_throw_when_server_is_null()
+        public void constructor_should_throw_when_serverEndpoint_is_null()
         {
             var channel = new Mock<IChannelHandle>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;

--- a/tests/MongoDB.Driver.Tests/Core/Bindings/ChannelChannelSourceTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Bindings/ChannelChannelSourceTests.cs
@@ -42,7 +42,7 @@ namespace MongoDB.Driver.Core.Bindings
         }
 
         [Fact]
-        public void constructor_should_throw_when_serverEndpoint_is_null()
+        public void constructor_should_throw_when_server_is_null()
         {
             var channel = new Mock<IChannelHandle>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;

--- a/tests/MongoDB.Driver.Tests/Core/Bindings/SingleServerReadBindingTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Bindings/SingleServerReadBindingTests.cs
@@ -37,7 +37,7 @@ public class SingleServerReadBindingTests
         var readPreference = ReadPreference.Primary;
         var session = new Mock<ICoreSessionHandle>().Object;
 
-        var result = new SingleServerReadBinding(cluster, server, readPreference, session);
+        var result = new SingleServerReadBinding(cluster, server.EndPoint, readPreference, session);
 
         result._cluster().Should().BeSameAs(cluster);
         result._disposed().Should().BeFalse();
@@ -52,7 +52,7 @@ public class SingleServerReadBindingTests
         var readPreference = ReadPreference.Primary;
         var session = new Mock<ICoreSessionHandle>().Object;
 
-        var exception = Record.Exception(() => new SingleServerReadBinding(null, server, readPreference, session));
+        var exception = Record.Exception(() => new SingleServerReadBinding(null, server.EndPoint, readPreference, session));
 
         var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
         e.ParamName.Should().Be("cluster");
@@ -68,7 +68,7 @@ public class SingleServerReadBindingTests
         var exception = Record.Exception(() => new SingleServerReadBinding(cluster, null, readPreference, session));
 
         var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
-        e.ParamName.Should().Be("server");
+        e.ParamName.Should().Be("serverEndpoint");
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class SingleServerReadBindingTests
         var server = CreateMockServer().Object;
         var session = new Mock<ICoreSessionHandle>().Object;
 
-        var exception = Record.Exception(() => new SingleServerReadBinding(cluster, server, null, session));
+        var exception = Record.Exception(() => new SingleServerReadBinding(cluster, server.EndPoint, null, session));
 
         var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
         e.ParamName.Should().Be("readPreference");
@@ -91,7 +91,7 @@ public class SingleServerReadBindingTests
         var server = CreateMockServer().Object;
         var readPreference = ReadPreference.Primary;
 
-        var exception = Record.Exception(() => new SingleServerReadBinding(cluster, server, readPreference, null));
+        var exception = Record.Exception(() => new SingleServerReadBinding(cluster, server.EndPoint, readPreference, null));
 
         var e = exception.Should().BeOfType<ArgumentNullException>().Subject;
         e.ParamName.Should().Be("session");
@@ -203,7 +203,7 @@ public class SingleServerReadBindingTests
 
         return new SingleServerReadBinding(
             cluster ?? new Mock<IClusterInternal>().Object,
-            server ?? CreateMockServer().Object,
+            (server ?? CreateMockServer().Object).EndPoint,
             readPreference ?? ReadPreference.Primary,
             session);
     }

--- a/tests/MongoDB.Driver.Tests/Core/Bindings/SingleServerReadBindingTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Bindings/SingleServerReadBindingTests.cs
@@ -59,7 +59,7 @@ public class SingleServerReadBindingTests
     }
 
     [Fact]
-    public void constructor_should_throw_when_server_is_null()
+    public void constructor_should_throw_when_serverEndpoint_is_null()
     {
         var cluster = new Mock<IClusterInternal>().Object;
         var readPreference = ReadPreference.Primary;

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -231,7 +231,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                     collection.InsertMany(session, documents);
                 }
 
-                // do read from all secondaries in case of replicaset to make sure the data is available there already
+                // do read from all secondaries in case of replica set to make sure the data is available there already
                 if (validateInitialDataPropagation)
                 {
                     var cluster = client.GetClusterInternal();
@@ -241,7 +241,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                         var runCommandOperation = new CountOperation(collection.CollectionNamespace, new MessageEncoderSettings()) { ReadConcern = ReadConcern.Local, };
                         foreach (var server in cluster.Description.Servers.Where(s => s.Type == ServerType.ReplicaSetSecondary))
                         {
-                            var singleServerBinding = new SingleServerReadBinding(cluster, server.EndPoint, ReadPreference.Secondary, session.WrappedCoreSession);
+                            using var singleServerBinding = new SingleServerReadBinding(cluster, server.EndPoint, ReadPreference.Secondary, session.WrappedCoreSession);
                             runCommandOperation.Execute(OperationContext.NoTimeout, singleServerBinding);
                         }
                     }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -241,7 +241,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                         var runCommandOperation = new CountOperation(collection.CollectionNamespace, new MessageEncoderSettings()) { ReadConcern = ReadConcern.Local, };
                         foreach (var server in cluster.Description.Servers.Where(s => s.Type == ServerType.ReplicaSetSecondary))
                         {
-                            using var singleServerBinding = new SingleServerReadBinding(cluster, server.EndPoint, ReadPreference.Secondary, session.WrappedCoreSession);
+                            using var singleServerBinding = new SingleServerReadBinding(cluster, server.EndPoint, ReadPreference.Secondary, session.WrappedCoreSession.Fork());
                             runCommandOperation.Execute(OperationContext.NoTimeout, singleServerBinding);
                         }
                     }

--- a/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/UnifiedTestOperations/UnifiedTestRunner.cs
@@ -22,10 +22,14 @@ using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core;
+using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Logging;
 using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.Operations;
+using MongoDB.Driver.Core.Servers;
 using MongoDB.Driver.Core.TestHelpers.Logging;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
 using MongoDB.Driver.Tests.UnifiedTestOperations.Matchers;
 using MongoDB.TestHelpers.XunitExtensions;
 using Xunit.Sdk;
@@ -85,7 +89,9 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             var outcome = testCase.Test.GetValue("outcome", null)?.AsBsonArray;
             var async = testCase.Test["async"].AsBoolean; // cannot be null
 
-            Run(schemaVersion, testSetRunOnRequirements, entities, initialData, runOnRequirements, skipReason, operations, expectEvents, expectedLogs, expectTracingMessages, outcome, async);
+            var validateInitialDataPropagation = testCase.Name.Contains("Aggregate with $out includes read preference for 5.0+ server");
+
+            Run(schemaVersion, testSetRunOnRequirements, entities, initialData, runOnRequirements, skipReason, operations, expectEvents, expectedLogs, expectTracingMessages, outcome, async, validateInitialDataPropagation);
         }
 
         public void Run(
@@ -100,7 +106,8 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
             BsonArray expectedLogs,
             BsonArray expectTracingMessages,
             BsonArray outcome,
-            bool async)
+            bool async,
+            bool validateInitialDataPropagation)
         {
             if (_runHasBeenCalled)
             {
@@ -127,7 +134,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 throw new SkipException($"Test skipped because '{skipReason}'.");
             }
 
-            var lastKnownClusterTime = AddInitialData(DriverTestConfiguration.Client, initialData);
+            var lastKnownClusterTime = AddInitialData(DriverTestConfiguration.Client, initialData, validateInitialDataPropagation);
             _entityMap = UnifiedEntityMap.Create(_eventFormatters, _loggingService.LoggingSettings, async, lastKnownClusterTime);
             _entityMap.AddRange(entities);
 
@@ -176,7 +183,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
         }
 
         // private methods
-        private BsonDocument AddInitialData(IMongoClient client, BsonArray initialData)
+        private BsonDocument AddInitialData(IMongoClient client, BsonArray initialData, bool validateInitialDataPropagation)
         {
             if (initialData == null)
             {
@@ -210,7 +217,7 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 }
 
                 _logger.LogDebug("Dropping {0}", collectionName);
-                using var session = client.StartSession();
+                using var session = client.StartSession(new ClientSessionOptions { CausalConsistency = true });
 
                 // For some QE spec tests we need to drop QE state collections (enxcol_.*.esc, enxcol_.*.ecoc).
                 // DropCollection with EncryptedFields automatically handles cleanup of those QE state collections
@@ -222,6 +229,22 @@ namespace MongoDB.Driver.Tests.UnifiedTestOperations
                 {
                     var collection = database.GetCollection<BsonDocument>(collectionName);
                     collection.InsertMany(session, documents);
+                }
+
+                // do read from all secondaries in case of replicaset to make sure the data is available there already
+                if (validateInitialDataPropagation)
+                {
+                    var cluster = client.GetClusterInternal();
+                    if (DriverTestConfiguration.IsReplicaSet(cluster))
+                    {
+                        var collection = database.GetCollection<BsonDocument>(collectionName);
+                        var runCommandOperation = new CountOperation(collection.CollectionNamespace, new MessageEncoderSettings()) { ReadConcern = ReadConcern.Local, };
+                        foreach (var server in cluster.Description.Servers.Where(s => s.Type == ServerType.ReplicaSetSecondary))
+                        {
+                            var singleServerBinding = new SingleServerReadBinding(cluster, server.EndPoint, ReadPreference.Secondary, session.WrappedCoreSession);
+                            runCommandOperation.Execute(OperationContext.NoTimeout, singleServerBinding);
+                        }
+                    }
                 }
 
                 lastKnownClusterTime = session.ClusterTime;


### PR DESCRIPTION
Partial solution to fix flaky test: Aggregate with $out includes read preference for 5.0+ server, while https://jira.mongodb.org/browse/DRIVERS-3471 is being backlogged: the functionality to make sure the data is available on the secondary before running the test case is done accordingly to the proposal in DRIVERS-3471, but the functionality is activated by the hardcoded test case name.
