### PR TITLE
CSHARP-5630: Add IAsyncDisposable support to cursors

### DIFF
--- a/src/MongoDB.Driver/Core/BatchTransformingAsyncCursor.cs
+++ b/src/MongoDB.Driver/Core/BatchTransformingAsyncCursor.cs
@@ -97,17 +97,23 @@ namespace MongoDB.Driver
         /// <inheritdoc/>
         public void Dispose()
         {
-            _disposed = true;
-            _current = null;
-            _wrapped.Dispose();
+            if (!_disposed)
+            {
+                _disposed = true;
+                _current = null;
+                _wrapped.Dispose();
+            }
         }
 
         /// <inheritdoc/>
         public async ValueTask DisposeAsync()
         {
-            _disposed = true;
-            _current = null;
-            await _wrapped.DisposeAsync().ConfigureAwait(false);
+            if (!_disposed)
+            {
+                _disposed = true;
+                _current = null;
+                await _wrapped.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         private void ThrowIfDisposed()

--- a/src/MongoDB.Driver/Core/BatchTransformingAsyncCursor.cs
+++ b/src/MongoDB.Driver/Core/BatchTransformingAsyncCursor.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver.Core.Misc;
@@ -101,6 +100,14 @@ namespace MongoDB.Driver
             _disposed = true;
             _current = null;
             _wrapped.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
+        {
+            _disposed = true;
+            _current = null;
+            await _wrapped.DisposeAsync().ConfigureAwait(false);
         }
 
         private void ThrowIfDisposed()

--- a/src/MongoDB.Driver/Core/DeferredAsyncCursor.cs
+++ b/src/MongoDB.Driver/Core/DeferredAsyncCursor.cs
@@ -117,13 +117,19 @@ namespace MongoDB.Driver
         {
             if (!_disposed)
             {
-                _disposeAction();
-                if (_cursor != null)
-                {
-                    await _cursor.DisposeAsync().ConfigureAwait(false);
-                    _cursor = null;
-                }
                 _disposed = true;
+                try
+                {
+                    _disposeAction();
+                }
+                finally
+                {
+                    if (_cursor != null)
+                    {
+                        await _cursor.DisposeAsync().ConfigureAwait(false);
+                        _cursor = null;
+                    }
+                }
             }
         }
 

--- a/src/MongoDB.Driver/Core/DeferredAsyncCursor.cs
+++ b/src/MongoDB.Driver/Core/DeferredAsyncCursor.cs
@@ -112,6 +112,21 @@ namespace MongoDB.Driver
             }
         }
 
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                _disposeAction();
+                if (_cursor != null)
+                {
+                    await _cursor.DisposeAsync().ConfigureAwait(false);
+                    _cursor = null;
+                }
+                _disposed = true;
+            }
+        }
+
         private void ThrowIfDisposed()
         {
             if (_disposed)

--- a/src/MongoDB.Driver/Core/IAsyncCursor.cs
+++ b/src/MongoDB.Driver/Core/IAsyncCursor.cs
@@ -28,7 +28,7 @@ namespace MongoDB.Driver
     /// Represents an asynchronous cursor.
     /// </summary>
     /// <typeparam name="TDocument">The type of the document.</typeparam>
-    public interface IAsyncCursor<out TDocument> : IDisposable
+    public interface IAsyncCursor<out TDocument> : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Gets the current batch of documents.
@@ -117,7 +117,7 @@ namespace MongoDB.Driver
         /// <returns>A Task whose result is true if the cursor contains any documents.</returns>
         public static async Task<bool> AnyAsync<TDocument>(this IAsyncCursor<TDocument> cursor, CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (cursor)
+            await using (cursor.ConfigureAwait(false))
             {
                 var batch = await GetFirstBatchAsync(cursor, cancellationToken).ConfigureAwait(false);
                 return batch.Any();
@@ -149,7 +149,7 @@ namespace MongoDB.Driver
         /// <returns>A Task whose result is the first document.</returns>
         public static async Task<TDocument> FirstAsync<TDocument>(this IAsyncCursor<TDocument> cursor, CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (cursor)
+            await using (cursor.ConfigureAwait(false))
             {
                 var batch = await GetFirstBatchAsync(cursor, cancellationToken).ConfigureAwait(false);
                 return batch.First();
@@ -181,7 +181,7 @@ namespace MongoDB.Driver
         /// <returns>A task whose result is the first document of the cursor, or a default value if the cursor contains no documents.</returns>
         public static async Task<TDocument> FirstOrDefaultAsync<TDocument>(this IAsyncCursor<TDocument> cursor, CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (cursor)
+            await using (cursor.ConfigureAwait(false))
             {
                 var batch = await GetFirstBatchAsync(cursor, cancellationToken).ConfigureAwait(false);
                 return batch.FirstOrDefault();
@@ -216,7 +216,7 @@ namespace MongoDB.Driver
 
             // yes, we are taking ownership... assumption being that they've
             // exhausted the thing and don't need it anymore.
-            using (source)
+            await using (source.ConfigureAwait(false))
             {
                 var index = 0;
                 while (await source.MoveNextAsync(cancellationToken).ConfigureAwait(false))
@@ -268,7 +268,7 @@ namespace MongoDB.Driver
 
             // yes, we are taking ownership... assumption being that they've
             // exhausted the thing and don't need it anymore.
-            using (source)
+            await using (source.ConfigureAwait(false))
             {
                 var index = 0;
                 while (await source.MoveNextAsync(cancellationToken).ConfigureAwait(false))
@@ -307,7 +307,7 @@ namespace MongoDB.Driver
         /// <returns>A Task whose result is the only document of a cursor.</returns>
         public static async Task<TDocument> SingleAsync<TDocument>(this IAsyncCursor<TDocument> cursor, CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (cursor)
+            await using (cursor.ConfigureAwait(false))
             {
                 var batch = await GetFirstBatchAsync(cursor, cancellationToken).ConfigureAwait(false);
                 return batch.Single();
@@ -341,7 +341,7 @@ namespace MongoDB.Driver
         /// <returns>A Task whose result is the only document of a cursor, or a default value if the cursor contains no documents.</returns>
         public static async Task<TDocument> SingleOrDefaultAsync<TDocument>(this IAsyncCursor<TDocument> cursor, CancellationToken cancellationToken = default(CancellationToken))
         {
-            using (cursor)
+            await using (cursor.ConfigureAwait(false))
             {
                 var batch = await GetFirstBatchAsync(cursor, cancellationToken).ConfigureAwait(false);
                 return batch.SingleOrDefault();
@@ -412,7 +412,7 @@ namespace MongoDB.Driver
 
             // yes, we are taking ownership... assumption being that they've
             // exhausted the thing and don't need it anymore.
-            using (source)
+            await using (source.ConfigureAwait(false))
             {
                 while (await source.MoveNextAsync(cancellationToken).ConfigureAwait(false))
                 {

--- a/src/MongoDB.Driver/Core/Operations/AsyncCursor.cs
+++ b/src/MongoDB.Driver/Core/Operations/AsyncCursor.cs
@@ -189,7 +189,7 @@ namespace MongoDB.Driver.Core.Operations
             }
             finally
             {
-                Dispose();
+                await DisposeAsync().ConfigureAwait(false);
             }
         }
 
@@ -349,6 +349,19 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
+        public async ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                await CloseIfNotAlreadyClosedFromDisposeAsync().ConfigureAwait(false);
+
+                _channelSource?.Dispose();
+                _session?.Dispose();
+                _disposed = true;
+            }
+            GC.SuppressFinalize(this);
+        }
+
         private void CloseIfNotAlreadyClosed(CancellationToken cancellationToken)
         {
             if (!_closed)
@@ -406,6 +419,18 @@ namespace MongoDB.Driver.Core.Operations
             try
             {
                 CloseIfNotAlreadyClosed(CancellationToken.None);
+            }
+            catch
+            {
+                // ignore any exceptions from CloseIfNotAlreadyClosed when called from Dispose
+            }
+        }
+
+        private async Task CloseIfNotAlreadyClosedFromDisposeAsync()
+        {
+            try
+            {
+                await CloseIfNotAlreadyClosedAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {

--- a/src/MongoDB.Driver/Core/Operations/AsyncCursor.cs
+++ b/src/MongoDB.Driver/Core/Operations/AsyncCursor.cs
@@ -341,10 +341,10 @@ namespace MongoDB.Driver.Core.Operations
             {
                 if (!_disposed)
                 {
+                    _disposed = true;
                     CloseIfNotAlreadyClosedFromDispose();
                     _channelSource?.Dispose();
                     _session?.Dispose();
-                    _disposed = true;
                 }
             }
         }
@@ -353,16 +353,16 @@ namespace MongoDB.Driver.Core.Operations
         {
             if (!_disposed)
             {
+                _disposed = true;
                 await CloseIfNotAlreadyClosedFromDisposeAsync().ConfigureAwait(false);
 
                 _channelSource?.Dispose();
                 _session?.Dispose();
-                _disposed = true;
             }
             GC.SuppressFinalize(this);
         }
 
-        private void CloseIfNotAlreadyClosed(CancellationToken cancellationToken)
+        private void CloseIfNotAlreadyClosed(CancellationToken cancellationToken = default)
         {
             if (!_closed)
             {
@@ -388,7 +388,7 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
-        private async Task CloseIfNotAlreadyClosedAsync(CancellationToken cancellationToken)
+        private async Task CloseIfNotAlreadyClosedAsync(CancellationToken cancellationToken = default)
         {
             if (!_closed)
             {
@@ -418,7 +418,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             try
             {
-                CloseIfNotAlreadyClosed(CancellationToken.None);
+                CloseIfNotAlreadyClosed();
             }
             catch
             {
@@ -430,7 +430,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             try
             {
-                await CloseIfNotAlreadyClosedAsync(CancellationToken.None).ConfigureAwait(false);
+                await CloseIfNotAlreadyClosedAsync().ConfigureAwait(false);
             }
             catch
             {

--- a/src/MongoDB.Driver/Core/Operations/AsyncCursorEnumerator.cs
+++ b/src/MongoDB.Driver/Core/Operations/AsyncCursorEnumerator.cs
@@ -69,6 +69,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 _disposed = true;
                 _batchEnumerator?.Dispose();
+                _batchEnumerator = null;
                 _cursor.Dispose();
             }
         }
@@ -79,6 +80,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 _disposed = true;
                 _batchEnumerator?.Dispose();
+                _batchEnumerator = null;
                 await _cursor.DisposeAsync().ConfigureAwait(false);
             }
         }

--- a/src/MongoDB.Driver/Core/Operations/AsyncCursorEnumerator.cs
+++ b/src/MongoDB.Driver/Core/Operations/AsyncCursorEnumerator.cs
@@ -73,13 +73,14 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            // TODO: implement true async disposal (CSHARP-5630)
-            Dispose();
-
-            // TODO: convert to ValueTask.CompletedTask once we stop supporting older target frameworks
-            return default; // Equivalent to ValueTask.CompletedTask which is not available on older target frameworks.
+            if (!_disposed)
+            {
+                _disposed = true;
+                _batchEnumerator?.Dispose();
+                await _cursor.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         public bool MoveNext()

--- a/src/MongoDB.Driver/Core/Operations/ChangeStreamCursor.cs
+++ b/src/MongoDB.Driver/Core/Operations/ChangeStreamCursor.cs
@@ -166,7 +166,7 @@ namespace MongoDB.Driver.Core.Operations
                 catch (Exception ex) when (RetryabilityHelper.IsResumableChangeStreamException(ex, _maxWireVersion))
                 {
                     var newCursor = await ResumeAsync(cancellationToken).ConfigureAwait(false);
-                    _cursor.Dispose();
+                    await _cursor.DisposeAsync().ConfigureAwait(false);
                     _cursor = newCursor;
                 }
             }

--- a/src/MongoDB.Driver/Core/Operations/ChangeStreamCursor.cs
+++ b/src/MongoDB.Driver/Core/Operations/ChangeStreamCursor.cs
@@ -108,6 +108,18 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                await _cursor.DisposeAsync().ConfigureAwait(false);
+                _binding.Dispose();
+                _session.Dispose();
+            }
+        }
+
+        /// <inheritdoc/>
         public BsonDocument GetResumeToken()
         {
             return

--- a/src/MongoDB.Driver/Core/SingleBatchAsyncCursor.cs
+++ b/src/MongoDB.Driver/Core/SingleBatchAsyncCursor.cs
@@ -68,6 +68,12 @@ namespace MongoDB.Driver
             _disposed = true;
         }
 
+        public ValueTask DisposeAsync()
+        {
+            _disposed = true;
+            return default;
+        }
+
         // private methods
         private void ThrowIfDisposed()
         {

--- a/tests/MongoDB.Driver.Tests/Core/BatchTransformingAsyncCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/BatchTransformingAsyncCursorTests.cs
@@ -19,15 +19,36 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using MongoDB.Bson;
-using MongoDB.Bson.TestHelpers;
 using MongoDB.TestHelpers.XunitExtensions;
+using Moq;
 using Xunit;
 
 namespace MongoDB.Driver
 {
     public class BatchTransformingAsyncCursorTests
     {
+        [Fact]
+        public void Dispose_should_dispose_wrapped_cursor()
+        {
+            var mockWrapped = new Mock<IAsyncCursor<int>>();
+            var subject = new BatchTransformingAsyncCursor<int, int>(mockWrapped.Object, x => x);
+
+            subject.Dispose();
+
+            mockWrapped.Verify(c => c.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_should_dispose_wrapped_cursor()
+        {
+            var mockWrapped = new Mock<IAsyncCursor<int>>();
+            var subject = new BatchTransformingAsyncCursor<int, int>(mockWrapped.Object, x => x);
+
+            await subject.DisposeAsync();
+
+            mockWrapped.Verify(c => c.DisposeAsync(), Times.Once);
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void Should_provide_back_all_results(
@@ -204,11 +225,12 @@ namespace MongoDB.Driver
             {
                 _current = null;
             }
-        }
-    }
 
-    internal static class BatchTransformingAsyncCursorReflector
-    {
-        public static IAsyncCursor<TIn> _wrapped<TIn, TOut>(this BatchTransformingAsyncCursor<TIn, TOut> obj) => (IAsyncCursor<TIn>)Reflector.GetFieldValue(obj, nameof(_wrapped));
+            public ValueTask DisposeAsync()
+            {
+                _current = null;
+                return default;
+            }
+        }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Core/BatchTransformingAsyncCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/BatchTransformingAsyncCursorTests.cs
@@ -39,11 +39,35 @@ namespace MongoDB.Driver
         }
 
         [Fact]
+        public void Dispose_can_be_called_more_than_once()
+        {
+            var mockWrapped = new Mock<IAsyncCursor<int>>();
+            var subject = new BatchTransformingAsyncCursor<int, int>(mockWrapped.Object, x => x);
+
+            subject.Dispose();
+            subject.Dispose();
+
+            mockWrapped.Verify(c => c.Dispose(), Times.Once);
+        }
+
+        [Fact]
         public async Task DisposeAsync_should_dispose_wrapped_cursor()
         {
             var mockWrapped = new Mock<IAsyncCursor<int>>();
             var subject = new BatchTransformingAsyncCursor<int, int>(mockWrapped.Object, x => x);
 
+            await subject.DisposeAsync();
+
+            mockWrapped.Verify(c => c.DisposeAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_can_be_called_more_than_once()
+        {
+            var mockWrapped = new Mock<IAsyncCursor<int>>();
+            var subject = new BatchTransformingAsyncCursor<int, int>(mockWrapped.Object, x => x);
+
+            await subject.DisposeAsync();
             await subject.DisposeAsync();
 
             mockWrapped.Verify(c => c.DisposeAsync(), Times.Once);

--- a/tests/MongoDB.Driver.Tests/Core/DeferredAsyncCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/DeferredAsyncCursorTests.cs
@@ -22,142 +22,130 @@ using MongoDB.TestHelpers.XunitExtensions;
 using Moq;
 using Xunit;
 
-namespace MongoDB.Driver.Tests
+namespace MongoDB.Driver.Tests;
+
+public class DeferredAsyncCursorTests
 {
-    public class DeferredAsyncCursorTests
+    [Fact]
+    public void Current_should_throw_when_disposed()
     {
-        [Fact]
-        public void Dispose_should_invoke_dispose_action_when_never_iterated()
+        var subject = CreateSubject(() => { });
+        subject.Dispose();
+
+        var exception = Record.Exception(() => { _ = subject.Current; });
+
+        exception.Should().BeOfType<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_should_be_idempotent()
+    {
+        var disposeActionCallCount = 0;
+        var subject = CreateSubject(() => disposeActionCallCount++);
+
+        await subject.DisposeAsync();
+        await subject.DisposeAsync();
+
+        disposeActionCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_should_dispose_cursor_and_invoke_dispose_action_when_iterated()
+    {
+        var disposeActionCallCount = 0;
+        var innerCursor = new Mock<IAsyncCursor<BsonDocument>>();
+        innerCursor.Setup(c => c.MoveNextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        var subject = new DeferredAsyncCursor<BsonDocument>(
+            () => disposeActionCallCount++,
+            _ => innerCursor.Object,
+            _ => Task.FromResult(innerCursor.Object));
+
+        await subject.MoveNextAsync(CancellationToken.None);
+        await subject.DisposeAsync();
+
+        disposeActionCallCount.Should().Be(1);
+        innerCursor.Verify(c => c.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_should_invoke_dispose_action_when_never_iterated()
+    {
+        var disposeActionCallCount = 0;
+        var subject = CreateSubject(() => disposeActionCallCount++);
+
+        await subject.DisposeAsync();
+
+        disposeActionCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Dispose_should_be_idempotent()
+    {
+        var disposeActionCallCount = 0;
+        var subject = CreateSubject(() => disposeActionCallCount++);
+
+        subject.Dispose();
+        subject.Dispose();
+
+        disposeActionCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Dispose_should_dispose_cursor_and_stay_disposed_when_dispose_action_throws()
+    {
+        var innerCursor = new Mock<IAsyncCursor<BsonDocument>>();
+        var disposeActionCallCount = 0;
+        var subject = new DeferredAsyncCursor<BsonDocument>(
+            () => { disposeActionCallCount++; throw new InvalidOperationException(); },
+            _ => innerCursor.Object,
+            _ => Task.FromResult(innerCursor.Object));
+        subject.MoveNext(CancellationToken.None); // populate the underlying cursor
+
+        Record.Exception(() => subject.Dispose()).Should().BeOfType<InvalidOperationException>();
+        subject.Dispose(); // must not run the dispose action a second time
+
+        disposeActionCallCount.Should().Be(1);
+        innerCursor.Verify(c => c.Dispose(), Times.Once);
+    }
+
+    [Theory]
+    [ParameterAttributeData]
+    public async Task Dispose_should_invoke_dispose_action_when_iterated(
+        [Values(false, true)] bool async)
+    {
+        var disposeActionCallCount = 0;
+        var subject = CreateSubject(() => disposeActionCallCount++);
+
+        if (async)
         {
-            var disposeActionCallCount = 0;
-            var subject = CreateSubject(() => disposeActionCallCount++);
-
-            subject.Dispose();
-
-            disposeActionCallCount.Should().Be(1);
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        public async Task Dispose_should_invoke_dispose_action_when_iterated(
-            [Values(false, true)] bool async)
-        {
-            var disposeActionCallCount = 0;
-            var subject = CreateSubject(() => disposeActionCallCount++);
-
-            if (async)
-            {
-                await subject.MoveNextAsync(CancellationToken.None);
-            }
-            else
-            {
-                subject.MoveNext(CancellationToken.None);
-            }
-            subject.Dispose();
-
-            disposeActionCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void Dispose_should_be_idempotent()
-        {
-            var disposeActionCallCount = 0;
-            var subject = CreateSubject(() => disposeActionCallCount++);
-
-            subject.Dispose();
-            subject.Dispose();
-
-            disposeActionCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public void Dispose_should_dispose_cursor_and_stay_disposed_when_dispose_action_throws()
-        {
-            var innerCursor = new Mock<IAsyncCursor<BsonDocument>>();
-            var disposeActionCallCount = 0;
-            var subject = new DeferredAsyncCursor<BsonDocument>(
-                () => { disposeActionCallCount++; throw new InvalidOperationException(); },
-                _ => innerCursor.Object,
-                _ => Task.FromResult(innerCursor.Object));
-            subject.MoveNext(CancellationToken.None); // populate the underlying cursor
-
-            Record.Exception(() => subject.Dispose()).Should().BeOfType<InvalidOperationException>();
-            subject.Dispose(); // must not run the dispose action a second time
-
-            disposeActionCallCount.Should().Be(1);
-            innerCursor.Verify(c => c.Dispose(), Times.Once);
-        }
-
-        [Fact]
-        public async Task DisposeAsync_should_invoke_dispose_action_when_never_iterated()
-        {
-            var disposeActionCallCount = 0;
-            var subject = CreateSubject(() => disposeActionCallCount++);
-
-            await subject.DisposeAsync();
-
-            disposeActionCallCount.Should().Be(1);
-        }
-
-        [Fact]
-        public async Task DisposeAsync_should_dispose_cursor_and_invoke_dispose_action_when_iterated()
-        {
-            var disposeActionCallCount = 0;
-            var innerCursor = new Mock<IAsyncCursor<BsonDocument>>();
-            innerCursor.Setup(c => c.MoveNextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
-            var subject = new DeferredAsyncCursor<BsonDocument>(
-                () => disposeActionCallCount++,
-                _ => innerCursor.Object,
-                _ => Task.FromResult(innerCursor.Object));
-
             await subject.MoveNextAsync(CancellationToken.None);
-            await subject.DisposeAsync();
-
-            disposeActionCallCount.Should().Be(1);
-            innerCursor.Verify(c => c.DisposeAsync(), Times.Once);
         }
-
-        [Fact]
-        public async Task DisposeAsync_should_be_idempotent()
+        else
         {
-            var disposeActionCallCount = 0;
-            var subject = CreateSubject(() => disposeActionCallCount++);
-
-            await subject.DisposeAsync();
-            await subject.DisposeAsync();
-
-            disposeActionCallCount.Should().Be(1);
+            subject.MoveNext(CancellationToken.None);
         }
+        subject.Dispose();
 
-        [Fact]
-        public void MoveNext_should_throw_when_disposed()
-        {
-            var subject = CreateSubject(() => { });
-            subject.Dispose();
+        disposeActionCallCount.Should().Be(1);
+    }
 
-            var exception = Record.Exception(() => subject.MoveNext(CancellationToken.None));
+    [Fact]
+    public void MoveNext_should_throw_when_disposed()
+    {
+        var subject = CreateSubject(() => { });
+        subject.Dispose();
 
-            exception.Should().BeOfType<ObjectDisposedException>();
-        }
+        var exception = Record.Exception(() => subject.MoveNext(CancellationToken.None));
 
-        [Fact]
-        public void Current_should_throw_when_disposed()
-        {
-            var subject = CreateSubject(() => { });
-            subject.Dispose();
+        exception.Should().BeOfType<ObjectDisposedException>();
+    }
 
-            var exception = Record.Exception(() => { _ = subject.Current; });
-
-            exception.Should().BeOfType<ObjectDisposedException>();
-        }
-
-        // private methods
-        private DeferredAsyncCursor<BsonDocument> CreateSubject(Action disposeAction)
-        {
-            return new DeferredAsyncCursor<BsonDocument>(
-                disposeAction,
-                _ => Mock.Of<IAsyncCursor<BsonDocument>>(),
-                _ => Task.FromResult(Mock.Of<IAsyncCursor<BsonDocument>>()));
-        }
+    // private methods
+    private DeferredAsyncCursor<BsonDocument> CreateSubject(Action disposeAction)
+    {
+        return new DeferredAsyncCursor<BsonDocument>(
+            disposeAction,
+            _ => Mock.Of<IAsyncCursor<BsonDocument>>(),
+            _ => Task.FromResult(Mock.Of<IAsyncCursor<BsonDocument>>()));
     }
 }

--- a/tests/MongoDB.Driver.Tests/Core/DeferredAsyncCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/DeferredAsyncCursorTests.cs
@@ -89,6 +89,47 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public async Task DisposeAsync_should_invoke_dispose_action_when_never_iterated()
+        {
+            var disposeActionCallCount = 0;
+            var subject = CreateSubject(() => disposeActionCallCount++);
+
+            await subject.DisposeAsync();
+
+            disposeActionCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_should_dispose_cursor_and_invoke_dispose_action_when_iterated()
+        {
+            var disposeActionCallCount = 0;
+            var innerCursor = new Mock<IAsyncCursor<BsonDocument>>();
+            innerCursor.Setup(c => c.MoveNextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+            var subject = new DeferredAsyncCursor<BsonDocument>(
+                () => disposeActionCallCount++,
+                _ => innerCursor.Object,
+                _ => Task.FromResult(innerCursor.Object));
+
+            await subject.MoveNextAsync(CancellationToken.None);
+            await subject.DisposeAsync();
+
+            disposeActionCallCount.Should().Be(1);
+            innerCursor.Verify(c => c.DisposeAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_should_be_idempotent()
+        {
+            var disposeActionCallCount = 0;
+            var subject = CreateSubject(() => disposeActionCallCount++);
+
+            await subject.DisposeAsync();
+            await subject.DisposeAsync();
+
+            disposeActionCallCount.Should().Be(1);
+        }
+
+        [Fact]
         public void MoveNext_should_throw_when_disposed()
         {
             var subject = CreateSubject(() => { });

--- a/tests/MongoDB.Driver.Tests/Core/IAsyncCursorExtensionsTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/IAsyncCursorExtensionsTests.cs
@@ -119,6 +119,20 @@ namespace MongoDB.Driver
             result.Should().Be(expectedResult);
         }
 
+        [Fact]
+        public async Task ForEachAsync_should_dispose_cursor_through_the_asynchronous_path()
+        {
+            var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
+            var batch = new[] { new BsonDocument("_id", 1) };
+            mockCursor.SetupSequence(c => c.MoveNextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true).ReturnsAsync(false);
+            mockCursor.Setup(c => c.Current).Returns(batch);
+
+            await mockCursor.Object.ForEachAsync(_ => { });
+
+            mockCursor.Verify(c => c.DisposeAsync(), Times.Once);
+            mockCursor.Verify(c => c.Dispose(), Times.Never);
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void Single_should_return_expected_result(
@@ -201,6 +215,40 @@ namespace MongoDB.Driver
             }
 
             action.ShouldThrow<InvalidOperationException>();
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public async Task Terminal_operator_should_dispose_cursor_through_the_expected_path(
+            [Values(
+                TerminalOperator.Any,
+                TerminalOperator.First,
+                TerminalOperator.FirstOrDefault,
+                TerminalOperator.Single,
+                TerminalOperator.SingleOrDefault,
+                TerminalOperator.ToList)]
+            TerminalOperator terminalOperator,
+            [Values(false, true)] bool async)
+        {
+            var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
+            var batch = new[] { new BsonDocument("_id", 1) };
+            mockCursor.SetupSequence(c => c.MoveNext(It.IsAny<CancellationToken>())).Returns(true).Returns(false);
+            mockCursor.SetupSequence(c => c.MoveNextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true).ReturnsAsync(false);
+            mockCursor.Setup(c => c.Current).Returns(batch);
+            var cursor = mockCursor.Object;
+
+            if (async)
+            {
+                await InvokeAsync(terminalOperator, cursor);
+                mockCursor.Verify(c => c.DisposeAsync(), Times.Once);
+                mockCursor.Verify(c => c.Dispose(), Times.Never);
+            }
+            else
+            {
+                Invoke(terminalOperator, cursor);
+                mockCursor.Verify(c => c.Dispose(), Times.Once);
+                mockCursor.Verify(c => c.DisposeAsync(), Times.Never);
+            }
         }
 
         [Fact]
@@ -347,6 +395,46 @@ namespace MongoDB.Driver
                 retryRequested: false,
                 maxAdaptiveRetries: 2,
                 enableOverloadRetargeting: false);
+        }
+
+        private static void Invoke(TerminalOperator terminalOperator, IAsyncCursor<BsonDocument> cursor)
+        {
+            switch (terminalOperator)
+            {
+                case TerminalOperator.Any: cursor.Any(); break;
+                case TerminalOperator.First: cursor.First(); break;
+                case TerminalOperator.FirstOrDefault: cursor.FirstOrDefault(); break;
+                case TerminalOperator.Single: cursor.Single(); break;
+                case TerminalOperator.SingleOrDefault: cursor.SingleOrDefault(); break;
+                case TerminalOperator.ToList: cursor.ToList(); break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(terminalOperator), terminalOperator, null);
+            }
+        }
+
+        private static async Task InvokeAsync(TerminalOperator terminalOperator, IAsyncCursor<BsonDocument> cursor)
+        {
+            switch (terminalOperator)
+            {
+                case TerminalOperator.Any: await cursor.AnyAsync(); break;
+                case TerminalOperator.First: await cursor.FirstAsync(); break;
+                case TerminalOperator.FirstOrDefault: await cursor.FirstOrDefaultAsync(); break;
+                case TerminalOperator.Single: await cursor.SingleAsync(); break;
+                case TerminalOperator.SingleOrDefault: await cursor.SingleOrDefaultAsync(); break;
+                case TerminalOperator.ToList: await cursor.ToListAsync(); break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(terminalOperator), terminalOperator, null);
+            }
+        }
+
+        public enum TerminalOperator
+        {
+            Any,
+            First,
+            FirstOrDefault,
+            Single,
+            SingleOrDefault,
+            ToList
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/Core/Operations/AsyncCursorEnumeratorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/AsyncCursorEnumeratorTests.cs
@@ -118,13 +118,13 @@ namespace MongoDB.Driver.Core.Operations
             if (async)
             {
                 await subject.DisposeAsync();
+                mockCursor.Verify(c => c.DisposeAsync(), Times.Once);
             }
             else
             {
                 subject.Dispose();
+                mockCursor.Verify(c => c.Dispose(), Times.Once);
             }
-
-            mockCursor.Verify(c => c.Dispose(), Times.Once);
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Tests/Core/Operations/AsyncCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/AsyncCursorTests.cs
@@ -389,6 +389,79 @@ namespace MongoDB.Driver.Core.Operations
             VerifyHowManyTimesKillCursorsCommandWasCalled(mockChannelHandle, Times.Never(), false);
         }
 
+        [Fact]
+        public void DisposeAsync_should_be_shielded_from_exceptions()
+        {
+            var mockChannelSource = new Mock<IChannelSource>();
+            mockChannelSource
+                .Setup(c => c.GetChannelAsync(It.IsAny<OperationContext>()))
+                .Throws<Exception>();
+
+            var subject = CreateSubject(cursorId: 1, channelSource: Optional.Create(mockChannelSource.Object));
+
+            subject.DisposeAsync().GetAwaiter().GetResult();
+        }
+
+        [Fact]
+        public void DisposeAsync_should_dispose_channel_source_when_cursor_id_is_zero()
+        {
+            var mockChannelSource = new Mock<IChannelSource>();
+            var subject = CreateSubject(cursorId: 0, channelSource: Optional.Create(mockChannelSource.Object));
+
+            subject.DisposeAsync().GetAwaiter().GetResult();
+
+            mockChannelSource.Verify(s => s.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void DisposeAsync_should_dispose_cursor_only_once()
+        {
+            int testCursorId = 1;
+            var mockChannelHandle = new Mock<IChannelHandle>();
+            var mockChannelSource = new Mock<IChannelSource>();
+            SetupChannelMocks(mockChannelSource, mockChannelHandle, async: true, $"{{ 'ok' : true, 'cursorsNotFound' : [], 'cursorsKilled' : [{testCursorId}] }}");
+
+            var subject = CreateSubject(cursorId: 1, channelSource: Optional.Create(mockChannelSource.Object));
+            subject.DisposeAsync().GetAwaiter().GetResult();
+            VerifyHowManyTimesKillCursorsCommandWasCalled(mockChannelHandle, Times.Once(), async: true);
+            subject.DisposeAsync().GetAwaiter().GetResult();
+            VerifyHowManyTimesKillCursorsCommandWasCalled(mockChannelHandle, Times.Once(), async: true);
+        }
+
+        [Fact]
+        public void DisposeAsync_should_not_call_kill_cursors_for_zero_cursor_id()
+        {
+            var mockChannelHandle = new Mock<IChannelHandle>();
+            mockChannelHandle
+                .Setup(c => c.ConnectionDescription)
+                .Returns(CreateConnectionDescriptionSupportingSession());
+
+            var mockChannelSource = new Mock<IChannelSource>();
+            mockChannelSource
+                .Setup(c => c.GetChannelAsync(It.IsAny<OperationContext>()))
+                .ReturnsAsync(mockChannelHandle.Object);
+
+            var subject = CreateSubject(cursorId: 0, channelSource: Optional.Create(mockChannelSource.Object));
+            subject.DisposeAsync().GetAwaiter().GetResult();
+
+            VerifyHowManyTimesKillCursorsCommandWasCalled(mockChannelHandle, Times.Never(), async: true);
+        }
+
+        [Fact]
+        public void DisposeAsync_should_send_kill_cursors_through_the_async_command_path()
+        {
+            int testCursorId = 1;
+            var mockChannelHandle = new Mock<IChannelHandle>();
+            var mockChannelSource = new Mock<IChannelSource>();
+            SetupChannelMocks(mockChannelSource, mockChannelHandle, async: true, $"{{ 'ok' : true, 'cursorsNotFound' : [], 'cursorsKilled' : [{testCursorId}] }}");
+
+            var subject = CreateSubject(cursorId: testCursorId, channelSource: Optional.Create(mockChannelSource.Object));
+            subject.DisposeAsync().GetAwaiter().GetResult();
+
+            VerifyHowManyTimesKillCursorsCommandWasCalled(mockChannelHandle, Times.Once(), async: true);
+            VerifyHowManyTimesKillCursorsCommandWasCalled(mockChannelHandle, Times.Never(), async: false);
+        }
+
         [Theory]
         [ParameterAttributeData]
         public void GetMore_should_use_same_session(

--- a/tests/MongoDB.Driver.Tests/Core/Operations/ChangeStreamCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/ChangeStreamCursorTests.cs
@@ -251,6 +251,52 @@ namespace MongoDB.Driver.Core.Operations
             mockBinding.Verify(s => s.Dispose(), Times.Once);
         }
 
+        [Fact]
+        public async Task DisposeAsync_should_set_disposed_to_true()
+        {
+            var subject = CreateSubject();
+
+            await subject.DisposeAsync();
+
+            subject._disposed().Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task DisposeAsync_should_call_DisposeAsync_on_cursor()
+        {
+            var mockCursor = new Mock<IAsyncCursor<RawBsonDocument>>();
+            var subject = CreateSubject(cursor: mockCursor.Object);
+
+            await subject.DisposeAsync();
+
+            mockCursor.Verify(s => s.DisposeAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_should_call_Dispose_on_binding()
+        {
+            var mockBinding = new Mock<IReadBinding>();
+            var subject = CreateSubject(binding: mockBinding.Object);
+
+            await subject.DisposeAsync();
+
+            mockBinding.Verify(s => s.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_can_be_called_more_than_once()
+        {
+            var mockCursor = new Mock<IAsyncCursor<RawBsonDocument>>();
+            var mockBinding = new Mock<IReadBinding>();
+            var subject = CreateSubject(cursor: mockCursor.Object, binding: mockBinding.Object);
+
+            await subject.DisposeAsync();
+            await subject.DisposeAsync();
+
+            mockCursor.Verify(s => s.DisposeAsync(), Times.Once);
+            mockBinding.Verify(s => s.Dispose(), Times.Once);
+        }
+
         [Theory]
         [InlineData("{ a : 1 }", "{ b : 2 }", "{ c : 3 }", "{ d : 4 }", "{ a : 1 }")]
         [InlineData(null, "{ b : 2 }", "{ c : 3 }", "{ d : 4 }", "{ b : 2 }")]

--- a/tests/MongoDB.Driver.Tests/Core/SingleBatchAsyncCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/SingleBatchAsyncCursorTests.cs
@@ -1,0 +1,47 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Xunit;
+
+namespace MongoDB.Driver;
+
+public class SingleBatchAsyncCursorTests
+{
+    [Fact]
+    public async Task DisposeAsync_should_dispose_cursor()
+    {
+        var subject = new SingleBatchAsyncCursor<BsonDocument>(new List<BsonDocument>());
+
+        await subject.DisposeAsync();
+
+        Record.Exception(() => { _ = subject.Current; }).Should().BeOfType<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_can_be_called_more_than_once()
+    {
+        var subject = new SingleBatchAsyncCursor<BsonDocument>(new List<BsonDocument>());
+
+        await subject.DisposeAsync();
+        var exception = await Record.ExceptionAsync(async () => await subject.DisposeAsync());
+
+        exception.Should().BeNull();
+    }
+}


### PR DESCRIPTION
Add DisposeAsync to IAsyncCursor and its implementers so await using / await foreach / async terminal operators release the server-side cursor through an async killCursors round-trip instead of blocking on the synchronous one.

- IAsyncCursor now implements IAsyncDisposable
- DisposeAsync on AsyncCursor, ChangeStreamCursor, BatchTransformingAsyncCursor, SingleBatchAsyncCursor, DeferredAsyncCursor (written leak-free), and a real AsyncCursorEnumerator.DisposeAsync
- IAsyncCursorExtensions async terminal operators use await using