### PR TITLE
CSHARP-6092: Avoid buffer allocations in ObjectId.Parse

### DIFF
--- a/src/MongoDB.Bson/BsonUtils.cs
+++ b/src/MongoDB.Bson/BsonUtils.cs
@@ -73,18 +73,18 @@ namespace MongoDB.Bson
         }
 
         /// <summary>
-        /// Parses a hex char span into its equivalent byte array.
+        /// Parses a hex char span into its equivalent byte span.
         /// </summary>
         /// <param name="s">The hex char span to parse.</param>
-        /// <param name="bytes">The result span to fill with the byte equivalent of the hex string.</param>
-        public static void ParseHexString(ReadOnlySpan<char> s, Span<byte> bytes)
+        /// <param name="destination">The destination span to fill with the byte equivalent of the hex string.</param>
+        public static void ParseHexString(ReadOnlySpan<char> s, Span<byte> destination)
         {
             int expectedLength = GetByteLength(s.Length);
-            if (bytes.Length != expectedLength)
+            if (destination.Length != expectedLength)
             {
                 throw new FormatException($"Target should be {expectedLength} bytes long");
             }
-            if (!TryParseHexString(s, bytes))
+            if (!TryParseHexString(s, destination))
             {
                 throw new FormatException("String should contain only hexadecimal digits.");
             }
@@ -250,22 +250,14 @@ namespace MongoDB.Bson
         }
 
         /// <summary>
-        /// Calculate the result byte length for the hex string length
+        /// Tries to parse a hex char span into its equivalent byte span.
         /// </summary>
-        /// <param name="hexStringLength">The length of the hex string</param>
-        /// <returns>The required length to convert the hex string to bytes</returns>
-        internal static int GetByteLength(int hexStringLength)
-            => (hexStringLength + 1) / 2;
-
-        /// <summary>
-        /// Tries to parse a hex char span to a byte span.
-        /// </summary>
-        /// <param name="s">The hex chars.</param>
-        /// <param name="bytes">A byte span.</param>
+        /// <param name="s">The hex char span to parse.</param>
+        /// <param name="destination">The destination span to fill with the byte equivalent of the hex string.</param>
         /// <returns>True if the hex char span was successfully parsed.</returns>
-        public static bool TryParseHexString(ReadOnlySpan<char> s, Span<byte> bytes)
+        public static bool TryParseHexString(ReadOnlySpan<char> s, Span<byte> destination)
         {
-            if (bytes.Length != GetByteLength(s.Length))
+            if (destination.Length != GetByteLength(s.Length))
                 return false;
 
             var i = 0;
@@ -279,7 +271,7 @@ namespace MongoDB.Bson
                 {
                     return false;
                 }
-                bytes[j++] = (byte)y;
+                destination[j++] = (byte)y;
             }
 
             while (i < s.Length)
@@ -293,13 +285,17 @@ namespace MongoDB.Bson
                 {
                     return false;
                 }
-                bytes[j++] = (byte)((x << 4) | y);
+                destination[j++] = (byte)((x << 4) | y);
             }
 
             return true;
         }
 
         // private static methods
+
+        private static int GetByteLength(int hexStringLength)
+            => (hexStringLength + 1) / 2;
+
         private static bool TryParseHexChar(char c, out int value)
         {
             if (c >= '0' && c <= '9')

--- a/src/MongoDB.Bson/BsonUtils.cs
+++ b/src/MongoDB.Bson/BsonUtils.cs
@@ -73,6 +73,24 @@ namespace MongoDB.Bson
         }
 
         /// <summary>
+        /// Parses a hex char span into its equivalent byte array.
+        /// </summary>
+        /// <param name="s">The hex char span to parse.</param>
+        /// <param name="bytes">The result span to fill with the byte equivalent of the hex string.</param>
+        public static void ParseHexString(ReadOnlySpan<char> s, Span<byte> bytes)
+        {
+            int expectedLength = GetByteLength(s.Length);
+            if (bytes.Length != expectedLength)
+            {
+                throw new FormatException($"Target should be {expectedLength} bytes long");
+            }
+            if (!TryParseHexString(s, bytes))
+            {
+                throw new FormatException("String should contain only hexadecimal digits.");
+            }
+        }
+
+        /// <summary>
         /// Converts from number of milliseconds since Unix epoch to DateTime.
         /// </summary>
         /// <param name="millisecondsSinceEpoch">The number of milliseconds since Unix epoch.</param>
