### PR TITLE
CSHARP-6009: Send afterClusterTime on writes in causally-consistent sessions - add more tests

### DIFF
--- a/specifications/transactions/tests/unified/commit.json
+++ b/specifications/transactions/tests/unified/commit.json
@@ -209,6 +209,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {
@@ -870,6 +873,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {
@@ -1042,6 +1048,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {
@@ -1200,6 +1209,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {

--- a/specifications/transactions/tests/unified/commit.yml
+++ b/specifications/transactions/tests/unified/commit.yml
@@ -136,6 +136,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '2' }
                 startTransaction: true
@@ -522,6 +523,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session0 }
                 # txnNumber 2 was skipped
                 txnNumber: { $numberLong: '3' }
@@ -617,6 +619,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session1 }
                 txnNumber: { $$exists: false }
                 startTransaction: { $$exists: false }
@@ -701,6 +704,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session1 }
                 txnNumber: { $$exists: false }
                 startTransaction: { $$exists: false }


### PR DESCRIPTION
Spec test sync accordingly to https://github.com/mongodb/specifications/pull/1951