### PR TITLE
CSHARP-6208: Port CSHARP-6158 fix requiring replacement to be a document from v3.x

### DIFF
--- a/src/MongoDB.Driver/BulkWriteReplaceOneModel.cs
+++ b/src/MongoDB.Driver/BulkWriteReplaceOneModel.cs
@@ -120,6 +120,7 @@ namespace MongoDB.Driver
             : base(collectionNamespace)
         {
             Filter = Ensure.IsNotNull(filter, nameof(filter));
+            ReplacementValidator.EnsureIsValidReplacement(replacement, nameof(replacement));
             Replacement = replacement;
             Collation = collation;
             Hint = hint;

--- a/src/MongoDB.Driver/Core/Misc/ReplacementValidator.cs
+++ b/src/MongoDB.Driver/Core/Misc/ReplacementValidator.cs
@@ -1,0 +1,38 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.Core.Misc
+{
+    internal static class ReplacementValidator
+    {
+        // A replacement is always sent as the value of an update field ("u" for update commands, "update" for
+        // findAndModify), and unlike an inserted document it is not written at the root of a document, so the BSON
+        // writer will happily emit whatever type it is given. The server reads an array there as an aggregation
+        // pipeline, so a loosely typed collection (for example IMongoCollection<BsonValue>) would otherwise let a
+        // BsonArray of pipeline stages be passed as a "replacement" and executed as update operators. A scalar is
+        // rejected for the same reason: it is not a replacement, and it only produces a confusing server error.
+        public static void EnsureIsValidReplacement(object replacement, string paramName)
+        {
+            if (replacement is BsonValue bsonValue && bsonValue.BsonType != BsonType.Document)
+            {
+                var message = string.Format("A replacement must be a document, not a {0}.", bsonValue.BsonType);
+                throw new ArgumentException(message, paramName);
+            }
+        }
+    }
+}

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -987,6 +987,7 @@ namespace MongoDB.Driver
             FindOneAndReplaceOptions<TDocument, TProjection> options)
         {
             options ??= new FindOneAndReplaceOptions<TDocument, TProjection>();
+            ReplacementValidator.EnsureIsValidReplacement(replacement, nameof(replacement));
 
             var renderArgs = GetRenderArgs();
             var projection = options.Projection ?? new ClientSideDeserializationProjectionDefinition<TDocument, TProjection>();

--- a/src/MongoDB.Driver/ReplaceOneModel.cs
+++ b/src/MongoDB.Driver/ReplaceOneModel.cs
@@ -42,6 +42,7 @@ namespace MongoDB.Driver
         public ReplaceOneModel(FilterDefinition<TDocument> filter, TDocument replacement)
         {
             _filter = Ensure.IsNotNull(filter, nameof(filter));
+            ReplacementValidator.EnsureIsValidReplacement(replacement, nameof(replacement));
             _replacement = replacement;
         }
 

--- a/tests/MongoDB.Driver.Tests/Core/Operations/ReplacementPipelineInjectionIntegrationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/ReplacementPipelineInjectionIntegrationTests.cs
@@ -1,0 +1,142 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Tests;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Operations
+{
+    // CSHARP-6158. A collection typed as IMongoCollection<BsonValue> let an attacker-controlled BsonArray be
+    // passed where a replacement document was expected, because BsonArray is-a BsonValue and nothing on the
+    // replace paths validated the shape. The server reads an array update as an aggregation pipeline, so the
+    // stages ran as update operators.
+    //
+    // FindOneAndReplace was fully exploitable: FindOneAndReplaceOperation builds { "update", _replacement } into
+    // a plain command document with no element name validator anywhere. ReplaceOne and the client bulkWrite
+    // happened to be saved by the ReplacementElementNameValidator they push at their sink, but only by accident
+    // of when BsonWriter swaps in a child validator, so all three are now guarded up front instead.
+    [Trait("Category", "Integration")]
+    public class ReplacementPipelineInjectionIntegrationTests
+    {
+        private const string CollectionName = "csharp6158_replacement_injection";
+
+        private static BsonArray AttackerPipeline() =>
+            new BsonArray { new BsonDocument("$set", new BsonDocument("role", "admin")) };
+
+        [Fact]
+        public void FindOneAndReplace_should_reject_an_array_replacement()
+        {
+            RequireServer.Check();
+
+            var eventCapturer = new EventCapturer().Capture<CommandStartedEvent>(e => e.CommandName == "findAndModify");
+            using var client = DriverTestConfiguration.CreateMongoClient(eventCapturer);
+            var collection = GetSeededCollection(client);
+
+            Action action = () => collection.FindOneAndReplace(new BsonDocument("_id", 1), AttackerPipeline());
+
+            action.ShouldThrow<ArgumentException>()
+                .And.ParamName.Should().Be("replacement");
+            eventCapturer.Events.Should().BeEmpty();
+
+            // before the fix the pipeline ran: "role" became "admin" while "name" survived, which a genuine
+            // replacement could never do. Assert the document is untouched.
+            var stored = collection.Find(new BsonDocument("_id", 1)).Single().AsBsonDocument;
+            stored["role"].AsString.Should().Be("user");
+            stored["name"].AsString.Should().Be("alice");
+        }
+
+        [Fact]
+        public async Task FindOneAndReplaceAsync_should_reject_an_array_replacement()
+        {
+            RequireServer.Check();
+
+            using var client = DriverTestConfiguration.CreateMongoClient(new EventCapturer());
+            var collection = GetSeededCollection(client);
+
+            // the async overload shares CreateFindOneAndReplaceOperation, but assert it explicitly
+            var exception = await Record.ExceptionAsync(
+                () => collection.FindOneAndReplaceAsync(new BsonDocument("_id", 1), AttackerPipeline()));
+
+            exception.Should().BeOfType<ArgumentException>()
+                .Which.ParamName.Should().Be("replacement");
+        }
+
+        [Fact]
+        public void ReplaceOne_should_reject_an_array_replacement()
+        {
+            RequireServer.Check();
+
+            var eventCapturer = new EventCapturer().Capture<CommandStartedEvent>(e => e.CommandName == "update");
+            using var client = DriverTestConfiguration.CreateMongoClient(eventCapturer);
+            var collection = GetSeededCollection(client);
+
+            Action action = () => collection.ReplaceOne(new BsonDocument("_id", 1), AttackerPipeline());
+
+            action.ShouldThrow<ArgumentException>()
+                .And.ParamName.Should().Be("replacement");
+            eventCapturer.Events.Should().BeEmpty();
+
+            collection.Find(new BsonDocument("_id", 1)).Single().AsBsonDocument["role"].AsString.Should().Be("user");
+        }
+
+        [Fact]
+        public void ReplaceOne_should_reject_a_scalar_replacement()
+        {
+            RequireServer.Check();
+
+            var eventCapturer = new EventCapturer().Capture<CommandStartedEvent>(e => e.CommandName == "update");
+            using var client = DriverTestConfiguration.CreateMongoClient(eventCapturer);
+            var collection = GetSeededCollection(client);
+
+            // previously this round-tripped and came back as "Update argument must be either an object or an array"
+            Action action = () => collection.ReplaceOne(new BsonDocument("_id", 1), BsonValue.Create(42));
+
+            action.ShouldThrow<ArgumentException>()
+                .And.ParamName.Should().Be("replacement");
+            eventCapturer.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ReplaceOne_should_still_accept_a_document_replacement()
+        {
+            RequireServer.Check();
+
+            using var client = DriverTestConfiguration.CreateMongoClient(new EventCapturer());
+            var collection = GetSeededCollection(client);
+
+            collection.ReplaceOne(new BsonDocument("_id", 1), new BsonDocument { { "_id", 1 }, { "name", "bob" } });
+
+            var stored = collection.Find(new BsonDocument("_id", 1)).Single().AsBsonDocument;
+            stored["name"].AsString.Should().Be("bob");
+            stored.Contains("role").Should().BeFalse(); // a real replacement drops the other fields
+        }
+
+        private static IMongoCollection<BsonValue> GetSeededCollection(IMongoClient client)
+        {
+            var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
+            database.DropCollection(CollectionName);
+            var collection = database.GetCollection<BsonValue>(CollectionName);
+            collection.InsertOne(new BsonDocument { { "_id", 1 }, { "name", "alice" }, { "role", "user" } });
+            return collection;
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Core/Operations/ReplacementPipelineInjectionTests.cs
+++ b/tests/MongoDB.Driver.Tests/Core/Operations/ReplacementPipelineInjectionTests.cs
@@ -1,0 +1,169 @@
+/* Copyright 2010-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver.Core.Operations.ElementNameValidators;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Operations
+{
+    // CSHARP-6158: a replacement is only ever meant to be a document, but nothing between the public
+    // ReplaceOne API and the wire enforces that. An attacker-supplied array reaches the server as the
+    // update 'u' field, where an array means "aggregation pipeline" rather than "replacement document".
+    public class ReplacementPipelineInjectionTests
+    {
+        private static BsonArray AttackerPipeline() =>
+            new BsonArray
+            {
+                new BsonDocument("$set", new BsonDocument("role", "admin")),
+                new BsonDocument("$unset", "auditTrail")
+            };
+
+        [Fact]
+        public void UpdateRequest_should_reject_an_array_when_update_type_is_Update_but_accepts_it_for_Replacement()
+        {
+            // for a real update an array is legitimate (a pipeline update), and an empty one is rejected
+            Action emptyPipelineUpdate = () => new UpdateRequest(UpdateType.Update, new BsonDocument(), new BsonArray());
+            emptyPipelineUpdate.ShouldThrow<ArgumentException>();
+
+            // for a Replacement, EnsureUpdateIsValid does nothing at all: an array is accepted, and so is a scalar
+            Action arrayReplacement = () => new UpdateRequest(UpdateType.Replacement, new BsonDocument(), AttackerPipeline());
+            Action scalarReplacement = () => new UpdateRequest(UpdateType.Replacement, new BsonDocument(), BsonValue.Create(42));
+
+            arrayReplacement.ShouldNotThrow();
+            scalarReplacement.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void ReplacementElementNameValidator_should_not_guard_child_content()
+        {
+            var subject = ElementNameValidatorFactory.ForUpdateType(UpdateType.Replacement);
+
+            // a top-level operator is correctly rejected ...
+            subject.IsValidElementName("$set").Should().BeFalse();
+
+            // ... but array indexes are valid names, and children are handed a no-op validator,
+            // so every pipeline-stage operator nested inside the array goes unchecked
+            subject.IsValidElementName("0").Should().BeTrue();
+            subject.GetValidatorForChildContent("0").Should().BeOfType<NoOpElementNameValidator>();
+            subject.GetValidatorForChildContent("0").IsValidElementName("$set").Should().BeTrue();
+        }
+
+        [Fact]
+        public void An_array_of_pipeline_stages_is_rejected_by_the_element_name_validator()
+        {
+            var request = new UpdateRequest(UpdateType.Replacement, new BsonDocument("_id", 1), AttackerPipeline());
+
+            Action action = () => SerializeUpdateFieldTheSameWayTheOperationDoes(request);
+
+            // Despite GetValidatorForChildContent returning a no-op validator, the pipeline is still blocked.
+            // BsonWriter only swaps in the child validator when _useChildValidator is set, and that flag is set
+            // by WriteName and then cleared again by PushElementNameValidator. SerializeUpdate pushes the
+            // validator *after* writing the "u" name, so the flag is false and GetValidatorForChildContent is
+            // never consulted. On top of that, BsonArraySerializer never calls WriteName for its items (array
+            // indexes are emitted directly by WriteNameHelper), so nothing ever swaps the validator either.
+            // The ReplacementElementNameValidator therefore stays in effect all the way into the array items,
+            // where it rejects every "$"-prefixed stage name.
+            action.ShouldThrow<BsonSerializationException>()
+                .WithMessage("Element name '$set' is not valid'.");
+        }
+
+        [Fact]
+        public void A_scalar_replacement_is_serialized_verbatim_as_the_wire_update_field()
+        {
+            var request = new UpdateRequest(UpdateType.Replacement, new BsonDocument("_id", 1), BsonValue.Create(42));
+
+            // a scalar contains no element names at all, so no validator ever sees it and it reaches the wire
+            var rendered = SerializeUpdateFieldTheSameWayTheOperationDoes(request);
+
+            rendered["u"].BsonType.Should().Be(BsonType.Int32);
+            rendered["u"].AsInt32.Should().Be(42);
+        }
+
+        [Fact]
+        public void An_array_of_non_operator_documents_is_serialized_verbatim_as_the_wire_update_field()
+        {
+            // no "$" prefixes, so the validator is satisfied, yet the server still receives an array 'u'
+            // and will interpret it as an aggregation pipeline rather than a replacement document
+            var request = new UpdateRequest(
+                UpdateType.Replacement,
+                new BsonDocument("_id", 1),
+                new BsonArray { new BsonDocument("role", "admin") });
+
+            var rendered = SerializeUpdateFieldTheSameWayTheOperationDoes(request);
+
+            rendered["u"].BsonType.Should().Be(BsonType.Array);
+        }
+
+        [Fact]
+        public void ReplaceOneModel_should_reject_a_non_document_replacement()
+        {
+            Action array = () => new ReplaceOneModel<BsonValue>(new BsonDocument(), AttackerPipeline());
+            Action scalar = () => new ReplaceOneModel<BsonValue>(new BsonDocument(), BsonValue.Create(42));
+
+            array.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("replacement");
+            scalar.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("replacement");
+        }
+
+        [Fact]
+        public void BulkWriteReplaceOneModel_should_reject_a_non_document_replacement()
+        {
+            var ns = CollectionNamespace.FromFullName("db.coll");
+
+            Action array = () => new BulkWriteReplaceOneModel<BsonValue>(ns, new BsonDocument(), AttackerPipeline());
+            Action scalar = () => new BulkWriteReplaceOneModel<BsonValue>(ns, new BsonDocument(), BsonValue.Create(42));
+
+            array.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("replacement");
+            scalar.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("replacement");
+        }
+
+        [Fact]
+        public void ReplaceOneModel_should_still_accept_a_document_replacement()
+        {
+            Action action = () => new ReplaceOneModel<BsonValue>(new BsonDocument(), new BsonDocument("a", 1));
+
+            action.ShouldNotThrow();
+        }
+
+        // mirrors RetryableUpdateCommandOperation.UpdateRequestSerializer.SerializeUpdate
+        private static BsonDocument SerializeUpdateFieldTheSameWayTheOperationDoes(UpdateRequest request)
+        {
+            var document = new BsonDocument();
+            using (var writer = new BsonDocumentWriter(document))
+            {
+                var context = BsonSerializationContext.CreateRoot(writer);
+                writer.WriteStartDocument();
+                writer.WriteName("u");
+                writer.PushElementNameValidator(ElementNameValidatorFactory.ForUpdateType(request.UpdateType));
+                try
+                {
+                    BsonValueSerializer.Instance.Serialize(context, request.Update);
+                }
+                finally
+                {
+                    writer.PopElementNameValidator();
+                }
+                writer.WriteEndDocument();
+            }
+
+            return document;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the CSHARP-6158 security fix from the v3.x branch to main.

CSHARP-6158: Replace/ReplaceOne operations could be given an array-shaped replacement via `ReplaceOneModel` / `BulkWriteReplaceOneModel`, which bypasses the update-shape validation and allows a pipeline-shaped (operator-injection) document to be treated as a replacement document. This fix requires replacement expressions to be documents.

## Source

Cherry-pick of v3.x commit `27bc81ddeb4` (shipped in v3.11.1).

## Changes

- Adds `ReplacementValidator` and requires `ReplaceOneModel`/`BulkWriteReplaceOneModel` replacements to be documents
- Adds `ReplacementPipelineInjectionTests` + integration tests