### PR TITLE
CSHARP-6111: Migrate rapid/latest Linux test variants to Ubuntu 22.04

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -1985,6 +1985,11 @@ axes:
         variables:
           OS: "ubuntu-2004"
         run_on: ubuntu2004-small
+      - id: "ubuntu-2204"
+        display_name: "Ubuntu 22.04"
+        variables:
+          OS: "ubuntu-2204"
+        run_on: ubuntu2204-small
       - id: "macos-14"
         display_name: "macOS 14.00"
         variables:
@@ -2489,7 +2494,15 @@ buildvariants:
           - test-netstandard21 # Apple M1 (arm64) cannot load runtimes lower then .NET 6.
 
 - matrix_name: "secure-tests-linux-2004"
-  matrix_spec: { version: ["4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"], topology: "*", auth: "auth", ssl: "ssl", os: "ubuntu-2004" }
+  matrix_spec: { version: ["4.4", "5.0", "6.0", "7.0", "8.0"], topology: "*", auth: "auth", ssl: "ssl", os: "ubuntu-2004" }
+  display_name: "${version} ${topology} ${auth} ${ssl} ${os}"
+  tags: ["tests-variant"]
+  tasks:
+    - name: test-netstandard21
+    - name: test-net60
+
+- matrix_name: "secure-tests-linux-2204"
+  matrix_spec: { version: ["rapid", "latest"], topology: "*", auth: "auth", ssl: "ssl", os: "ubuntu-2204" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${os}"
   tags: ["tests-variant"]
   tasks:
@@ -2521,7 +2534,15 @@ buildvariants:
           - test-netstandard21 # Apple M1 (arm64) cannot load runtimes lower then .NET 6.
 
 - matrix_name: "unsecure-tests-linux-2004"
-  matrix_spec: { version: ["4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"], topology: "*", auth: "noauth", ssl: "nossl", os: "ubuntu-2004" }
+  matrix_spec: { version: ["4.4", "5.0", "6.0", "7.0", "8.0"], topology: "*", auth: "noauth", ssl: "nossl", os: "ubuntu-2004" }
+  display_name: "${version} ${topology} ${auth} ${ssl} ${os}"
+  tags: ["tests-variant"]
+  tasks:
+    - name: test-netstandard21
+    - name: test-net60
+
+- matrix_name: "unsecure-tests-linux-2204"
+  matrix_spec: { version: ["rapid", "latest"], topology: "*", auth: "noauth", ssl: "nossl", os: "ubuntu-2204" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${os}"
   tags: ["tests-variant"]
   tasks:
@@ -2553,7 +2574,15 @@ buildvariants:
           - test-netstandard21 # Apple M1 (arm64) cannot load runtimes lower then .NET 6.
 
 - matrix_name: "tests-compression-linux-2004"
-  matrix_spec: { compressor: "*", auth: "noauth", ssl: "nossl", version: ["4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"], topology: "standalone", os: "ubuntu-2004" }
+  matrix_spec: { compressor: "*", auth: "noauth", ssl: "nossl", version: ["4.4", "5.0", "6.0", "7.0", "8.0"], topology: "standalone", os: "ubuntu-2004" }
+  display_name: "${version} ${compressor} ${topology} ${auth} ${ssl} ${os} "
+  tags: ["tests-variant"]
+  tasks:
+    - name: test-netstandard21
+    - name: test-net60
+
+- matrix_name: "tests-compression-linux-2204"
+  matrix_spec: { compressor: "*", auth: "noauth", ssl: "nossl", version: ["rapid", "latest"], topology: "standalone", os: "ubuntu-2204" }
   display_name: "${version} ${compressor} ${topology} ${auth} ${ssl} ${os} "
   tags: ["tests-variant"]
   tasks:
@@ -2562,7 +2591,7 @@ buildvariants:
 
 # Auth tests
 - matrix_name: plain-auth-tests
-  matrix_spec: { os: "*" }
+  matrix_spec: { os: ["windows-64", "ubuntu-2204", "macos-14", "macos-14-arm64"] }
   display_name: "PLAIN (LDAP) Auth Tests ${os}"
   tasks:
     - name: plain-auth-tests
@@ -2642,21 +2671,35 @@ buildvariants:
     - name: test-gssapi-net60
 
 - matrix_name: "x509-tests"
-  matrix_spec: { os: ["ubuntu-2004", "macos-14", "windows-64"], ssl: ["ssl"], version: ["latest"], topology: ["standalone"] }
+  matrix_spec: { os: ["ubuntu-2204", "macos-14", "windows-64"], ssl: ["ssl"], version: ["latest"], topology: ["standalone"] }
   display_name: "X509 tests ${version} ${os}"
   tasks:
     - name: x509-auth-tests
 
 # Load balancer tests
 - matrix_name: load-balancer-tests
-  matrix_spec: { version: ["5.0", "6.0", "7.0", "8.0", "rapid", "latest"], auth: "noauth", ssl: "nossl", topology: "sharded-cluster", os: "ubuntu-2004" }
+  matrix_spec: { version: ["5.0", "6.0", "7.0", "8.0"], auth: "noauth", ssl: "nossl", topology: "sharded-cluster", os: "ubuntu-2004" }
+  display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
+  tasks:
+    - name: "test-load-balancer-netstandard21"
+    - name: "test-load-balancer-net60"
+
+- matrix_name: load-balancer-tests-2204
+  matrix_spec: { version: ["rapid", "latest"], auth: "noauth", ssl: "nossl", topology: "sharded-cluster", os: "ubuntu-2204" }
   display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
   tasks:
     - name: "test-load-balancer-netstandard21"
     - name: "test-load-balancer-net60"
 
 - matrix_name: load-balancer-tests-secure
-  matrix_spec: { version: ["5.0", "6.0", "7.0", "8.0", "rapid", "latest"], auth: "auth", ssl: "ssl", topology: "sharded-cluster", os: "ubuntu-2004" }
+  matrix_spec: { version: ["5.0", "6.0", "7.0", "8.0"], auth: "auth", ssl: "ssl", topology: "sharded-cluster", os: "ubuntu-2004" }
+  display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
+  tasks:
+    - name: "test-load-balancer-netstandard21"
+    - name: "test-load-balancer-net60"
+
+- matrix_name: load-balancer-tests-secure-2204
+  matrix_spec: { version: ["rapid", "latest"], auth: "auth", ssl: "ssl", topology: "sharded-cluster", os: "ubuntu-2204" }
   display_name: "Load Balancer ${version} ${auth} ${ssl} ${os}"
   tasks:
     - name: "test-load-balancer-netstandard21"
@@ -2695,7 +2738,7 @@ buildvariants:
 
 # Socks5 Proxy tests
 - matrix_name: "socks5-proxy-tests-linux"
-  matrix_spec: { os: "ubuntu-2004", ssl: ["nossl", "ssl"], version: ["latest"], topology: ["replicaset"] }
+  matrix_spec: { os: "ubuntu-2204", ssl: ["nossl", "ssl"], version: ["latest"], topology: ["replicaset"] }
   display_name: "Socks5 Proxy ${version} ${os} ${ssl}"
   tasks:
     - name: test-socks5-proxy-netstandard21
@@ -2729,7 +2772,16 @@ buildvariants:
     - name: test-csfle-with-mongocryptd-net60
 
 - matrix_name: "csfle-with-mocked-kms-tests-linux-2004"
-  matrix_spec: { os: "ubuntu-2004", ssl: "nossl", version: ["4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"], topology: ["replicaset"] }
+  matrix_spec: { os: "ubuntu-2004", ssl: "nossl", version: ["4.4", "5.0", "6.0", "7.0", "8.0"], topology: ["replicaset"] }
+  display_name: "CSFLE Mocked KMS ${version} ${os}"
+  tasks:
+    - name: test-csfle-with-mocked-kms-tls-netstandard21
+    - name: test-csfle-with-mocked-kms-tls-net60
+    - name: test-csfle-with-mongocryptd-netstandard21
+    - name: test-csfle-with-mongocryptd-net60
+
+- matrix_name: "csfle-with-mocked-kms-tests-linux-2204"
+  matrix_spec: { os: "ubuntu-2204", ssl: "nossl", version: ["rapid", "latest"], topology: ["replicaset"] }
   display_name: "CSFLE Mocked KMS ${version} ${os}"
   tasks:
     - name: test-csfle-with-mocked-kms-tls-netstandard21
@@ -2773,7 +2825,7 @@ buildvariants:
 # Smoke tests
 - matrix_name: "smoke-tests"
   matrix_spec:
-    os: ["ubuntu-2004", "macos-14", "windows-64"]
+    os: ["macos-14", "windows-64"]
     ssl: "nossl"
     version: ["5.0", "6.0", "7.0", "8.0", "latest"]
     topology: ["replicaset"]
@@ -2787,10 +2839,40 @@ buildvariants:
     - name: test-smoke-tests-net80
     - name: test-smoke-tests-net100
   rules:
-    - if: { version: "*", topology: "*", ssl: "*", os: ["ubuntu-2004", "macos-14"] }
+    - if: { version: "*", topology: "*", ssl: "*", os: ["macos-14"] }
       then:
         remove_tasks:
           - test-smoke-tests-net472 # net472 is supported on Windows only.
+
+- matrix_name: "smoke-tests-linux-2004"
+  matrix_spec:
+    os: ["ubuntu-2004"]
+    ssl: "nossl"
+    version: ["5.0", "6.0", "7.0", "8.0"]
+    topology: ["replicaset"]
+  display_name: "smoke-tests ${version} on ${os}"
+  batchtime: 1440 # 1 day
+  tasks:
+    - name: test-smoke-tests-netcoreapp31
+    - name: test-smoke-tests-net50
+    - name: test-smoke-tests-net60
+    - name: test-smoke-tests-net80
+    - name: test-smoke-tests-net100
+
+- matrix_name: "smoke-tests-linux-2204"
+  matrix_spec:
+    os: ["ubuntu-2204"]
+    ssl: "nossl"
+    version: ["latest"]
+    topology: ["replicaset"]
+  display_name: "smoke-tests ${version} on ${os}"
+  batchtime: 1440 # 1 day
+  tasks:
+    - name: test-smoke-tests-netcoreapp31
+    - name: test-smoke-tests-net50
+    - name: test-smoke-tests-net60
+    - name: test-smoke-tests-net80
+    - name: test-smoke-tests-net100
 
 # Package release variants
 - matrix_name: build-packages
@@ -2884,8 +2966,32 @@ buildvariants:
 - matrix_name: odata-tests
   batchtime: 720 # 12 hours
   matrix_spec:
-    os: ["ubuntu-2004", "windows-64"]
+    os: ["windows-64"]
     version: ["4.4", "8.0", "latest"]
+  display_name: "OData tests on ${os} with MongoDB ${version}"
+  tasks:
+    - name: test-odata
+      depends_on:
+        - name: push-packages-myget
+          variant: ".push-packages-myget"
+
+- matrix_name: odata-tests-linux-2004
+  batchtime: 720 # 12 hours
+  matrix_spec:
+    os: ["ubuntu-2004"]
+    version: ["4.4", "8.0"]
+  display_name: "OData tests on ${os} with MongoDB ${version}"
+  tasks:
+    - name: test-odata
+      depends_on:
+        - name: push-packages-myget
+          variant: ".push-packages-myget"
+
+- matrix_name: odata-tests-linux-2204
+  batchtime: 720 # 12 hours
+  matrix_spec:
+    os: ["ubuntu-2204"]
+    version: ["latest"]
   display_name: "OData tests on ${os} with MongoDB ${version}"
   tasks:
     - name: test-odata
@@ -2907,8 +3013,34 @@ buildvariants:
 - matrix_name: efcore-tests
   batchtime: 720 # 12 hours
   matrix_spec:
-    os: ["ubuntu-2004", "windows-64"]
+    os: ["windows-64"]
     version: ["5.0", "8.0", "latest"]
+    topology: "replicaset"
+  display_name: "Efcore tests on ${os} with MongoDB ${version}"
+  tasks:
+    - name: test-efcore
+      depends_on:
+        - name: push-packages-myget
+          variant: ".push-packages-myget"
+
+- matrix_name: efcore-tests-linux-2004
+  batchtime: 720 # 12 hours
+  matrix_spec:
+    os: ["ubuntu-2004"]
+    version: ["5.0", "8.0"]
+    topology: "replicaset"
+  display_name: "Efcore tests on ${os} with MongoDB ${version}"
+  tasks:
+    - name: test-efcore
+      depends_on:
+        - name: push-packages-myget
+          variant: ".push-packages-myget"
+
+- matrix_name: efcore-tests-linux-2204
+  batchtime: 720 # 12 hours
+  matrix_spec:
+    os: ["ubuntu-2204"]
+    version: ["latest"]
     topology: "replicaset"
   display_name: "Efcore tests on ${os} with MongoDB ${version}"
   tasks:


### PR DESCRIPTION
# Summary

Ubuntu 20.04 (`ubuntu2004-small`) no longer receives fresh `latest` (9.0+) MongoDB server builds, so Linux test variants running those versions pull stale builds. This first surfaced in CSHARP-6105, where `CSFLE Mocked KMS latest` failed because its stale server predated the `substring` feature flag.

This migrates only the `rapid`/`latest` cells of the affected Linux test variants to a new **Ubuntu 22.04** (`ubuntu2204-small`) distro. Versions 4.4–8.0 still have ubuntu 20.04 builds and stay on `ubuntu-2004`.

# Not in scope (follow-ups)

- **`aws-auth-tests-linux` stays on ubuntu2004.** drivers-tools' AWS ECS setup (`aws_tester.py` `setup_ecs`) only handles ubuntu2004/ubuntu2404, not ubuntu2204, so migrating it breaks the ECS credential test. Moving it needs shared-infra ECS support investigation and will be tracked separately.

# Testing

Evergreen patch (rapid/latest cells on `ubuntu-2204`): the failed variants are expected as CSHARP-6105 https://spruce.corp.mongodb.com/version/6a4d1b07ff0cd90007c6d2c3


