### PR TITLE
CSHARP-6005: CSFLE/QE support for HTTP Proxies

### DIFF
--- a/src/MongoDB.Driver.Encryption/AutoEncryptionLibMongoController.cs
+++ b/src/MongoDB.Driver.Encryption/AutoEncryptionLibMongoController.cs
@@ -65,7 +65,7 @@ namespace MongoDB.Driver.Encryption
             IMongoClient metadataClient,
             CryptClient cryptClient,
             AutoEncryptionOptions autoEncryptionOptions)
-            : base(cryptClient, keyVaultClient, autoEncryptionOptions.KeyVaultNamespace, autoEncryptionOptions.KmsProviders, autoEncryptionOptions.TlsOptions)
+            : base(cryptClient, keyVaultClient, autoEncryptionOptions.KeyVaultNamespace, autoEncryptionOptions.KmsProviders, autoEncryptionOptions.TlsOptions, autoEncryptionOptions.KmsConnector)
         {
             _internalClient = internalClient; // can be null
             _metadataClient = metadataClient; // can be null

--- a/src/MongoDB.Driver.Encryption/ClientEncryptionOptions.cs
+++ b/src/MongoDB.Driver.Encryption/ClientEncryptionOptions.cs
@@ -26,6 +26,7 @@ namespace MongoDB.Driver.Encryption
     {
         // private fields
         private TimeSpan? _keyExpiration;
+        private readonly IKmsConnector _kmsConnector;
         private readonly IMongoClient _keyVaultClient;
         private readonly CollectionNamespace _keyVaultNamespace;
         private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> _kmsProviders;
@@ -39,12 +40,14 @@ namespace MongoDB.Driver.Encryption
         /// <param name="keyVaultNamespace">The key vault namespace.</param>
         /// <param name="kmsProviders">The KMS providers.</param>
         /// <param name="tlsOptions">The tls options.</param>
+        /// <param name="kmsConnector">The KMS connector used to open connections to KMS hosts.</param>
         public ClientEncryptionOptions(
             IMongoClient keyVaultClient,
             CollectionNamespace keyVaultNamespace,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> kmsProviders,
-            Optional<IReadOnlyDictionary<string, SslSettings>> tlsOptions = default)
-            : this(keyVaultClient, keyVaultNamespace, kmsProviders, tlsOptions, keyExpiration: null)
+            Optional<IReadOnlyDictionary<string, SslSettings>> tlsOptions = default,
+            Optional<IKmsConnector> kmsConnector = default)
+            : this(keyVaultClient, keyVaultNamespace, kmsProviders, tlsOptions, kmsConnector, keyExpiration: null)
         {
         }
 
@@ -53,12 +56,14 @@ namespace MongoDB.Driver.Encryption
             CollectionNamespace keyVaultNamespace,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> kmsProviders,
             Optional<IReadOnlyDictionary<string, SslSettings>> tlsOptions = default,
+            Optional<IKmsConnector> kmsConnector = default,
             Optional<TimeSpan?> keyExpiration = default)
         {
             _keyVaultClient = Ensure.IsNotNull(keyVaultClient, nameof(keyVaultClient));
             _keyVaultNamespace = Ensure.IsNotNull(keyVaultNamespace, nameof(keyVaultNamespace));
             _kmsProviders = Ensure.IsNotNull(kmsProviders, nameof(kmsProviders));
             _tlsOptions = tlsOptions.WithDefault(new Dictionary<string, SslSettings>());
+            _kmsConnector = kmsConnector.WithDefault(null);
             _keyExpiration = keyExpiration.WithDefault(null);
 
             EnsureKmsProvidersAreValid(_kmsProviders);
@@ -71,6 +76,14 @@ namespace MongoDB.Driver.Encryption
         /// Gets the data encryption key cache expiration time.
         /// </summary>
         public TimeSpan? KeyExpiration => _keyExpiration;
+
+        /// <summary>
+        /// Gets the KMS connector used to open connections to KMS hosts.
+        /// </summary>
+        /// <value>
+        /// The KMS connector to connect directly to KMS hosts.
+        /// </value>
+        public IKmsConnector KmsConnector => _kmsConnector;
 
         /// <summary>
         /// Gets the key vault client.
@@ -111,18 +124,21 @@ namespace MongoDB.Driver.Encryption
         /// <param name="keyVaultNamespace">The key vault namespace.</param>
         /// <param name="kmsProviders">The KMS providers.</param>
         /// <param name="tlsOptions">The tls options.</param>
+        /// <param name="kmsConnector">The KMS connector used to open connections to KMS hosts.</param>
         /// <returns>A new ClientEncryptionOptions instance.</returns>
         public ClientEncryptionOptions With(
             Optional<IMongoClient> keyVaultClient = default,
             Optional<CollectionNamespace> keyVaultNamespace = default,
             Optional<IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>>> kmsProviders = default,
-            Optional<IReadOnlyDictionary<string, SslSettings>> tlsOptions = default)
+            Optional<IReadOnlyDictionary<string, SslSettings>> tlsOptions = default,
+            Optional<IKmsConnector> kmsConnector = default)
         {
             return new ClientEncryptionOptions(
                 keyVaultClient: keyVaultClient.WithDefault(_keyVaultClient),
                 keyVaultNamespace: keyVaultNamespace.WithDefault(_keyVaultNamespace),
                 kmsProviders: kmsProviders.WithDefault(_kmsProviders),
                 tlsOptions: Optional.Create(tlsOptions.WithDefault(_tlsOptions)),
+                kmsConnector: Optional.Create(kmsConnector.WithDefault(_kmsConnector)),
                 keyExpiration: _keyExpiration);
         }
 

--- a/src/MongoDB.Driver.Encryption/ClientEncryptionOptions.cs
+++ b/src/MongoDB.Driver.Encryption/ClientEncryptionOptions.cs
@@ -81,7 +81,7 @@ namespace MongoDB.Driver.Encryption
         /// Gets the KMS connector used to open connections to KMS hosts.
         /// </summary>
         /// <value>
-        /// The KMS connector to connect directly to KMS hosts.
+        /// The KMS connector used to open connections to KMS hosts.
         /// </value>
         public IKmsConnector KmsConnector => _kmsConnector;
 

--- a/src/MongoDB.Driver.Encryption/ExplicitEncryptionLibMongoCryptController.cs
+++ b/src/MongoDB.Driver.Encryption/ExplicitEncryptionLibMongoCryptController.cs
@@ -34,7 +34,7 @@ namespace MongoDB.Driver.Encryption
             ClientEncryptionOptions clientEncryptionOptions)
             : base(cryptClient,
                   Ensure.IsNotNull(Ensure.IsNotNull(clientEncryptionOptions, nameof(clientEncryptionOptions)).KeyVaultClient, nameof(clientEncryptionOptions.KeyVaultClient)),
-                  clientEncryptionOptions.KeyVaultNamespace, clientEncryptionOptions.KmsProviders, clientEncryptionOptions.TlsOptions)
+                  clientEncryptionOptions.KeyVaultNamespace, clientEncryptionOptions.KmsProviders, clientEncryptionOptions.TlsOptions, clientEncryptionOptions.KmsConnector)
         {
         }
 