@@ -212,14 +230,43 @@ namespace MongoDB.Bson
         /// <returns>True if the hex string was successfully parsed.</returns>
         public static bool TryParseHexString(string s, out byte[] bytes)
         {
-            bytes = null;
-
             if (s == null)
             {
+                bytes = null;
                 return false;
             }
 
-            var buffer = new byte[(s.Length + 1) / 2];
+            var buffer = new byte[GetByteLength(s.Length)];
+            if (TryParseHexString(s.AsSpan(), buffer))
+            {
+                bytes = buffer;
+                return true;
+            }
+            else
+            {
+                bytes = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Calculate the result byte length for the hex string length
+        /// </summary>
+        /// <param name="hexStringLength">The length of the hex string</param>
+        /// <returns>The required length to convert the hex string to bytes</returns>
+        internal static int GetByteLength(int hexStringLength)
+            => (hexStringLength + 1) / 2;
+
+        /// <summary>
+        /// Tries to parse a hex char span to a byte span.
+        /// </summary>
+        /// <param name="s">The hex chars.</param>
+        /// <param name="bytes">A byte span.</param>
+        /// <returns>True if the hex char span was successfully parsed.</returns>
+        public static bool TryParseHexString(ReadOnlySpan<char> s, Span<byte> bytes)
+        {
+            if (bytes.Length != GetByteLength(s.Length))
+                return false;
 
             var i = 0;
             var j = 0;
@@ -232,7 +279,7 @@ namespace MongoDB.Bson
                 {
                     return false;
                 }
-                buffer[j++] = (byte)y;
+                bytes[j++] = (byte)y;
             }
 
             while (i < s.Length)
@@ -246,10 +293,9 @@ namespace MongoDB.Bson
                 {
                     return false;
                 }
-                buffer[j++] = (byte)((x << 4) | y);
+                bytes[j++] = (byte)((x << 4) | y);
             }
 
-            bytes = buffer;
             return true;
         }
 

--- a/src/MongoDB.Bson/ObjectModel/ObjectId.cs
+++ b/src/MongoDB.Bson/ObjectModel/ObjectId.cs
@@ -87,8 +87,8 @@ namespace MongoDB.Bson
             {
                 throw new ArgumentNullException(nameof(value));
             }
-
-            var bytes = BsonUtils.ParseHexString(value);
+            Span<byte> bytes = stackalloc byte[12];
+            BsonUtils.ParseHexString(value.AsSpan(), bytes);
             FromBytesSpan(bytes, out _a, out _b, out _c);
         }
 
@@ -255,11 +255,27 @@ namespace MongoDB.Bson
         /// <returns>True if the string was parsed successfully.</returns>
         public static bool TryParse(string s, out ObjectId objectId)
         {
-            // don't throw ArgumentNullException if s is null
-            if (s != null && s.Length == 24)
+            if (s == null)
             {
-                byte[] bytes;
-                if (BsonUtils.TryParseHexString(s, out bytes))
+                // don't throw ArgumentNullException if s is null
+                objectId = default(ObjectId);
+                return false;
+            }
+            return TryParse(s.AsSpan(), out objectId);
+        }
+
+        /// <summary>
+        /// Tries to parse a span of chars and create a new ObjectId.
+        /// </summary>
+        /// <param name="s">The span value.</param>
+        /// <param name="objectId">The new ObjectId.</param>
+        /// <returns>True if the string was parsed successfully.</returns>
+        public static bool TryParse(ReadOnlySpan<char> s, out ObjectId objectId)
+        {
+            if (s.Length == 24)
+            {
+                Span<byte> bytes = stackalloc byte[12];
+                if (BsonUtils.TryParseHexString(s, bytes))
                 {
                     objectId = new ObjectId(bytes);
                     return true;

--- a/tests/MongoDB.Bson.Tests/BsonUtilsTests.cs
+++ b/tests/MongoDB.Bson.Tests/BsonUtilsTests.cs
@@ -14,6 +14,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using Xunit;
@@ -102,15 +104,23 @@ namespace MongoDB.Bson.Tests
             Assert.Equal(expected, actual);
         }
 
+        public static IEnumerable<object[]> ParseHexStringValidInput
+        {
+            get
+            {
+                yield return new object[] { "", new byte[0] };
+                yield return new object[] { "1", new byte[] { 0x01 } };
+                yield return new object[] { "12", new byte[] { 0x12 } };
+                yield return new object[] { "123", new byte[] { 0x01, 0x23 } };
+                yield return new object[] { "1234", new byte[] { 0x12, 0x34 } };
+                yield return new object[] { "12345", new byte[] { 0x01, 0x23, 0x45 } };
+                yield return new object[] { "123456", new byte[] { 0x12, 0x34, 0x56 } };
+                yield return new object[] { "0123456789abcdefABCDEF", new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef } };
+            }
+        }
+
         [Theory]
-        [InlineData("", new byte[0])]
-        [InlineData("1", new byte[] { 0x01 })]
-        [InlineData("12", new byte[] { 0x12 })]
-        [InlineData("123", new byte[] { 0x01, 0x23 })]
-        [InlineData("1234", new byte[] { 0x12, 0x34 })]
-        [InlineData("12345", new byte[] { 0x01, 0x23, 0x45 })]
-        [InlineData("123456", new byte[] { 0x12, 0x34, 0x56 })]
-        [InlineData("0123456789abcdefABCDEF", new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef })]
+        [MemberData(nameof(ParseHexStringValidInput))]
         public void ParseHexString_should_return_expected_result(string s, byte[] expectedResult)
         {
             var result = BsonUtils.ParseHexString(s);
@@ -119,16 +129,43 @@ namespace MongoDB.Bson.Tests
         }
 
         [Theory]
