### PR TITLE
CSHARP-2043: Add AssumeIndexesExist option to GridFSBucketOptions

### DIFF
--- a/src/MongoDB.Driver/GridFS/GridFSBucket.cs
+++ b/src/MongoDB.Driver/GridFS/GridFSBucket.cs
@@ -897,6 +897,11 @@ namespace MongoDB.Driver.GridFS
 
         private void EnsureIndexes(OperationContext operationContext, IReadWriteBindingHandle binding)
         {
+            if (_options.AssumeIndexesExist)
+            {
+                return;
+            }
+
             _ensureIndexesSemaphore.Wait(operationContext.RemainingTimeout, operationContext.CancellationToken);
             try
             {
@@ -926,6 +931,11 @@ namespace MongoDB.Driver.GridFS
 
         private async Task EnsureIndexesAsync(OperationContext operationContext, IReadWriteBindingHandle binding)
         {
+            if (_options.AssumeIndexesExist)
+            {
+                return;
+            }
+
             await _ensureIndexesSemaphore.WaitAsync(operationContext.RemainingTimeout, operationContext.CancellationToken).ConfigureAwait(false);
             try
             {

--- a/src/MongoDB.Driver/GridFS/GridFSBucketOptions.cs
+++ b/src/MongoDB.Driver/GridFS/GridFSBucketOptions.cs
@@ -74,6 +74,9 @@ namespace MongoDB.Driver.GridFS
         /// <summary>
         /// Gets or sets whether to assume the GridFS indexes already exist, skipping the index check and creation before the first upload.
         /// </summary>
+        /// <remarks>
+        /// When <c>true</c>, the driver never verifies or creates the GridFS indexes, so the caller is responsible for ensuring they exist.
+        /// </remarks>
         /// <value>
         /// <c>true</c> if the GridFS indexes are assumed to exist; otherwise, <c>false</c>.
         /// </value>
@@ -211,6 +214,9 @@ namespace MongoDB.Driver.GridFS
         /// <summary>
         /// Gets whether to assume the GridFS indexes already exist, skipping the index check and creation before the first upload.
         /// </summary>
+        /// <remarks>
+        /// When <c>true</c>, the driver never verifies or creates the GridFS indexes, so the caller is responsible for ensuring they exist.
+        /// </remarks>
         /// <value>
         /// <c>true</c> if the GridFS indexes are assumed to exist; otherwise, <c>false</c>.
         /// </value>

--- a/src/MongoDB.Driver/GridFS/GridFSBucketOptions.cs
+++ b/src/MongoDB.Driver/GridFS/GridFSBucketOptions.cs
@@ -24,6 +24,7 @@ namespace MongoDB.Driver.GridFS
     public class GridFSBucketOptions
     {
         // fields
+        private bool _assumeIndexesExist;
         private string _bucketName;
         private int _chunkSizeBytes;
         private ReadConcern _readConcern;
@@ -46,6 +47,7 @@ namespace MongoDB.Driver.GridFS
         public GridFSBucketOptions(GridFSBucketOptions other)
         {
             Ensure.IsNotNull(other, nameof(other));
+            _assumeIndexesExist = other.AssumeIndexesExist;
             _bucketName = other.BucketName;
             _chunkSizeBytes = other.ChunkSizeBytes;
             _readConcern = other.ReadConcern;
@@ -60,6 +62,7 @@ namespace MongoDB.Driver.GridFS
         public GridFSBucketOptions(ImmutableGridFSBucketOptions other)
         {
             Ensure.IsNotNull(other, nameof(other));
+            _assumeIndexesExist = other.AssumeIndexesExist;
             _bucketName = other.BucketName;
             _chunkSizeBytes = other.ChunkSizeBytes;
             _readConcern = other.ReadConcern;
@@ -68,6 +71,18 @@ namespace MongoDB.Driver.GridFS
         }
 
         // properties
+        /// <summary>
+        /// Gets or sets whether to assume the GridFS indexes already exist, skipping the index check and creation before the first upload.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the GridFS indexes are assumed to exist; otherwise, <c>false</c>.
+        /// </value>
+        public bool AssumeIndexesExist
+        {
+            get { return _assumeIndexesExist; }
+            set { _assumeIndexesExist = value; }
+        }
+
         /// <summary>
         /// Gets or sets the bucket name.
         /// </summary>
@@ -160,6 +175,7 @@ namespace MongoDB.Driver.GridFS
         #endregion
 
         // fields
+        private readonly bool _assumeIndexesExist;
         private readonly string _bucketName;
         private readonly int _chunkSizeBytes;
         private readonly ReadConcern _readConcern;
@@ -183,6 +199,7 @@ namespace MongoDB.Driver.GridFS
         public ImmutableGridFSBucketOptions(GridFSBucketOptions other)
         {
             Ensure.IsNotNull(other, nameof(other));
+            _assumeIndexesExist = other.AssumeIndexesExist;
             _bucketName = other.BucketName;
             _chunkSizeBytes = other.ChunkSizeBytes;
             _readConcern = other.ReadConcern;
@@ -191,6 +208,17 @@ namespace MongoDB.Driver.GridFS
         }
 
         // properties
+        /// <summary>
+        /// Gets whether to assume the GridFS indexes already exist, skipping the index check and creation before the first upload.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the GridFS indexes are assumed to exist; otherwise, <c>false</c>.
+        /// </value>
+        public bool AssumeIndexesExist
+        {
+            get { return _assumeIndexesExist; }
+        }
+
         /// <summary>
         /// Gets the bucket name.
         /// </summary>

--- a/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketOptionsTests.cs
+++ b/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketOptionsTests.cs
@@ -27,6 +27,32 @@ namespace MongoDB.Driver.Tests.GridFS
 {
     public class GridFSBucketOptionsTests
     {
+        [Theory]
+        [ParameterAttributeData]
+        public void AssumeIndexesExist_get_should_return_expected_result(
+            [Values(false, true)]
+            bool value)
+        {
+            var subject = new GridFSBucketOptions { AssumeIndexesExist = value };
+
+            var result = subject.AssumeIndexesExist;
+
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void AssumeIndexesExist_set_should_have_expected_result(
+            [Values(false, true)]
+            bool value)
+        {
+            var subject = new GridFSBucketOptions();
+
+            subject.AssumeIndexesExist = value;
+
+            subject.AssumeIndexesExist.Should().Be(value);
+        }
+
         [Fact]
         public void BucketName_get_should_return_expected_result()
         {
@@ -103,11 +129,12 @@ namespace MongoDB.Driver.Tests.GridFS
         [Fact]
         public void constructor_with_immutable_other_should_initialize_instance()
         {
-            var mutable = new GridFSBucketOptions { BucketName = "bucket", ChunkSizeBytes = 123, ReadConcern = ReadConcern.Majority, ReadPreference = ReadPreference.Secondary, WriteConcern = WriteConcern.WMajority };
+            var mutable = new GridFSBucketOptions { AssumeIndexesExist = true, BucketName = "bucket", ChunkSizeBytes = 123, ReadConcern = ReadConcern.Majority, ReadPreference = ReadPreference.Secondary, WriteConcern = WriteConcern.WMajority };
             var other = new ImmutableGridFSBucketOptions(mutable);
 
             var result = new GridFSBucketOptions(other);
 
+            result.AssumeIndexesExist.Should().Be(other.AssumeIndexesExist);
             result.BucketName.Should().Be(other.BucketName);
             result.ChunkSizeBytes.Should().Be(other.ChunkSizeBytes);
             result.ReadConcern.Should().Be(other.ReadConcern);
@@ -118,10 +145,11 @@ namespace MongoDB.Driver.Tests.GridFS
         [Fact]
         public void constructor_with_mutable_other_should_initialize_instance()
         {
-            var other = new GridFSBucketOptions { BucketName = "bucket", ChunkSizeBytes = 123, ReadConcern = ReadConcern.Majority, ReadPreference = ReadPreference.Secondary, WriteConcern = WriteConcern.WMajority };
+            var other = new GridFSBucketOptions { AssumeIndexesExist = true, BucketName = "bucket", ChunkSizeBytes = 123, ReadConcern = ReadConcern.Majority, ReadPreference = ReadPreference.Secondary, WriteConcern = WriteConcern.WMajority };
 
             var result = new GridFSBucketOptions(other);
 
+            result.AssumeIndexesExist.Should().Be(other.AssumeIndexesExist);
             result.BucketName.Should().Be(other.BucketName);
             result.ChunkSizeBytes.Should().Be(other.ChunkSizeBytes);
             result.ReadConcern.Should().Be(other.ReadConcern);
@@ -134,6 +162,7 @@ namespace MongoDB.Driver.Tests.GridFS
         {
             var result = new GridFSBucketOptions();
 
+            result.AssumeIndexesExist.Should().BeFalse();
             result.BucketName.Should().Be("fs");
             result.ChunkSizeBytes.Should().Be(255 * 1024);
             result.ReadPreference.Should().BeNull();
@@ -203,6 +232,19 @@ namespace MongoDB.Driver.Tests.GridFS
 
     public class ImmutableGridFSBucketOptionsTests
     {
+        [Theory]
+        [ParameterAttributeData]
+        public void AssumeIndexesExist_get_should_return_expected_result(
+            [Values(false, true)]
+            bool value)
+        {
+            var subject = new ImmutableGridFSBucketOptions(new GridFSBucketOptions { AssumeIndexesExist = value });
+
+            var result = subject.AssumeIndexesExist;
+
+            result.Should().Be(value);
+        }
+
         [Fact]
         public void BucketName_get_should_return_expected_result()
         {
@@ -228,6 +270,7 @@ namespace MongoDB.Driver.Tests.GridFS
         {
             var mutable = new GridFSBucketOptions
             {
+                AssumeIndexesExist = true,
                 BucketName = "bucket",
                 ChunkSizeBytes = 123,
                 ReadConcern = ReadConcern.Majority,
@@ -237,6 +280,7 @@ namespace MongoDB.Driver.Tests.GridFS
 
             var result = new ImmutableGridFSBucketOptions(mutable);
 
+            result.AssumeIndexesExist.Should().BeTrue();
             result.BucketName.Should().Be("bucket");
             result.ChunkSizeBytes.Should().Be(123);
             result.ReadConcern.Should().Be(ReadConcern.Majority);
@@ -249,6 +293,7 @@ namespace MongoDB.Driver.Tests.GridFS
         {
             var result = new GridFSBucketOptions();
 
+            result.AssumeIndexesExist.Should().BeFalse();
             result.BucketName.Should().Be("fs");
             result.ChunkSizeBytes.Should().Be(255 * 1024);
             result.ReadConcern.Should().BeNull();
@@ -270,6 +315,7 @@ namespace MongoDB.Driver.Tests.GridFS
         {
             var result = ImmutableGridFSBucketOptions.Defaults;
 
+            result.AssumeIndexesExist.Should().BeFalse();
             result.BucketName.Should().Be("fs");
             result.ChunkSizeBytes.Should().Be(255 * 1024);
             result.ReadConcern.Should().BeNull();

--- a/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketOptionsTests.cs
+++ b/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketOptionsTests.cs
@@ -291,7 +291,7 @@ namespace MongoDB.Driver.Tests.GridFS
         [Fact]
         public void constructor_with_no_arguments_should_initialize_instance_with_default_values()
         {
-            var result = new GridFSBucketOptions();
+            var result = new ImmutableGridFSBucketOptions();
 
             result.AssumeIndexesExist.Should().BeFalse();
             result.BucketName.Should().Be("fs");

--- a/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
+++ b/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
@@ -714,25 +714,30 @@ namespace MongoDB.Driver.Tests.GridFS
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
             var options = new GridFSBucketOptions { AssumeIndexesExist = true };
             var subject = new GridFSBucket(database, options);
-            subject.Drop();
+            DropBucket(subject, async);
 
-            if (async)
+            try
             {
-                subject.UploadFromBytesAsync("filename", new byte[] { 0 }).GetAwaiter().GetResult();
+                if (async)
+                {
+                    subject.UploadFromBytesAsync("filename", new byte[] { 0 }).GetAwaiter().GetResult();
+                }
+                else
+                {
+                    subject.UploadFromBytes("filename", new byte[] { 0 });
+                }
+
+                var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
+                filesIndexes.Should().NotContain(index => index["name"] == "filename_1_uploadDate_1");
+                var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
+                chunksIndexes.Should().NotContain(index => index["name"] == "files_id_1_n_1");
             }
-            else
+            finally
             {
-                subject.UploadFromBytes("filename", new byte[] { 0 });
+                // restore shared state: without cleanup this test leaves fs.* non-empty and without the
+                // GridFS indexes, which would suppress index creation for later tests reusing the default bucket
+                DropBucket(subject, async);
             }
-
-            var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
-            filesIndexes.Should().NotContain(index => index["name"] == "filename_1_uploadDate_1");
-            var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
-            chunksIndexes.Should().NotContain(index => index["name"] == "files_id_1_n_1");
-
-            // clean up: this test leaves the shared collections non-empty without the GridFS indexes,
-            // which would suppress index creation for later tests that share the same bucket
-            subject.Drop();
         }
 
         [Theory]
@@ -745,21 +750,28 @@ namespace MongoDB.Driver.Tests.GridFS
             var client = DriverTestConfiguration.Client;
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
             var subject = new GridFSBucket(database);
-            subject.Drop();
+            DropBucket(subject, async);
 
-            if (async)
+            try
             {
-                subject.UploadFromBytesAsync("filename", new byte[] { 0 }).GetAwaiter().GetResult();
-            }
-            else
-            {
-                subject.UploadFromBytes("filename", new byte[] { 0 });
-            }
+                if (async)
+                {
+                    subject.UploadFromBytesAsync("filename", new byte[] { 0 }).GetAwaiter().GetResult();
+                }
+                else
+                {
+                    subject.UploadFromBytes("filename", new byte[] { 0 });
+                }
 
-            var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
-            filesIndexes.Should().Contain(index => index["name"] == "filename_1_uploadDate_1");
-            var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
-            chunksIndexes.Should().Contain(index => index["name"] == "files_id_1_n_1");
+                var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
+                filesIndexes.Should().Contain(index => index["name"] == "filename_1_uploadDate_1");
+                var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
+                chunksIndexes.Should().Contain(index => index["name"] == "files_id_1_n_1");
+            }
+            finally
+            {
+                DropBucket(subject, async);
+            }
         }
 
         // private methods
@@ -781,6 +793,18 @@ namespace MongoDB.Driver.Tests.GridFS
         private void EnsureBucketExists(IGridFSBucket bucket)
         {
             bucket.UploadFromBytes("filename", new byte[0]);
+        }
+
+        private void DropBucket(IGridFSBucket bucket, bool async)
+        {
+            if (async)
+            {
+                bucket.DropAsync().GetAwaiter().GetResult();
+            }
+            else
+            {
+                bucket.Drop();
+            }
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
+++ b/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
@@ -729,6 +729,10 @@ namespace MongoDB.Driver.Tests.GridFS
             filesIndexes.Should().NotContain(index => index["name"] == "filename_1_uploadDate_1");
             var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
             chunksIndexes.Should().NotContain(index => index["name"] == "files_id_1_n_1");
+
+            // clean up: this test leaves the shared collections non-empty without the GridFS indexes,
+            // which would suppress index creation for later tests that share the same bucket
+            subject.Drop();
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
+++ b/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
@@ -726,7 +726,7 @@ namespace MongoDB.Driver.Tests.GridFS
             }
 
             var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
-            filesIndexes.Should().OnlyContain(index => index["name"] == "_id_");
+            filesIndexes.Should().NotContain(index => index["name"] == "filename_1_uploadDate_1");
             var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
             chunksIndexes.Should().NotContain(index => index["name"] == "files_id_1_n_1");
         }

--- a/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
+++ b/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
@@ -703,6 +703,61 @@ namespace MongoDB.Driver.Tests.GridFS
             }
         }
 
+        [Theory]
+        [ParameterAttributeData]
+        [Trait("Category", "Integration")]
+        public void Upload_should_not_create_indexes_when_AssumeIndexesExist_is_true(
+            [Values(false, true)] bool async)
+        {
+            RequireServer.Check();
+            var client = DriverTestConfiguration.Client;
+            var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
+            var options = new GridFSBucketOptions { AssumeIndexesExist = true };
+            var subject = new GridFSBucket(database, options);
+            subject.Drop();
+
+            if (async)
+            {
+                subject.UploadFromBytesAsync("filename", new byte[] { 0 }).GetAwaiter().GetResult();
+            }
+            else
+            {
+                subject.UploadFromBytes("filename", new byte[] { 0 });
+            }
+
+            var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
+            filesIndexes.Should().OnlyContain(index => index["name"] == "_id_");
+            var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
+            chunksIndexes.Should().NotContain(index => index["name"] == "files_id_1_n_1");
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        [Trait("Category", "Integration")]
+        public void Upload_should_create_indexes_when_AssumeIndexesExist_is_false(
+            [Values(false, true)] bool async)
+        {
+            RequireServer.Check();
+            var client = DriverTestConfiguration.Client;
+            var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
+            var subject = new GridFSBucket(database);
+            subject.Drop();
+
+            if (async)
+            {
+                subject.UploadFromBytesAsync("filename", new byte[] { 0 }).GetAwaiter().GetResult();
+            }
+            else
+            {
+                subject.UploadFromBytes("filename", new byte[] { 0 });
+            }
+
+            var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
+            filesIndexes.Should().Contain(index => index["name"] == "filename_1_uploadDate_1");
+            var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
+            chunksIndexes.Should().Contain(index => index["name"] == "files_id_1_n_1");
+        }
+
         // private methods
         private GridFSBucket CreateSubject(GridFSBucketOptions options = null)
         {

--- a/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
+++ b/tests/MongoDB.Driver.Tests/GridFS/GridFSBucketTests.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
@@ -706,21 +707,22 @@ namespace MongoDB.Driver.Tests.GridFS
         [Theory]
         [ParameterAttributeData]
         [Trait("Category", "Integration")]
-        public void Upload_should_not_create_indexes_when_AssumeIndexesExist_is_true(
+        public async Task Upload_should_create_indexes_unless_AssumeIndexesExist_is_true(
+            [Values(false, true)] bool assumeIndexesExist,
             [Values(false, true)] bool async)
         {
             RequireServer.Check();
             var client = DriverTestConfiguration.Client;
             var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
-            var options = new GridFSBucketOptions { AssumeIndexesExist = true };
+            var options = new GridFSBucketOptions { AssumeIndexesExist = assumeIndexesExist };
             var subject = new GridFSBucket(database, options);
-            DropBucket(subject, async);
+            await DropBucketAsync(subject, async);
 
             try
             {
                 if (async)
                 {
-                    subject.UploadFromBytesAsync("filename", new byte[] { 0 }).GetAwaiter().GetResult();
+                    await subject.UploadFromBytesAsync("filename", new byte[] { 0 });
                 }
                 else
                 {
@@ -728,49 +730,23 @@ namespace MongoDB.Driver.Tests.GridFS
                 }
 
                 var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
-                filesIndexes.Should().NotContain(index => index["name"] == "filename_1_uploadDate_1");
                 var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
-                chunksIndexes.Should().NotContain(index => index["name"] == "files_id_1_n_1");
+                if (assumeIndexesExist)
+                {
+                    filesIndexes.Should().NotContain(index => index["name"] == "filename_1_uploadDate_1");
+                    chunksIndexes.Should().NotContain(index => index["name"] == "files_id_1_n_1");
+                }
+                else
+                {
+                    filesIndexes.Should().Contain(index => index["name"] == "filename_1_uploadDate_1");
+                    chunksIndexes.Should().Contain(index => index["name"] == "files_id_1_n_1");
+                }
             }
             finally
             {
-                // restore shared state: without cleanup this test leaves fs.* non-empty and without the
+                // restore shared state: with AssumeIndexesExist the upload leaves fs.* non-empty and without the
                 // GridFS indexes, which would suppress index creation for later tests reusing the default bucket
-                DropBucket(subject, async);
-            }
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        [Trait("Category", "Integration")]
-        public void Upload_should_create_indexes_when_AssumeIndexesExist_is_false(
-            [Values(false, true)] bool async)
-        {
-            RequireServer.Check();
-            var client = DriverTestConfiguration.Client;
-            var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
-            var subject = new GridFSBucket(database);
-            DropBucket(subject, async);
-
-            try
-            {
-                if (async)
-                {
-                    subject.UploadFromBytesAsync("filename", new byte[] { 0 }).GetAwaiter().GetResult();
-                }
-                else
-                {
-                    subject.UploadFromBytes("filename", new byte[] { 0 });
-                }
-
-                var filesIndexes = database.GetCollection<BsonDocument>("fs.files").Indexes.List().ToList();
-                filesIndexes.Should().Contain(index => index["name"] == "filename_1_uploadDate_1");
-                var chunksIndexes = database.GetCollection<BsonDocument>("fs.chunks").Indexes.List().ToList();
-                chunksIndexes.Should().Contain(index => index["name"] == "files_id_1_n_1");
-            }
-            finally
-            {
-                DropBucket(subject, async);
+                await DropBucketAsync(subject, async);
             }
         }
 
@@ -795,11 +771,11 @@ namespace MongoDB.Driver.Tests.GridFS
             bucket.UploadFromBytes("filename", new byte[0]);
         }
 
-        private void DropBucket(IGridFSBucket bucket, bool async)
+        private async Task DropBucketAsync(IGridFSBucket bucket, bool async)
         {
             if (async)
             {
-                bucket.DropAsync().GetAwaiter().GetResult();
+                await bucket.DropAsync();
             }
             else
             {


### PR DESCRIPTION
Adds a `AssumeIndexesExist` option to `GridFSBucketOptions` that lets users opt out of the automatic GridFS index check and creation on the first upload.

Based on the original contribution by John Gibbons (@jg11jg) in #294, updated for the current `src/MongoDB.Driver/` project layout and with added coverage. Supersedes #292 and #294.