--- a/src/MongoDB.Driver.Encryption/KmsConnectorStreamFactory.cs
+++ b/src/MongoDB.Driver.Encryption/KmsConnectorStreamFactory.cs
@@ -1,4 +1,4 @@
-/* Copyright 2019-present MongoDB Inc.
+/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,26 +34,24 @@ internal sealed class KmsConnectorStreamFactory : IStreamFactory
 
     public Stream CreateStream(EndPoint endPoint, CancellationToken cancellationToken)
     {
-        var (host, port) = GetHostAndPort(endPoint);
-        var stream = _kmsConnector.Connect(host, port, cancellationToken);
+        var stream = _kmsConnector.Connect(CreateConnectionContext(endPoint), cancellationToken);
         return EnsureConnectResult(stream, nameof(IKmsConnector.Connect));
     }
 
     public async Task<Stream> CreateStreamAsync(EndPoint endPoint, CancellationToken cancellationToken)
     {
-        var (host, port) = GetHostAndPort(endPoint);
-        var stream = await _kmsConnector.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
+        var stream = await _kmsConnector.ConnectAsync(CreateConnectionContext(endPoint), cancellationToken).ConfigureAwait(false);
         return EnsureConnectResult(stream, nameof(IKmsConnector.ConnectAsync));
+    }
+
+    private static KmsConnectionContext CreateConnectionContext(EndPoint endPoint)
+    {
+        var dnsEndPoint = (DnsEndPoint)endPoint;
+        return new KmsConnectionContext(dnsEndPoint.Host, dnsEndPoint.Port);
     }
 
     private static Stream EnsureConnectResult(Stream stream, string methodName)
     {
         return stream ?? throw new InvalidOperationException($"{nameof(IKmsConnector)}.{methodName} returned null.");
-    }
-
-    private static (string Host, int Port) GetHostAndPort(EndPoint endPoint)
-    {
-        var dnsEndPoint = (DnsEndPoint)endPoint;
-        return (dnsEndPoint.Host, dnsEndPoint.Port);
     }
 }

--- a/src/MongoDB.Driver.Encryption/KmsConnectorStreamFactory.cs
+++ b/src/MongoDB.Driver.Encryption/KmsConnectorStreamFactory.cs
@@ -1,0 +1,53 @@
+/* Copyright 2019-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver.Core.Connections;
+using MongoDB.Driver.Core.Misc;
+
+namespace MongoDB.Driver.Encryption;
+
+internal sealed class KmsConnectorStreamFactory : IStreamFactory
+{
+    private readonly IKmsConnector _kmsConnector;
+
+    public KmsConnectorStreamFactory(IKmsConnector kmsConnector)
+    {
+        _kmsConnector = Ensure.IsNotNull(kmsConnector, nameof(kmsConnector));
+    }
+
+    public Stream CreateStream(EndPoint endPoint, CancellationToken cancellationToken)
+    {
+        var (host, port) = GetHostAndPort(endPoint);
+        var stream = _kmsConnector.Connect(host, port, cancellationToken);
+        return Ensure.IsNotNull(stream, $"{nameof(IKmsConnector)}.{nameof(IKmsConnector.Connect)}");
+    }
+
+    public async Task<Stream> CreateStreamAsync(EndPoint endPoint, CancellationToken cancellationToken)
+    {
+        var (host, port) = GetHostAndPort(endPoint);
+        var stream = await _kmsConnector.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
+        return Ensure.IsNotNull(stream, $"{nameof(IKmsConnector)}.{nameof(IKmsConnector.ConnectAsync)}");
+    }
+
+    private static (string Host, int Port) GetHostAndPort(EndPoint endPoint)
+    {
+        var dnsEndPoint = (DnsEndPoint)endPoint;
+        return (dnsEndPoint.Host, dnsEndPoint.Port);
+    }
+}

--- a/src/MongoDB.Driver.Encryption/KmsConnectorStreamFactory.cs
+++ b/src/MongoDB.Driver.Encryption/KmsConnectorStreamFactory.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.IO;
 using System.Net;
 using System.Threading;
@@ -35,14 +36,19 @@ internal sealed class KmsConnectorStreamFactory : IStreamFactory
     {
         var (host, port) = GetHostAndPort(endPoint);
         var stream = _kmsConnector.Connect(host, port, cancellationToken);
-        return Ensure.IsNotNull(stream, $"{nameof(IKmsConnector)}.{nameof(IKmsConnector.Connect)}");
+        return EnsureConnectResult(stream, nameof(IKmsConnector.Connect));
     }
 
     public async Task<Stream> CreateStreamAsync(EndPoint endPoint, CancellationToken cancellationToken)
     {
         var (host, port) = GetHostAndPort(endPoint);
         var stream = await _kmsConnector.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
-        return Ensure.IsNotNull(stream, $"{nameof(IKmsConnector)}.{nameof(IKmsConnector.ConnectAsync)}");
+        return EnsureConnectResult(stream, nameof(IKmsConnector.ConnectAsync));
+    }
+
+    private static Stream EnsureConnectResult(Stream stream, string methodName)
+    {
+        return stream ?? throw new InvalidOperationException($"{nameof(IKmsConnector)}.{methodName} returned null.");
     }
 
     private static (string Host, int Port) GetHostAndPort(EndPoint endPoint)

--- a/src/MongoDB.Driver.Encryption/LibMongoCryptControllerBase.cs
+++ b/src/MongoDB.Driver.Encryption/LibMongoCryptControllerBase.cs
@@ -39,6 +39,7 @@ namespace MongoDB.Driver.Encryption
         protected readonly CollectionNamespace _keyVaultNamespace;
 
         // private fields
+        private readonly IKmsConnector _kmsConnector;
         private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> _kmsProviders;
         private readonly IStreamFactory _networkStreamFactory;
         private readonly IReadOnlyDictionary<string, SslSettings> _tlsOptions;
@@ -49,7 +50,8 @@ namespace MongoDB.Driver.Encryption
              IMongoClient keyVaultClient,
              CollectionNamespace keyVaultNamespace,
              IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> kmsProviders,
-             IReadOnlyDictionary<string, SslSettings> tlsOptions)
+             IReadOnlyDictionary<string, SslSettings> tlsOptions,
+             IKmsConnector kmsConnector)
         {
             _cryptClient = Ensure.IsNotNull(cryptClient, nameof(cryptClient));
             _keyVaultClient = Ensure.IsNotNull(keyVaultClient, nameof(keyVaultClient)); // _keyVaultClient might not be fully constructed at this point, don't call any instance methods on it yet
@@ -58,6 +60,7 @@ namespace MongoDB.Driver.Encryption
             _kmsProviders = Ensure.IsNotNull(kmsProviders, nameof(kmsProviders));
             _networkStreamFactory = new NetworkStreamFactory();
             _tlsOptions = Ensure.IsNotNull(tlsOptions, nameof(tlsOptions));
+            _kmsConnector = kmsConnector; // optional; null means connect directly to the KMS host
         }
 
         // public properties
@@ -199,6 +202,9 @@ namespace MongoDB.Driver.Encryption
             return new DnsEndPoint(host, port);
         }
 
+        private IStreamFactory GetBaseStreamFactory() =>
+            _kmsConnector != null ? new KmsConnectorStreamFactory(_kmsConnector) : _networkStreamFactory;
+
         private SslStreamSettings GetTlsStreamSettings(string kmsProvider)
         {
             if (!_tlsOptions.TryGetValue(kmsProvider, out var tlsSettings))
@@ -287,7 +293,7 @@ namespace MongoDB.Driver.Encryption
                 var endpoint = CreateKmsEndPoint(request.Endpoint);
 
                 var tlsStreamSettings = GetTlsStreamSettings(request.KmsProvider);
-                var sslStreamFactory = new SslStreamFactory(tlsStreamSettings, _networkStreamFactory);
+                var sslStreamFactory = new SslStreamFactory(tlsStreamSettings, GetBaseStreamFactory());
                 using var sslStream = sslStreamFactory.CreateStream(endpoint, cancellation);
 
                 var sleepMs = request.Sleep;
@@ -331,7 +337,7 @@ namespace MongoDB.Driver.Encryption
                 var endpoint = CreateKmsEndPoint(request.Endpoint);
 
                 var tlsStreamSettings = GetTlsStreamSettings(request.KmsProvider);
-                var sslStreamFactory = new SslStreamFactory(tlsStreamSettings, _networkStreamFactory);
+                var sslStreamFactory = new SslStreamFactory(tlsStreamSettings, GetBaseStreamFactory());
                 using var sslStream = await sslStreamFactory.CreateStreamAsync(endpoint, cancellation).ConfigureAwait(false);
 
                 var sleepMs = request.Sleep;

--- a/src/MongoDB.Driver.Encryption/LibMongoCryptControllerBase.cs
+++ b/src/MongoDB.Driver.Encryption/LibMongoCryptControllerBase.cs
@@ -39,9 +39,8 @@ namespace MongoDB.Driver.Encryption
         protected readonly CollectionNamespace _keyVaultNamespace;
 
         // private fields
-        private readonly IKmsConnector _kmsConnector;
+        private readonly IStreamFactory _kmsStreamFactory;
         private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> _kmsProviders;
-        private readonly IStreamFactory _networkStreamFactory;
         private readonly IReadOnlyDictionary<string, SslSettings> _tlsOptions;
 
         // constructors
@@ -58,9 +57,8 @@ namespace MongoDB.Driver.Encryption
             _keyVaultNamespace = Ensure.IsNotNull(keyVaultNamespace, nameof(keyVaultNamespace));
             _keyVaultCollection = new Lazy<IMongoCollection<BsonDocument>>(GetKeyVaultCollection); // delay use _keyVaultClient
             _kmsProviders = Ensure.IsNotNull(kmsProviders, nameof(kmsProviders));
-            _networkStreamFactory = new NetworkStreamFactory();
             _tlsOptions = Ensure.IsNotNull(tlsOptions, nameof(tlsOptions));
-            _kmsConnector = kmsConnector; // optional; null means connect directly to the KMS host
+            _kmsStreamFactory = kmsConnector != null ? new KmsConnectorStreamFactory(kmsConnector) : new NetworkStreamFactory(); // kmsConnector is optional; null means connect directly to the KMS host
         }
 
         // public properties
@@ -202,9 +200,6 @@ namespace MongoDB.Driver.Encryption
             return new DnsEndPoint(host, port);
         }
 
-        private IStreamFactory GetBaseStreamFactory() =>
-            _kmsConnector != null ? new KmsConnectorStreamFactory(_kmsConnector) : _networkStreamFactory;
-
         private SslStreamSettings GetTlsStreamSettings(string kmsProvider)
         {
             if (!_tlsOptions.TryGetValue(kmsProvider, out var tlsSettings))
@@ -293,7 +288,7 @@ namespace MongoDB.Driver.Encryption
                 var endpoint = CreateKmsEndPoint(request.Endpoint);
 
                 var tlsStreamSettings = GetTlsStreamSettings(request.KmsProvider);
-                var sslStreamFactory = new SslStreamFactory(tlsStreamSettings, GetBaseStreamFactory());
+                var sslStreamFactory = new SslStreamFactory(tlsStreamSettings, _kmsStreamFactory);
                 using var sslStream = sslStreamFactory.CreateStream(endpoint, cancellation);
 
                 var sleepMs = request.Sleep;
@@ -337,7 +332,7 @@ namespace MongoDB.Driver.Encryption
                 var endpoint = CreateKmsEndPoint(request.Endpoint);
 
                 var tlsStreamSettings = GetTlsStreamSettings(request.KmsProvider);
-                var sslStreamFactory = new SslStreamFactory(tlsStreamSettings, GetBaseStreamFactory());
+                var sslStreamFactory = new SslStreamFactory(tlsStreamSettings, _kmsStreamFactory);
                 using var sslStream = await sslStreamFactory.CreateStreamAsync(endpoint, cancellation).ConfigureAwait(false);
 
                 var sleepMs = request.Sleep;

--- a/src/MongoDB.Driver/AutoEncryptionOptions.cs
+++ b/src/MongoDB.Driver/AutoEncryptionOptions.cs
@@ -38,6 +38,7 @@ namespace MongoDB.Driver
         private TimeSpan? _keyExpiration;
         private readonly IReadOnlyDictionary<string, BsonDocument> _encryptedFieldsMap;
         private readonly IReadOnlyDictionary<string, object> _extraOptions;
+        private readonly IKmsConnector _kmsConnector;
         private readonly IMongoClient _keyVaultClient;
         private readonly CollectionNamespace _keyVaultNamespace;
         private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> _kmsProviders;
@@ -57,6 +58,7 @@ namespace MongoDB.Driver
         /// <param name="tlsOptions">The tls options.</param>
         /// <param name="encryptedFieldsMap">The encryptedFields map.</param>
         /// <param name="bypassQueryAnalysis">The bypass query analysis flag.</param>
+        /// <param name="kmsConnector">The KMS connector used to open connections to KMS hosts.</param>
         public AutoEncryptionOptions(
             CollectionNamespace keyVaultNamespace,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>> kmsProviders,
@@ -66,8 +68,9 @@ namespace MongoDB.Driver
             Optional<IReadOnlyDictionary<string, BsonDocument>> schemaMap = default,
             Optional<IReadOnlyDictionary<string, SslSettings>> tlsOptions = default,
             Optional<IReadOnlyDictionary<string, BsonDocument>> encryptedFieldsMap = default,
-            Optional<bool?> bypassQueryAnalysis = default)
-            : this(keyVaultNamespace, kmsProviders, bypassAutoEncryption, extraOptions, keyVaultClient, schemaMap, tlsOptions, encryptedFieldsMap, bypassQueryAnalysis, keyExpiration: null)
+            Optional<bool?> bypassQueryAnalysis = default,
+            Optional<IKmsConnector> kmsConnector = default)
+            : this(keyVaultNamespace, kmsProviders, bypassAutoEncryption, extraOptions, keyVaultClient, schemaMap, tlsOptions, encryptedFieldsMap, bypassQueryAnalysis, kmsConnector, keyExpiration: null)
         {
         }
 
@@ -81,6 +84,7 @@ namespace MongoDB.Driver
             Optional<IReadOnlyDictionary<string, SslSettings>> tlsOptions,
             Optional<IReadOnlyDictionary<string, BsonDocument>> encryptedFieldsMap,
             Optional<bool?> bypassQueryAnalysis,
+            Optional<IKmsConnector> kmsConnector,
             Optional<TimeSpan?> keyExpiration)
         {
             _keyVaultNamespace = Ensure.IsNotNull(keyVaultNamespace, nameof(keyVaultNamespace));
@@ -89,6 +93,7 @@ namespace MongoDB.Driver
             _bypassQueryAnalysis = bypassQueryAnalysis.WithDefault(null);
             _keyExpiration = keyExpiration.WithDefault(null);
             _extraOptions = extraOptions.WithDefault(null);
+            _kmsConnector = kmsConnector.WithDefault(null);
             _keyVaultClient = keyVaultClient.WithDefault(null);
             _schemaMap = schemaMap.WithDefault(null);
             _tlsOptions = tlsOptions.WithDefault(new Dictionary<string, SslSettings>());
@@ -136,6 +141,14 @@ namespace MongoDB.Driver
         /// as it is an error to load more that one crypt_shared dynamic library simultaneously in a single operating system process.
         /// </remarks>
         public IReadOnlyDictionary<string, object> ExtraOptions => _extraOptions;
+
+        /// <summary>
+        /// Gets the KMS connector used to open connections to KMS hosts.
+        /// </summary>
+        /// <value>
+        /// The KMS connector to connect directly to KMS hosts.
+        /// </value>
+        public IKmsConnector KmsConnector => _kmsConnector;
 
         /// <summary>
         /// Gets the key vault client.
@@ -199,6 +212,7 @@ namespace MongoDB.Driver
         /// <param name="schemaMap">The schema map.</param>
         /// <param name="tlsOptions">The tls options.</param>
         /// <param name="encryptedFieldsMap">The encryptedFields map.</param>
+        /// <param name="kmsConnector">The KMS connector used to open connections to KMS hosts.</param>
         /// <returns>A new instance of <see cref="AutoEncryptionOptions"/>.</returns>
         public AutoEncryptionOptions With(
             Optional<CollectionNamespace> keyVaultNamespace = default,
@@ -209,7 +223,8 @@ namespace MongoDB.Driver
             Optional<IMongoClient> keyVaultClient = default,
             Optional<IReadOnlyDictionary<string, BsonDocument>> schemaMap = default,
             Optional<IReadOnlyDictionary<string, SslSettings>> tlsOptions = default,
-            Optional<IReadOnlyDictionary<string, BsonDocument>> encryptedFieldsMap = default)
+            Optional<IReadOnlyDictionary<string, BsonDocument>> encryptedFieldsMap = default,
+            Optional<IKmsConnector> kmsConnector = default)
         {
             return new AutoEncryptionOptions(
                 keyVaultNamespace.WithDefault(_keyVaultNamespace),
@@ -221,6 +236,7 @@ namespace MongoDB.Driver
                 Optional.Create(tlsOptions.WithDefault(_tlsOptions)),
                 Optional.Create(encryptedFieldsMap.WithDefault(_encryptedFieldsMap)),
                 Optional.Create(bypassQueryAnalysis.WithDefault(_bypassQueryAnalysis)),
+                Optional.Create(kmsConnector.WithDefault(_kmsConnector)),
                 _keyExpiration);
         }
 
@@ -235,6 +251,7 @@ namespace MongoDB.Driver
                 _bypassQueryAnalysis == rhs._bypassQueryAnalysis &&
                 _keyExpiration == rhs._keyExpiration &&
                 ExtraOptionsEquals(_extraOptions, rhs._extraOptions) &&
+                object.ReferenceEquals(_kmsConnector, rhs._kmsConnector) &&
                 object.ReferenceEquals(_keyVaultClient, rhs._keyVaultClient) &&
                 _keyVaultNamespace.Equals(rhs._keyVaultNamespace) &&
                 KmsProvidersEqualityHelper.Equals(_kmsProviders, rhs._kmsProviders) &&
@@ -251,6 +268,7 @@ namespace MongoDB.Driver
                 .Hash(_bypassQueryAnalysis)
                 .Hash(_keyExpiration)
                 .HashElements(_extraOptions)
+                .Hash(_kmsConnector)
                 .Hash(_keyVaultClient)
                 .Hash(_keyVaultNamespace)
                 .HashElements(_kmsProviders)

--- a/src/MongoDB.Driver/AutoEncryptionOptions.cs
+++ b/src/MongoDB.Driver/AutoEncryptionOptions.cs
@@ -146,7 +146,7 @@ namespace MongoDB.Driver
         /// Gets the KMS connector used to open connections to KMS hosts.
         /// </summary>
         /// <value>
-        /// The KMS connector to connect directly to KMS hosts.
+        /// The KMS connector used to open connections to KMS hosts.
         /// </value>
         public IKmsConnector KmsConnector => _kmsConnector;
 

--- a/src/MongoDB.Driver/Encryption/IKmsConnector.cs
+++ b/src/MongoDB.Driver/Encryption/IKmsConnector.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Driver.Encryption;
 
 /// <summary>
 /// Opens the transport connection used to reach a KMS host. When supplied via
-/// ClientEncryptionOptions or <see cref="AutoEncryptionOptions"/>, the driver
+/// <c>ClientEncryptionOptions</c> or <see cref="AutoEncryptionOptions"/>, the driver
 /// invokes this instead of opening a direct TCP connection to the KMS host, then wraps the
 /// returned stream in TLS using the KMS provider's configured TLS options.
 /// The primary use case is routing KMS traffic through an HTTP proxy via HTTPS CONNECT.

--- a/src/MongoDB.Driver/Encryption/IKmsConnector.cs
+++ b/src/MongoDB.Driver/Encryption/IKmsConnector.cs
@@ -1,0 +1,48 @@
+/* Copyright 2019-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MongoDB.Driver.Encryption;
+
+/// <summary>
+/// Opens the transport connection used to reach a KMS host. When supplied via
+/// ClientEncryptionOptions or <see cref="AutoEncryptionOptions"/>, the driver
+/// invokes this instead of opening a direct TCP connection to the KMS host, then wraps the
+/// returned stream in TLS using the KMS provider's configured TLS options.
+/// The primary use case is routing KMS traffic through an HTTP proxy via HTTPS CONNECT.
+/// </summary>
+public interface IKmsConnector
+{
+    /// <summary>
+    /// Opens a connection to the specified KMS host.
+    /// </summary>
+    /// <param name="host">The KMS hostname (for example, <c>kms.us-east-1.amazonaws.com</c>).</param>
+    /// <param name="port">The KMS port.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A stream connected to the KMS host. The driver wraps this stream in TLS.</returns>
+    Stream Connect(string host, int port, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Opens a connection to the specified KMS host.
+    /// </summary>
+    /// <param name="host">The KMS hostname (for example, <c>kms.us-east-1.amazonaws.com</c>).</param>
+    /// <param name="port">The KMS port.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A stream connected to the KMS host. The driver wraps this stream in TLS.</returns>
+    Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken);
+}

--- a/src/MongoDB.Driver/Encryption/IKmsConnector.cs
+++ b/src/MongoDB.Driver/Encryption/IKmsConnector.cs
@@ -1,4 +1,4 @@
-/* Copyright 2019-present MongoDB Inc.
+/* Copyright 2010-present MongoDB Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,18 +37,16 @@ public interface IKmsConnector
     /// <summary>
     /// Opens a connection to the specified KMS host.
     /// </summary>
-    /// <param name="host">The KMS hostname (for example, <c>kms.us-east-1.amazonaws.com</c>).</param>
-    /// <param name="port">The KMS port.</param>
+    /// <param name="context">Describes the KMS host to connect to.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A stream connected to the KMS host. The driver wraps this stream in TLS. Must not be null.</returns>
-    Stream Connect(string host, int port, CancellationToken cancellationToken);
+    Stream Connect(KmsConnectionContext context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Opens a connection to the specified KMS host.
     /// </summary>
-    /// <param name="host">The KMS hostname (for example, <c>kms.us-east-1.amazonaws.com</c>).</param>
-    /// <param name="port">The KMS port.</param>
+    /// <param name="context">Describes the KMS host to connect to.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A stream connected to the KMS host. The driver wraps this stream in TLS. Must not be null.</returns>
-    Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken);
+    Task<Stream> ConnectAsync(KmsConnectionContext context, CancellationToken cancellationToken);
 }

--- a/src/MongoDB.Driver/Encryption/IKmsConnector.cs
+++ b/src/MongoDB.Driver/Encryption/IKmsConnector.cs
@@ -26,6 +26,12 @@ namespace MongoDB.Driver.Encryption;
 /// returned stream in TLS using the KMS provider's configured TLS options.
 /// The primary use case is routing KMS traffic through an HTTP proxy via HTTPS CONNECT.
 /// </summary>
+/// <remarks>
+/// Both <see cref="Connect"/> and <see cref="ConnectAsync"/> must be implemented, even if the
+/// application only uses one of the driver's sync or async encryption APIs: the driver calls
+/// whichever method matches the API used for the operation in progress. An implementation that
+/// only supports one direction can have the other throw.
+/// </remarks>
 public interface IKmsConnector
 {
     /// <summary>
@@ -34,7 +40,7 @@ public interface IKmsConnector
     /// <param name="host">The KMS hostname (for example, <c>kms.us-east-1.amazonaws.com</c>).</param>
     /// <param name="port">The KMS port.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A stream connected to the KMS host. The driver wraps this stream in TLS.</returns>
+    /// <returns>A stream connected to the KMS host. The driver wraps this stream in TLS. Must not be null.</returns>
     Stream Connect(string host, int port, CancellationToken cancellationToken);
 
     /// <summary>
@@ -43,6 +49,6 @@ public interface IKmsConnector
     /// <param name="host">The KMS hostname (for example, <c>kms.us-east-1.amazonaws.com</c>).</param>
     /// <param name="port">The KMS port.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A stream connected to the KMS host. The driver wraps this stream in TLS.</returns>
+    /// <returns>A stream connected to the KMS host. The driver wraps this stream in TLS. Must not be null.</returns>
     Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken);
 }

--- a/src/MongoDB.Driver/Encryption/KmsConnectionContext.cs
+++ b/src/MongoDB.Driver/Encryption/KmsConnectionContext.cs
@@ -1,0 +1,46 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Driver.Core.Misc;
+
+namespace MongoDB.Driver.Encryption;
+
+/// <summary>
+/// Describes the KMS host that an <see cref="IKmsConnector"/> is being asked to connect to.
+/// </summary>
+public sealed class KmsConnectionContext
+{
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KmsConnectionContext"/> class.
+    /// </summary>
+    /// <param name="host">The KMS hostname.</param>
+    /// <param name="port">The KMS port.</param>
+    public KmsConnectionContext(string host, int port)
+    {
+        Host = Ensure.IsNotNullOrEmpty(host, nameof(host));
+        Port = port;
+    }
+
+    /// <summary>
+    /// Gets the KMS hostname (for example, <c>kms.us-east-1.amazonaws.com</c>).
+    /// </summary>
+    public string Host { get; }
+
+    /// <summary>
+    /// Gets the KMS port.
+    /// </summary>
+    public int Port { get; }
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -947,7 +947,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
         {
             RequireEnvironment.Check().KmsProvider("aws");
             RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
-            var caCertificate = LoadProxyCaCertificate();
+            using var caCertificate = LoadProxyCaCertificate();
 
             ResetProxyMetrics(HttpsProxyPort, useTls: true, caCertificate);
 
@@ -4356,20 +4356,20 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             public async Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken)
             {
                 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                await socket.ConnectAsync("127.0.0.1", _proxyPort).ConfigureAwait(false);
+                await socket.ConnectAsync("127.0.0.1", _proxyPort);
                 Stream stream = new NetworkStream(socket, ownsSocket: true);
                 try
                 {
                     if (_useTls)
                     {
                         var sslStream = CreateProxySslStream(stream);
-                        await sslStream.AuthenticateAsClientAsync("127.0.0.1").ConfigureAwait(false);
+                        await sslStream.AuthenticateAsClientAsync("127.0.0.1");
                         stream = sslStream;
                     }
 
                     var request = Encoding.ASCII.GetBytes(BuildConnectRequest(host, port));
-                    await stream.WriteAsync(request, 0, request.Length, cancellationToken).ConfigureAwait(false);
-                    EnsureConnectSucceeded(await ReadConnectResponseAsync(stream, cancellationToken).ConfigureAwait(false));
+                    await stream.WriteAsync(request, 0, request.Length, cancellationToken);
+                    EnsureConnectSucceeded(await ReadConnectResponseAsync(stream, cancellationToken));
                     return stream;
                 }
                 catch
@@ -4377,7 +4377,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 #if NETFRAMEWORK
                     stream.Dispose();
 #else
-                    await stream.DisposeAsync().ConfigureAwait(false);
+                    await stream.DisposeAsync();
 #endif
                     throw;
                 }
@@ -4420,7 +4420,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             {
                 var builder = new StringBuilder();
                 var buffer = new byte[1];
-                while (await stream.ReadAsync(buffer, 0, 1, cancellationToken).ConfigureAwait(false) != 0)
+                while (await stream.ReadAsync(buffer, 0, 1, cancellationToken) != 0)
                 {
                     builder.Append((char)buffer[0]);
                     if (EndsWithHeaderTerminator(builder))
@@ -4487,7 +4487,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                     throw new IOException("Simulated transient network error.");
                 }
 
-                return await _inner.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
+                return await _inner.ConnectAsync(host, port, cancellationToken);
             }
         }
     }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -4327,7 +4327,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 _caCertificate = caCertificate;
             }
 
-            public Stream Connect(string host, int port, CancellationToken cancellationToken)
+            public Stream Connect(KmsConnectionContext context, CancellationToken cancellationToken)
             {
                 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
                 socket.Connect("127.0.0.1", _proxyPort);
@@ -4341,7 +4341,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                         stream = sslStream;
                     }
 
-                    var request = Encoding.ASCII.GetBytes(BuildConnectRequest(host, port));
+                    var request = Encoding.ASCII.GetBytes(BuildConnectRequest(context.Host, context.Port));
                     stream.Write(request, 0, request.Length);
                     EnsureConnectSucceeded(ReadConnectResponse(stream));
                     return stream;
@@ -4353,7 +4353,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 }
             }
 
-            public async Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken)
+            public async Task<Stream> ConnectAsync(KmsConnectionContext context, CancellationToken cancellationToken)
             {
                 var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
                 await socket.ConnectAsync("127.0.0.1", _proxyPort);
@@ -4367,7 +4367,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                         stream = sslStream;
                     }
 
-                    var request = Encoding.ASCII.GetBytes(BuildConnectRequest(host, port));
+                    var request = Encoding.ASCII.GetBytes(BuildConnectRequest(context.Host, context.Port));
                     await stream.WriteAsync(request, 0, request.Length, cancellationToken);
                     EnsureConnectSucceeded(await ReadConnectResponseAsync(stream, cancellationToken));
                     return stream;
@@ -4449,10 +4449,10 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 _message = message;
             }
 
-            public Stream Connect(string host, int port, CancellationToken cancellationToken) =>
+            public Stream Connect(KmsConnectionContext context, CancellationToken cancellationToken) =>
                 throw new InvalidOperationException(_message);
 
-            public Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken) =>
+            public Task<Stream> ConnectAsync(KmsConnectionContext context, CancellationToken cancellationToken) =>
                 throw new InvalidOperationException(_message);
         }
 
@@ -4470,24 +4470,24 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
             public int InvocationCount => _invocationCount;
 
-            public Stream Connect(string host, int port, CancellationToken cancellationToken)
+            public Stream Connect(KmsConnectionContext context, CancellationToken cancellationToken)
             {
                 if (Interlocked.Increment(ref _invocationCount) == 1)
                 {
                     throw new IOException("Simulated transient network error.");
                 }
 
-                return _inner.Connect(host, port, cancellationToken);
+                return _inner.Connect(context, cancellationToken);
             }
 
-            public async Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken)
+            public async Task<Stream> ConnectAsync(KmsConnectionContext context, CancellationToken cancellationToken)
             {
                 if (Interlocked.Increment(ref _invocationCount) == 1)
                 {
                     throw new IOException("Simulated transient network error.");
                 }
 
-                return await _inner.ConnectAsync(host, port, cancellationToken);
+                return await _inner.ConnectAsync(context, cancellationToken);
             }
         }
     }

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -947,7 +947,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
         {
             RequireEnvironment.Check().KmsProvider("aws");
             RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
-            var caCertificate = LoadProxyCaCertificateOrSkip();
+            var caCertificate = LoadProxyCaCertificate();
 
             ResetProxyMetrics(HttpsProxyPort, useTls: true, caCertificate);
 
@@ -4234,13 +4234,9 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             using var httpClient = CreateProxyHttpClient(useTls ? caCertificate : null);
             var body = httpClient.GetStringAsync(ProxyUrl(port, useTls, "metrics")).GetAwaiter().GetResult();
 
-            // The proxy reports metrics as one "key value" pair per line; find the connect_count line
-            // rather than assuming its position.
-            var line = body.Split('\n')
-                .Select(l => l.Trim())
-                .FirstOrDefault(l => l.StartsWith("connect_count ", StringComparison.Ordinal));
-            line.Should().NotBeNull("proxy /metrics response should contain a connect_count line, but was:\n{0}", body);
-            return int.Parse(line.Split(' ')[1], CultureInfo.InvariantCulture);
+            // The proxy's /metrics response starts with "connect_count <N>" as its first line
+            var connectCount = body.Split('\n')[0].Split(' ')[1];
+            return int.Parse(connectCount, CultureInfo.InvariantCulture);
         }
 
         private static string ProxyUrl(int port, bool useTls, string path) =>
@@ -4260,25 +4256,31 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             return new HttpClient(handler);
         }
 
-        private static X509Certificate2 LoadProxyCaCertificateOrSkip()
+        private static X509Certificate2 LoadProxyCaCertificate()
         {
             var caFile = Environment.GetEnvironmentVariable("CSFLE_TLS_CA_FILE");
             if (string.IsNullOrEmpty(caFile))
             {
-                throw new SkipException("CSFLE_TLS_CA_FILE environment variable is not set.");
+                throw new InvalidOperationException("CSFLE_TLS_CA_FILE is not set while KMS_MOCK_SERVERS_ENABLED is; the proxy test environment is misconfigured.");
             }
 
             if (!File.Exists(caFile))
             {
-                throw new SkipException($"Proxy CA file was not found at {caFile}.");
+                throw new FileNotFoundException($"Proxy CA file was not found at {caFile}.", caFile);
             }
 
             var pem = File.ReadAllText(caFile);
             const string header = "-----BEGIN CERTIFICATE-----";
             const string footer = "-----END CERTIFICATE-----";
-            var start = pem.IndexOf(header, StringComparison.Ordinal) + header.Length;
-            var end = pem.IndexOf(footer, StringComparison.Ordinal);
-            var base64 = pem.Substring(start, end - start).Replace("\r", "").Replace("\n", "").Trim();
+            var headerIndex = pem.IndexOf(header, StringComparison.Ordinal);
+            var footerIndex = pem.IndexOf(footer, StringComparison.Ordinal);
+            if (headerIndex < 0 || footerIndex <= headerIndex)
+            {
+                throw new FormatException($"Proxy CA file {caFile} is not a valid PEM certificate.");
+            }
+
+            var start = headerIndex + header.Length;
+            var base64 = pem.Substring(start, footerIndex - start).Replace("\r", "").Replace("\n", "").Trim();
             return LoadCertificate(Convert.FromBase64String(base64));
         }
 
@@ -4309,7 +4311,7 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
 
             var elements = chain.ChainElements;
             var root = elements[elements.Count - 1].Certificate;
-            return root.Thumbprint == caCertificate.Thumbprint;
+            return string.Equals(root.Thumbprint, caCertificate.Thumbprint, StringComparison.OrdinalIgnoreCase);
         }
 
         private sealed class HttpConnectProxyKmsConnector : IKmsConnector

--- a/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/client-side-encryption/prose-tests/ClientEncryptionProseTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -907,6 +908,148 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
                 var decrypted = ExplicitDecrypt(testCaseClientEncryption, encrypted, async);
                 decrypted.Should().Be(BsonValue.Create(value));
             }
+        }
+
+        // KMS Connect Callback prose tests (prose test 28).
+        // https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#28-kms-connect-callback
+        // Case 5 (callback receives timeout) is omitted because it requires CSOT, which the C# driver does not implement
+
+        // Case 1: plain HTTP proxy. The connector tunnels KMS traffic through the plain HTTP proxy on
+        // port 9004; the driver still negotiates TLS end-to-end with the KMS host through the tunnel.
+        // https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-1-plain-http-proxy
+        [Theory]
+        [ParameterAttributeData]
+        public void KmsConnectCallback_via_plain_http_proxy([Values(false, true)] bool async)
+        {
+            RequireEnvironment.Check().KmsProvider("aws");
+            RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
+
+            ResetProxyMetrics(HttpProxyPort, useTls: false);
+
+            using var client = ConfigureClient();
+            var connector = new HttpConnectProxyKmsConnector(HttpProxyPort, useTls: false, caCertificate: null);
+            using var clientEncryption = CreateAwsClientEncryptionWithConnector(client, connector);
+
+            var dataKeyId = CreateDataKey(clientEncryption, "aws", new DataKeyOptions(masterKey: AwsMasterKey()), async);
+
+            dataKeyId.Should().NotBe(Guid.Empty);
+            GetProxyConnectCount(HttpProxyPort, useTls: false).Should().BeGreaterOrEqualTo(1);
+        }
+
+        // Case 2: HTTPS proxy. Two independent TLS layers are in play: the connector's client-to-proxy
+        // TLS (verified against the proxy CA) and the driver's client-to-KMS TLS carried through the
+        // CONNECT tunnel (verified against the real KMS host). Success confirms the KMS host - not the
+        // proxy - was verified.
+        // https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-2-https-proxy
+        [Theory]
+        [ParameterAttributeData]
+        public void KmsConnectCallback_via_https_proxy([Values(false, true)] bool async)
+        {
+            RequireEnvironment.Check().KmsProvider("aws");
+            RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
+            var caCertificate = LoadProxyCaCertificateOrSkip();
+
+            ResetProxyMetrics(HttpsProxyPort, useTls: true, caCertificate);
+
+            using var client = ConfigureClient();
+            var connector = new HttpConnectProxyKmsConnector(HttpsProxyPort, useTls: true, caCertificate);
+            using var clientEncryption = CreateAwsClientEncryptionWithConnector(client, connector);
+
+            var dataKeyId = CreateDataKey(clientEncryption, "aws", new DataKeyOptions(masterKey: AwsMasterKey()), async);
+
+            dataKeyId.Should().NotBe(Guid.Empty);
+            GetProxyConnectCount(HttpsProxyPort, useTls: true, caCertificate).Should().BeGreaterOrEqualTo(1);
+        }
+
+        // Case 3: full auto encryption pipeline via proxy. Exercises encrypt-on-insert and
+        // decrypt-on-find with KMS traffic routed through the proxy.
+        // https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-3-full-auto-encryption-pipeline-via-proxy
+        [Theory]
+        [ParameterAttributeData]
+        public void KmsConnectCallback_full_auto_encryption_pipeline([Values(false, true)] bool async)
+        {
+            RequireEnvironment.Check().KmsProvider("aws");
+            RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
+
+            using var client = ConfigureClient();
+            var connector = new HttpConnectProxyKmsConnector(HttpProxyPort, useTls: false, caCertificate: null);
+            using var clientEncryption = CreateAwsClientEncryptionWithConnector(client, connector);
+
+            var dataKeyId = CreateDataKey(clientEncryption, "aws", new DataKeyOptions(masterKey: AwsMasterKey()), async);
+
+            var schema = new BsonDocument
+            {
+                { "bsonType", "object" },
+                {
+                    "properties",
+                    new BsonDocument("encrypted_string", new BsonDocument("encrypt", new BsonDocument
+                    {
+                        { "keyId", new BsonArray { new BsonBinaryData(dataKeyId, GuidRepresentation.Standard) } },
+                        { "bsonType", "string" },
+                        { "algorithm", "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic" }
+                    }))
+                }
+            };
+
+            ResetProxyMetrics(HttpProxyPort, useTls: false);
+
+            using var clientEncrypted = ConfigureClientEncrypted(
+                schemaMap: new BsonDocument(__collCollectionNamespace.FullName, schema),
+                kmsProviderFilter: "aws",
+                autoEncryptionOptionsConfigurator: options => options.With(kmsConnector: Optional.Create<IKmsConnector>(connector)));
+
+            var encryptedCollection = GetCollection(clientEncrypted, __collCollectionNamespace);
+            Insert(encryptedCollection, async, new BsonDocument { { "_id", 1 }, { "encrypted_string", "hello" } });
+
+            var decrypted = Find(encryptedCollection, new BsonDocument("_id", 1), async).Single();
+            decrypted["encrypted_string"].AsString.Should().Be("hello");
+
+            var stillEncrypted = Find(GetCollection(client, __collCollectionNamespace), new BsonDocument("_id", 1), async).Single();
+            stillEncrypted["encrypted_string"].BsonType.Should().Be(BsonType.Binary);
+
+            // Exactly one KMS request is expected since the decrypted key is cached; more than one would indicate a DEK caching regression.
+            GetProxyConnectCount(HttpProxyPort, useTls: false).Should().Be(1);
+        }
+
+        // Case 4: Error. A connector that fails with a non-network error must surface the error to the caller
+        // rather than having it swallowed by the KMS retry path.
+        // https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-4-error
+        [Theory]
+        [ParameterAttributeData]
+        public void KmsConnectCallback_error_propagates([Values(false, true)] bool async)
+        {
+            RequireEnvironment.Check().KmsProvider("aws");
+            RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
+
+            using var client = ConfigureClient();
+            var connector = new FailingKmsConnector("Test Error");
+            using var clientEncryption = CreateAwsClientEncryptionWithConnector(client, connector);
+
+            var exception = Record.Exception(() => CreateDataKey(clientEncryption, "aws", new DataKeyOptions(masterKey: AwsMasterKey()), async));
+
+            exception.Should().NotBeNull();
+            GetExceptionChain(exception).Should().Contain(e => e.Message.Contains("Test Error"));
+        }
+
+        // Case 6: Retry. A connector that fails with a network error must be retried.
+        // https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-6-retry
+        [Theory]
+        [ParameterAttributeData]
+        public void KmsConnectCallback_retries_after_network_error([Values(false, true)] bool async)
+        {
+            RequireEnvironment.Check().KmsProvider("aws");
+            RequireEnvironment.Check().EnvironmentVariable("KMS_MOCK_SERVERS_ENABLED", isDefined: true);
+
+            ResetProxyMetrics(HttpProxyPort, useTls: false);
+
+            using var client = ConfigureClient();
+            var connector = new RetryOnceKmsConnector(new HttpConnectProxyKmsConnector(HttpProxyPort, useTls: false, caCertificate: null));
+            using var clientEncryption = CreateAwsClientEncryptionWithConnector(client, connector);
+
+            var dataKeyId = CreateDataKey(clientEncryption, "aws", new DataKeyOptions(masterKey: AwsMasterKey()), async);
+
+            dataKeyId.Should().NotBe(Guid.Empty);
+            connector.InvocationCount.Should().BeGreaterThan(1);
         }
 
         [Theory]
@@ -4048,6 +4191,302 @@ namespace MongoDB.Driver.Tests.Specifications.client_side_encryption.prose_tests
             public ObjectId Id { get; set; }
             public string Name { get; set; }
             public string Ssn { get; set; }
+        }
+
+        // KMS Connect Callback helpers (prose test 28)
+        private const int HttpProxyPort = 9004;
+        private const int HttpsProxyPort = 9005;
+
+        private static BsonDocument AwsMasterKey() => new BsonDocument
+        {
+            { "region", "us-east-1" },
+            { "key", "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0" }
+        };
+
+        private ClientEncryption CreateAwsClientEncryptionWithConnector(IMongoClient client, IKmsConnector kmsConnector)
+        {
+            var kmsProviders = EncryptionTestHelper.GetKmsProviders("aws");
+            var clientEncryptionOptions = new ClientEncryptionOptions(
+                keyVaultClient: client,
+                keyVaultNamespace: __keyVaultCollectionNamespace,
+                kmsProviders: kmsProviders,
+                kmsConnector: Optional.Create(kmsConnector));
+            return new ClientEncryption(clientEncryptionOptions);
+        }
+
+        private static IEnumerable<Exception> GetExceptionChain(Exception exception)
+        {
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                yield return current;
+            }
+        }
+
+        private static void ResetProxyMetrics(int port, bool useTls, X509Certificate2 caCertificate = null)
+        {
+            using var httpClient = CreateProxyHttpClient(useTls ? caCertificate : null);
+            using var response = httpClient.PostAsync(ProxyUrl(port, useTls, "reset"), content: null).GetAwaiter().GetResult();
+            response.EnsureSuccessStatusCode();
+        }
+
+        private static int GetProxyConnectCount(int port, bool useTls, X509Certificate2 caCertificate = null)
+        {
+            using var httpClient = CreateProxyHttpClient(useTls ? caCertificate : null);
+            var body = httpClient.GetStringAsync(ProxyUrl(port, useTls, "metrics")).GetAwaiter().GetResult();
+
+            // The proxy reports metrics as one "key value" pair per line; find the connect_count line
+            // rather than assuming its position.
+            var line = body.Split('\n')
+                .Select(l => l.Trim())
+                .FirstOrDefault(l => l.StartsWith("connect_count ", StringComparison.Ordinal));
+            line.Should().NotBeNull("proxy /metrics response should contain a connect_count line, but was:\n{0}", body);
+            return int.Parse(line.Split(' ')[1], CultureInfo.InvariantCulture);
+        }
+
+        private static string ProxyUrl(int port, bool useTls, string path) =>
+            $"{(useTls ? "https" : "http")}://127.0.0.1:{port}/{path}";
+
+        private static HttpClient CreateProxyHttpClient(X509Certificate2 caCertificate)
+        {
+            if (caCertificate == null)
+            {
+                return new HttpClient();
+            }
+
+            var handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = (request, cert, chain, errors) => ValidateAgainstCa(cert, caCertificate)
+            };
+            return new HttpClient(handler);
+        }
+
+        private static X509Certificate2 LoadProxyCaCertificateOrSkip()
+        {
+            var caFile = Environment.GetEnvironmentVariable("CSFLE_TLS_CA_FILE");
+            if (string.IsNullOrEmpty(caFile))
+            {
+                throw new SkipException("CSFLE_TLS_CA_FILE environment variable is not set.");
+            }
+
+            if (!File.Exists(caFile))
+            {
+                throw new SkipException($"Proxy CA file was not found at {caFile}.");
+            }
+
+            var pem = File.ReadAllText(caFile);
+            const string header = "-----BEGIN CERTIFICATE-----";
+            const string footer = "-----END CERTIFICATE-----";
+            var start = pem.IndexOf(header, StringComparison.Ordinal) + header.Length;
+            var end = pem.IndexOf(footer, StringComparison.Ordinal);
+            var base64 = pem.Substring(start, end - start).Replace("\r", "").Replace("\n", "").Trim();
+            return LoadCertificate(Convert.FromBase64String(base64));
+        }
+
+        private static X509Certificate2 LoadCertificate(byte[] rawData)
+        {
+#if NET9_0_OR_GREATER
+            return X509CertificateLoader.LoadCertificate(rawData);
+#else
+            return new X509Certificate2(rawData);
+#endif
+        }
+
+        private static bool ValidateAgainstCa(X509Certificate2 certificate, X509Certificate2 caCertificate)
+        {
+            using var chain = new X509Chain();
+            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+            chain.ChainPolicy.ExtraStore.Add(caCertificate);
+
+            // Build must succeed - it validates expiry, signatures, and chain integrity.
+            // AllowUnknownCertificateAuthority only forgives the CA being absent from the machine trust
+            // store; the thumbprint check then confirms the chain terminates at our expected CA rather
+            // than any other root.
+            if (!chain.Build(certificate))
+            {
+                return false;
+            }
+
+            var elements = chain.ChainElements;
+            var root = elements[elements.Count - 1].Certificate;
+            return root.Thumbprint == caCertificate.Thumbprint;
+        }
+
+        private sealed class HttpConnectProxyKmsConnector : IKmsConnector
+        {
+            private readonly X509Certificate2 _caCertificate;
+            private readonly int _proxyPort;
+            private readonly bool _useTls;
+
+            public HttpConnectProxyKmsConnector(int proxyPort, bool useTls, X509Certificate2 caCertificate)
+            {
+                _proxyPort = proxyPort;
+                _useTls = useTls;
+                _caCertificate = caCertificate;
+            }
+
+            public Stream Connect(string host, int port, CancellationToken cancellationToken)
+            {
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                socket.Connect("127.0.0.1", _proxyPort);
+                Stream stream = new NetworkStream(socket, ownsSocket: true);
+                try
+                {
+                    if (_useTls)
+                    {
+                        var sslStream = CreateProxySslStream(stream);
+                        sslStream.AuthenticateAsClient("127.0.0.1");
+                        stream = sslStream;
+                    }
+
+                    var request = Encoding.ASCII.GetBytes(BuildConnectRequest(host, port));
+                    stream.Write(request, 0, request.Length);
+                    EnsureConnectSucceeded(ReadConnectResponse(stream));
+                    return stream;
+                }
+                catch
+                {
+                    stream.Dispose();
+                    throw;
+                }
+            }
+
+            public async Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken)
+            {
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                await socket.ConnectAsync("127.0.0.1", _proxyPort).ConfigureAwait(false);
+                Stream stream = new NetworkStream(socket, ownsSocket: true);
+                try
+                {
+                    if (_useTls)
+                    {
+                        var sslStream = CreateProxySslStream(stream);
+                        await sslStream.AuthenticateAsClientAsync("127.0.0.1").ConfigureAwait(false);
+                        stream = sslStream;
+                    }
+
+                    var request = Encoding.ASCII.GetBytes(BuildConnectRequest(host, port));
+                    await stream.WriteAsync(request, 0, request.Length, cancellationToken).ConfigureAwait(false);
+                    EnsureConnectSucceeded(await ReadConnectResponseAsync(stream, cancellationToken).ConfigureAwait(false));
+                    return stream;
+                }
+                catch
+                {
+#if NETFRAMEWORK
+                    stream.Dispose();
+#else
+                    await stream.DisposeAsync().ConfigureAwait(false);
+#endif
+                    throw;
+                }
+            }
+
+            private SslStream CreateProxySslStream(Stream inner) =>
+                new(inner, leaveInnerStreamOpen: false,
+                    (sender, cert, chain, errors) => ValidateAgainstCa(LoadCertificate(cert.Export(X509ContentType.Cert)), _caCertificate));
+
+            private static string BuildConnectRequest(string host, int port) =>
+                $"CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n";
+
+            private static void EnsureConnectSucceeded(string response)
+            {
+                if (!response.StartsWith("HTTP/1.1 200", StringComparison.Ordinal))
+                {
+                    throw new IOException($"Unexpected proxy CONNECT response: {response}");
+                }
+            }
+
+            // Reads the CONNECT response headers up to and including the terminating CRLFCRLF,
+            // one byte at a time so no bytes of the tunnelled TLS stream are consumed.
+            private static string ReadConnectResponse(Stream stream)
+            {
+                var builder = new StringBuilder();
+                int b;
+                while ((b = stream.ReadByte()) != -1)
+                {
+                    builder.Append((char)b);
+                    if (EndsWithHeaderTerminator(builder))
+                    {
+                        break;
+                    }
+                }
+
+                return builder.ToString();
+            }
+
+            private static async Task<string> ReadConnectResponseAsync(Stream stream, CancellationToken cancellationToken)
+            {
+                var builder = new StringBuilder();
+                var buffer = new byte[1];
+                while (await stream.ReadAsync(buffer, 0, 1, cancellationToken).ConfigureAwait(false) != 0)
+                {
+                    builder.Append((char)buffer[0]);
+                    if (EndsWithHeaderTerminator(builder))
+                    {
+                        break;
+                    }
+                }
+
+                return builder.ToString();
+            }
+
+            private static bool EndsWithHeaderTerminator(StringBuilder builder)
+            {
+                var n = builder.Length;
+                return n >= 4 &&
+                    builder[n - 4] == '\r' && builder[n - 3] == '\n' && builder[n - 2] == '\r' && builder[n - 1] == '\n';
+            }
+        }
+
+        private sealed class FailingKmsConnector : IKmsConnector
+        {
+            private readonly string _message;
+
+            public FailingKmsConnector(string message)
+            {
+                _message = message;
+            }
+
+            public Stream Connect(string host, int port, CancellationToken cancellationToken) =>
+                throw new InvalidOperationException(_message);
+
+            public Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken) =>
+                throw new InvalidOperationException(_message);
+        }
+
+        // Fails with a network error on its first invocation, then delegates to the wrapped connector.
+        // Exercises the driver's KMS retry re-invoking kmsConnectCallback after a transient failure.
+        private sealed class RetryOnceKmsConnector : IKmsConnector
+        {
+            private readonly IKmsConnector _inner;
+            private int _invocationCount;
+
+            public RetryOnceKmsConnector(IKmsConnector inner)
+            {
+                _inner = inner;
+            }
+
+            public int InvocationCount => _invocationCount;
+
+            public Stream Connect(string host, int port, CancellationToken cancellationToken)
+            {
+                if (Interlocked.Increment(ref _invocationCount) == 1)
+                {
+                    throw new IOException("Simulated transient network error.");
+                }
+
+                return _inner.Connect(host, port, cancellationToken);
+            }
+
+            public async Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken)
+            {
+                if (Interlocked.Increment(ref _invocationCount) == 1)
+                {
+                    throw new IOException("Simulated transient network error.");
+                }
+
+                return await _inner.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-6005

Adds support for routing CSFLE/Queryable Encryption KMS traffic through an HTTP proxy (HTTP `CONNECT` tunnel), implementing the spec proposed in [specifications#1956](https://github.com/mongodb/specifications/pull/1956) (DRIVERS-2920).

## Public API

A new optional `IKmsConnector` can be set on `ClientEncryptionOptions` and `AutoEncryptionOptions`:

```csharp
public interface IKmsConnector
{
    Stream Connect(string host, int port, CancellationToken cancellationToken);
    Task<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken);
}
```

When supplied, the driver invokes the connector to obtain the transport stream to a KMS host (`host`/`port`) instead of opening a direct socket, then performs the KMS TLS handshake over the returned stream using the provider's configured TLS options. The typical implementation opens an `HTTP CONNECT` tunnel to a proxy and returns the tunnel stream. When no connector is set, behavior is unchanged (direct connection).

## How it works

The KMS state machine already builds `new SslStreamFactory(tlsOptions, baseStreamFactory)` and runs TLS against the KMS endpoint. This change swaps the inner `baseStreamFactory` for a connector-backed `KmsConnectorStreamFactory` when a connector is configured. Because the endpoint is unchanged, SNI and certificate/hostname verification still target the **real KMS host**, not the proxy — so the driver verifies KMS's identity end-to-end through the tunnel. This applies to both explicit encryption (`ClientEncryption`) and auto-encryption, and the existing KMS retry re-invokes the connector on transient network errors.

No libmongocrypt change is required — this is entirely driver-side.

## Why a new `IKmsConnector` rather than reusing `IStreamFactory`?

`IStreamFactory` is public and already models "create a stream to an endpoint," so it was a candidate for the callback type. We introduced a dedicated interface instead, for three reasons:

- **Contract shape.** `IStreamFactory` operates on `EndPoint`, which would force users to unpack a `DnsEndPoint` and leak transport plumbing into their callback. The KMS-connect contract is conceptually `(host, port) -> stream`; `IKmsConnector` exposes exactly that, matching the cross-driver spec's `kmsConnectCallback(host, port)` and the shapes used by the Node and C drivers.
- **Scope and coupling.** `IStreamFactory` is the general-purpose transport abstraction used throughout SDAM, connection pools, TLS, and SOCKS5. Reusing it as the KMS-proxy hook would conflate a narrow, KMS-only extension point with a broad internal-transport contract, and would couple this public API to an interface that evolves for unrelated transport reasons. A purpose-built interface keeps the public surface minimal and decoupled.
- **Intent and discoverability.** `IKmsConnector.Connect(host, port)` communicates what an implementer is expected to do; `IStreamFactory.CreateStream(EndPoint)` does not.

Internally we still reuse the existing machinery rather than reimplementing it: `KmsConnectorStreamFactory` adapts `IKmsConnector` to `IStreamFactory`, so the TLS wrapping (`SslStreamFactory`) and the KMS state machine are unchanged — we only swap the base stream source.

## Notes

- **Sync/async interface rather than a single callback.** The driver mandates paired sync/async I/O (no sync-over-async), and the KMS path has both `SendKmsRequest` and `SendKmsRequestAsync`, so the connector is a two-method interface. Consumers that only use async encryption APIs may throw from the sync method.
- **Timeout (spec Case 5) not implemented.** The C# KMS path threads only a `CancellationToken`, not a deadline; CSOT is not available. The connect-callback timeout case is therefore not supported and its prose test is skipped.

## Testing

Adds prose test 28 (`KMS Connect Callback`) — cases 1-4 and 6; case 5 (timeout) is skipped as above. The tests exercise the plain and TLS HTTP proxies, the full auto-encryption pipeline, error propagation, and retry-after-network-error. They require real AWS KMS credentials and the `kms_http_proxy.py` servers (ports 9004/9005) started by drivers-evergreen-tools, so they gate on `KMS_MOCK_SERVERS_ENABLED` and run in the mocked-KMS-TLS Evergreen variants.