-        [InlineData("x")]
-        [InlineData("/")] // character just before "0"
-        [InlineData(":")] // character just after "9"
-        [InlineData("`")] // character just before "a"
-        [InlineData("g")] // character just after "f"
-        [InlineData("@")] // character just before "A"
-        [InlineData("G")] // character just after "F"
+        [MemberData(nameof(ParseHexStringValidInput))]
+        public void ParseHexStringSpan_should_return_expected_result(string s, byte[] expectedResult)
+        {
+            Span<byte> result = stackalloc byte[(s.Length + 1) / 2];
+            BsonUtils.ParseHexString(s.AsSpan(), result);
+
+            result.ToArray().Should().Equal(expectedResult);
+        }
+
+        public static IEnumerable<object[]> ParseHexStringInvalidInput
+        {
+            get
+            {
+                yield return new object[] { "x" };
+                yield return new object[] { "/" };  // character just before "0"
+                yield return new object[] { ":" };  // character just after "9"
+                yield return new object[] { "`" };  // character just before "a"
+                yield return new object[] { "g" };  // character just after "f"
+                yield return new object[] { "@" };  // character just before "A"
+                yield return new object[] { "G" };  // character just after "F"
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ParseHexStringInvalidInput))]
         public void ParseHexString_should_throw_when_string_is_invalid(string s)
         {
             var exception = Record.Exception(() => BsonUtils.ParseHexString(s));
+
+            exception.Should().BeOfType<FormatException>();
+        }
+
+        [Theory]
+        [MemberData(nameof(ParseHexStringInvalidInput))]
+        public void ParseHexStringSpan_should_throw_when_string_is_invalid(string s)
+        {
+            var exception = Record.Exception(() => BsonUtils.ParseHexString(s.AsSpan(), new byte[(s.Length + 1) / 2]));
 
             exception.Should().BeOfType<FormatException>();
         }
@@ -140,6 +177,43 @@ namespace MongoDB.Bson.Tests
 
             var argumentNullException = exception.Should().BeOfType<ArgumentNullException>().Subject;
             argumentNullException.ParamName.Should().Be("s");
+        }
+
+        [Theory]
+        [InlineData(1, 0, true)]
+        [InlineData(1, 1, false)]
+        [InlineData(1, 2, true)]
+        [InlineData(1, 3, true)]
+        [InlineData(2, 0, true)]
+        [InlineData(2, 1, false)]
+        [InlineData(2, 2, true)]
+        [InlineData(2, 3, true)]
+        [InlineData(9, 1, true)]
+        [InlineData(9, 4, true)]
+        [InlineData(9, 5, false)]
+        [InlineData(9, 6, true)]
+        [InlineData(10, 1, true)]
+        [InlineData(10, 4, true)]
+        [InlineData(10, 5, false)]
+        [InlineData(10, 6, true)]
+        [InlineData(11, 1, true)]
+        [InlineData(11, 4, true)]
+        [InlineData(11, 5, true)]
+        [InlineData(11, 6, false)]
+        [InlineData(11, 7, true)]
+        public void ParseHexStringSpan_should_throw_when_length_is_incorrect(int inputLength, int destinationLength, bool shouldThrow)
+        {
+            var exception = Record.Exception(() => BsonUtils.ParseHexString(new string('0', inputLength).AsSpan(), new byte[destinationLength]));
+
+            if (shouldThrow)
+            {
+                var formatException = exception.Should().BeOfType<FormatException>().Subject;
+                formatException.Message.Should().Be($"Target should be {(inputLength + 1) / 2} bytes long");
+            }
+            else
+            {
+                exception.Should().BeNull();
+            }
         }
 
         [Theory]
@@ -165,14 +239,7 @@ namespace MongoDB.Bson.Tests
         }
 
         [Theory]
