### PR TITLE
CSHARP-6066: FilteredMongoCollectionBase.FindOneAndUpdate throws NullReferenceException when options is null

### DIFF
--- a/src/MongoDB.Driver/FilteredMongoCollectionBase.cs
+++ b/src/MongoDB.Driver/FilteredMongoCollectionBase.cs
@@ -304,22 +304,22 @@ namespace MongoDB.Driver
 
         public override TProjection FindOneAndUpdate<TProjection>(FilterDefinition<TDocument> filter, UpdateDefinition<TDocument> update, FindOneAndUpdateOptions<TDocument, TProjection> options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _wrappedCollection.FindOneAndUpdate(CombineFilters(filter), AdjustUpdateDefinition(update, options.IsUpsert), options, cancellationToken);
+            return _wrappedCollection.FindOneAndUpdate(CombineFilters(filter), AdjustUpdateDefinition(update, options?.IsUpsert ?? false), options, cancellationToken);
         }
 
         public override TProjection FindOneAndUpdate<TProjection>(IClientSessionHandle session, FilterDefinition<TDocument> filter, UpdateDefinition<TDocument> update, FindOneAndUpdateOptions<TDocument, TProjection> options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _wrappedCollection.FindOneAndUpdate(session, CombineFilters(filter), AdjustUpdateDefinition(update, options.IsUpsert), options, cancellationToken);
+            return _wrappedCollection.FindOneAndUpdate(session, CombineFilters(filter), AdjustUpdateDefinition(update, options?.IsUpsert ?? false), options, cancellationToken);
         }
 
         public override Task<TProjection> FindOneAndUpdateAsync<TProjection>(FilterDefinition<TDocument> filter, UpdateDefinition<TDocument> update, FindOneAndUpdateOptions<TDocument, TProjection> options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _wrappedCollection.FindOneAndUpdateAsync(CombineFilters(filter), AdjustUpdateDefinition(update, options.IsUpsert), options, cancellationToken);
+            return _wrappedCollection.FindOneAndUpdateAsync(CombineFilters(filter), AdjustUpdateDefinition(update, options?.IsUpsert ?? false), options, cancellationToken);
         }
 
         public override Task<TProjection> FindOneAndUpdateAsync<TProjection>(IClientSessionHandle session, FilterDefinition<TDocument> filter, UpdateDefinition<TDocument> update, FindOneAndUpdateOptions<TDocument, TProjection> options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _wrappedCollection.FindOneAndUpdateAsync(session, CombineFilters(filter), AdjustUpdateDefinition(update, options.IsUpsert), options, cancellationToken);
+            return _wrappedCollection.FindOneAndUpdateAsync(session, CombineFilters(filter), AdjustUpdateDefinition(update, options?.IsUpsert ?? false), options, cancellationToken);
         }
 
         [Obsolete("Use Aggregation pipeline instead.")]

--- a/tests/MongoDB.Driver.Tests/OfTypeMongoCollectionTests.cs
+++ b/tests/MongoDB.Driver.Tests/OfTypeMongoCollectionTests.cs
@@ -757,19 +757,14 @@ namespace MongoDB.Driver.Tests
             var subject = CreateSubject();
             var update = new BsonDocument("$set", new BsonDocument("x", 5));
 
-            var exception = Record.Exception(() =>
+            if (async)
             {
-                if (async)
-                {
-                    subject.FindOneAndUpdateAsync(_providedFilter, update, null, CancellationToken.None);
-                }
-                else
-                {
-                    subject.FindOneAndUpdate(_providedFilter, update, null, CancellationToken.None);
-                }
-            });
-
-            exception.Should().BeNull();
+                subject.FindOneAndUpdateAsync(_providedFilter, update, null, CancellationToken.None);
+            }
+            else
+            {
+                subject.FindOneAndUpdate(_providedFilter, update, null, CancellationToken.None);
+            }
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Tests/OfTypeMongoCollectionTests.cs
+++ b/tests/MongoDB.Driver.Tests/OfTypeMongoCollectionTests.cs
@@ -769,6 +769,25 @@ namespace MongoDB.Driver.Tests
 
         [Theory]
         [ParameterAttributeData]
+        public void FindOneAndUpdate_with_session_should_not_throw_when_options_is_null(
+            [Values(false, true)] bool async)
+        {
+            var subject = CreateSubject();
+            var session = CreateSession(usingSession: true);
+            var update = new BsonDocument("$set", new BsonDocument("x", 5));
+
+            if (async)
+            {
+                subject.FindOneAndUpdateAsync(session, _providedFilter, update, null, CancellationToken.None);
+            }
+            else
+            {
+                subject.FindOneAndUpdate(session, _providedFilter, update, null, CancellationToken.None);
+            }
+        }
+
+        [Theory]
+        [ParameterAttributeData]
         public async Task MapReduce_should_include_the_filter_when_one_was_not_provided(
             [Values(false, true)] bool async)
         {

--- a/tests/MongoDB.Driver.Tests/OfTypeMongoCollectionTests.cs
+++ b/tests/MongoDB.Driver.Tests/OfTypeMongoCollectionTests.cs
@@ -751,6 +751,29 @@ namespace MongoDB.Driver.Tests
 
         [Theory]
         [ParameterAttributeData]
+        public void FindOneAndUpdate_should_not_throw_when_options_is_null(
+            [Values(false, true)] bool async)
+        {
+            var subject = CreateSubject();
+            var update = new BsonDocument("$set", new BsonDocument("x", 5));
+
+            var exception = Record.Exception(() =>
+            {
+                if (async)
+                {
+                    subject.FindOneAndUpdateAsync(_providedFilter, update, null, CancellationToken.None);
+                }
+                else
+                {
+                    subject.FindOneAndUpdate(_providedFilter, update, null, CancellationToken.None);
+                }
+            });
+
+            exception.Should().BeNull();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
         public async Task MapReduce_should_include_the_filter_when_one_was_not_provided(
             [Values(false, true)] bool async)
         {


### PR DESCRIPTION
## Summary

Fixes https://jira.mongodb.org/browse/CSHARP-6066

All four `FindOneAndUpdate` / `FindOneAndUpdateAsync` overloads in `FilteredMongoCollectionBase` access `options.IsUpsert` without a null check, despite the options parameter defaulting to null. This causes a `NullReferenceException` when callers rely on the default value, e.g. `collection.OfType<Derived>().FindOneAndUpdate(filter, update).`

## Fix

Replace `options.IsUpsert` with `options?.IsUpsert ?? false` in all four overloads. This is consistent with how `IsUpsert` defaults to false in `FindOneAndUpdateOptions`, and matches the null-tolerant pattern used elsewhere in the same file (e.g. MapReduce does options = options ?? new ...).

## Testing

Added `FindOneAndUpdate_should_not_throw_when_options_is_null` unit test covering both sync and async paths.