### PR TITLE
CSHARP-6102: Skip the ServerDiscoveryProseTests.Connection_Pool_Backpressure test on 9+ version on Mac

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/prose-tests/ServerDiscoveryProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/server-discovery-and-monitoring/prose-tests/ServerDiscoveryProseTests.cs
@@ -107,6 +107,9 @@ namespace MongoDB.Driver.Tests.Specifications.server_discovery_and_monitoring.pr
         public async Task Connection_Pool_Backpressure([Values(true, false)]bool async)
         {
             RequireServer.Check().VersionGreaterThanOrEqualTo("7.0.23");
+#if MACOS
+            RequireServer.Check().VersionLessThan("8.99.99"); // Skip the test on MacOS, more details in CSHARP-6102
+#endif
 
             var setupClient = DriverTestConfiguration.Client;
             var adminDatabase = setupClient.GetDatabase(DatabaseNamespace.Admin.DatabaseName);


### PR DESCRIPTION
Here is the ticket to unskip the test once server ticket will be sorted out: https://jira.mongodb.org/browse/CSHARP-6104