### PR TITLE
CSHARP-6114: Run CSFLE latest Linux test variant on Ubuntu 22.04

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1985,6 +1985,11 @@ axes:
         variables:
           OS: "ubuntu-2004"
         run_on: ubuntu2004-small
+      - id: "ubuntu-2204"
+        display_name: "Ubuntu 22.04"
+        variables:
+          OS: "ubuntu-2204"
+        run_on: ubuntu2204-small
       - id: "macos-14"
         display_name: "macOS 14.00"
         variables:
@@ -2729,7 +2734,16 @@ buildvariants:
     - name: test-csfle-with-mongocryptd-net60
 
 - matrix_name: "csfle-with-mocked-kms-tests-linux-2004"
-  matrix_spec: { os: "ubuntu-2004", ssl: "nossl", version: ["4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"], topology: ["replicaset"] }
+  matrix_spec: { os: "ubuntu-2004", ssl: "nossl", version: ["4.4", "5.0", "6.0", "7.0", "8.0", "rapid"], topology: ["replicaset"] }
+  display_name: "CSFLE Mocked KMS ${version} ${os}"
+  tasks:
+    - name: test-csfle-with-mocked-kms-tls-netstandard21
+    - name: test-csfle-with-mocked-kms-tls-net60
+    - name: test-csfle-with-mongocryptd-netstandard21
+    - name: test-csfle-with-mongocryptd-net60
+
+- matrix_name: "csfle-with-mocked-kms-tests-linux-2204"
+  matrix_spec: { os: "ubuntu-2204", ssl: "nossl", version: ["latest"], topology: ["replicaset"] }
   display_name: "CSFLE Mocked KMS ${version} ${os}"
   tasks:
     - name: test-csfle-with-mocked-kms-tls-netstandard21


### PR DESCRIPTION
## Summary
Move the `latest` cell of the CSFLE mocked-KMS Linux test matrix from Ubuntu 20.04 (`ubuntu2004-small`) to Ubuntu 22.04 (`ubuntu2204-small`).

Ubuntu 20.04 is being EOL'd as a MongoDB server build target for 9.0 — `ubuntu2004-small` no longer receives fresh `latest` server builds. Its stale build predates the substring feature flag (SERVER-128600) being enabled, so the QE "substring" GA tests added in CSHARP-6105 fail on the `CSFLE Mocked KMS latest ubuntu-2004` variant with:

> Enumeration value 'substring' for field 'create.encryptedFields.fields.queries.queryType' is not a valid value.

This is the minimal CI fix that unblocks verification of CSHARP-6105. Only `latest` is affected: it is the only CSFLE Linux variant that runs the substring GA tests (gated on server 9.0) and that ubuntu-2004 can no longer build fresh. The 6.0/7.0/8.0 cells still have ubuntu-2004 builds and don't run substring tests; migrating them is consistency work tracked in CSHARP-6111.

JIRA: https://jira.mongodb.org/browse/CSHARP-6114