### PR TITLE
CSHARP-6093: Compile one-shot LINQ eval lambdas with preferInterpretation

### DIFF
--- a/src/MongoDB.Driver/Linq/Linq3Implementation/ExtensionMethods/ExpressionExtensions.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/ExtensionMethods/ExpressionExtensions.cs
@@ -31,9 +31,22 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.ExtensionMethods
             else
             {
                 LambdaExpression lambda = Expression.Lambda(expression);
-                Delegate fn = lambda.Compile();
+                Delegate fn = lambda.CompileForOneShotEvaluation();
                 return fn.DynamicInvoke(null);
             }
+        }
+
+        // Compiles a lambda that will be invoked exactly once and then discarded. Preferring
+        // interpretation avoids creating a DynamicMethod for the single invocation, which sidesteps
+        // a .NET 10 tiered-JIT race where the background recompiler can dereference the method's IL
+        // after the delegate has become GC-eligible (CSHARP-6093, originally reported as CSHARP-6087).
+        internal static Delegate CompileForOneShotEvaluation(this LambdaExpression lambda)
+        {
+#if NET472
+            return lambda.Compile();
+#else
+            return lambda.Compile(preferInterpretation: true);
+#endif
         }
 
         public static (string CollectionName, IBsonSerializer DocumentSerializer) GetCollectionInfoFromQueryable(this Expression queryableExpression, Expression containerExpression)

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/ExtensionMethods/ExpressionExtensions.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/ExtensionMethods/ExpressionExtensions.cs
@@ -40,11 +40,21 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.ExtensionMethods
         // interpretation avoids creating a DynamicMethod for the single invocation, which sidesteps
         // a .NET 10 tiered-JIT race where the background recompiler can dereference the method's IL
         // after the delegate has become GC-eligible (CSHARP-6093, originally reported as CSHARP-6087).
+        //
+        // The interpreted path can be disabled at runtime via:
+        //   AppContext.SetSwitch("Switch.MongoDB.Driver.DisableLinqInterpretedEvaluation", true);
+        // which reverts to JIT compilation (lambda.Compile()). The switch has no effect on net472,
+        // which never had the preferInterpretation overload.
         internal static Delegate CompileForOneShotEvaluation(this LambdaExpression lambda)
         {
 #if NET472
             return lambda.Compile();
 #else
+            if (AppContext.TryGetSwitch("Switch.MongoDB.Driver.DisableLinqInterpretedEvaluation", out var disabled) && disabled)
+            {
+                return lambda.Compile();
+            }
+
             return lambda.Compile(preferInterpretation: true);
 #endif
         }

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Misc/PartialEvaluator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Misc/PartialEvaluator.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using MongoDB.Driver.Linq.Linq3Implementation.ExtensionMethods;
 using MongoDB.Driver.Linq.Linq3Implementation.Reflection;
 
 namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
@@ -217,7 +218,7 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Misc
                     return expression;
                 }
                 LambdaExpression lambda = Expression.Lambda(expression);
-                Delegate fn = lambda.Compile();
+                Delegate fn = lambda.CompileForOneShotEvaluation();
                 return Expression.Constant(fn.DynamicInvoke(null), expression.Type);
             }
 

--- a/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/PickMethodToAggregationExpressionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Linq3Implementation/Translators/ExpressionToAggregationExpressionTranslators/MethodTranslators/PickMethodToAggregationExpressionTranslator.cs
@@ -187,11 +187,11 @@ namespace MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToAggreg
                 return sortByExpression.GetConstantValue<object>(sortByExpression);
             }
 
-            // we get here when the PartialEvaluator couldn't fully evalute the SortDefinition
+            // we get here when the PartialEvaluator couldn't fully evaluate the SortDefinition
             try
             {
                 LambdaExpression lambda = Expression.Lambda(sortByExpression);
-                Delegate @delegate = lambda.Compile();
+                Delegate @delegate = lambda.CompileForOneShotEvaluation();
                 return @delegate.DynamicInvoke(null);
             }
             catch (Exception ex)

--- a/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/ExtensionMethods/ExpressionExtensionsTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Linq3Implementation/ExtensionMethods/ExpressionExtensionsTests.cs
@@ -1,0 +1,59 @@
+﻿/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Driver.Linq.Linq3Implementation.ExtensionMethods;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Linq3Implementation.ExtensionMethods;
+
+public class ExpressionExtensionsTests : IDisposable
+{
+    // One-shot LINQ evaluation lambdas are compiled with preferInterpretation: true to avoid a
+    // .NET 10 tiered-JIT/GC race (CSHARP-6093). The interpreted path can be disabled at runtime via
+    // this AppContext switch, reverting to lambda.Compile() (JIT). The observable result is identical
+    // regardless of compile strategy, so these tests verify only that both paths are wired correctly.
+    private const string SwitchName = "Switch.MongoDB.Driver.DisableLinqInterpretedEvaluation";
+
+    [Fact]
+    public void CompileForOneShotEvaluation_should_return_working_delegate_when_switch_unset()
+    {
+        AppContext.SetSwitch(SwitchName, false);
+        var lambda = Expression.Lambda(Expression.Add(Expression.Constant(2), Expression.Constant(3)));
+
+        var fn = lambda.CompileForOneShotEvaluation();
+
+        fn.DynamicInvoke(null).Should().Be(5);
+    }
+
+    [Fact]
+    public void CompileForOneShotEvaluation_should_return_working_delegate_when_interpretation_disabled()
+    {
+        AppContext.SetSwitch(SwitchName, true);
+        var lambda = Expression.Lambda(Expression.Add(Expression.Constant(2), Expression.Constant(3)));
+
+        var fn = lambda.CompileForOneShotEvaluation();
+
+        fn.DynamicInvoke(null).Should().Be(5);
+    }
+
+    public void Dispose()
+    {
+        // Reset the global AppContext switch so it cannot leak into other tests.
+        AppContext.SetSwitch(SwitchName, false);
+    }
+}


### PR DESCRIPTION
Implements [CSHARP-6093](https://jira.mongodb.org/browse/CSHARP-6093).

LINQ providers have been using the `preferInterpretation: true` overload of `LamdaExpression.Compile` to improve performance and memory overhead where they need to one-shot/evaluate branches of the expression tree to replace them with constant expressions such as in a partial evaluator.

Examples:
- [EF Core provider](https://github.com/dotnet/efcore/issues/29814)
- [Azure LINQ provider](https://github.com/azure/azure-cosmos-dotnet-v3/issues/5702)

Additionally this may provide a way to avoid a race condition in .NET 10 reported under [CSHARP-6087](https://jira.mongodb.org/browse/CSHARP-6087).

This feature is not available on NET472 but is available on .NET Core.

This enhancement can be disabled using the `Switch.MongoDB.Driver.DisableLinqInterpretedEvaluation` AppContext switch. If you find yourself doing this please advise us with your scenario so we can further examine unexpected compatibility regressions.