### PR TITLE
CSHARP-5696: Bump AWSSDK.SecurityToken to v4

### DIFF
--- a/src/MongoDB.Driver.Authentication.AWS/MongoDB.Driver.Authentication.AWS.csproj
+++ b/src/MongoDB.Driver.Authentication.AWS/MongoDB.Driver.Authentication.AWS.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.14" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.100" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump the AWSSDK.SecurityToken package to v4 in the AWS Authentication package