### PR TITLE
CSHARP-5998: RawBsonDocument refactoring/removal

### DIFF
--- a/src/MongoDB.Driver/Core/Operations/ChangeStreamCursor.cs
+++ b/src/MongoDB.Driver/Core/Operations/ChangeStreamCursor.cs
@@ -14,8 +14,6 @@
 */
 
 using MongoDB.Bson;
-using MongoDB.Bson.IO;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Misc;
 using System;
@@ -36,10 +34,8 @@ namespace MongoDB.Driver.Core.Operations
         private readonly IReadBinding _binding;
         private readonly IChangeStreamOperation<TDocument> _changeStreamOperation;
         private IEnumerable<TDocument> _current;
-        private IAsyncCursor<RawBsonDocument> _cursor;
+        private IAsyncCursor<TDocument> _cursor;
         private bool _disposed;
-        private BsonDocument _documentResumeToken;
-        private readonly IBsonSerializer<TDocument> _documentSerializer;
         private readonly BsonTimestamp _initialOperationTime;
         private readonly ICoreSessionHandle _session;
         private BsonDocument _postBatchResumeToken;
@@ -57,7 +53,6 @@ namespace MongoDB.Driver.Core.Operations
         /// Initializes a new instance of the <see cref="ChangeStreamCursor{TDocument}" /> class.
         /// </summary>
         /// <param name="cursor">The cursor.</param>
-        /// <param name="documentSerializer">The document serializer.</param>
         /// <param name="binding">The binding.</param>
         /// <param name="session">The session.</param>
         /// <param name="changeStreamOperation">The change stream operation.</param>
