### PR TITLE
CSHARP-5998: RawBsonDocument refactoring/removal

### DIFF
--- a/src/MongoDB.Driver.Encryption/AutoEncryptionLibMongoController.cs
+++ b/src/MongoDB.Driver.Encryption/AutoEncryptionLibMongoController.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Core.Servers;
 
 namespace MongoDB.Driver.Encryption
@@ -181,7 +182,7 @@ namespace MongoDB.Driver.Encryption
             var database = _metadataClient.GetDatabase(databaseName);
             using var binary = context.GetOperation();
             var filterBytes = binary.ToArray();
-            using var filterDocument = new RawBsonDocument(filterBytes);
+            var filterDocument = BsonSerializer.Deserialize<BsonDocument>(filterBytes);
             var filter = new BsonDocumentFilterDefinition<BsonDocument>(filterDocument);
             var options = new ListCollectionsOptions { Filter = filter };
             var cursor = database.ListCollections(options, cancellationToken);
@@ -200,7 +201,7 @@ namespace MongoDB.Driver.Encryption
             var database = _metadataClient.GetDatabase(databaseName);
             using var binary = context.GetOperation();
             var filterBytes = binary.ToArray();
-            using var filterDocument = new RawBsonDocument(filterBytes);
+            var filterDocument = BsonSerializer.Deserialize<BsonDocument>(filterBytes);
             var filter = new BsonDocumentFilterDefinition<BsonDocument>(filterDocument);
             var options = new ListCollectionsOptions { Filter = filter };
             var cursor = await database.ListCollectionsAsync(options, cancellationToken).ConfigureAwait(false);
@@ -213,7 +214,7 @@ namespace MongoDB.Driver.Encryption
             var database = _mongocryptdClient.Value.GetDatabase(databaseName);
             using var binary = context.GetOperation();
             var commandBytes = binary.ToArray();
-            using var commandDocument = new RawBsonDocument(commandBytes);
+            var commandDocument = BsonSerializer.Deserialize<BsonDocument>(commandBytes);
             var command = new BsonDocumentCommand<BsonDocument>(commandDocument);
 
             BsonDocument response = null;
@@ -238,7 +239,7 @@ namespace MongoDB.Driver.Encryption
             var database = _mongocryptdClient.Value.GetDatabase(databaseName);
             using var binary = context.GetOperation();
             var commandBytes = binary.ToArray();
-            using var commandDocument = new RawBsonDocument(commandBytes);
+            var commandDocument = BsonSerializer.Deserialize<BsonDocument>(commandBytes);
             var command = new BsonDocumentCommand<BsonDocument>(commandDocument);
 
             BsonDocument response = null;

--- a/src/MongoDB.Driver.Encryption/LibMongoCryptControllerBase.cs
+++ b/src/MongoDB.Driver.Encryption/LibMongoCryptControllerBase.cs
@@ -24,6 +24,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
@@ -237,7 +238,7 @@ namespace MongoDB.Driver.Encryption
         {
             using var binary = context.GetOperation();
             var filterBytes = binary.ToArray();
-            using var filterDocument = new RawBsonDocument(filterBytes);
+            var filterDocument = BsonSerializer.Deserialize<BsonDocument>(filterBytes);
             var filter = new BsonDocumentFilterDefinition<BsonDocument>(filterDocument);
             var cursor = _keyVaultCollection.Value.FindSync(filter, cancellationToken: cancellationToken);
             var results = cursor.ToList(cancellationToken);
@@ -267,7 +268,7 @@ namespace MongoDB.Driver.Encryption
         {
             using var binary = context.GetOperation();
             var filterBytes = binary.ToArray();
-            using var filterDocument = new RawBsonDocument(filterBytes);
+            var filterDocument = BsonSerializer.Deserialize<BsonDocument>(filterBytes);
             var filter = new BsonDocumentFilterDefinition<BsonDocument>(filterDocument);
             var cursor = await _keyVaultCollection.Value.FindAsync(filter, cancellationToken: cancellationToken).ConfigureAwait(false);
             var results = await cursor.ToListAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
RawBsonDocument refactoring/removal - part 3 out of 4.

Although this change materializes each filter/command document up front via BsonSerializer.Deserialize<BsonDocument>, it does not add any materialization that wasn't already happening: because these documents were embedded as nested values inside a command, they were serialized to the wire through BsonValueSerializer → BsonDocumentSerializer, which dispatches by BsonType and walks elements one at a time — the zero-copy RawBsonDocument fast path (WriteRawBsonDocument) was never reached. In fact RawBsonDocument caches nothing and re-parses its byte buffer from the start on every GetElement/ElementCount call, so the old code re-parsed the slice repeatedly during serialization; the new code parses once into a reusable tree. The result is functionally identical BSON with slightly less work, and it removes the IDisposable/unmanaged-buffer lifetime concern as a bonus.