-        [InlineData("", new byte[0])]
-        [InlineData("1", new byte[] { 0x01 })]
-        [InlineData("12", new byte[] { 0x12 })]
-        [InlineData("123", new byte[] { 0x01, 0x23 })]
-        [InlineData("1234", new byte[] { 0x12, 0x34 })]
-        [InlineData("12345", new byte[] { 0x01, 0x23, 0x45 })]
-        [InlineData("123456", new byte[] { 0x12, 0x34, 0x56 })]
-        [InlineData("0123456789abcdefABCDEF", new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef })]
+        [MemberData(nameof(ParseHexStringValidInput))]
         public void TryParseHexString_should_return_expected_result(string s, byte[] expectedBytes)
         {
             byte[] bytes;
@@ -181,16 +248,20 @@ namespace MongoDB.Bson.Tests
             result.Should().BeTrue();
             bytes.Should().Equal(expectedBytes);
         }
+        [Theory]
+        [MemberData(nameof(ParseHexStringValidInput))]
+        public void TryParseHexStringSpan_should_return_expected_result(string s, byte[] expectedBytes)
+        {
+            Span<byte> bytes = stackalloc byte[expectedBytes.Length];
+            var result = BsonUtils.TryParseHexString(s.AsSpan(), bytes);
+
+            result.Should().BeTrue();
+            bytes.ToArray().Should().Equal(expectedBytes);
+        }
 
         [Theory]
+        [MemberData(nameof(ParseHexStringInvalidInput))]
         [InlineData(null)]
-        [InlineData("x")]
-        [InlineData("/")] // character just before "0"
-        [InlineData(":")] // character just after "9"
-        [InlineData("`")] // character just before "a"
-        [InlineData("g")] // character just after "f"
-        [InlineData("@")] // character just before "A"
-        [InlineData("G")] // character just after "F"
         public void TryParseHexString_should_return_expected_result_when_string_is_invalid(string s)
         {
             byte[] bytes;
@@ -198,6 +269,19 @@ namespace MongoDB.Bson.Tests
 
             result.Should().BeFalse();
             bytes.Should().BeNull();
+        }
+
+        [Theory]
+        [MemberData(nameof(ParseHexStringInvalidInput))]
+        public void TryParseHexStringSpan_should_return_expected_result_when_string_is_invalid(string s)
+        {
+            string input = "12345" + s;
+            int length = (input.Length + 1) / 2;
+            Span<byte> bytes = stackalloc byte[length];
+            var result = BsonUtils.TryParseHexString(input.AsSpan(), bytes);
+
+            result.Should().BeFalse();
+            bytes.ToArray().Should().Equal(new byte[] { 0x12, 0x34 }.Concat(new byte[length - 2]));
         }
     }
 }

--- a/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
@@ -431,6 +431,21 @@ public class ObjectIdTests
     }
 
     [Fact]
+    public void TestTryParseSpan()
+    {
+        ObjectId objectId1, objectId2;
+        Assert.True(ObjectId.TryParse("0102030405060708090a0b0c".AsSpan(), out objectId1)); // lower case
+        Assert.True(ObjectId.TryParse("0102030405060708090A0B0C".AsSpan(), out objectId2)); // upper case
+        Assert.True(objectId1.ToByteArray().SequenceEqual(objectId2.ToByteArray()));
+        Assert.True(objectId1.ToString() == "0102030405060708090a0b0c"); // ToString returns lower case
+        Assert.True(objectId1.ToString() == objectId2.ToString());
+        Assert.False(ObjectId.TryParse("102030405060708090a0b0c".AsSpan(), out objectId1)); // too short
+        Assert.False(ObjectId.TryParse("x102030405060708090a0b0c".AsSpan(), out objectId1)); // invalid character
+        Assert.False(ObjectId.TryParse("00102030405060708090a0b0c".AsSpan(), out objectId1)); // too long
+        Assert.False(ObjectId.TryParse(ReadOnlySpan<char>.Empty, out objectId1)); // should return false not throw ArgumentNullException
+    }
+
+    [Fact]
     public void TestConvertObjectIdToObjectId()
     {
         var oid = ObjectId.GenerateNewId();

--- a/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/ObjectIdTests.cs
@@ -427,7 +427,7 @@ public class ObjectIdTests
         Assert.False(ObjectId.TryParse("102030405060708090a0b0c", out objectId1)); // too short
         Assert.False(ObjectId.TryParse("x102030405060708090a0b0c", out objectId1)); // invalid character
         Assert.False(ObjectId.TryParse("00102030405060708090a0b0c", out objectId1)); // too long
-        Assert.False(ObjectId.TryParse(null, out objectId1)); // should return false not throw ArgumentNullException
+        Assert.False(ObjectId.TryParse(default(string), out objectId1)); // should return false not throw ArgumentNullException
     }
 
     [Fact]


### PR DESCRIPTION
- Eliminate byte array allocation in ObjectId(string) ctor and ObjectId.TryParse(string, out ObjectId)
- Added new Span-based TryParse method