@@ -68,8 +63,7 @@ namespace MongoDB.Driver.Core.Operations
         /// <param name="initialStartAtOperationTime">The start at operation time value.</param>
         /// <param name="maxWireVersion">The maximum wire version.</param>
         public ChangeStreamCursor(
-            IAsyncCursor<RawBsonDocument> cursor,
-            IBsonSerializer<TDocument> documentSerializer,
+            IAsyncCursor<TDocument> cursor,
             IReadBinding binding,
             ICoreSessionHandle session,
             IChangeStreamOperation<TDocument> changeStreamOperation,
@@ -81,7 +75,6 @@ namespace MongoDB.Driver.Core.Operations
             int maxWireVersion)
         {
             _cursor = Ensure.IsNotNull(cursor, nameof(cursor));
-            _documentSerializer = Ensure.IsNotNull(documentSerializer, nameof(documentSerializer));
             _binding = Ensure.IsNotNull(binding, nameof(binding));
             _changeStreamOperation = Ensure.IsNotNull(changeStreamOperation, nameof(changeStreamOperation));
             _session = Ensure.IsNotNull(session, nameof(session));
@@ -124,7 +117,6 @@ namespace MongoDB.Driver.Core.Operations
         {
             return
                 _postBatchResumeToken ??
-                _documentResumeToken ??
                 _initialStartAfter ??
                 _initialResumeAfter;
         }
@@ -176,55 +168,11 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         // private methods
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
-        private TDocument DeserializeDocument(RawBsonDocument rawDocument)
-        {
-            using (var stream = new ByteBufferStream(rawDocument.Slice, ownsBuffer: false))
-            using (var reader = new BsonBinaryReader(stream))
-            {
-                var context = BsonDeserializationContext.CreateRoot(reader);
-                return _documentSerializer.Deserialize(context);
-            }
-        }
-
-        private IEnumerable<TDocument> DeserializeDocuments(IEnumerable<RawBsonDocument> rawDocuments)
-        {
-            var documents = new List<TDocument>();
-            RawBsonDocument lastRawDocument = null;
-
-            _postBatchResumeToken = ((ICursorBatchInfo)_cursor).PostBatchResumeToken;
-
-            foreach (var rawDocument in rawDocuments)
-            {
-                if (!rawDocument.Contains("_id"))
-                {
-                    throw new MongoClientException("Cannot provide resume functionality when the resume token is missing.");
-                }
-
-                var document = DeserializeDocument(rawDocument);
-                documents.Add(document);
-
-                lastRawDocument = rawDocument;
-            }
-
-            if (lastRawDocument != null)
-            {
-                _documentResumeToken = lastRawDocument["_id"].DeepClone().AsBsonDocument;
-            }
-
-            return documents;
-        }
-
         private ResumeValues GetResumeValues()
         {
             if (_postBatchResumeToken != null)
             {
                 return new ResumeValues { ResumeAfter = _postBatchResumeToken };
-            }
-
-            if (_documentResumeToken != null)
-            {
-                return new ResumeValues { ResumeAfter = _documentResumeToken };
             }
 
             if (_initialStartAfter != null)
@@ -249,17 +197,8 @@ namespace MongoDB.Driver.Core.Operations
         {
             if (hasMore)
             {
-                try
-                {
-                    _current = DeserializeDocuments(_cursor.Current);
-                }
-                finally
-                {
-                    foreach (var rawDocument in _cursor.Current)
-                    {
-                        rawDocument.Dispose();
-                    }
-                }
+                _current = _cursor.Current;
+                _postBatchResumeToken = ((ICursorBatchInfo)_cursor).PostBatchResumeToken;
             }
             else
             {
@@ -275,7 +214,7 @@ namespace MongoDB.Driver.Core.Operations
             _changeStreamOperation.StartAtOperationTime = resumeValues.StartAtOperationTime;
         }
 
-        private IAsyncCursor<RawBsonDocument> Resume(CancellationToken cancellationToken)
+        private IAsyncCursor<TDocument> Resume(CancellationToken cancellationToken)
         {
             ReconfigureOperationResumeValues();
             // TODO: CSOT implement proper way to obtain the operationContext
@@ -283,7 +222,7 @@ namespace MongoDB.Driver.Core.Operations
             return _changeStreamOperation.Resume(operationContext, _binding);
         }
 
-        private async Task<IAsyncCursor<RawBsonDocument>> ResumeAsync(CancellationToken cancellationToken)
+        private async Task<IAsyncCursor<TDocument>> ResumeAsync(CancellationToken cancellationToken)
         {
             ReconfigureOperationResumeValues();
             // TODO: CSOT implement proper way to obtain the operationContext

--- a/src/MongoDB.Driver/Core/Operations/ChangeStreamOperation.cs
+++ b/src/MongoDB.Driver/Core/Operations/ChangeStreamOperation.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
@@ -29,12 +28,11 @@ namespace MongoDB.Driver.Core.Operations
     internal interface IChangeStreamOperation<TResult> : IReadOperation<IChangeStreamCursor<TResult>>
     {
         BsonDocument ResumeAfter { get; set; }
-        bool? ShowExpandedEvents { get; set; }
         BsonDocument StartAfter { get; set; }
         BsonTimestamp StartAtOperationTime { get; set; }
 
-        IAsyncCursor<RawBsonDocument> Resume(OperationContext operationContext, IReadBinding binding);
-        Task<IAsyncCursor<RawBsonDocument>> ResumeAsync(OperationContext operationContext, IReadBinding binding);
+        IAsyncCursor<TResult> Resume(OperationContext operationContext, IReadBinding binding);
+        Task<IAsyncCursor<TResult>> ResumeAsync(OperationContext operationContext, IReadBinding binding);
     }
 
     internal sealed class ChangeStreamOperation<TResult> : IChangeStreamOperation<TResult>
@@ -280,7 +278,7 @@ namespace MongoDB.Driver.Core.Operations
                 throw new ArgumentException("The binding value passed to ChangeStreamOperation.Execute must implement IReadBindingHandle.", nameof(binding));
             }
 
-            IAsyncCursor<RawBsonDocument> cursor;
+            IAsyncCursor<TResult> cursor;
             ICursorBatchInfo cursorBatchInfo;
             BsonTimestamp initialOperationTime;
             using (var context = new RetryableReadContext(binding, _retryRequested, _maxAdaptiveRetries, _enableOverloadRetargeting))
@@ -293,7 +291,6 @@ namespace MongoDB.Driver.Core.Operations
 
                 return new ChangeStreamCursor<TResult>(
                     cursor,
-                    _resultSerializer,
                     bindingHandle.Fork(),
                     operationContext.Session.Fork(),
                     this,
@@ -316,7 +313,7 @@ namespace MongoDB.Driver.Core.Operations
                 throw new ArgumentException("The binding value passed to ChangeStreamOperation.ExecuteAsync must implement IReadBindingHandle.", nameof(binding));
             }
 
-            IAsyncCursor<RawBsonDocument> cursor;
+            IAsyncCursor<TResult> cursor;
             ICursorBatchInfo cursorBatchInfo;
             BsonTimestamp initialOperationTime;
             using (var context = new RetryableReadContext(binding, _retryRequested, _maxAdaptiveRetries, _enableOverloadRetargeting))
@@ -329,7 +326,6 @@ namespace MongoDB.Driver.Core.Operations
 
                 return new ChangeStreamCursor<TResult>(
                     cursor,
-                    _resultSerializer,
                     bindingHandle.Fork(),
                     operationContext.Session.Fork(),
                     this,
@@ -343,7 +339,7 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         /// <inheritdoc />
-        public IAsyncCursor<RawBsonDocument> Resume(OperationContext operationContext, IReadBinding binding)
+        public IAsyncCursor<TResult> Resume(OperationContext operationContext, IReadBinding binding)
         {
             using (var context = new RetryableReadContext(binding, retryRequested: false, _maxAdaptiveRetries, _enableOverloadRetargeting))
             {
@@ -352,7 +348,7 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         /// <inheritdoc />
-        public async Task<IAsyncCursor<RawBsonDocument>> ResumeAsync(OperationContext operationContext, IReadBinding binding)
+        public async Task<IAsyncCursor<TResult>> ResumeAsync(OperationContext operationContext, IReadBinding binding)
         {
             using (var context = new RetryableReadContext(binding, retryRequested: false, _maxAdaptiveRetries, _enableOverloadRetargeting))
             {
@@ -361,15 +357,15 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         // private methods
-        private AggregateOperation<RawBsonDocument> CreateAggregateOperation()
+        private AggregateOperation<TResult> CreateAggregateOperation()
         {
             var changeStreamStage = CreateChangeStreamStage();
             var combinedPipeline = CreateCombinedPipeline(changeStreamStage);
 
-            AggregateOperation<RawBsonDocument> operation;
+            AggregateOperation<TResult> operation;
             if (_collectionNamespace != null)
             {
-                operation = new AggregateOperation<RawBsonDocument>(_collectionNamespace, combinedPipeline, RawBsonDocumentSerializer.Instance, _messageEncoderSettings)
+                operation = new AggregateOperation<TResult>(_collectionNamespace, combinedPipeline, _resultSerializer, _messageEncoderSettings)
                 {
                     EnableOverloadRetargeting = _enableOverloadRetargeting,
                     MaxAdaptiveRetries = _maxAdaptiveRetries,
@@ -379,7 +375,7 @@ namespace MongoDB.Driver.Core.Operations
             else
             {
                 var databaseNamespace = _databaseNamespace ?? DatabaseNamespace.Admin;
-                operation = new AggregateOperation<RawBsonDocument>(databaseNamespace, combinedPipeline, RawBsonDocumentSerializer.Instance, _messageEncoderSettings)
+                operation = new AggregateOperation<TResult>(databaseNamespace, combinedPipeline, _resultSerializer, _messageEncoderSettings)
                 {
                     EnableOverloadRetargeting = _enableOverloadRetargeting,
                     MaxAdaptiveRetries = _maxAdaptiveRetries,
@@ -419,13 +415,13 @@ namespace MongoDB.Driver.Core.Operations
             return combinedPipeline;
         }
 
-        private IAsyncCursor<RawBsonDocument> ExecuteAggregateOperation(OperationContext operationContext, RetryableReadContext context)
+        private IAsyncCursor<TResult> ExecuteAggregateOperation(OperationContext operationContext, RetryableReadContext context)
         {
             var aggregateOperation = CreateAggregateOperation();
             return aggregateOperation.Execute(operationContext, context);
         }
 
-        private Task<IAsyncCursor<RawBsonDocument>> ExecuteAggregateOperationAsync(OperationContext operationContext, RetryableReadContext context)
+        private Task<IAsyncCursor<TResult>> ExecuteAggregateOperationAsync(OperationContext operationContext, RetryableReadContext context)
         {
             var aggregateOperation = CreateAggregateOperation();
             return aggregateOperation.ExecuteAsync(operationContext, context);

--- a/tests/MongoDB.Driver.Tests/Core/Operations/ChangeStreamCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/ChangeStreamCursorTests.cs
@@ -41,18 +41,16 @@ namespace MongoDB.Driver.Core.Operations
         #endregion
 
         [Theory]
-        [InlineData("{ 'd' : '4' }", "{ 'a' : '1' }", "{ 'b' : '2' }", 3L, "{ 'c' : '3' }", null, "{ 'd' : '4' }", null)]
-        [InlineData(null, "{ 'a' : '1' }", "{ 'b' : '2' }", 3L, "{ 'c' : '3' }", null, "{ 'c' : '3' }", null)]
-        [InlineData(null, "{ 'a' : '1' }", "{ 'b' : '2' }", 3L, null, null, "{ 'b' : '2' }", null)]
-        [InlineData(null, "{ 'a' : '1' }", null, 3L, null, null, "{ 'a' : '1' }", null)]
-        [InlineData(null, null, null, 3L, null, null, null, 3L)]
-        [InlineData(null, null, null, null, null, 4L, null, 4L)]
+        [InlineData("{ 'd' : '4' }", "{ 'a' : '1' }", "{ 'b' : '2' }", 3L, null, "{ 'd' : '4' }", null)]
+        [InlineData(null, "{ 'a' : '1' }", "{ 'b' : '2' }", 3L, null, "{ 'b' : '2' }", null)]
+        [InlineData(null, "{ 'a' : '1' }", null, 3L, null, "{ 'a' : '1' }", null)]
+        [InlineData(null, null, null, 3L, null, null, 3L)]
+        [InlineData(null, null, null, null, 4L, null, 4L)]
         public void ChangeStreamOperation_should_have_expected_change_stream_operation_options_for_resume_process_after_resumable_error(
             string postBatchResumeTokenJson,
             string resumeAfterJson,
             string startAfterJson,
             object startAtOperationTimeValue,
-            string documentResumeTokenJson,
             object initialOperationTimeObj,
             string expectedResumeAfter,
             object expectedStartAtOperationTimeValue)
@@ -61,7 +59,6 @@ namespace MongoDB.Driver.Core.Operations
             var resumeAfter = resumeAfterJson != null ? BsonDocument.Parse(resumeAfterJson) : null;
             var startAfter = startAfterJson != null ? BsonDocument.Parse(startAfterJson) : null;
             var startAtOperationTime = startAtOperationTimeValue != null ? BsonTimestamp.Create(startAtOperationTimeValue) : null;
-            var documentResumeToken = documentResumeTokenJson != null ? BsonDocument.Parse(documentResumeTokenJson) : null;
             var initialOperationTime = initialOperationTimeObj != null ? BsonTimestamp.Create(initialOperationTimeObj) : null;
 
             var mockCursor = CreateMockCursor();
@@ -72,8 +69,6 @@ namespace MongoDB.Driver.Core.Operations
                 startAtOperationTime: startAtOperationTime,
                 postBatchResumeToken: postBatchResumeToken,
                 initialOperationTime: initialOperationTime);
-
-            subject._documentResumeToken(documentResumeToken);
 
             var result = subject.GetResumeValues();
 
@@ -86,7 +81,6 @@ namespace MongoDB.Driver.Core.Operations
         public void constructor_should_initialize_instance()
         {
             var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
-            var documentSerializer = new Mock<IBsonSerializer<BsonDocument>>().Object;
             var binding = new Mock<IReadBinding>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
@@ -98,7 +92,6 @@ namespace MongoDB.Driver.Core.Operations
 
             var subject = new ChangeStreamCursor<BsonDocument>(
                 cursor,
-                documentSerializer,
                 binding,
                 session,
                 changeStreamOperation,
@@ -114,7 +107,6 @@ namespace MongoDB.Driver.Core.Operations
             subject._current().Should().BeNull();
             subject._cursor().Should().BeSameAs(cursor);
             subject._disposed().Should().BeFalse();
-            subject._documentSerializer().Should().BeSameAs(documentSerializer);
             subject._postBatchResumeToken().Should().BeSameAs(postBatchResumeToken);
             subject._initialOperationTime().Should().BeSameAs(initialOperationTime);
             subject._initialStartAfter().Should().Be(startAfter);
@@ -127,82 +119,62 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public void constructor_should_throw_when_cursor_is_null()
         {
-            var documentSerializer = new Mock<IBsonSerializer<BsonDocument>>().Object;
             var binding = new Mock<IReadBinding>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
             var postBatchResumeToken = Mock.Of<BsonDocument>();
             var changeStreamOperation = CreateChangeStreamOperation();
 
-            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(null, documentSerializer, binding, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, null, null, null, __dummyMaxWireVersion));
+            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(null, binding, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, null, null, null, __dummyMaxWireVersion));
 
             var argumnetNullException = exception.Should().BeOfType<ArgumentNullException>().Subject;
             argumnetNullException.ParamName.Should().Be("cursor");
         }
 
         [Fact]
-        public void constructor_should_throw_when_documentSerializer_is_null()
-        {
-            var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
-            var binding = new Mock<IReadBinding>().Object;
-            var session = new Mock<ICoreSessionHandle>().Object;
-            var initialOperationTime = new BsonTimestamp(3L);
-            var postBatchResumeToken = Mock.Of<BsonDocument>();
-            var changeStreamOperation = CreateChangeStreamOperation();
-
-            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(cursor, null, binding, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, null, null, null, __dummyMaxWireVersion));
-
-            var argumnetNullException = exception.Should().BeOfType<ArgumentNullException>().Subject;
-            argumnetNullException.ParamName.Should().Be("documentSerializer");
-        }
-
-        [Fact]
         public void constructor_should_throw_when_binding_is_null()
         {
             var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
-            var documentSerializer = new Mock<IBsonSerializer<BsonDocument>>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
             var postBatchResumeToken = Mock.Of<BsonDocument>();
             var changeStreamOperation = CreateChangeStreamOperation();
 
-            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(cursor, documentSerializer, null, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, null, null, null, __dummyMaxWireVersion));
+            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(cursor, null, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, null, null, null, __dummyMaxWireVersion));
 
-            var argumnetNullException = exception.Should().BeOfType<ArgumentNullException>().Subject;
-            argumnetNullException.ParamName.Should().Be("binding");
+            exception.Should().BeOfType<ArgumentNullException>().Subject
+                .ParamName.Should().Be("binding");
         }
 
         [Fact]
         public void constructor_should_throw_when_changeStreamOperation_is_null()
         {
             var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
-            var documentSerializer = new Mock<IBsonSerializer<BsonDocument>>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
             var postBatchResumeToken = Mock.Of<BsonDocument>();
             var binding = new Mock<IReadBinding>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;
 
-            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(cursor, documentSerializer, binding, session, null, postBatchResumeToken, initialOperationTime, null, null, null, __dummyMaxWireVersion));
+            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(cursor, binding, session, null, postBatchResumeToken, initialOperationTime, null, null, null, __dummyMaxWireVersion));
 
-            var argumnetNullException = exception.Should().BeOfType<ArgumentNullException>().Subject;
-            argumnetNullException.ParamName.Should().Be("changeStreamOperation");
+            exception.Should().BeOfType<ArgumentNullException>().Subject
+                .ParamName.Should().Be("changeStreamOperation");
         }
 
         [Fact]
         public void constructor_should_throw_when_maxWireVersion_is_negative()
         {
             var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
-            var documentSerializer = new Mock<IBsonSerializer<BsonDocument>>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
             var postBatchResumeToken = Mock.Of<BsonDocument>();
             var binding = new Mock<IReadBinding>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;
             var changeStreamOperation = CreateChangeStreamOperation();
 
-            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(cursor, documentSerializer, binding, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, null, null, null, -1));
+            var exception = Record.Exception(() => new ChangeStreamCursor<BsonDocument>(cursor, binding, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, null, null, null, -1));
 
-            var argumnetNullException = exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject;
-            argumnetNullException.ParamName.Should().Be("maxWireVersion");
+            exception.Should().BeOfType<ArgumentOutOfRangeException>().Subject
+                .ParamName.Should().Be("maxWireVersion");
         }
 
         [Fact]
@@ -298,21 +270,18 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         [Theory]
-        [InlineData("{ a : 1 }", "{ b : 2 }", "{ c : 3 }", "{ d : 4 }", "{ a : 1 }")]
-        [InlineData(null, "{ b : 2 }", "{ c : 3 }", "{ d : 4 }", "{ b : 2 }")]
-        [InlineData(null, null, "{ c : 3 }", "{ d : 4 }", "{ c : 3 }")]
-        [InlineData(null, null, null, "{ d : 4 }", "{ d : 4 }")]
-        [InlineData(null, null, null, null, null)]
+        [InlineData("{ a : 1 }", "{ b : 2 }", "{ c : 3 }", "{ a : 1 }")]
+        [InlineData(null, "{ b : 2 }", "{ c : 3 }", "{ b : 2 }")]
+        [InlineData(null, null, "{ c : 3 }", "{ c : 3 }")]
+        [InlineData(null, null, null, null)]
         public void GetResumeToken_should_return_expected_result(
             string postBatchResumeTokenJson,
-            string documentResumeTokenJson,
             string startAfterJson,
             string resumeAfterJson,
             string expectedResult)
         {
             var mockCursor = CreateMockCursor();
             var postBatchResumeToken = postBatchResumeTokenJson != null ? BsonDocument.Parse(postBatchResumeTokenJson) : null;
-            var documentResumeToken = documentResumeTokenJson != null ? BsonDocument.Parse(documentResumeTokenJson) : null;
             var startAfter = startAfterJson != null ? BsonDocument.Parse(startAfterJson) : null;
             var resumeAfter = resumeAfterJson != null ? BsonDocument.Parse(resumeAfterJson) : null;
 
@@ -321,7 +290,6 @@ namespace MongoDB.Driver.Core.Operations
                 postBatchResumeToken: postBatchResumeToken,
                 startAfter: startAfter,
                 resumeAfter: resumeAfter);
-            subject._documentResumeToken(documentResumeToken);
             subject.GetResumeToken().Should().Be(expectedResult);
         }
 
@@ -462,8 +430,7 @@ namespace MongoDB.Driver.Core.Operations
             var mockResumedCursor = CreateMockCursor();
 
             // process the first batch so that we have a resume token
-            var resumeToken = BsonDocument.Parse("{ resumeToken : 1 }");
-            var firstDocument = BsonDocument.Parse("{ _id : { resumeToken : 1 }, operationType : \"insert\", ns : { db : \"db\", coll : \"coll\" }, documentKey : { _id : 1 }, fullDocument : { _id : 1 } }");
+            var firstDocument = BsonDocument.Parse("{ _id : { resumeToken : 1 }, operationType : 'insert', ns : { db : 'db', coll : 'coll' }, documentKey : { _id : 1 }, fullDocument : { _id : 1 } }");
             var firstBatch = new[] { ToRawDocument(firstDocument) };
             mockCursor.Setup(c => c.MoveNext(It.IsAny<CancellationToken>())).Returns(true);
             mockCursor.SetupGet(c => c.Current).Returns(firstBatch);
@@ -498,143 +465,6 @@ namespace MongoDB.Driver.Core.Operations
             result.Should().Be(expectedResult);
         }
 
-        [Theory]
-        [ParameterAttributeData]
-        void ProcessBatch_should_deserialize_documents(
-            [Values(false, true)] bool async)
-        {
-            var mockCursor = CreateMockCursor();
-            var mockSerializer = new Mock<IBsonSerializer<BsonDocument>>();
-            var subject = CreateSubject(cursor: mockCursor.Object, documentSerializer: mockSerializer.Object);
-            var document = BsonDocument.Parse("{ _id : { resumeAfter : 1 }, operationType : \"insert\", ns : { db : \"db\", coll : \"coll\" }, documentKey : { _id : 1 }, fullDocument : { _id : 1 } }");
-            var rawDocuments = new[] { ToRawDocument(document) };
-            using var cancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = cancellationTokenSource.Token;
-
-            mockCursor.SetupGet(c => c.Current).Returns(rawDocuments);
-            mockSerializer.Setup(s => s.Deserialize(It.IsAny<BsonDeserializationContext>(), It.IsAny<BsonDeserializationArgs>())).Returns(document);
-
-            bool result;
-            if (async)
-            {
-                mockCursor.Setup(c => c.MoveNextAsync(cancellationToken)).Returns(Task.FromResult(true));
-
-                result = subject.MoveNextAsync(cancellationToken).GetAwaiter().GetResult();
-            }
-            else
-            {
-                mockCursor.Setup(c => c.MoveNext(cancellationToken)).Returns(true);
-
-                result = subject.MoveNext(cancellationToken);
-            }
-
-            result.Should().BeTrue();
-            subject.Current.Should().Equal(new[] { document });
-            mockSerializer.Verify(s => s.Deserialize(It.IsAny<BsonDeserializationContext>(), It.IsAny<BsonDeserializationArgs>()), Times.Once);
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        void ProcessBatch_should_Dispose_rawDocuments(
-            [Values(false, true)] bool async)
-        {
-            var mockCursor = CreateMockCursor();
-            var mockSerializer = new Mock<IBsonSerializer<BsonDocument>>();
-            var subject = CreateSubject(cursor: mockCursor.Object, documentSerializer: mockSerializer.Object);
-            var document = BsonDocument.Parse("{ _id : { resumeAfter : 1 }, operationType : \"insert\", ns : { db : \"db\", coll : \"coll\" }, documentKey : { _id : 1 }, fullDocument : { _id : 1 } }");
-            var rawDocument = ToRawDocument(document);
-            var rawDocuments = new[] { rawDocument };
-            using var cancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = cancellationTokenSource.Token;
-
-            mockCursor.SetupGet(c => c.Current).Returns(rawDocuments);
-            mockSerializer.Setup(s => s.Deserialize(It.IsAny<BsonDeserializationContext>(), It.IsAny<BsonDeserializationArgs>())).Returns(document);
-
-            bool result;
-            if (async)
-            {
-                mockCursor.Setup(c => c.MoveNextAsync(cancellationToken)).Returns(Task.FromResult(true));
-
-                result = subject.MoveNextAsync(cancellationToken).GetAwaiter().GetResult();
-            }
-            else
-            {
-                mockCursor.Setup(c => c.MoveNext(cancellationToken)).Returns(true);
-
-                result = subject.MoveNext(cancellationToken);
-            }
-
-            var exception = Record.Exception(() => rawDocument.Contains("x"));
-            exception.Should().BeOfType<ObjectDisposedException>();
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        void ProcessBatch_should_save_documentResumeToken(
-            [Values(false, true)] bool async)
-        {
-            var postBatchResumeToken = new BsonDocument("a", 1);
-            var mockCursor = CreateMockCursor(postBatchResumeToken);
-            var mockSerializer = new Mock<IBsonSerializer<BsonDocument>>();
-            var subject = CreateSubject(cursor: mockCursor.Object, documentSerializer: mockSerializer.Object);
-            var document = BsonDocument.Parse("{ _id : { resumeAfter : 1 }, operationType : \"insert\", ns : { db : \"db\", coll : \"coll\" }, documentKey : { _id : 1 }, fullDocument : { _id : 1 } }");
-            var rawDocuments = new[] { ToRawDocument(document) };
-            using var cancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = cancellationTokenSource.Token;
-
-            mockCursor.SetupGet(c => c.Current).Returns(rawDocuments);
-            mockSerializer.Setup(s => s.Deserialize(It.IsAny<BsonDeserializationContext>(), It.IsAny<BsonDeserializationArgs>())).Returns(document);
-
-            bool result;
-            if (async)
-            {
-                mockCursor.Setup(c => c.MoveNextAsync(cancellationToken)).Returns(Task.FromResult(true));
-
-                result = subject.MoveNextAsync(cancellationToken).GetAwaiter().GetResult();
-            }
-            else
-            {
-                mockCursor.Setup(c => c.MoveNext(cancellationToken)).Returns(true);
-
-                result = subject.MoveNext(cancellationToken);
-            }
-
-            subject._documentResumeToken().Should().Be("{ resumeAfter : 1 }");
-            subject._postBatchResumeToken().Should().Be(postBatchResumeToken);
-        }
-
-        [Theory]
-        [ParameterAttributeData]
-        void ProcessBatch_should_throw_when_resume_token_is_missing(
-            [Values(false, true)] bool async)
-        {
-            var mockCursor = CreateMockCursor();
-            var subject = CreateSubject(cursor: mockCursor.Object);
-            var document = BsonDocument.Parse("{ operationType : \"insert\", ns : { db : \"db\", coll : \"coll\" }, documentKey : { _id : 1 }, fullDocument : { _id : 1 } }");
-            var rawDocuments = new[] { ToRawDocument(document) };
-            using var cancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = cancellationTokenSource.Token;
-
-            mockCursor.SetupGet(c => c.Current).Returns(rawDocuments);
-
-            Exception exception;
-            if (async)
-            {
-                mockCursor.Setup(c => c.MoveNextAsync(cancellationToken)).Returns(Task.FromResult(true));
-
-                exception = Record.Exception(() => subject.MoveNextAsync(cancellationToken).GetAwaiter().GetResult());
-            }
-            else
-            {
-                mockCursor.Setup(c => c.MoveNext(cancellationToken)).Returns(true);
-
-                exception = Record.Exception(() => subject.MoveNext(cancellationToken));
-            }
-
-            exception.Should().BeOfType<MongoClientException>();
-            exception.Message.Should().Be("Cannot provide resume functionality when the resume token is missing.");
-        }
-
         // private methods
         private ChangeStreamOperation<BsonDocument> CreateChangeStreamOperation()
         {
@@ -652,16 +482,15 @@ namespace MongoDB.Driver.Core.Operations
             return completionSource.Task;
         }
 
-        private Mock<IAsyncCursor<RawBsonDocument>> CreateMockCursor(BsonDocument postBatchResumeToken = null)
+        private Mock<IAsyncCursor<BsonDocument>> CreateMockCursor(BsonDocument postBatchResumeToken = null)
         {
             var mockBatchInfo = new Mock<ICursorBatchInfo>();
             mockBatchInfo.Setup(c => c.PostBatchResumeToken).Returns(postBatchResumeToken);
-            return mockBatchInfo.As<IAsyncCursor<RawBsonDocument>>();
+            return mockBatchInfo.As<IAsyncCursor<BsonDocument>>();
         }
 
         private ChangeStreamCursor<BsonDocument> CreateSubject(
-            IAsyncCursor<RawBsonDocument> cursor = null,
-            IBsonSerializer<BsonDocument> documentSerializer = null,
+            IAsyncCursor<BsonDocument> cursor = null,
             IReadBinding binding = null,
             ICoreSessionHandle session = null,
             IChangeStreamOperation<BsonDocument> changeStreamOperation = null,
@@ -671,12 +500,11 @@ namespace MongoDB.Driver.Core.Operations
             BsonTimestamp startAtOperationTime = null,
             BsonTimestamp initialOperationTime = null)
         {
-            cursor ??= new Mock<IAsyncCursor<RawBsonDocument>>().Object;
-            documentSerializer ??= new Mock<IBsonSerializer<BsonDocument>>().Object;
+            cursor ??= new Mock<IAsyncCursor<BsonDocument>>().Object;
             binding ??= new Mock<IReadBinding>().Object;
             session ??= new Mock<ICoreSessionHandle>().Object;
             changeStreamOperation ??= Mock.Of<IChangeStreamOperation<BsonDocument>>();
-            return new ChangeStreamCursor<BsonDocument>(cursor, documentSerializer, binding, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, startAfter, resumeAfter, startAtOperationTime, __dummyMaxWireVersion);
+            return new ChangeStreamCursor<BsonDocument>(cursor, binding, session, changeStreamOperation, postBatchResumeToken, initialOperationTime, startAfter, resumeAfter, startAtOperationTime, __dummyMaxWireVersion);
         }
 
         private BsonDocument GenerateResumeAfterToken(bool async, bool shouldBeEmpty = false)
@@ -732,15 +560,6 @@ namespace MongoDB.Driver.Core.Operations
 
         public static bool _disposed(this ChangeStreamCursor<BsonDocument> cursor) =>
             (bool)Reflector.GetFieldValue(cursor, nameof(_disposed));
-
-        public static IBsonSerializer<BsonDocument> _documentSerializer(this ChangeStreamCursor<BsonDocument> cursor) =>
-            (IBsonSerializer<BsonDocument>)Reflector.GetFieldValue(cursor, nameof(_documentSerializer));
-
-        public static BsonDocument _documentResumeToken<TDocument>(this IChangeStreamCursor<TDocument> cursor) =>
-            (BsonDocument)Reflector.GetFieldValue(cursor, nameof(_documentResumeToken));
-
-        public static void _documentResumeToken<TDocument>(this IChangeStreamCursor<TDocument> cursor, BsonDocument value) =>
-            Reflector.SetFieldValue(cursor, nameof(_documentResumeToken), value);
 
         public static ChangeStreamCursor<TDocument>.ResumeValues GetResumeValues<TDocument>(this IChangeStreamCursor<TDocument> cursor) =>
             (ChangeStreamCursor<TDocument>.ResumeValues)Reflector.Invoke(cursor, nameof(GetResumeValues));

--- a/tests/MongoDB.Driver.Tests/Core/Operations/ChangeStreamCursorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/ChangeStreamCursorTests.cs
@@ -80,7 +80,7 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public void constructor_should_initialize_instance()
         {
-            var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
+            var cursor = new Mock<IAsyncCursor<BsonDocument>>().Object;
             var binding = new Mock<IReadBinding>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
@@ -134,7 +134,7 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public void constructor_should_throw_when_binding_is_null()
         {
-            var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
+            var cursor = new Mock<IAsyncCursor<BsonDocument>>().Object;
             var session = new Mock<ICoreSessionHandle>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
             var postBatchResumeToken = Mock.Of<BsonDocument>();
@@ -149,7 +149,7 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public void constructor_should_throw_when_changeStreamOperation_is_null()
         {
-            var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
+            var cursor = new Mock<IAsyncCursor<BsonDocument>>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
             var postBatchResumeToken = Mock.Of<BsonDocument>();
             var binding = new Mock<IReadBinding>().Object;
@@ -164,7 +164,7 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public void constructor_should_throw_when_maxWireVersion_is_negative()
         {
-            var cursor = new Mock<IAsyncCursor<RawBsonDocument>>().Object;
+            var cursor = new Mock<IAsyncCursor<BsonDocument>>().Object;
             var initialOperationTime = new BsonTimestamp(3L);
             var postBatchResumeToken = Mock.Of<BsonDocument>();
             var binding = new Mock<IReadBinding>().Object;
@@ -190,7 +190,7 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public void Dispose_should_call_Dispose_on_cursor()
         {
-            var mockCursor = new Mock<IAsyncCursor<RawBsonDocument>>();
+            var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
             var subject = CreateSubject(cursor: mockCursor.Object);
 
             subject.Dispose();
@@ -212,7 +212,7 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public void Dispose_can_be_called_more_than_once()
         {
-            var mockCursor = new Mock<IAsyncCursor<RawBsonDocument>>();
+            var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
             var mockBinding = new Mock<IReadBinding>();
             var subject = CreateSubject(cursor: mockCursor.Object, binding: mockBinding.Object);
 
@@ -236,7 +236,7 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public async Task DisposeAsync_should_call_DisposeAsync_on_cursor()
         {
-            var mockCursor = new Mock<IAsyncCursor<RawBsonDocument>>();
+            var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
             var subject = CreateSubject(cursor: mockCursor.Object);
 
             await subject.DisposeAsync();
@@ -258,7 +258,7 @@ namespace MongoDB.Driver.Core.Operations
         [Fact]
         public async Task DisposeAsync_can_be_called_more_than_once()
         {
-            var mockCursor = new Mock<IAsyncCursor<RawBsonDocument>>();
+            var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
             var mockBinding = new Mock<IReadBinding>();
             var subject = CreateSubject(cursor: mockCursor.Object, binding: mockBinding.Object);
 
@@ -431,7 +431,7 @@ namespace MongoDB.Driver.Core.Operations
 
             // process the first batch so that we have a resume token
             var firstDocument = BsonDocument.Parse("{ _id : { resumeToken : 1 }, operationType : 'insert', ns : { db : 'db', coll : 'coll' }, documentKey : { _id : 1 }, fullDocument : { _id : 1 } }");
-            var firstBatch = new[] { ToRawDocument(firstDocument) };
+            var firstBatch = new[] { firstDocument };
             mockCursor.Setup(c => c.MoveNext(It.IsAny<CancellationToken>())).Returns(true);
             mockCursor.SetupGet(c => c.Current).Returns(firstBatch);
             subject.MoveNext(CancellationToken.None);
@@ -533,15 +533,6 @@ namespace MongoDB.Driver.Core.Operations
                 return enumerator.Current.ResumeToken;
             }
         }
-
-        private RawBsonDocument ToRawDocument(BsonDocument document)
-        {
-            using (var reader = new BsonDocumentReader(document))
-            {
-                var context = BsonDeserializationContext.CreateRoot(reader);
-                return RawBsonDocumentSerializer.Instance.Deserialize(context);
-            }
-        }
     }
 
     internal static class ChangeStreamCursorReflector
@@ -555,8 +546,8 @@ namespace MongoDB.Driver.Core.Operations
         public static IEnumerable<BsonDocument> _current(this ChangeStreamCursor<BsonDocument> cursor) =>
             (IEnumerable<BsonDocument>)Reflector.GetFieldValue(cursor, nameof(_current));
 
-        public static IAsyncCursor<RawBsonDocument> _cursor(this ChangeStreamCursor<BsonDocument> cursor) =>
-            (IAsyncCursor<RawBsonDocument>)Reflector.GetFieldValue(cursor, nameof(_cursor));
+        public static IAsyncCursor<BsonDocument> _cursor(this ChangeStreamCursor<BsonDocument> cursor) =>
+            (IAsyncCursor<BsonDocument>)Reflector.GetFieldValue(cursor, nameof(_cursor));
 
         public static bool _disposed(this ChangeStreamCursor<BsonDocument> cursor) =>
             (bool)Reflector.GetFieldValue(cursor, nameof(_disposed));

--- a/tests/MongoDB.Driver.Tests/Core/Operations/ChangeStreamOperationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/ChangeStreamOperationTests.cs
@@ -702,7 +702,7 @@ namespace MongoDB.Driver.Core.Operations
             result.MessageEncoderSettings.Should().BeSameAs(messageEncoderSettings);
             result.Pipeline.Should().Equal(expectedPipeline);
             result.ReadConcern.Should().Be(readConcern);
-            result.ResultSerializer.Should().Be(RawBsonDocumentSerializer.Instance);
+            result.ResultSerializer.Should().Be(BsonDocumentSerializer.Instance);
             result.RetryRequested.Should().BeFalse();
         }
 
@@ -723,9 +723,9 @@ namespace MongoDB.Driver.Core.Operations
 
     internal static class ChangeStreamOperationReflector
     {
-        public static AggregateOperation<RawBsonDocument> CreateAggregateOperation(this ChangeStreamOperation<BsonDocument> subject)
+        public static AggregateOperation<BsonDocument> CreateAggregateOperation(this ChangeStreamOperation<BsonDocument> subject)
         {
-            return (AggregateOperation<RawBsonDocument>)Reflector.Invoke(subject, nameof(CreateAggregateOperation));
+            return (AggregateOperation<BsonDocument>)Reflector.Invoke(subject, nameof(CreateAggregateOperation));
         }
 
         public static BsonDocument CreateChangeStreamStage(this ChangeStreamOperation<ChangeStreamDocument<BsonDocument>> subject)


### PR DESCRIPTION
Part 2 of the RawBsonDocument deprecation work: remove RawBsonDocument from ChangeStreams.