### PR TITLE
CSHARP-6119: Disable apicompat validation for v4.0 development

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -2888,6 +2888,7 @@ buildvariants:
   matrix_spec:
     os: "ubuntu-2004"
   display_name: "Validate API compatibility"
+  activate: false
   tasks:
     - name: validate-apicompat-task-group
       depends_on:

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -2888,9 +2888,9 @@ buildvariants:
   matrix_spec:
     os: "ubuntu-2004"
   display_name: "Validate API compatibility"
-  disable: true
   tasks:
     - name: validate-apicompat-task-group
+      disable: true
       depends_on:
         - name: build-packages
           variant: ".build-packages"

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -2888,7 +2888,7 @@ buildvariants:
   matrix_spec:
     os: "ubuntu-2004"
   display_name: "Validate API compatibility"
-  activate: false
+  disable: true
   tasks:
     - name: validate-apicompat-task-group
       depends_on:


### PR DESCRIPTION
validate-apicompat task was disabled for v4.0 development where we are expecting breaking changes. It's not scheduled for PR build and should not be scheduled for main branch build too.

@BorisDog we need to remove the check from PR's required checks.