### PR TITLE
CSHARP-6091: Support checked arithmetic operators in LINQ translation

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitUnary.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/SerializerFinders/SerializerFinderVisitUnary.cs
@@ -35,6 +35,7 @@ internal partial class SerializerFinderVisitor
         switch (unaryOperator)
         {
             case ExpressionType.Negate:
+            case ExpressionType.NegateChecked:
                 DeduceNegateSerializers(); // TODO: fold into general case?
                 break;
 

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/BinaryExpressionToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/BinaryExpressionToAggregationExpressionTranslator.cs
@@ -152,7 +152,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             return expression.NodeType switch
             {
                 ExpressionType.Add => true,
+                ExpressionType.AddChecked => true,
                 ExpressionType.Subtract => true,
+                ExpressionType.SubtractChecked => true,
                 _ => false
             };
         }
@@ -167,14 +169,17 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             return nodeType switch
             {
                 ExpressionType.Add => true,
+                ExpressionType.AddChecked => true,
                 ExpressionType.And => true, // bitwise and
                 ExpressionType.Divide => true,
                 ExpressionType.ExclusiveOr => true, // bitwise xor
                 ExpressionType.Modulo => true,
                 ExpressionType.Multiply => true,
+                ExpressionType.MultiplyChecked => true,
                 ExpressionType.Or => true, // bitwise or
                 ExpressionType.Power => true,
                 ExpressionType.Subtract => true,
+                ExpressionType.SubtractChecked => true,
                 _ => false
             };
         }
@@ -259,14 +264,17 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             var ast = expression.NodeType switch
             {
                 ExpressionType.Add => AstExpression.Add(leftAst, rightAst),
+                ExpressionType.AddChecked => AstExpression.Add(leftAst, rightAst),
                 ExpressionType.And => AstExpression.BitAnd(leftAst, rightAst),
                 ExpressionType.Divide => AstExpression.Divide(leftAst, rightAst),
                 ExpressionType.ExclusiveOr => AstExpression.BitXor(leftAst, rightAst),
                 ExpressionType.Modulo => AstExpression.Mod(leftAst, rightAst),
                 ExpressionType.Multiply => AstExpression.Multiply(leftAst, rightAst),
+                ExpressionType.MultiplyChecked => AstExpression.Multiply(leftAst, rightAst),
                 ExpressionType.Or => AstExpression.BitOr(leftAst, rightAst),
                 ExpressionType.Power => AstExpression.Pow(leftAst, rightAst),
                 ExpressionType.Subtract => AstExpression.Subtract(leftAst, rightAst),
+                ExpressionType.SubtractChecked => AstExpression.Subtract(leftAst, rightAst),
                 _ => throw new ExpressionNotSupportedException(expression)
             };
             var serializer = StandardSerializers.GetSerializer(expression.Type);
@@ -405,7 +413,9 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
             var ast = expression.NodeType switch
             {
                 ExpressionType.Add => AstExpression.Add(leftAst, rightAst),
+                ExpressionType.AddChecked => AstExpression.Add(leftAst, rightAst),
                 ExpressionType.Subtract => AstExpression.Subtract(leftAst, rightAst),
+                ExpressionType.SubtractChecked => AstExpression.Subtract(leftAst, rightAst),
                 _ => throw new ExpressionNotSupportedException(expression)
             };
             var serializer = enumTranslation.Serializer;

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ExpressionToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/ExpressionToAggregationExpressionTranslator.cs
@@ -55,6 +55,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                     return NotExpressionToAggregationExpressionTranslator.Translate(context, (UnaryExpression)expression);
 
                 case ExpressionType.Add:
+                case ExpressionType.AddChecked:
                 case ExpressionType.And:
                 case ExpressionType.AndAlso:
                 case ExpressionType.Coalesce:
@@ -67,11 +68,13 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 case ExpressionType.LessThanOrEqual:
                 case ExpressionType.Modulo:
                 case ExpressionType.Multiply:
+                case ExpressionType.MultiplyChecked:
                 case ExpressionType.NotEqual:
                 case ExpressionType.Or:
                 case ExpressionType.OrElse:
                 case ExpressionType.Power:
                 case ExpressionType.Subtract:
+                case ExpressionType.SubtractChecked:
                     return BinaryExpressionToAggregationExpressionTranslator.Translate(context, (BinaryExpression)expression);
 
                 case ExpressionType.ArrayIndex:
@@ -93,6 +96,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 case ExpressionType.MemberInit:
                     return MemberInitExpressionToAggregationExpressionTranslator.Translate(context, (MemberInitExpression)expression);
                 case ExpressionType.Negate:
+                case ExpressionType.NegateChecked:
                     return NegateExpressionToAggregationExpressionTranslator.Translate(context, (UnaryExpression)expression);
                 case ExpressionType.New:
                     return NewExpressionToAggregationExpressionTranslator.Translate(context, (NewExpression)expression);

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/NegateExpressionToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/NegateExpressionToAggregationExpressionTranslator.cs
@@ -23,7 +23,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
     {
         public static TranslatedExpression Translate(TranslationContext context, UnaryExpression expression)
         {
-            if (expression.NodeType == ExpressionType.Negate)
+            if (expression.NodeType == ExpressionType.Negate || expression.NodeType == ExpressionType.NegateChecked)
             {
                 var operandExpression = expression.Operand;
                 var operandTranslation = ExpressionToAggregationExpressionTranslator.Translate(context, operandExpression);

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp6091Tests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/Jira/CSharp6091Tests.cs
@@ -1,0 +1,341 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using MongoDB.Driver.TestHelpers;
+using FluentAssertions;
+using MongoDB.TestHelpers.XunitExtensions;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.Jira;
+
+public class CSharp6091Tests : LinqIntegrationTest<CSharp6091Tests.ClassFixture>
+{
+    public CSharp6091Tests(ClassFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Select_with_checked_or_unchecked_add_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, R>> projection;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                projection = x => new R { V = x.A + x.B };
+            }
+        }
+        else
+        {
+            projection = x => new R { V = x.A + x.B };
+        }
+
+        var queryable = collection.AsQueryable().Select(projection);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $project : { V : { $add : ['$A', '$B'] }, _id : 0 } }");
+
+        var results = queryable.ToList().OrderBy(x => x.V).ToList();
+        results.Select(x => x.V).Should().Equal(11, 22);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Select_with_checked_or_unchecked_subtract_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, R>> projection;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                projection = x => new R { V = x.A - x.B };
+            }
+        }
+        else
+        {
+            projection = x => new R { V = x.A - x.B };
+        }
+
+        var queryable = collection.AsQueryable().Select(projection);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $project : { V : { $subtract : ['$A', '$B'] }, _id : 0 } }");
+
+        var results = queryable.ToList().OrderBy(x => x.V).ToList();
+        results.Select(x => x.V).Should().Equal(9, 18);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Select_with_checked_or_unchecked_multiply_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, R>> projection;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                projection = x => new R { V = x.A * x.B };
+            }
+        }
+        else
+        {
+            projection = x => new R { V = x.A * x.B };
+        }
+
+        var queryable = collection.AsQueryable().Select(projection);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $project : { V : { $multiply : ['$A', '$B'] }, _id : 0 } }");
+
+        var results = queryable.ToList().OrderBy(x => x.V).ToList();
+        results.Select(x => x.V).Should().Equal(10, 40);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Select_with_checked_or_unchecked_negate_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, R>> projection;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                projection = x => new R { V = -x.A };
+            }
+        }
+        else
+        {
+            projection = x => new R { V = -x.A };
+        }
+
+        var queryable = collection.AsQueryable().Select(projection);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $project : { V : { $subtract : [0, '$A'] }, _id : 0 } }");
+
+        var results = queryable.ToList().OrderBy(x => x.V).ToList();
+        results.Select(x => x.V).Should().Equal(-20, -10);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Where_with_checked_or_unchecked_add_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, bool>> predicate;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                predicate = x => x.A + x.B > 15;
+            }
+        }
+        else
+        {
+            predicate = x => x.A + x.B > 15;
+        }
+
+        var queryable = collection.AsQueryable().Where(predicate);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $match : { $expr : { $gt : [{ $add : ['$A', '$B'] }, 15] } } }");
+
+        var results = queryable.ToList();
+        results.Select(x => x.Id).Should().Equal(2);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Where_with_checked_or_unchecked_subtract_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, bool>> predicate;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                predicate = x => x.A - x.B > 10;
+            }
+        }
+        else
+        {
+            predicate = x => x.A - x.B > 10;
+        }
+
+        var queryable = collection.AsQueryable().Where(predicate);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $match : { $expr : { $gt : [{ $subtract : ['$A', '$B'] }, 10] } } }");
+
+        var results = queryable.ToList();
+        results.Select(x => x.Id).Should().Equal(2);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Where_with_checked_or_unchecked_multiply_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, bool>> predicate;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                predicate = x => x.A * x.B > 30;
+            }
+        }
+        else
+        {
+            predicate = x => x.A * x.B > 30;
+        }
+
+        var queryable = collection.AsQueryable().Where(predicate);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $match : { $expr : { $gt : [{ $multiply : ['$A', '$B'] }, 30] } } }");
+
+        var results = queryable.ToList();
+        results.Select(x => x.Id).Should().Equal(2);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Where_with_checked_or_unchecked_negate_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, bool>> predicate;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                predicate = x => -x.A < -15;
+            }
+        }
+        else
+        {
+            predicate = x => -x.A < -15;
+        }
+
+        var queryable = collection.AsQueryable().Where(predicate);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $match : { $expr : { $lt : [{ $subtract : [0, '$A'] }, -15] } } }");
+
+        var results = queryable.ToList();
+        results.Select(x => x.Id).Should().Equal(2);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public void Select_with_checked_or_unchecked_enum_add_should_work(
+        [Values(false, true)] bool @checked)
+    {
+        var collection = Fixture.Collection;
+
+        Expression<Func<C, RE>> projection;
+        if (@checked)
+        {
+            checked // default compiler setting is not checked
+            {
+                projection = x => new RE { S = x.Status + 1 };
+            }
+        }
+        else
+        {
+            projection = x => new RE { S = x.Status + 1 };
+        }
+
+        var queryable = collection.AsQueryable().Select(projection);
+
+        var stages = Translate(collection, queryable);
+        AssertStages(
+            stages,
+            "{ $project : { S : { $add : ['$Status', 1] }, _id : 0 } }");
+
+        var results = queryable.ToList().OrderBy(x => x.S).ToList();
+        results.Select(x => x.S).Should().Equal(E.B, E.C);
+    }
+
+    public enum E { A = 0, B = 1, C = 2 }
+
+    public class C
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+        public E Status { get; set; }
+    }
+
+    public class R
+    {
+        public int V { get; set; }
+    }
+
+    public class RE
+    {
+        public E S { get; set; }
+    }
+
+    public sealed class ClassFixture : MongoCollectionFixture<C>
+    {
+        protected override IEnumerable<C> InitialData =>
+        [
+            new C { Id = 1, A = 10, B = 1, Status = E.A },
+            new C { Id = 2, A = 20, B = 2, Status = E.B },
+        ];
+    }
+}


### PR DESCRIPTION
Fixes [CSHARP-6091](https://jira.mongodb.org/browse/CSHARP-6091) as a prelude for fixing [EF-249](https://jira.mongodb.org/browse/EF-249)

Tests are a little unusual in exercising both checked and unchecked paths but follows the structure laid out in [CSHARP-5606](https://github.com/mongodb/mongo-csharp-driver/pull/1856/changes#diff-23b290b99744ec15d6365c41ee862752676f4e6cc7650263db8fdd95fb0d6724)