### PR TITLE
CSHARP-6213: Normalize SRV target host names to lower case during SRV polling

### DIFF
--- a/src/MongoDB.Driver/Core/Clusters/DnsMonitor.cs
+++ b/src/MongoDB.Driver/Core/Clusters/DnsMonitor.cs
@@ -133,14 +133,14 @@ namespace MongoDB.Driver.Core.Clusters
 
             foreach (var srvRecord in srvRecords)
             {
-                var endPoint = srvRecord.EndPoint;
-                var host = endPoint.Host;
+                // DNS names are case-insensitive, and SDAM requires host names to be normalized to lower-case
+                var host = srvRecord.EndPoint.Host.ToLowerInvariant();
                 if (host.EndsWith(".", StringComparison.Ordinal))
                 {
                     host = host.Substring(0, host.Length - 1);
-                    endPoint = new DnsEndPoint(host, endPoint.Port);
                 }
 
+                var endPoint = new DnsEndPoint(host, srvRecord.EndPoint.Port);
                 if (IsValidHost(endPoint))
                 {
                     validEndPoints.Add(endPoint);

--- a/tests/MongoDB.Driver.Tests/Core/Clusters/DnsMonitorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Clusters/DnsMonitorTests.cs
@@ -314,6 +314,23 @@ namespace MongoDB.Driver.Core.Clusters
         }
 
         [Theory]
+        [InlineData("x.B.CoM", "x.b.com")]     // parent-domain labels
+        [InlineData("X1.b.com", "x1.b.com")]   // leftmost label only
+        [InlineData("X1.b.com.", "x1.b.com")]  // trailing dot, as the resolver returns it
+        public void GetValidEndPoints_should_normalize_host_to_lower_case(string srvHost, string expectedHost)
+        {
+            var subject = CreateSubject(lookupDomainName: "a.b.com");
+            var srvRecords = new List<SrvRecord>
+            {
+                new SrvRecord(new DnsEndPoint(srvHost, 27017), TimeSpan.FromHours(24))
+            };
+
+            var result = subject.GetValidEndPoints(srvRecords);
+
+            result.Single().Host.Should().Be(expectedHost);
+        }
+
+        [Theory]
         [InlineData("a.b.com", "x.b.com", true)]
         [InlineData("a.b.com", "x.com", false)]
         [InlineData("a.b.com", "x.c.com", false)]


### PR DESCRIPTION
## Problem

During SRV polling, `DnsMonitor` compared the host names returned by the resolver against the parent domain case-sensitively. DNS names are case-insensitive ([RFC 4343](https://www.ietf.org/rfc/rfc4343.txt)), and SDAM requires that [hostnames are normalized to lower-case](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md#hostnames-are-normalized-to-lower-case).

The initial seedlist path and the polling path reach the same comparison by different routes, and only one of them folded case:

- **Initial discovery** — `ConnectionString.ValidateResolvedHosts` parses each resolved host through `EndPointHelper.TryParse`, which lower-cases. The seed side was lower-cased by the same call during connection string parsing. Both operands are folded, so the ordinal comparison in `HasValidParentDomain` is correct.
- **Polling** — `DnsMonitor.GetValidEndPoints` took `srvRecord.EndPoint` straight from the resolver and stripped the trailing dot by hand, never going through `EndPointHelper`. `_lookupDomainName` *was* lower-cased (it comes from `ClusterSettings.EndPoints`), so a raw, possibly mixed-case target was compared ordinally against a lower-cased anchor.

